### PR TITLE
Fix shutdown syntax hint, following intention

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -7431,18 +7431,28 @@ commandHistory SHUTDOWN_History[] = {
 #define SHUTDOWN_Keyspecs NULL
 #endif
 
-/* SHUTDOWN save_selector argument table */
-struct COMMAND_ARG SHUTDOWN_save_selector_Subargs[] = {
+/* SHUTDOWN abort_selector save_selector_block save_selector argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_save_selector_block_save_selector_Subargs[] = {
 {MAKE_ARG("nosave",ARG_TYPE_PURE_TOKEN,-1,"NOSAVE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("save",ARG_TYPE_PURE_TOKEN,-1,"SAVE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
-/* SHUTDOWN argument table */
-struct COMMAND_ARG SHUTDOWN_Args[] = {
-{MAKE_ARG("save-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_save_selector_Subargs},
+/* SHUTDOWN abort_selector save_selector_block argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_save_selector_block_Subargs[] = {
+{MAKE_ARG("save-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_abort_selector_save_selector_block_save_selector_Subargs},
 {MAKE_ARG("now",ARG_TYPE_PURE_TOKEN,-1,"NOW",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("force",ARG_TYPE_PURE_TOKEN,-1,"FORCE",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("abort",ARG_TYPE_PURE_TOKEN,-1,"ABORT",NULL,"7.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+};
+
+/* SHUTDOWN abort_selector argument table */
+struct COMMAND_ARG SHUTDOWN_abort_selector_Subargs[] = {
+{MAKE_ARG("save-selector-block",ARG_TYPE_BLOCK,-1,NULL,NULL,NULL,CMD_ARG_NONE,3,NULL),.subargs=SHUTDOWN_abort_selector_save_selector_block_Subargs},
+{MAKE_ARG("abort",ARG_TYPE_PURE_TOKEN,-1,"ABORT",NULL,"7.0.0",CMD_ARG_NONE,0,NULL)},
+};
+
+/* SHUTDOWN argument table */
+struct COMMAND_ARG SHUTDOWN_Args[] = {
+{MAKE_ARG("abort-selector",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=SHUTDOWN_abort_selector_Subargs},
 };
 
 /********** SLAVEOF ********************/
@@ -10798,7 +10808,7 @@ struct COMMAND_STRUCT redisCommandTable[] = {
 {MAKE_CMD("restore-asking","An internal command for migrating keys in a cluster.","O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).","3.0.0",CMD_DOC_SYSCMD,NULL,NULL,"server",COMMAND_GROUP_SERVER,RESTORE_ASKING_History,3,RESTORE_ASKING_Tips,0,restoreCommand,-4,CMD_WRITE|CMD_DENYOOM|CMD_ASKING,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,RESTORE_ASKING_Keyspecs,1,NULL,7),.args=RESTORE_ASKING_Args},
 {MAKE_CMD("role","Returns the replication role.","O(1)","2.8.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,ROLE_History,0,ROLE_Tips,0,roleCommand,1,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_FAST|CMD_SENTINEL,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS,ROLE_Keyspecs,0,NULL,0)},
 {MAKE_CMD("save","Synchronously saves the database(s) to disk.","O(N) where N is the total number of keys in all databases","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SAVE_History,0,SAVE_Tips,0,saveCommand,1,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_NO_MULTI,0,SAVE_Keyspecs,0,NULL,0)},
-{MAKE_CMD("shutdown","Synchronously saves the database(s) to disk and shuts down the server.","O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SHUTDOWN_History,1,SHUTDOWN_Tips,0,shutdownCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_NO_MULTI|CMD_SENTINEL|CMD_ALLOW_BUSY,0,SHUTDOWN_Keyspecs,0,NULL,4),.args=SHUTDOWN_Args},
+{MAKE_CMD("shutdown","Synchronously saves the database(s) to disk and shuts down the server.","O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SHUTDOWN_History,1,SHUTDOWN_Tips,0,shutdownCommand,-1,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_NO_MULTI|CMD_SENTINEL|CMD_ALLOW_BUSY,0,SHUTDOWN_Keyspecs,0,NULL,1),.args=SHUTDOWN_Args},
 {MAKE_CMD("slaveof","Sets a server as a replica of another, or promotes it to being a master.","O(1)","1.0.0",CMD_DOC_DEPRECATED,"`REPLICAOF`","5.0.0","server",COMMAND_GROUP_SERVER,SLAVEOF_History,0,SLAVEOF_Tips,0,replicaofCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_NOSCRIPT|CMD_STALE,0,SLAVEOF_Keyspecs,0,NULL,1),.args=SLAVEOF_Args},
 {MAKE_CMD("slowlog","A container for slow log commands.","Depends on subcommand.","2.2.12",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SLOWLOG_History,0,SLOWLOG_Tips,0,NULL,-2,0,0,SLOWLOG_Keyspecs,0,NULL,0),.subcommands=SLOWLOG_Subcommands},
 {MAKE_CMD("swapdb","Swaps two databases.","O(N) where N is the count of clients watching or blocking on keys from both databases.","4.0.0",CMD_DOC_NONE,NULL,NULL,"server",COMMAND_GROUP_SERVER,SWAPDB_History,0,SWAPDB_Tips,0,swapdbCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_DANGEROUS,SWAPDB_Keyspecs,0,NULL,2),.args=SWAPDB_Args},

--- a/src/commands/shutdown.json
+++ b/src/commands/shutdown.json
@@ -23,42 +23,54 @@
         ],
         "arguments": [
             {
-                "name": "save-selector",
+                "name": "abort-selector",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [
                     {
-                        "name": "nosave",
-                        "type": "pure-token",
-                        "token": "NOSAVE"
+                        "name": "save-selector-block",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "save-selector",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "nosave",
+                                        "type": "pure-token",
+                                        "token": "NOSAVE"
+                                    },
+                                    {
+                                        "name": "save",
+                                        "type": "pure-token",
+                                        "token": "SAVE"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "now",
+                                "type": "pure-token",
+                                "token": "NOW",
+                                "optional": true,
+                                "since": "7.0.0"
+                            },
+                            {
+                                "name": "force",
+                                "type": "pure-token",
+                                "token": "FORCE",
+                                "optional": true,
+                                "since": "7.0.0"
+                            }
+                        ]
                     },
                     {
-                        "name": "save",
+                        "name": "abort",
                         "type": "pure-token",
-                        "token": "SAVE"
+                        "token": "ABORT",
+                        "since": "7.0.0"
                     }
                 ]
-            },
-            {
-                "name": "now",
-                "type": "pure-token",
-                "token": "NOW",
-                "optional": true,
-                "since": "7.0.0"
-            },
-            {
-                "name": "force",
-                "type": "pure-token",
-                "token": "FORCE",
-                "optional": true,
-                "since": "7.0.0"
-            },
-            {
-                "name": "abort",
-                "type": "pure-token",
-                "token": "ABORT",
-                "optional": true,
-                "since": "7.0.0"
             }
         ],
         "reply_schema": {

--- a/src/db.c
+++ b/src/db.c
@@ -1234,6 +1234,7 @@ void typeCommand(client *c) {
     addReplyStatus(c, getObjectTypeName(o));
 }
 
+/* SHUTDOWN [[NOSAVE | SAVE] [NOW] [FORCE] | ABORT] */
 void shutdownCommand(client *c) {
     int flags = SHUTDOWN_NOFLAGS;
     int abort = 0;


### PR DESCRIPTION
This change is the thing I suggested to redis when it was BSD, and thankfully was reviewed by @zuiderkwast

### Problem
valkey-cli, for now, is not fancy I thought.
The intention was that we cannot use 'ABORT' option with others - this only can be used alone.
But for now the hints show us that we can use it together, though this actually leads syntax error.
![image](https://github.com/valkey-io/valkey/assets/38001238/6ba8f9ba-d18a-408e-a91b-fbf3e8141848)
![image](https://github.com/valkey-io/valkey/assets/38001238/282da83f-ecd6-4d59-a2e3-109af5c9bd70)
![image](https://github.com/valkey-io/valkey/assets/38001238/a79b6feb-c545-453a-a23a-b7a60dddc037)


### solved
simply fix hint
![image](https://github.com/valkey-io/valkey/assets/38001238/bd2e8bda-0903-45a1-bc33-24b0bf3dcb7c)

#### ABORT will not be appeared when others
![image](https://github.com/valkey-io/valkey/assets/38001238/ec4780aa-9787-4d0a-a03b-155c3bb73a77)

#### other options will not be appeared when using ABORT
![image](https://github.com/valkey-io/valkey/assets/38001238/0336b3fb-f12b-441c-844d-1054fb2a069b)


### Note
Of course, I did refer to previous commit, but didn't fully reuse it.
I edit json, build, and check it certainly again :)
Thanks valkey!
![image](https://github.com/valkey-io/valkey/assets/38001238/de069639-536f-4e86-9f67-824cff68d339)

p.s. when testing it, found the left word 'Redis' from first line in above img. Renaming redis to valkey is already in lots of PR, so I had checked previous PRs, and found PR that covered most of it, but not covering this phrase: 'Redis version=255.255.255'. Left suggestion comment in https://github.com/valkey-io/valkey/pull/88