### PR TITLE
Cleanup tcl tmp directory leaking resources

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -328,7 +328,8 @@ proc cleanup {} {
     if {!$::quiet} {puts -nonewline "Cleanup: may take some time... "}
     flush stdout
     catch {exec rm -rf {*}[glob tests/tmp/redis.conf.*]}
-    catch {exec rm -rf {*}[glob tests/tmp/server.*]}
+    catch {exec rm -rf {*}[glob tests/tmp/server*.*]}
+    catch {exec rm -rf {*}[glob tests/tmp/*.acl.*]}
     if {!$::quiet} {puts "OK"}
 }
 


### PR DESCRIPTION
Few of the servers log are stored as `server1/2/3.log` . Various type of acl files are created and weren't getting cleaned up prior to this change.