### PR TITLE
add valkey.conf test configuration to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/transfer.sh
 src/configs
 redis.ds
 src/redis.conf
+src/valkey.conf
 src/nodes.conf
 deps/lua/src/lua
 deps/lua/src/luac


### PR DESCRIPTION
As I used to place my redis.conf test configuration under the /src folder to run my local tests. Using this wonderful valkey replacement for Redis, I renamed my redis.conf to valkey.conf but kept it under the same /src folder for my own local test purpose. 

This PR adds the following line to the ".gitignore" file (similiar as "/src/redis.conf" already existed in .gitignore). This is so that I can exclude this test configuration from my check-in when contributing commits later. Please consider including it. Thanks. (Signed-off-by)

 +src/valkey.conf