### PR TITLE
Remove unused var desc in luaRegisterFunctionReadPositionalArgs

### DIFF
--- a/src/function_lua.c
+++ b/src/function_lua.c
@@ -354,7 +354,6 @@ error:
 static int luaRegisterFunctionReadPositionalArgs(lua_State *lua, registerFunctionArgs *register_f_args) {
     char *err = NULL;
     sds name = NULL;
-    sds desc = NULL;
     luaFunctionCtx *lua_f_ctx = NULL;
     if (!(name = luaGetStringSds(lua, 1))) {
         err = "first argument to redis.register_function must be a string";
@@ -377,7 +376,6 @@ static int luaRegisterFunctionReadPositionalArgs(lua_State *lua, registerFunctio
 
 error:
     if (name) sdsfree(name);
-    if (desc) sdsfree(desc);
     luaPushError(lua, err);
     return C_ERR;
 }


### PR DESCRIPTION
desc is set to NULL, never set to anything, and then
checked if it should be freed on the error path if it's NULL.
This can be cleaned up, since it's really unused.

Fixes #129