### PR TITLE
Update coverity to reflect project name

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,19 +14,18 @@ jobs:
     - uses: actions/checkout@main
     - name: Download and extract the Coverity Build Tool
       run: |
-          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=valkey-unstable" -O cov-analysis-linux64.tar.gz
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=valkey-io%2Fvalkey" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
     - name: Install Valkey dependencies
-      run: sudo apt install -y gcc tcl8.6 tclx procps libssl-dev
+      run: sudo apt install -y gcc procps libssl-dev
     - name: Build with cov-build
       run: cov-analysis-linux64/bin/cov-build --dir cov-int make
     - name: Upload the result
       run: |
           tar czvf cov-int.tgz cov-int
           curl \
-            --form project=valkey-unstable \
             --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
             --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
             --form file=@cov-int.tgz \
-            https://scan.coverity.com/builds
+            https://scan.coverity.com/builds?project=valkey-io%2Fvalkey


### PR DESCRIPTION
Fix the coverity name to reflect the actual name in coverity. See successful build here: https://github.com/valkey-io/valkey/actions/runs/8516329554. Also removed unnecessary TCL dependency from the install.