### PR TITLE
Restore all tests state prior to fork

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,11 @@ name: Daily
 
 on:
   pull_request:
+    branches:
+      # any PR to a release branch.
+      - '[0-9].[0-9]'
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       skipjobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,8 +1,7 @@
 name: Daily
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  pull_request:
   workflow_dispatch:
     inputs:
       skipjobs:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -1,10 +1,10 @@
 name: External Server Tests
 
 on:
-    pull_request:
-    push:
-    schedule:
-    - cron: '* * * * *'
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test-external-standalone:


### PR DESCRIPTION
Related to https://github.com/valkey-io/valkey/pull/11#issuecomment-2028930612
Restore all tests state prior to fork and re-enables Daily tests on PRs on release branches.
Reverts https://github.com/valkey-io/valkey/commit/2aa820f945a7db9a09203b1f60dfb70662cdd3a6