### PR TITLE
Apply renaming changes to default configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/transfer.sh
 src/configs
 redis.ds
 src/redis.conf
+src/valkey.conf
 src/nodes.conf
 deps/lua/src/lua
 deps/lua/src/luac

--- a/deps/hiredis/test.sh
+++ b/deps/hiredis/test.sh
@@ -62,7 +62,7 @@ cleanup() {
 trap cleanup INT TERM EXIT
 
 # base config
-cat > ${tmpdir}/redis.conf <<EOF
+cat > ${tmpdir}/valkey.conf <<EOF
 pidfile ${PID_FILE}
 port ${REDIS_PORT}
 unixsocket ${SOCK_FILE}
@@ -71,7 +71,7 @@ EOF
 
 # if not running in docker add these:
 if [ ! -n "${REDIS_DOCKER}" ]; then
-cat >> ${tmpdir}/redis.conf <<EOF
+cat >> ${tmpdir}/valkey.conf <<EOF
 daemonize yes
 ${ENABLE_DEBUG_CMD}
 bind 127.0.0.1
@@ -80,7 +80,7 @@ fi
 
 # if doing ssl, add these
 if [ "$TEST_SSL" = "1" ]; then
-    cat >> ${tmpdir}/redis.conf <<EOF
+    cat >> ${tmpdir}/valkey.conf <<EOF
 tls-port ${REDIS_SSL_PORT}
 tls-ca-cert-file ${SSL_CA_CERT}
 tls-cert-file ${SSL_CERT}
@@ -89,7 +89,7 @@ EOF
 fi
 
 echo ${tmpdir}
-cat ${tmpdir}/redis.conf
+cat ${tmpdir}/valkey.conf
 if [ -n "${REDIS_DOCKER}" ] ; then
     chmod a+wx ${tmpdir}
     chmod a+r ${tmpdir}/*
@@ -98,9 +98,9 @@ if [ -n "${REDIS_DOCKER}" ] ; then
         -p ${REDIS_SSL_PORT}:${REDIS_SSL_PORT} \
         -v ${tmpdir}:${tmpdir} \
         ${REDIS_DOCKER} \
-        redis-server ${tmpdir}/redis.conf
+        redis-server ${tmpdir}/valkey.conf
 else
-    ${REDIS_SERVER} ${tmpdir}/redis.conf
+    ${REDIS_SERVER} ${tmpdir}/valkey.conf
 fi
 # Wait until we detect the unix socket
 echo waiting for server

--- a/redis.conf
+++ b/redis.conf
@@ -1,9 +1,9 @@
-# Redis configuration file example.
+# Valkey configuration file example.
 #
-# Note that in order to read the configuration file, Redis must be
+# Note that in order to read the configuration file, Valkey must be
 # started with the file path as first argument:
 #
-# ./redis-server /path/to/redis.conf
+# ./valkey-server /path/to/redis.conf
 
 # Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
@@ -20,12 +20,12 @@
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all Redis servers but also need
+# have a standard template that goes to all Valkey servers but also need
 # to customize a few per-server settings.  Include files can include
 # other files, so use this wisely.
 #
 # Note that option "include" won't be rewritten by command "CONFIG REWRITE"
-# from admin or Redis Sentinel. Since Redis always uses the last processed
+# from admin or Redis Sentinel. Since Valkey always uses the last processed
 # line as value of a configuration directive, you'd better put includes
 # at the beginning of this file to avoid overwriting config change at runtime.
 #
@@ -55,11 +55,11 @@
 
 ################################## NETWORK #####################################
 
-# By default, if no "bind" configuration directive is specified, Redis listens
+# By default, if no "bind" configuration directive is specified, Valkey listens
 # for connections from all available network interfaces on the host machine.
 # It is possible to listen to just one or multiple selected interfaces using
 # the "bind" configuration directive, followed by one or more IP addresses.
-# Each address can be prefixed by "-", which means that redis will not fail to
+# Each address can be prefixed by "-", which means that Valkey will not fail to
 # start if the address is not available. Being not available only refers to
 # addresses that does not correspond to any network interface. Addresses that
 # are already in use will always fail, and unsupported protocols will always BE
@@ -71,11 +71,11 @@
 # bind 127.0.0.1 ::1              # listens on loopback IPv4 and IPv6
 # bind * -::*                     # like the default, all available interfaces
 #
-# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# ~~~ WARNING ~~~ If the computer running Valkey is directly exposed to the
 # internet, binding to all the interfaces is dangerous and will expose the
 # instance to everybody on the internet. So by default we uncomment the
-# following bind directive, that will force Redis to listen only on the
-# IPv4 and IPv6 (if available) loopback interface addresses (this means Redis
+# following bind directive, that will force Valkey to listen only on the
+# IPv4 and IPv6 (if available) loopback interface addresses (this means Valkey
 # will only be able to accept client connections from the same host that it is
 # running on).
 #
@@ -100,26 +100,26 @@ bind 127.0.0.1 -::1
 # bind-source-addr 10.0.0.1
 
 # Protected mode is a layer of security protection, in order to avoid that
-# Redis instances left open on the internet are accessed and exploited.
+# Valkey instances left open on the internet are accessed and exploited.
 #
 # When protected mode is on and the default user has no password, the server
 # only accepts local connections from the IPv4 address (127.0.0.1), IPv6 address
 # (::1) or Unix domain sockets.
 #
 # By default protected mode is enabled. You should disable it only if
-# you are sure you want clients from other hosts to connect to Redis
+# you are sure you want clients from other hosts to connect to Valkey
 # even if no authentication is configured.
 protected-mode yes
 
-# Redis uses default hardened security configuration directives to reduce the
+# Valkey uses default hardened security configuration directives to reduce the
 # attack surface on innocent users. Therefore, several sensitive configuration
 # directives are immutable, and some potentially-dangerous commands are blocked.
 #
-# Configuration directives that control files that Redis writes to (e.g., 'dir'
+# Configuration directives that control files that Valkey writes to (e.g., 'dir'
 # and 'dbfilename') and that aren't usually modified during runtime
 # are protected by making them immutable.
 #
-# Commands that can increase the attack surface of Redis and that aren't usually
+# Commands that can increase the attack surface of Valkey and that aren't usually
 # called by users are blocked by default.
 #
 # These can be exposed to either all connections or just local ones by setting
@@ -135,7 +135,7 @@ protected-mode yes
 # enable-module-command no
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
-# If port 0 is specified Redis will not listen on a TCP socket.
+# If port 0 is specified Valkey will not listen on a TCP socket.
 port 6379
 
 # TCP listen() backlog.
@@ -150,10 +150,10 @@ tcp-backlog 511
 # Unix socket.
 #
 # Specify the path for the Unix socket that will be used to listen for
-# incoming connections. There is no default, so Redis will not listen
+# incoming connections. There is no default, so Valkey will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /run/redis.sock
+# unixsocket /run/valkey.sock
 # unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -199,15 +199,15 @@ tcp-keepalive 300
 # server to connected clients, masters or cluster peers.  These files should be
 # PEM formatted.
 #
-# tls-cert-file redis.crt
-# tls-key-file redis.key
+# tls-cert-file valkey.crt
+# tls-key-file valkey.key
 #
 # If the key file is encrypted using a passphrase, it can be included here
 # as well.
 #
 # tls-key-file-pass secret
 
-# Normally Redis uses the same certificate for both server functions (accepting
+# Normally Valkey uses the same certificate for both server functions (accepting
 # connections) and client functions (replicating from a master, establishing
 # cluster bus connections, etc.).
 #
@@ -228,10 +228,10 @@ tcp-keepalive 300
 # required by older versions of OpenSSL (<3.0). Newer versions do not require
 # this configuration and recommend against it.
 #
-# tls-dh-params-file redis.dh
+# tls-dh-params-file valkey.dh
 
 # Configure a CA certificate(s) bundle or directory to authenticate TLS/SSL
-# clients and peers.  Redis requires an explicit configuration of at least one
+# clients and peers.  Valkey requires an explicit configuration of at least one
 # of these, and will not implicitly use the system wide configuration.
 #
 # tls-ca-cert-file ca.crt
@@ -247,14 +247,14 @@ tcp-keepalive 300
 # tls-auth-clients no
 # tls-auth-clients optional
 
-# By default, a Redis replica does not attempt to establish a TLS connection
+# By default, a Valkey replica does not attempt to establish a TLS connection
 # with its master.
 #
 # Use the following directive to enable TLS on replication links.
 #
 # tls-replication yes
 
-# By default, the Redis Cluster bus uses a plain TCP connection. To enable
+# By default, the Valkey Cluster bus uses a plain TCP connection. To enable
 # TLS for the bus protocol, use the following directive:
 #
 # tls-cluster yes
@@ -304,18 +304,18 @@ tcp-keepalive 300
 
 ################################# GENERAL #####################################
 
-# By default Redis does not run as a daemon. Use 'yes' if you need it.
-# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-# When Redis is supervised by upstart or systemd, this parameter has no impact.
+# By default Valkey does not run as a daemon. Use 'yes' if you need it.
+# Note that Valkey will write a pid file in /var/run/redis.pid when daemonized.
+# When Valkey is supervised by upstart or systemd, this parameter has no impact.
 daemonize no
 
-# If you run Redis from upstart or systemd, Redis can interact with your
+# If you run Valkey from upstart or systemd, Valkey can interact with your
 # supervision tree. Options:
 #   supervised no      - no supervision interaction
-#   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#   supervised upstart - signal upstart by putting Valkey into SIGSTOP mode
 #                        requires "expect stop" in your upstart job config
 #   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
-#                        on startup, and updating Redis status on a regular
+#                        on startup, and updating Valkey status on a regular
 #                        basis.
 #   supervised auto    - detect upstart or systemd method based on
 #                        UPSTART_JOB or NOTIFY_SOCKET environment variables
@@ -327,14 +327,14 @@ daemonize no
 #
 # supervised auto
 
-# If a pid file is specified, Redis writes it where specified at startup
+# If a pid file is specified, Valkey writes it where specified at startup
 # and removes it at exit.
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
 # is used even if not specified, defaulting to "/var/run/redis.pid".
 #
-# Creating a pid file is best effort: if Redis is not able to create it
+# Creating a pid file is best effort: if Valkey is not able to create it
 # nothing bad happens, the server will start and run normally.
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
@@ -351,7 +351,7 @@ pidfile /var/run/redis_6379.pid
 loglevel notice
 
 # Specify the log file name. Also the empty string can be used to force
-# Redis to log on the standard output. Note that if you use standard
+# Valkey to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
 logfile ""
 
@@ -371,7 +371,7 @@ logfile ""
 # crash-log-enabled no
 
 # To disable the fast memory check that's run as part of the crash log, which
-# will possibly let redis terminate sooner, uncomment the following:
+# will possibly let Valkey terminate sooner, uncomment the following:
 #
 # crash-memcheck-enabled no
 
@@ -380,7 +380,7 @@ logfile ""
 # dbid is a number between 0 and 'databases'-1
 databases 16
 
-# By default Redis shows an ASCII art logo only when started to log to the
+# By default Valkey shows an ASCII art logo only when started to log to the
 # standard output and if the standard output is a TTY and syslog logging is
 # disabled. Basically this means that normally a logo is displayed only in
 # interactive sessions.
@@ -389,12 +389,12 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
-# By default, Redis modifies the process title (as seen in 'top' and 'ps') to
+# By default, Valkey modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave
 # the process name as executed by setting the following to no.
 set-proc-title yes
 
-# When changing the process title, Redis uses the following template to construct
+# When changing the process title, Valkey uses the following template to construct
 # the modified title.
 #
 # Template variables are specified in curly brackets. The following variables are
@@ -411,8 +411,8 @@ set-proc-title yes
 #
 proc-title-template "{title} {listen-addr} {server-mode}"
 
-# Set the local environment which is used for string comparison operations, and 
-# also affect the performance of Lua scripts. Empty String indicates the locale 
+# Set the local environment which is used for string comparison operations, and
+# also affect the performance of Lua scripts. Empty String indicates the locale
 # is derived from the environment variables.
 locale-collate ""
 
@@ -422,7 +422,7 @@ locale-collate ""
 #
 # save <seconds> <changes> [<seconds> <changes> ...]
 #
-# Redis will save the DB if the given number of seconds elapsed and it
+# Valkey will save the DB if the given number of seconds elapsed and it
 # surpassed the given number of write operations against the DB.
 #
 # Snapshotting can be completely disabled with a single empty string argument
@@ -430,7 +430,7 @@ locale-collate ""
 #
 # save ""
 #
-# Unless specified otherwise, by default Redis will save the DB:
+# Unless specified otherwise, by default Valkey will save the DB:
 #   * After 3600 seconds (an hour) if at least 1 change was performed
 #   * After 300 seconds (5 minutes) if at least 100 changes were performed
 #   * After 60 seconds if at least 10000 changes were performed
@@ -439,17 +439,17 @@ locale-collate ""
 #
 # save 3600 1 300 100 60 10000
 
-# By default Redis will stop accepting writes if RDB snapshots are enabled
+# By default Valkey will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
 # This will make the user aware (in a hard way) that data is not persisting
 # on disk properly, otherwise chances are that no one will notice and some
 # disaster will happen.
 #
-# If the background saving process will start working again Redis will
+# If the background saving process will start working again Valkey will
 # automatically allow writes again.
 #
-# However if you have setup your proper monitoring of the Redis server
-# and persistence, you may want to disable this feature so that Redis will
+# However if you have setup your proper monitoring of the Valkey server
+# and persistence, you may want to disable this feature so that Valkey will
 # continue to work as usual even if there are problems with disk,
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
@@ -512,18 +512,18 @@ dir ./
 
 ################################# REPLICATION #################################
 
-# Master-Replica replication. Use replicaof to make a Redis instance a copy of
-# another Redis server. A few things to understand ASAP about Redis replication.
+# Master-Replica replication. Use replicaof to make a Valkey instance a copy of
+# another Valkey server. A few things to understand ASAP about Valkey replication.
 #
 #   +------------------+      +---------------+
 #   |      Master      | ---> |    Replica    |
 #   | (receive writes) |      |  (exact copy) |
 #   +------------------+      +---------------+
 #
-# 1) Redis replication is asynchronous, but you can configure a master to
+# 1) Valkey replication is asynchronous, but you can configure a master to
 #    stop accepting writes if it appears to be not connected with at least
 #    a given number of replicas.
-# 2) Redis replicas are able to perform a partial resynchronization with the
+# 2) Valkey replicas are able to perform a partial resynchronization with the
 #    master if the replication link is lost for a relatively small amount of
 #    time. You may want to configure the replication backlog size (see the next
 #    sections of this file) with a sensible value depending on your needs.
@@ -540,7 +540,7 @@ dir ./
 #
 # masterauth <master-password>
 #
-# However this is not enough if you are using Redis ACLs (for Redis version
+# However this is not enough if you are using Valkey ACLs (for Redis version
 # 6 or greater), and the default user is not capable of running the PSYNC
 # command and/or other commands needed for replication. In this case it's
 # better to configure a special user to use with replication, and specify the
@@ -592,10 +592,10 @@ replica-read-only yes
 #
 # The transmission can happen in two different ways:
 #
-# 1) Disk-backed: The Redis master creates a new process that writes the RDB
+# 1) Disk-backed: The Valkey master creates a new process that writes the RDB
 #                 file on disk. Later the file is transferred by the parent
 #                 process to the replicas incrementally.
-# 2) Diskless: The Redis master creates a new process that directly writes the
+# 2) Diskless: The Valkey master creates a new process that directly writes the
 #              RDB file to replica sockets, without touching the disk at all.
 #
 # With disk-backed replication, while the RDB file is generated, more replicas
@@ -627,13 +627,13 @@ repl-diskless-sync-delay 5
 # When diskless replication is enabled with a delay, it is possible to let
 # the replication start before the maximum delay is reached if the maximum
 # number of replicas expected have connected. Default of 0 means that the
-# maximum is not defined and Redis will wait the full delay.
+# maximum is not defined and Valkey will wait the full delay.
 repl-diskless-sync-max-replicas 0
 
 # -----------------------------------------------------------------------------
 # WARNING: Since in this setup the replica does not immediately store an RDB on
-# disk, it may cause data loss during failovers. RDB diskless load + Redis
-# modules not handling I/O reads may cause Redis to abort in case of I/O errors
+# disk, it may cause data loss during failovers. RDB diskless load + Valkey
+# modules not handling I/O reads may cause Valkey to abort in case of I/O errors
 # during the initial synchronization stage with the master.
 # -----------------------------------------------------------------------------
 #
@@ -657,7 +657,7 @@ repl-diskless-sync-max-replicas 0
 #                 replication history.
 #                 Note that this requires sufficient memory, if you don't have it,
 #                 you risk an OOM kill.
-# "on-empty-db" - Use diskless load only when current dataset is empty. This is 
+# "on-empty-db" - Use diskless load only when current dataset is empty. This is
 #                 safer and avoid having old and new dataset loaded side by side
 #                 during replication.
 repl-diskless-load disabled
@@ -683,7 +683,7 @@ repl-diskless-load disabled
 
 # Disable TCP_NODELAY on the replica socket after SYNC?
 #
-# If you select "yes" Redis will use a smaller number of TCP packets and
+# If you select "yes" Valkey will use a smaller number of TCP packets and
 # less bandwidth to send data to replicas. But this can add a delay for
 # the data to appear on the replica side, up to 40 milliseconds with
 # Linux kernels using a default configuration.
@@ -722,7 +722,7 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-ttl 3600
 
-# The replica priority is an integer number published by Redis in the INFO
+# The replica priority is an integer number published by Valkey in the INFO
 # output. It is used by Redis Sentinel in order to select a replica to promote
 # into a master if the master is no longer working correctly.
 #
@@ -737,7 +737,7 @@ repl-disable-tcp-nodelay no
 # By default the priority is 100.
 replica-priority 100
 
-# The propagation error behavior controls how Redis will behave when it is
+# The propagation error behavior controls how Valkey will behave when it is
 # unable to handle a command being processed in the replication stream from a master
 # or processed while reading from an AOF file. Errors that occur during propagation
 # are unexpected, and can cause data inconsistency. However, there are edge cases
@@ -796,7 +796,7 @@ replica-priority 100
 # By default min-replicas-to-write is set to 0 (feature disabled) and
 # min-replicas-max-lag is set to 10.
 
-# A Redis master is able to list the address and port of the attached
+# A Valkey master is able to list the address and port of the attached
 # replicas in different ways. For example the "INFO replication" section
 # offers this information, which is used, among other tools, by
 # Redis Sentinel in order to discover replica instances.
@@ -827,7 +827,7 @@ replica-priority 100
 
 ############################### KEYS TRACKING #################################
 
-# Redis implements server assisted support for client side caching of values.
+# Valkey implements server assisted support for client side caching of values.
 # This is implemented using an invalidation table that remembers, using
 # a radix key indexed by key name, what clients have which keys. In turn
 # this is used in order to send invalidation messages to clients. Please
@@ -836,22 +836,22 @@ replica-priority 100
 #   https://redis.io/topics/client-side-caching
 #
 # When tracking is enabled for a client, all the read only queries are assumed
-# to be cached: this will force Redis to store information in the invalidation
+# to be cached: this will force Valkey to store information in the invalidation
 # table. When keys are modified, such information is flushed away, and
 # invalidation messages are sent to the clients. However if the workload is
-# heavily dominated by reads, Redis could use more and more memory in order
+# heavily dominated by reads, Valkey could use more and more memory in order
 # to track the keys fetched by many clients.
 #
 # For this reason it is possible to configure a maximum fill value for the
 # invalidation table. By default it is set to 1M of keys, and once this limit
-# is reached, Redis will start to evict keys in the invalidation table
+# is reached, Valkey will start to evict keys in the invalidation table
 # even if they were not modified, just to reclaim memory: this will in turn
 # force the clients to invalidate the cached values. Basically the table
 # maximum size is a trade off between the memory you want to spend server
 # side to track information about who cached what, and the ability of clients
 # to retain cached objects in memory.
 #
-# If you set the value to 0, it means there are no limits, and Redis will
+# If you set the value to 0, it means there are no limits, and Valkey will
 # retain as many keys as needed in the invalidation table.
 # In the "stats" INFO section, you can find information about the number of
 # keys in the invalidation table at every given moment.
@@ -863,7 +863,7 @@ replica-priority 100
 
 ################################## SECURITY ###################################
 
-# Warning: since Redis is pretty fast, an outside user can try up to
+# Warning: since Valkey is pretty fast, an outside user can try up to
 # 1 million passwords per second against a modern box. This means that you
 # should use very strong passwords, otherwise they will be very easy to break.
 # Note that because the password is really a shared secret between the client
@@ -871,7 +871,7 @@ replica-priority 100
 # can be easily a long string from /dev/urandom or whatever, so by using a
 # long and unguessable password no brute force attack will be possible.
 
-# Redis ACL users are defined in the following format:
+# Valkey ACL users are defined in the following format:
 #
 #   user <username> ... acl rules ...
 #
@@ -902,7 +902,7 @@ replica-priority 100
 #  +@<category> Allow the execution of all the commands in such category
 #               with valid categories are like @admin, @set, @sortedset, ...
 #               and so forth, see the full list in the server.c file where
-#               the Redis command table is described and defined.
+#               the Valkey command table is described and defined.
 #               The special category @all means all the commands, but currently
 #               present in the server, and that will be loaded in the future
 #               via modules.
@@ -918,10 +918,10 @@ replica-priority 100
 #               commands. For instance ~* allows all the keys. The pattern
 #               is a glob-style pattern like the one of KEYS.
 #               It is possible to specify multiple patterns.
-# %R~<pattern>  Add key read pattern that specifies which keys can be read 
+# %R~<pattern>  Add key read pattern that specifies which keys can be read
 #               from.
 # %W~<pattern>  Add key write pattern that specifies which keys can be
-#               written to. 
+#               written to.
 #  allkeys      Alias for ~*
 #  resetkeys    Flush the list of allowed keys patterns.
 #  &<pattern>   Add a glob-style pattern of Pub/Sub channels that can be
@@ -948,10 +948,10 @@ replica-priority 100
 #               allchannels (if acl-pubsub-default is set), off, clearselectors, -@all.
 #               The user returns to the same state it has immediately after its creation.
 # (<options>)   Create a new selector with the options specified within the
-#               parentheses and attach it to the user. Each option should be 
-#               space separated. The first character must be ( and the last 
+#               parentheses and attach it to the user. Each option should be
+#               space separated. The first character must be ( and the last
 #               character must be ).
-# clearselectors            Remove all of the currently attached selectors. 
+# clearselectors            Remove all of the currently attached selectors.
 #                           Note this does not change the "root" user permissions,
 #                           which are the permissions directly applied onto the
 #                           user (outside the parentheses).
@@ -977,7 +977,7 @@ replica-priority 100
 # Basically ACL rules are processed left-to-right.
 #
 # The following is a list of command categories and their meanings:
-# * keyspace - Writing or reading from keys, databases, or their metadata 
+# * keyspace - Writing or reading from keys, databases, or their metadata
 #     in a type agnostic way. Includes DEL, RESTORE, DUMP, RENAME, EXISTS, DBSIZE,
 #     KEYS, EXPIRE, TTL, FLUSHALL, etc. Commands that may modify the keyspace,
 #     key or metadata will also have `write` category. Commands that only read
@@ -1085,15 +1085,15 @@ acllog-max-len 128
 ################################### CLIENTS ####################################
 
 # Set the max number of connected clients at the same time. By default
-# this limit is set to 10000 clients, however if the Redis server is not
+# this limit is set to 10000 clients, however if the Valkey server is not
 # able to configure the process file limit to allow for the specified limit
 # the max number of allowed clients is set to the current file limit
-# minus 32 (as Redis reserves a few file descriptors for internal uses).
+# minus 32 (as Valkey reserves a few file descriptors for internal uses).
 #
-# Once the limit is reached Redis will close all the new connections sending
+# Once the limit is reached Valkey will close all the new connections sending
 # an error 'max number of clients reached'.
 #
-# IMPORTANT: When Redis Cluster is used, the max number of connections is also
+# IMPORTANT: When Valkey Cluster is used, the max number of connections is also
 # shared with the cluster bus: every node in the cluster will use two
 # connections, one incoming and another outgoing. It is important to size the
 # limit accordingly in case of very large clusters.
@@ -1103,15 +1103,15 @@ acllog-max-len 128
 ############################## MEMORY MANAGEMENT ################################
 
 # Set a memory usage limit to the specified amount of bytes.
-# When the memory limit is reached Redis will try to remove keys
+# When the memory limit is reached Valkey will try to remove keys
 # according to the eviction policy selected (see maxmemory-policy).
 #
-# If Redis can't remove keys according to the policy, or if the policy is
-# set to 'noeviction', Redis will start to reply with errors to commands
+# If Valkey can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Valkey will start to reply with errors to commands
 # that would use more memory, like SET, LPUSH, and so on, and will continue
 # to reply to read-only commands like GET.
 #
-# This option is usually useful when using Redis as an LRU or LFU cache, or to
+# This option is usually useful when using Valkey as an LRU or LFU cache, or to
 # set a hard memory limit for an instance (using the 'noeviction' policy).
 #
 # WARNING: If you have replicas attached to an instance with maxmemory on,
@@ -1127,7 +1127,7 @@ acllog-max-len 128
 #
 # maxmemory <bytes>
 
-# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# MAXMEMORY POLICY: how Valkey will select what to remove when maxmemory
 # is reached. You can select one from the following behaviors:
 #
 # volatile-lru -> Evict using approximated LRU, only keys with an expire set.
@@ -1146,7 +1146,7 @@ acllog-max-len 128
 # randomized algorithms.
 #
 # Note: with any of the above policies, when there are no suitable keys for
-# eviction, Redis will return an error on write operations that require
+# eviction, Valkey will return an error on write operations that require
 # more memory. These are usually commands that create new keys, add data or
 # modify existing keys. A few examples are: SET, INCR, HSET, LPUSH, SUNIONSTORE,
 # SORT (due to the STORE argument), and EXEC (if the transaction includes any
@@ -1158,7 +1158,7 @@ acllog-max-len 128
 
 # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or
-# accuracy. By default Redis will check five keys and pick the one that was
+# accuracy. By default Valkey will check five keys and pick the one that was
 # used least recently, you can change the sample size using the following
 # configuration directive.
 #
@@ -1196,7 +1196,7 @@ acllog-max-len 128
 #
 # replica-ignore-maxmemory yes
 
-# Redis reclaims expired keys in two ways: upon access when those keys are
+# Valkey reclaims expired keys in two ways: upon access when those keys are
 # found to be expired, and also in background, in what is called the
 # "active expire key". The key space is slowly and interactively scanned
 # looking for expired keys to reclaim, so that it is possible to free memory
@@ -1215,16 +1215,16 @@ acllog-max-len 128
 
 ############################# LAZY FREEING ####################################
 
-# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# Valkey has two primitives to delete keys. One is called DEL and is a blocking
 # deletion of the object. It means that the server stops processing new commands
 # in order to reclaim all the memory associated with an object in a synchronous
 # way. If the key deleted is associated with a small object, the time needed
 # in order to execute the DEL command is very small and comparable to most other
-# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# O(1) or O(log_N) commands in Valkey. However if the key is associated with an
 # aggregated value containing millions of elements, the server can block for
 # a long time (even seconds) in order to complete the operation.
 #
-# For the above reasons Redis also offers non blocking deletion primitives
+# For the above reasons Valkey also offers non blocking deletion primitives
 # such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
 # FLUSHDB commands, in order to reclaim memory in background. Those commands
 # are executed in constant time. Another thread will incrementally free the
@@ -1232,9 +1232,9 @@ acllog-max-len 128
 #
 # DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
 # It's up to the design of the application to understand when it is a good
-# idea to use one or the other. However the Redis server sometimes has to
+# idea to use one or the other. However the Valkey server sometimes has to
 # delete keys or flush the whole database as a side effect of other operations.
-# Specifically Redis deletes objects independently of a user call in the
+# Specifically Valkey deletes objects independently of a user call in the
 # following scenarios:
 #
 # 1) On eviction, because of the maxmemory and maxmemory policy configurations,
@@ -1278,21 +1278,21 @@ lazyfree-lazy-user-flush no
 
 ################################ THREADED I/O #################################
 
-# Redis is mostly single threaded, however there are certain threaded
+# Valkey is mostly single threaded, however there are certain threaded
 # operations such as UNLINK, slow I/O accesses and other things that are
 # performed on side threads.
 #
-# Now it is also possible to handle Redis clients socket reads and writes
+# Now it is also possible to handle Valkey clients socket reads and writes
 # in different I/O threads. Since especially writing is so slow, normally
-# Redis users use pipelining in order to speed up the Redis performances per
+# Valkey users use pipelining in order to speed up the Valkey performances per
 # core, and spawn multiple instances in order to scale more. Using I/O
-# threads it is possible to easily speedup two times Redis without resorting
+# threads it is possible to easily speedup two times Valkey without resorting
 # to pipelining nor sharding of the instance.
 #
 # By default threading is disabled, we suggest enabling it only in machines
 # that have at least 4 or more cores, leaving at least one spare core.
 # Using more than 8 threads is unlikely to help much. We also recommend using
-# threaded I/O only if you actually have performance problems, with Redis
+# threaded I/O only if you actually have performance problems, with Valkey
 # instances being able to use a quite big percentage of CPU time, otherwise
 # there is no point in using this feature.
 #
@@ -1317,9 +1317,9 @@ lazyfree-lazy-user-flush no
 # CONFIG SET. Also, this feature currently does not work when SSL is
 # enabled.
 #
-# NOTE 2: If you want to test the Redis speedup using redis-benchmark, make
+# NOTE 2: If you want to test the Valkey speedup using redis-benchmark, make
 # sure you also run the benchmark itself in threaded mode, using the
-# --threads option to match the number of Redis threads, otherwise you'll not
+# --threads option to match the number of Valkey threads, otherwise you'll not
 # be able to notice the improvements.
 
 ############################ KERNEL OOM CONTROL ##############################
@@ -1327,12 +1327,12 @@ lazyfree-lazy-user-flush no
 # On Linux, it is possible to hint the kernel OOM killer on what processes
 # should be killed first when out of memory.
 #
-# Enabling this feature makes Redis actively control the oom_score_adj value
+# Enabling this feature makes Valkey actively control the oom_score_adj value
 # for all its processes, depending on their role. The default scores will
 # attempt to have background child processes killed before all others, and
 # replicas killed before masters.
 #
-# Redis supports these options:
+# Valkey supports these options:
 #
 # no:       Don't make changes to oom-score-adj (default).
 # yes:      Alias to "relative" see below.
@@ -1359,7 +1359,7 @@ oom-score-adj-values 0 200 800
 # Usually the kernel Transparent Huge Pages control is set to "madvise" or
 # or "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
 # case this config has no effect. On systems in which it is set to "always",
-# redis will attempt to disable it specifically for the redis process in order
+# Valkey will attempt to disable it specifically for the Valkey process in order
 # to avoid latency problems specifically with fork(2) and CoW.
 # If for some reason you prefer to keep it enabled, you can set this config to
 # "no" and the kernel global to "always".
@@ -1368,20 +1368,20 @@ disable-thp yes
 
 ############################## APPEND ONLY MODE ###############################
 
-# By default Redis asynchronously dumps the dataset on disk. This mode is
-# good enough in many applications, but an issue with the Redis process or
+# By default Valkey asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Valkey process or
 # a power outage may result into a few minutes of writes lost (depending on
 # the configured save points).
 #
 # The Append Only File is an alternative persistence mode that provides
 # much better durability. For instance using the default data fsync policy
-# (see later in the config file) Redis can lose just one second of writes in a
+# (see later in the config file) Valkey can lose just one second of writes in a
 # dramatic event like a server power outage, or a single write if something
-# wrong with the Redis process itself happens, but the operating system is
+# wrong with the Valkey process itself happens, but the operating system is
 # still running correctly.
 #
 # AOF and RDB persistence can be enabled at the same time without problems.
-# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# If the AOF is enabled on startup Valkey will load the AOF, that is the file
 # with the better durability guarantees.
 #
 # Note that changing this value in a config file of an existing database and
@@ -1406,7 +1406,7 @@ appendonly no
 # In addition, manifest files are used to track the files and the order in
 # which they were created and should be applied.
 #
-# Append-only file names are created by Redis following a specific pattern.
+# Append-only file names are created by Valkey following a specific pattern.
 # The file name's prefix is based on the 'appendfilename' configuration
 # parameter, followed by additional information about the sequence and type.
 #
@@ -1419,7 +1419,7 @@ appendonly no
 
 appendfilename "appendonly.aof"
 
-# For convenience, Redis stores all persistent append-only files in a dedicated
+# For convenience, Valkey stores all persistent append-only files in a dedicated
 # directory. The name of the directory is determined by the appenddirname
 # configuration parameter.
 
@@ -1429,7 +1429,7 @@ appenddirname "appendonlydir"
 # instead of waiting for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
-# Redis supports three different modes:
+# Valkey supports three different modes:
 #
 # no: don't fsync, just let the OS flush the data when it wants. Faster.
 # always: fsync after every write to the append only log. Slow, Safest.
@@ -1455,7 +1455,7 @@ appendfsync everysec
 # When the AOF fsync policy is set to always or everysec, and a background
 # saving process (a background save or AOF log background rewriting) is
 # performing a lot of I/O against the disk, in some Linux configurations
-# Redis may block too long on the fsync() call. Note that there is no fix for
+# Valkey may block too long on the fsync() call. Note that there is no fix for
 # this currently, as even performing fsync in a different thread will block
 # our synchronous write(2) call.
 #
@@ -1463,7 +1463,7 @@ appendfsync everysec
 # that will prevent fsync() from being called in the main process while a
 # BGSAVE or BGREWRITEAOF is in progress.
 #
-# This means that while another child is saving, the durability of Redis is
+# This means that while another child is saving, the durability of Valkey is
 # the same as "appendfsync no". In practical terms, this means that it is
 # possible to lose up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
@@ -1474,10 +1474,10 @@ appendfsync everysec
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
-# Redis is able to automatically rewrite the log file implicitly calling
+# Valkey is able to automatically rewrite the log file implicitly calling
 # BGREWRITEAOF when the AOF log size grows by the specified percentage.
 #
-# This is how it works: Redis remembers the size of the AOF file after the
+# This is how it works: Valkey remembers the size of the AOF file after the
 # latest rewrite (if no rewrite has happened since the restart, the size of
 # the AOF at startup is used).
 #
@@ -1493,19 +1493,19 @@ no-appendfsync-on-rewrite no
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 
-# An AOF file may be found to be truncated at the end during the Redis
+# An AOF file may be found to be truncated at the end during the Valkey
 # startup process, when the AOF data gets loaded back into memory.
-# This may happen when the system where Redis is running
+# This may happen when the system where Valkey is running
 # crashes, especially when an ext4 filesystem is mounted without the
-# data=ordered option (however this can't happen when Redis itself
+# data=ordered option (however this can't happen when Valkey itself
 # crashes or aborts but the operating system still works correctly).
 #
-# Redis can either exit with an error when this happens, or load as much
+# Valkey can either exit with an error when this happens, or load as much
 # data as possible (the default now) and start if the AOF file is found
 # to be truncated at the end. The following option controls this behavior.
 #
 # If aof-load-truncated is set to yes, a truncated AOF file is loaded and
-# the Redis server starts emitting a log to inform the user of the event.
+# the Valkey server starts emitting a log to inform the user of the event.
 # Otherwise if the option is set to no, the server aborts with an error
 # and refuses to start. When the option is set to no, the user requires
 # to fix the AOF file using the "redis-check-aof" utility before to restart
@@ -1513,16 +1513,16 @@ auto-aof-rewrite-min-size 64mb
 #
 # Note that if the AOF file will be found to be corrupted in the middle
 # the server will still exit with an error. This option only applies when
-# Redis will try to read more data from the AOF file but not enough bytes
+# Valkey will try to read more data from the AOF file but not enough bytes
 # will be found.
 aof-load-truncated yes
 
-# Redis can create append-only base files in either RDB or AOF formats. Using
+# Valkey can create append-only base files in either RDB or AOF formats. Using
 # the RDB format is always faster and more efficient, and disabling it is only
 # supported for backward compatibility purposes.
 aof-use-rdb-preamble yes
 
-# Redis supports recording timestamp annotations in the AOF to support restoring
+# Valkey supports recording timestamp annotations in the AOF to support restoring
 # the data from a specific point-in-time. However, using this capability changes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
@@ -1541,7 +1541,7 @@ aof-timestamp-enabled no
 #
 # shutdown-timeout 10
 
-# When Redis receives a SIGINT or SIGTERM, shutdown is initiated and by default
+# When Valkey receives a SIGINT or SIGTERM, shutdown is initiated and by default
 # an RDB snapshot is written to disk in a blocking operation if save points are configured.
 # The options used on signaled shutdown can include the following values:
 # default:  Saves RDB snapshot only if save points are configured.
@@ -1560,12 +1560,12 @@ aof-timestamp-enabled no
 ################ NON-DETERMINISTIC LONG BLOCKING COMMANDS #####################
 
 # Maximum time in milliseconds for EVAL scripts, functions and in some cases
-# modules' commands before Redis can start processing or rejecting other clients.
+# modules' commands before Valkey can start processing or rejecting other clients.
 #
-# If the maximum execution time is reached Redis will start to reply to most
+# If the maximum execution time is reached Valkey will start to reply to most
 # commands with a BUSY error.
 #
-# In this state Redis will only allow a handful of commands to be executed.
+# In this state Valkey will only allow a handful of commands to be executed.
 # For instance, SCRIPT KILL, FUNCTION KILL, SHUTDOWN NOSAVE and possibly some
 # module specific 'allow-busy' commands.
 #
@@ -1581,17 +1581,17 @@ aof-timestamp-enabled no
 # lua-time-limit 5000
 # busy-reply-threshold 5000
 
-################################ REDIS CLUSTER  ###############################
+################################ VALKEY CLUSTER  ###############################
 
-# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
-# started as cluster nodes can. In order to start a Redis instance as a
+# Normal Valkey instances can't be part of a Valkey Cluster; only nodes that are
+# started as cluster nodes can. In order to start a Valkey instance as a
 # cluster node enable the cluster support uncommenting the following:
 #
 # cluster-enabled yes
 
 # Every cluster node has a cluster configuration file. This file is not
-# intended to be edited by hand. It is created and updated by Redis nodes.
-# Every Redis Cluster node requires a different cluster configuration file.
+# intended to be edited by hand. It is created and updated by Valkey nodes.
+# Every Valkey Cluster node requires a different cluster configuration file.
 # Make sure that instances running in the same system do not have
 # overlapping cluster configuration file names.
 #
@@ -1603,8 +1603,8 @@ aof-timestamp-enabled no
 #
 # cluster-node-timeout 15000
 
-# The cluster port is the port that the cluster bus will listen for inbound connections on. When set 
-# to the default value, 0, it will be bound to the command port + 10000. Setting this value requires 
+# The cluster port is the port that the cluster bus will listen for inbound connections on. When set
+# to the default value, 0, it will be bound to the command port + 10000. Setting this value requires
 # you to specify the cluster bus port when executing cluster meet.
 # cluster-port 0
 
@@ -1681,7 +1681,7 @@ aof-timestamp-enabled no
 #
 # cluster-allow-replica-migration yes
 
-# By default Redis Cluster nodes stop accepting queries if they detect there
+# By default Valkey Cluster nodes stop accepting queries if they detect there
 # is at least a hash slot uncovered (no available node is serving it).
 # This way if the cluster is partially down (for example a range of hash slots
 # are no longer covered) all the cluster becomes, eventually, unavailable.
@@ -1739,12 +1739,12 @@ aof-timestamp-enabled no
 # PubSub message by default. (client-query-buffer-limit default value is 1gb)
 #
 # cluster-link-sendbuf-limit 0
- 
-# Clusters can configure their announced hostname using this config. This is a common use case for 
+
+# Clusters can configure their announced hostname using this config. This is a common use case for
 # applications that need to use TLS Server Name Indication (SNI) or dealing with DNS based
 # routing. By default this value is only shown as additional metadata in the CLUSTER SLOTS
-# command, but can be changed using 'cluster-preferred-endpoint-type' config. This value is 
-# communicated along the clusterbus to all nodes, setting it to an empty string will remove 
+# command, but can be changed using 'cluster-preferred-endpoint-type' config. This value is
+# communicated along the clusterbus to all nodes, setting it to an empty string will remove
 # the hostname and also propagate the removal.
 #
 # cluster-announce-hostname ""
@@ -1758,13 +1758,13 @@ aof-timestamp-enabled no
 # a user defined hostname, or by declaring they have no endpoint. Which endpoint is
 # shown as the preferred endpoint is set by using the cluster-preferred-endpoint-type
 # config with values 'ip', 'hostname', or 'unknown-endpoint'. This value controls how
-# the endpoint returned for MOVED/ASKING requests as well as the first field of CLUSTER SLOTS. 
-# If the preferred endpoint type is set to hostname, but no announced hostname is set, a '?' 
+# the endpoint returned for MOVED/ASKING requests as well as the first field of CLUSTER SLOTS.
+# If the preferred endpoint type is set to hostname, but no announced hostname is set, a '?'
 # will be returned instead.
 #
 # When a cluster advertises itself as having an unknown endpoint, it's indicating that
-# the server doesn't know how clients can reach the cluster. This can happen in certain 
-# networking situations where there are multiple possible routes to the node, and the 
+# the server doesn't know how clients can reach the cluster. This can happen in certain
+# networking situations where there are multiple possible routes to the node, and the
 # server doesn't know which one the client took. In this case, the server is expecting
 # the client to reach out on the same endpoint it used for making the last request, but use
 # the port provided in the response.
@@ -1776,11 +1776,11 @@ aof-timestamp-enabled no
 
 ########################## CLUSTER DOCKER/NAT support  ########################
 
-# In certain deployments, Redis Cluster nodes address discovery fails, because
+# In certain deployments, Valkey Cluster nodes address discovery fails, because
 # addresses are NAT-ted or because ports are forwarded (the typical case is
 # Docker and other containers).
 #
-# In order to make Redis Cluster working in such environments, a static
+# In order to make Valkey Cluster working in such environments, a static
 # configuration where each node knows its public address is needed. The
 # following four options are used for this scope, and are:
 #
@@ -1798,7 +1798,7 @@ aof-timestamp-enabled no
 # to zero, then cluster-announce-port refers to the TLS port. Note also that
 # cluster-announce-tls-port has no effect if tls-cluster is set to no.
 #
-# If the above options are not used, the normal Redis Cluster auto-detection
+# If the above options are not used, the normal Valkey Cluster auto-detection
 # will be used instead.
 #
 # Note that when remapped, the bus port may not be at the fixed offset of
@@ -1815,14 +1815,14 @@ aof-timestamp-enabled no
 
 ################################## SLOW LOG ###################################
 
-# The Redis Slow Log is a system to log queries that exceeded a specified
+# The Valkey Slow Log is a system to log queries that exceeded a specified
 # execution time. The execution time does not include the I/O operations
 # like talking with the client, sending the reply and so forth,
 # but just the time needed to actually execute the command (this is the only
 # stage of command execution where the thread is blocked and can not serve
 # other requests in the meantime).
 #
-# You can configure the slow log with two parameters: one tells Redis
+# You can configure the slow log with two parameters: one tells Valkey
 # what is the execution time, in microseconds, to exceed in order for the
 # command to get logged, and the other parameter is the length of the
 # slow log. When a new command is logged the oldest one is removed from the
@@ -1839,9 +1839,9 @@ slowlog-max-len 128
 
 ################################ LATENCY MONITOR ##############################
 
-# The Redis latency monitoring subsystem samples different operations
+# The Valkey latency monitoring subsystem samples different operations
 # at runtime in order to collect data related to possible sources of
-# latency of a Redis instance.
+# latency of a Valkey instance.
 #
 # Via the LATENCY command this information is available to the user that can
 # print graphs and obtain reports.
@@ -1860,7 +1860,7 @@ latency-monitor-threshold 0
 
 ################################ LATENCY TRACKING ##############################
 
-# The Redis extended latency monitoring tracks the per command latencies and enables
+# The Valkey extended latency monitoring tracks the per command latencies and enables
 # exporting the percentile distribution via the INFO latencystats command,
 # and cumulative latency distributions (histograms) via the LATENCY command.
 #
@@ -1874,7 +1874,7 @@ latency-monitor-threshold 0
 
 ############################# EVENT NOTIFICATION ##############################
 
-# Redis can notify Pub/Sub clients about events happening in the key space.
+# Valkey can notify Pub/Sub clients about events happening in the key space.
 # This feature is documented at https://redis.io/topics/notifications
 #
 # For instance if keyspace events notification is enabled, and a client
@@ -1884,7 +1884,7 @@ latency-monitor-threshold 0
 # PUBLISH __keyspace@0__:foo del
 # PUBLISH __keyevent@0__:del foo
 #
-# It is possible to select the events that Redis will notify among a set
+# It is possible to select the events that Valkey will notify among a set
 # of classes. Every class is identified by a single character:
 #
 #  K     Keyspace events, published with __keyspace@<db>__ prefix.
@@ -2009,8 +2009,8 @@ stream-node-max-bytes 4096
 stream-node-max-entries 100
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
-# order to help rehashing the main Redis hash table (the one mapping top-level
-# keys to values). The hash table implementation Redis uses (see dict.c)
+# order to help rehashing the main Valkey hash table (the one mapping top-level
+# keys to values). The hash table implementation Valkey uses (see dict.c)
 # performs a lazy rehashing: the more operation you run into a hash table
 # that is rehashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
@@ -2021,7 +2021,7 @@ stream-node-max-entries 100
 #
 # If unsure:
 # use "activerehashing no" if you have hard latency requirements and it is
-# not a good thing in your environment that Redis can reply from time to time
+# not a good thing in your environment that Valkey can reply from time to time
 # to queries with 2 milliseconds delay.
 #
 # use "activerehashing yes" if you don't have such hard requirements but
@@ -2084,7 +2084,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # errors or data eviction. To avoid this we can cap the accumulated memory
 # used by all client connections (all pubsub and normal clients). Once we
 # reach that limit connections will be dropped by the server freeing up
-# memory. The server will attempt to drop the connections using the most 
+# memory. The server will attempt to drop the connections using the most
 # memory first. We call this mechanism "client eviction".
 #
 # Client eviction is configured using the maxmemory-clients setting as follows:
@@ -2105,15 +2105,15 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 #
 # proto-max-bulk-len 512mb
 
-# Redis calls an internal function to perform many background tasks, like
+# Valkey calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are
 # never requested, and so forth.
 #
-# Not all tasks are performed with the same frequency, but Redis checks for
+# Not all tasks are performed with the same frequency, but Valkey checks for
 # tasks to perform according to the specified "hz" value.
 #
 # By default "hz" is set to 10. Raising the value will use more CPU when
-# Redis is idle, but at the same time will make Redis more responsive when
+# Valkey is idle, but at the same time will make Valkey more responsive when
 # there are many keys expiring at the same time, and timeouts may be
 # handled with more precision.
 #
@@ -2127,7 +2127,7 @@ hz 10
 # avoid too many clients are processed for each background task invocation
 # in order to avoid latency spikes.
 #
-# Since the default HZ value by default is conservatively set to 10, Redis
+# Since the default HZ value by default is conservatively set to 10, Valkey
 # offers, and enables by default, the ability to use an adaptive HZ value
 # which will temporarily raise when there are many connected clients.
 #
@@ -2144,22 +2144,22 @@ dynamic-hz yes
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
 
-# When redis saves RDB file, if the following option is enabled
+# When Valkey saves RDB file, if the following option is enabled
 # the file will be fsync-ed every 4 MB of data generated. This is useful
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 rdb-save-incremental-fsync yes
 
-# Redis LFU eviction (see maxmemory setting) can be tuned. However it is a good
+# Valkey LFU eviction (see maxmemory setting) can be tuned. However it is a good
 # idea to start with the default settings and only change them after investigating
 # how to improve the performances and how the keys LFU change over time, which
 # is possible to inspect via the OBJECT FREQ command.
 #
-# There are two tunable parameters in the Redis LFU implementation: the
+# There are two tunable parameters in the Valkey LFU implementation: the
 # counter logarithm factor and the counter decay time. It is important to
 # understand what the two parameters mean before changing them.
 #
-# The LFU counter is just 8 bits per key, it's maximum value is 255, so Redis
+# The LFU counter is just 8 bits per key, it's maximum value is 255, so Valkey
 # uses a probabilistic increment with logarithmic behavior. Given the value
 # of the old counter, when a key is accessed, the counter is incremented in
 # this way:
@@ -2211,11 +2211,11 @@ rdb-save-incremental-fsync yes
 # Adjusting this to a larger number can slightly improve efficiency for new connections
 # at the risk of causing timeouts for regular commands on established connections.  It is
 # not advised to change this without ensuring that all clients have limited connection
-# pools and exponential backoff in the case of command/connection timeouts. 
+# pools and exponential backoff in the case of command/connection timeouts.
 #
 # If your application is establishing a large number of new connections per second you should
 # also consider tuning the value of tcp-backlog, which allows the kernel to buffer more
-# pending connections before dropping or rejecting connections. 
+# pending connections before dropping or rejecting connections.
 #
 # max-new-connections-per-cycle 10
 # max-new-tls-connections-per-cycle 1
@@ -2226,7 +2226,7 @@ rdb-save-incremental-fsync yes
 # What is active defragmentation?
 # -------------------------------
 #
-# Active (online) defragmentation allows a Redis server to compact the
+# Active (online) defragmentation allows a Valkey server to compact the
 # spaces left between small allocations and deallocations of data in memory,
 # thus allowing to reclaim back memory.
 #
@@ -2238,7 +2238,7 @@ rdb-save-incremental-fsync yes
 # in a "hot" way, while the server is running.
 #
 # Basically when the fragmentation is over a certain level (see the
-# configuration options below) Redis will start to create new copies of the
+# configuration options below) Valkey will start to create new copies of the
 # values in contiguous memory regions by exploiting certain specific Jemalloc
 # features (in order to understand if an allocation is causing fragmentation
 # and to allocate it in a better place), and at the same time, will release the
@@ -2247,8 +2247,8 @@ rdb-save-incremental-fsync yes
 #
 # Important things to understand:
 #
-# 1. This feature is disabled by default, and only works if you compiled Redis
-#    to use the copy of Jemalloc we ship with the source code of Redis.
+# 1. This feature is disabled by default, and only works if you compiled Valkey
+#    to use the copy of Jemalloc we ship with the source code of Valkey.
 #    This is the default with Linux builds.
 #
 # 2. You never need to enable this feature if you don't have fragmentation
@@ -2288,20 +2288,20 @@ rdb-save-incremental-fsync yes
 # Jemalloc background thread for purging will be enabled by default
 jemalloc-bg-thread yes
 
-# It is possible to pin different threads and processes of Redis to specific
+# It is possible to pin different threads and processes of Valkey to specific
 # CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different Redis threads in different
-# CPUs, but also in order to make sure that multiple Redis instances running
+# This is useful both in order to pin different Valkey threads in different
+# CPUs, but also in order to make sure that multiple Valkey instances running
 # in the same host will be pinned to different CPUs.
 #
 # Normally you can do this using the "taskset" command, however it is also
-# possible to this via Redis configuration directly, both in Linux and FreeBSD.
+# possible to this via Valkey configuration directly, both in Linux and FreeBSD.
 #
 # You can pin the server/IO threads, bio threads, aof rewrite child process, and
 # the bgsave child process. The syntax to specify the cpu list is the same as
 # the taskset command:
 #
-# Set redis server/io threads to cpu affinity 0,2,4,6:
+# Set Valkey server/io threads to cpu affinity 0,2,4,6:
 # server-cpulist 0-7:2
 #
 # Set bio threads to cpu affinity 1,3:
@@ -2313,7 +2313,7 @@ jemalloc-bg-thread yes
 # Set bgsave child process to cpu affinity 1,10,11
 # bgsave-cpulist 1,10-11
 
-# In some cases redis will emit warnings and even refuse to start if it detects
+# In some cases Valkey will emit warnings and even refuse to start if it detects
 # that the system is in bad state, it is possible to suppress these warnings
 # by setting the following config which takes a space delimited list of warnings
 # to suppress

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -146,7 +146,7 @@ sentinel down-after-milliseconds mymaster 30000
 #
 # For more information about ACL configuration please refer to the Redis
 # website at https://redis.io/topics/acl and redis server configuration 
-# template redis.conf.
+# template valkey.conf.
 
 # ACL LOG
 #
@@ -164,7 +164,7 @@ acllog-max-len 128
 # ACL file, the server will refuse to start.
 #
 # The format of the external ACL user file is exactly the same as the
-# format that is used inside redis.conf to describe users.
+# format that is used inside valkey.conf to describe users.
 #
 # aclfile /etc/redis/sentinel-users.acl
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -64,7 +64,7 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     char *name;
     uint64_t flag;
-} ACLDefaultCommandCategories[] = { /* See redis.conf for details on each category. */
+} ACLDefaultCommandCategories[] = { /* See valkey.conf for details on each category. */
     {"keyspace", ACL_CATEGORY_KEYSPACE},
     {"read", ACL_CATEGORY_READ},
     {"write", ACL_CATEGORY_WRITE},
@@ -2272,7 +2272,7 @@ int ACLLoadConfiguredUsers(void) {
 
 /* This function loads the ACL from the specified filename: every line
  * is validated and should be either empty or in the format used to specify
- * users in the redis.conf configuration or in the ACL file, that is:
+ * users in the valkey.conf configuration or in the ACL file, that is:
  *
  *  user <username> ... rules ...
  *
@@ -2566,17 +2566,17 @@ cleanup:
 
 /* This function is called once the server is already running, modules are
  * loaded, and we are ready to start, in order to load the ACLs either from
- * the pending list of users defined in redis.conf, or from the ACL file.
+ * the pending list of users defined in valkey.conf, or from the ACL file.
  * The function will just exit with an error if the user is trying to mix
  * both the loading methods. */
 void ACLLoadUsersAtStartup(void) {
     if (server.acl_filename[0] != '\0' && listLength(UsersToLoad) != 0) {
         serverLog(LL_WARNING,
-            "Configuring Redis with users defined in redis.conf and at "
+            "Configuring Redis with users defined in valkey.conf and at "
             "the same setting an ACL file path is invalid. This setup "
             "is very likely to lead to configuration errors and security "
             "holes, please define either an ACL file or declare users "
-            "directly in your redis.conf, but not both.");
+            "directly in your valkey.conf, but not both.");
         exit(1);
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -1275,7 +1275,7 @@ int rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *optio
 }
 
 /* Write the long long 'bytes' value as a string in a way that is parsable
- * inside redis.conf. If possible uses the GB, MB, KB notation. */
+ * inside valkey.conf. If possible uses the GB, MB, KB notation. */
 int rewriteConfigFormatMemory(char *buf, size_t len, long long bytes) {
     int gb = 1024*1024*1024;
     int mb = 1024*1024;
@@ -1473,7 +1473,7 @@ void rewriteConfigReplicaOfOption(standardConfig *config, const char *name, stru
 
     /* If this is a master, we want all the slaveof config options
      * in the file to be removed. Note that if this is a cluster instance
-     * we don't want a slaveof directive inside redis.conf. */
+     * we don't want a slaveof directive inside valkey.conf. */
     if (server.cluster_enabled || server.masterhost == NULL) {
         rewriteConfigMarkAsProcessed(state, name);
         return;

--- a/src/module.c
+++ b/src/module.c
@@ -8703,7 +8703,7 @@ void moduleReleaseGIL(void) {
  * used to send anything to the client, and has the db number where the event
  * occurred as its selected db number.
  *
- * Notice that it is not necessary to enable notifications in redis.conf for
+ * Notice that it is not necessary to enable notifications in valkey.conf for
  * module notifications to work.
  *
  * Warning: the notification callbacks are performed in a synchronous manner,

--- a/src/replication.c
+++ b/src/replication.c
@@ -3738,7 +3738,7 @@ void replicationCron(void) {
     if (server.masterhost && server.repl_state == REPL_STATE_TRANSFER &&
         (time(NULL)-server.repl_transfer_lastio) > server.repl_timeout)
     {
-        serverLog(LL_WARNING,"Timeout receiving bulk data from MASTER... If the problem persists try to set the 'repl-timeout' parameter in redis.conf to a larger value.");
+        serverLog(LL_WARNING,"Timeout receiving bulk data from MASTER... If the problem persists try to set the 'repl-timeout' parameter in valkey.conf to a larger value.");
         cancelReplicationHandshake(1);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2142,7 +2142,7 @@ void initServerConfig(void) {
 
     /* Command table -- we initialize it here as it is part of the
      * initial configuration, since command names may be changed via
-     * redis.conf using the rename-command directive. */
+     * valkey.conf using the rename-command directive. */
     server.commands = dictCreate(&commandTableDictType);
     server.orig_commands = dictCreate(&commandTableDictType);
     populateCommandTable();
@@ -3081,7 +3081,7 @@ void populateCommandTable(void) {
 
         retval1 = dictAdd(server.commands, sdsdup(c->fullname), c);
         /* Populate an additional dictionary that will be unaffected
-         * by rename-command statements in redis.conf. */
+         * by rename-command statements in valkey.conf. */
         retval2 = dictAdd(server.orig_commands, sdsdup(c->fullname), c);
         serverAssert(retval1 == DICT_OK && retval2 == DICT_OK);
     }
@@ -3236,7 +3236,7 @@ struct redisCommand *lookupCommandByCString(const char *s) {
 
 /* Lookup the command in the current table, if not found also check in
  * the original table containing the original command names unaffected by
- * redis.conf rename-command statement.
+ * valkey.conf rename-command statement.
  *
  * This is used by functions rewriting the argument vector such as
  * rewriteClientCommandVector() in order to set client->cmd pointer
@@ -6275,7 +6275,7 @@ sds getVersion(void) {
 }
 
 void usage(void) {
-    fprintf(stderr,"Usage: ./redis-server [/path/to/redis.conf] [options] [-]\n");
+    fprintf(stderr,"Usage: ./redis-server [/path/to/valkey.conf] [options] [-]\n");
     fprintf(stderr,"       ./redis-server - (read config from stdin)\n");
     fprintf(stderr,"       ./redis-server -v or --version\n");
     fprintf(stderr,"       ./redis-server -h or --help\n");
@@ -6288,8 +6288,8 @@ void usage(void) {
     fprintf(stderr,"       ./redis-server /etc/redis/6379.conf\n");
     fprintf(stderr,"       ./redis-server --port 7777\n");
     fprintf(stderr,"       ./redis-server --port 7777 --replicaof 127.0.0.1 8888\n");
-    fprintf(stderr,"       ./redis-server /etc/myredis.conf --loglevel verbose -\n");
-    fprintf(stderr,"       ./redis-server /etc/myredis.conf --loglevel verbose\n\n");
+    fprintf(stderr,"       ./redis-server /etc/myvalkey.conf --loglevel verbose -\n");
+    fprintf(stderr,"       ./redis-server /etc/myvalkey.conf --loglevel verbose\n\n");
     fprintf(stderr,"Sentinel mode:\n");
     fprintf(stderr,"       ./redis-server /etc/sentinel.conf --sentinel\n");
     exit(1);
@@ -6306,7 +6306,7 @@ void redisAsciiArt(void) {
 
     /* Show the ASCII logo if: log file is stdout AND stdout is a
      * tty AND syslog logging is disabled. Also show logo if the user
-     * forced us to do so via redis.conf. */
+     * forced us to do so via valkey.conf. */
     int show_logo = ((!server.syslog_enabled &&
                       server.logfile[0] == '\0' &&
                       isatty(fileno(stdout))) ||
@@ -6700,7 +6700,7 @@ void redisOutOfMemoryHandler(size_t allocation_size) {
         allocation_size);
 }
 
-/* Callback for sdstemplate on proc-title-template. See redis.conf for
+/* Callback for sdstemplate on proc-title-template. See valkey.conf for
  * supported variables.
  */
 static sds redisProcTitleGetVariable(const sds varname, void *arg)
@@ -7162,7 +7162,7 @@ int main(int argc, char **argv) {
             (int)getpid());
 
     if (argc == 1) {
-        serverLog(LL_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/redis.conf", argv[0]);
+        serverLog(LL_WARNING, "Warning: no config file specified, using the default config. In order to specify a config file use %s /path/to/valkey.conf", argv[0]);
     } else {
         serverLog(LL_NOTICE, "Configuration loaded");
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1734,7 +1734,7 @@ struct redisServer {
     durationStats duration_stats[EL_DURATION_TYPE_NUM];
 
     /* Configuration */
-    int verbosity;                  /* Loglevel in redis.conf */
+    int verbosity;                  /* Loglevel in valkey.conf */
     int maxidletime;                /* Client timeout in seconds */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
@@ -1959,7 +1959,7 @@ struct redisServer {
     int sort_alpha;
     int sort_bypattern;
     int sort_store;
-    /* Zip structure config, see redis.conf for more information  */
+    /* Zip structure config, see valkey.conf for more information  */
     size_t hash_max_listpack_entries;
     size_t hash_max_listpack_value;
     size_t set_max_intset_entries;
@@ -2314,7 +2314,7 @@ typedef int redisGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, ge
  *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
- * See redis.conf for the exact meaning of each.
+ * See valkey.conf for the exact meaning of each.
  *
  * @keyspace, @read, @write, @set, @sortedset, @list, @hash, @string, @bitmap,
  * @hyperloglog, @stream, @admin, @fast, @slow, @pubsub, @blocking, @dangerous,

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -536,7 +536,7 @@ proc start_server {options {code undefined}} {
     }
 
     # write new configuration to temporary file
-    set config_file [tmpfile redis.conf]
+    set config_file [tmpfile valkey.conf]
     create_server_config_file $config_file $config $config_lines
 
     set stdout [format "%s/%s" [dict get $config "dir"] "stdout"]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -327,7 +327,7 @@ proc run_solo {name code} {
 proc cleanup {} {
     if {!$::quiet} {puts -nonewline "Cleanup: may take some time... "}
     flush stdout
-    catch {exec rm -rf {*}[glob tests/tmp/redis.conf.*]}
+    catch {exec rm -rf {*}[glob tests/tmp/valkey.conf.*]}
     catch {exec rm -rf {*}[glob tests/tmp/server*.*]}
     catch {exec rm -rf {*}[glob tests/tmp/*.acl.*]}
     if {!$::quiet} {puts "OK"}

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -419,7 +419,7 @@ start_server {tags {"other external:skip"}} {
             assert_equal $expect_port [lindex $cmdline 3]
             assert_equal $expect_tls_port [lindex $cmdline 4]
             assert_match "*/tests/tmp/server.*/socket" [lindex $cmdline 5]
-            assert_match "*/tests/tmp/redis.conf.*" [lindex $cmdline 6]
+            assert_match "*/tests/tmp/valkey.conf.*" [lindex $cmdline 6]
 
             # Try setting a bad template
             catch {r config set "proc-title-template" "{invalid-var}"} err

--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -166,7 +166,7 @@ mkdir -p "$REDIS_DATA_DIR" || die "Could not create redis data directory"
 
 #render the templates
 TMP_FILE="/tmp/${REDIS_PORT}.conf"
-DEFAULT_CONFIG="${SCRIPTPATH}/../redis.conf"
+DEFAULT_CONFIG="${SCRIPTPATH}/../valkey.conf"
 INIT_TPL_FILE="${SCRIPTPATH}/redis_init_script.tpl"
 INIT_SCRIPT_DEST="/etc/init.d/redis_${REDIS_PORT}"
 PIDFILE="/var/run/redis_${REDIS_PORT}.pid"

--- a/utils/systemd-redis_server.service
+++ b/utils/systemd-redis_server.service
@@ -26,7 +26,7 @@ After=network-online.target
 [Service]
 ExecStart=/usr/local/bin/redis-server --supervised systemd --daemonize no
 ## Alternatively, have redis-server load a configuration file:
-#ExecStart=/usr/local/bin/redis-server /path/to/your/redis.conf
+#ExecStart=/usr/local/bin/redis-server /path/to/your/valkey.conf
 LimitNOFILE=10032
 NoNewPrivileges=yes
 #OOMScoreAdjust=-900

--- a/valkey.conf
+++ b/valkey.conf
@@ -3,7 +3,7 @@
 # Note that in order to read the configuration file, Valkey must be
 # started with the file path as first argument:
 #
-# ./valkey-server /path/to/redis.conf
+# ./valkey-server /path/to/valkey.conf
 
 # Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
@@ -1029,7 +1029,7 @@ acllog-max-len 128
 # ACL file, the server will refuse to start.
 #
 # The format of the external ACL user file is exactly the same as the
-# format that is used inside redis.conf to describe users.
+# format that is used inside valkey.conf to describe users.
 #
 # aclfile /etc/redis/users.acl
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1317,7 +1317,7 @@ lazyfree-lazy-user-flush no
 # CONFIG SET. Also, this feature currently does not work when SSL is
 # enabled.
 #
-# NOTE 2: If you want to test the Valkey speedup using redis-benchmark, make
+# NOTE 2: If you want to test the Valkey speedup using valkey-benchmark, make
 # sure you also run the benchmark itself in threaded mode, using the
 # --threads option to match the number of Valkey threads, otherwise you'll not
 # be able to notice the improvements.


### PR DESCRIPTION
Left naming when it was referencing an old Redis OSS version, Redis Sentinel, or is related to a default in the code. Also fixed some trailing whitespace throughout the config.