### PR TITLE
Change skip list P value to 1/e, which improves search times

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -522,7 +522,7 @@ typedef enum {
 #define UNUSED(V) ((void) V)
 
 #define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-#define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
+#define ZSKIPLIST_P 1/M_E /* Skiplist P = 1/e */
 #define ZSKIPLIST_MAX_SEARCH 10
 
 /* Append only defines */


### PR DESCRIPTION
The probability of adding new nodes to each level of a skip list (the node's height) is determined by successively "rolling the dice" at each level until it doesn't meet a probability P or it reaches a maximum level.

I have observed default P values for skip lists "in the wild" ranging from 0.25 to 0.5. In Redis, ZSKIPLIST_P is 0.25 with a ZSKIPLIST_MAXLEVEL of 32.

The optimal value for P in a general-purpose skip list is 1/e, where e is Euler's number. For a detailed proof, see [Analysis of an optimized search algorithm for skip lists by Kirschenhofer et al (1995)](http://www.sciencedirect.com/science/article/pii/030439759400296U).

There is some discussion about this on [the identical Redis PR](https://github.com/redis/redis/pull/3889). The memory/speed tradeoff is optimal in the general case and benchmarks show appreciable improvements for large sets with a modest increase in memory footprint. The Redis benchmark suite using p50 times and small sets did not show enough of a change for them to accept this PR, but I believe it stands on the merits laid out by Kirschenhofer et al. I don't want to sign their new CLA and have closed the original PR, opening it here instead.