### PR TITLE
Sharded pubsub command execution within multi/exec

### DIFF
--- a/tests/unit/cluster/sharded-pubsub.tcl
+++ b/tests/unit/cluster/sharded-pubsub.tcl
@@ -1,0 +1,56 @@
+start_cluster 1 1 {tags {external:skip cluster}} {
+        set primary_id 0
+        set replica1_id 1
+
+        set primary [Rn $primary_id]
+        set replica [Rn $replica1_id]
+
+    test "Sharded pubsub publish behavior within multi/exec" {
+        foreach {node} {primary replica} {
+            set node [set $node]
+            $node MULTI
+            $node SPUBLISH ch1 "hello"
+            $node EXEC
+        }
+    }
+
+    test "Sharded pubsub within multi/exec with cross slot operation" {
+        $primary MULTI
+        $primary SPUBLISH ch1 "hello"
+        $primary GET foo
+        catch {[$primary EXEC]} err
+        assert_match {CROSSSLOT*} $err
+    }
+
+    test "Sharded pubsub publish behavior within multi/exec with read operation on primary" {
+        $primary MULTI
+        $primary SPUBLISH foo "hello"
+        $primary GET foo
+        $primary EXEC
+    } {0 {}}
+
+    test "Sharded pubsub publish behavior within multi/exec with read operation on replica" {
+        $replica MULTI
+        $replica SPUBLISH foo "hello"
+        catch {[$replica GET foo]} err
+        assert_match {MOVED*} $err
+        catch {[$replica EXEC]} err
+        assert_match {EXECABORT*} $err
+    }
+
+    test "Sharded pubsub publish behavior within multi/exec with write operation on primary" {
+        $primary MULTI
+        $primary SPUBLISH foo "hello"
+        $primary SET foo bar
+        $primary EXEC
+    } {0 OK}
+
+    test "Sharded pubsub publish behavior within multi/exec with write operation on replica" {
+        $replica MULTI
+        $replica SPUBLISH foo "hello"
+        catch {[$replica SET foo bar]} err
+        assert_match {MOVED*} $err
+        catch {[$replica EXEC]} err
+        assert_match {EXECABORT*} $err
+    }
+}

--- a/tests/unit/cluster/sharded-pubsub.tcl
+++ b/tests/unit/cluster/sharded-pubsub.tcl
@@ -1,9 +1,9 @@
 start_cluster 1 1 {tags {external:skip cluster}} {
-        set primary_id 0
-        set replica1_id 1
+    set primary_id 0
+    set replica1_id 1
 
-        set primary [Rn $primary_id]
-        set replica [Rn $replica1_id]
+    set primary [Rn $primary_id]
+    set replica [Rn $replica1_id]
 
     test "Sharded pubsub publish behavior within multi/exec" {
         foreach {node} {primary replica} {


### PR DESCRIPTION
Allow SPUBLISH command within multi/exec on replica

Behavior on unstable:

```
127.0.0.1:6380> CLUSTER NODES
39ce8aa20f1f0d91f1a88d976ee1926dfefcdf1a 127.0.0.1:6380@16380 myself,slave 8b0feb120b68aac489d6a5af9c77dc40d71bc792 0 0 0 connected
8b0feb120b68aac489d6a5af9c77dc40d71bc792 127.0.0.1:6379@16379 master - 0 1705091681202 0 connected 0-16383
127.0.0.1:6380> SPUBLISH hello world
(integer) 0
127.0.0.1:6380> MULTI
OK
127.0.0.1:6380(TX)> SPUBLISH hello world
QUEUED
127.0.0.1:6380(TX)> EXEC
(error) MOVED 866 127.0.0.1:6379
```

With this change:

```
127.0.0.1:6380> SPUBLISH hello world
(integer) 0
127.0.0.1:6380> MULTI
OK
127.0.0.1:6380(TX)> SPUBLISH hello world
QUEUED
127.0.0.1:6380(TX)> EXEC
1) (integer) 0
```