### PR TITLE
For additional compatibility this adds REDIS_CFLAGS and REDIS_LDFLAGS support to MAKEFILE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -123,8 +123,15 @@ endif
 -include .make-settings
 
 # For added compatibility REDIS_CFLAGS and REDIS_LDFLAGS are also supported.
-FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(SERVER_CFLAGS) $(REDIS_CFLAGS)
-FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(SERVER_LDFLAGS) $(DEBUG) $(REDIS_LDFLAGS)
+ifdef REDIS_CFLAGS
+    SERVER_CFLAGS := $(REDIS_CFLAGS)
+endif
+ifdef REDIS_LDFLAGS
+    SERVER_LDFLAGS := $(REDIS_LDFLAGS)
+endif
+
+FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(SERVER_CFLAGS)
+FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(SERVER_LDFLAGS) $(DEBUG)
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 
@@ -342,7 +349,7 @@ QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(EN
 QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
-ifneq (,$(or $(findstring LOG_REQ_RES,$(SERVER_CFLAGS)), $(findstring LOG_REQ_RES,$(REDIS_CFLAGS))))
+ifneq (, $(findstring LOG_REQ_RES, $(SERVER_CFLAGS)))
 	COMMANDS_DEF_FILENAME=commands_with_reply_schema
 	GEN_COMMANDS_FLAGS=--with-reply-schema
 else
@@ -387,8 +394,6 @@ persist-settings: distclean
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo SERVER_CFLAGS=$(SERVER_CFLAGS) >> .make-settings
 	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
-	echo REDIS_CFLAGS=$(REDIS_CFLAGS) >> .make-settings
-	echo REDIS_LDFLAGS=$(REDIS_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,12 @@
-# Redis Makefile
+# Valkey Makefile
 # Copyright (C) 2009 Salvatore Sanfilippo <antirez at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 #
 # The Makefile composes the final FINAL_CFLAGS and FINAL_LDFLAGS using
-# what is needed for Redis plus the standard CFLAGS and LDFLAGS passed.
+# what is needed for Valkey plus the standard CFLAGS and LDFLAGS passed.
 # However when building the dependencies (Jemalloc, Lua, Hiredis, ...)
 # CFLAGS and LDFLAGS are propagated to the dependencies, so to pass
-# flags only to be used when compiling / linking Redis itself SERVER_CFLAGS
+# flags only to be used when compiling / linking Valkey itself SERVER_CFLAGS
 # and SERVER_LDFLAGS are used instead (this is the case of 'make gcov').
 #
 # Dependencies are stored in the Makefile.dep file. To rebuild this file
@@ -76,7 +76,7 @@ ifeq ($(uname_S),Linux)
 	MALLOC=jemalloc
 endif
 
-# To get ARM stack traces if Redis crashes we need a special C flag.
+# To get ARM stack traces if Valkey crashes we need a special C flag.
 ifneq (,$(filter aarch64 armv%,$(uname_M)))
         CFLAGS+=-funwind-tables
 endif
@@ -122,8 +122,9 @@ endif
 # Override default settings if possible
 -include .make-settings
 
-FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(SERVER_CFLAGS)
-FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(SERVER_LDFLAGS) $(DEBUG)
+# For added compatibility REDIS_CFLAGS and REDIS_LDFLAGS are also supported.
+FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(SERVER_CFLAGS) $(REDIS_CFLAGS)
+FINAL_LDFLAGS=$(LDFLAGS) $(OPT) $(SERVER_LDFLAGS) $(DEBUG) $(REDIS_LDFLAGS)
 FINAL_LIBS=-lm
 DEBUG=-g -ggdb
 
@@ -341,7 +342,7 @@ QUIET_LINK = @printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$@$(EN
 QUIET_INSTALL = @printf '    %b %b\n' $(LINKCOLOR)INSTALL$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR) 1>&2;
 endif
 
-ifneq (, $(findstring LOG_REQ_RES, $(SERVER_CFLAGS)))
+ifneq (,$(or $(findstring LOG_REQ_RES,$(SERVER_CFLAGS)), $(findstring LOG_REQ_RES,$(REDIS_CFLAGS))))
 	COMMANDS_DEF_FILENAME=commands_with_reply_schema
 	GEN_COMMANDS_FLAGS=--with-reply-schema
 else
@@ -386,6 +387,8 @@ persist-settings: distclean
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo SERVER_CFLAGS=$(SERVER_CFLAGS) >> .make-settings
 	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
+	echo REDIS_CFLAGS=$(REDIS_CFLAGS) >> .make-settings
+	echo REDIS_LDFLAGS=$(REDIS_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))


### PR DESCRIPTION
This resolves (1.viii) from https://github.com/valkey-io/valkey/issues/43
> REDIS_FLAGS will be updated to SERVER_FLAGS. Maybe we should also allow REDIS_FLAGS -> SERVER_FLAGS as well, for an extra layer of compatibility.