### PR TITLE
Fix rename REDIS_TEST to SERVER_TEST to pass the Daily workflow

### DIFF
--- a/deps/hiredis/sds.h
+++ b/deps/hiredis/sds.h
@@ -273,7 +273,7 @@ void *hi_sds_malloc(size_t size);
 void *hi_sds_realloc(void *ptr, size_t size);
 void hi_sds_free(void *ptr);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int hi_sdsTest(int argc, char *argv[]);
 #endif
 

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -123,7 +123,7 @@ uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l) {
 }
 
 /* Test main */
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <stdio.h>
 
 #define UNUSED(x) (void)(x)

--- a/src/crc64.h
+++ b/src/crc64.h
@@ -6,7 +6,7 @@
 void crc64_init(void);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int crc64Test(int argc, char *argv[], int flags);
 #endif
 

--- a/src/dict.c
+++ b/src/dict.c
@@ -1755,7 +1755,7 @@ void dictGetStats(char *buf, size_t bufsize, dict *d, int full) {
 
 /* ------------------------------- Benchmark ---------------------------------*/
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include "testhelp.h"
 
 #define UNUSED(V) ((void) V)

--- a/src/dict.h
+++ b/src/dict.h
@@ -249,7 +249,7 @@ dictStats* dictGetStatsHt(dict *d, int htidx, int full);
 void dictCombineStats(dictStats *from, dictStats *into);
 void dictFreeStats(dictStats *stats);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int dictTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/endianconv.c
+++ b/src/endianconv.c
@@ -101,7 +101,7 @@ uint64_t intrev64(uint64_t v) {
     return v;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <stdio.h>
 
 #define UNUSED(x) (void)(x)

--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -71,7 +71,7 @@ uint64_t intrev64(uint64_t v);
 #define ntohu64(v) intrev64(v)
 #endif
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int endianconvTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/intset.c
+++ b/src/intset.c
@@ -342,7 +342,7 @@ int intsetValidateIntegrity(const unsigned char *p, size_t size, int deep) {
     return 1;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <sys/time.h>
 #include <time.h>
 

--- a/src/intset.h
+++ b/src/intset.h
@@ -50,7 +50,7 @@ uint32_t intsetLen(const intset *is);
 size_t intsetBlobLen(intset *is);
 int intsetValidateIntegrity(const unsigned char *is, size_t size, int deep);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int intsetTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -866,7 +866,7 @@ int kvstoreDictDelete(kvstore *kvs, int didx, const void *key) {
     return ret;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <stdio.h>
 #include "testhelp.h"
 

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -72,7 +72,7 @@ dictEntry *kvstoreDictTwoPhaseUnlinkFind(kvstore *kvs, int didx, const void *key
 void kvstoreDictTwoPhaseUnlinkFree(kvstore *kvs, int didx, dictEntry *he, dictEntry **plink, int table_index);
 int kvstoreDictDelete(kvstore *kvs, int didx, const void *key);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int kvstoreTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1679,7 +1679,7 @@ void lpRepr(unsigned char *lp) {
     printf("{end}\n\n");
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 
 #include <sys/time.h>
 #include "adlist.h"

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -99,7 +99,7 @@ unsigned char *lpNextRandom(unsigned char *lp, unsigned char *p, unsigned int *i
 int lpSafeToAdd(unsigned char* lp, size_t add);
 void lpRepr(unsigned char *lp);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int listpackTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -212,7 +212,7 @@ void quicklistRelease(quicklist *quicklist) {
  * Returns 1 if listpack compressed successfully.
  * Returns 0 if compression failed or if listpack too small to compress. */
 REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
     node->attempted_compress = 1;
 #endif
     if (node->dont_compress) return 0;
@@ -254,7 +254,7 @@ REDIS_STATIC int __quicklistCompressNode(quicklistNode *node) {
 /* Uncompress the listpack in 'node' and update encoding details.
  * Returns 1 on successful decode, 0 on failure to decode. */
 REDIS_STATIC int __quicklistDecompressNode(quicklistNode *node) {
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
     node->attempted_compress = 0;
 #endif
     node->recompress = 0;
@@ -1791,7 +1791,7 @@ void quicklistBookmarksClear(quicklist *ql) {
 }
 
 /* The rest of this file is test cases and test helpers. */
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <stdint.h>
 #include <sys/time.h>
 #include "testhelp.h"

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -204,7 +204,7 @@ quicklistNode *quicklistBookmarkFind(quicklist *ql, const char *name);
 void quicklistBookmarksClear(quicklist *ql);
 int quicklistSetPackedThreshold(size_t sz);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int quicklistTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/sds.c
+++ b/src/sds.c
@@ -1229,7 +1229,7 @@ error:
     return NULL;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <stdio.h>
 #include <limits.h>
 #include "testhelp.h"

--- a/src/sds.h
+++ b/src/sds.h
@@ -280,7 +280,7 @@ void *sds_malloc(size_t size);
 void *sds_realloc(void *ptr, size_t size);
 void sds_free(void *ptr);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int sdsTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/server.c
+++ b/src/server.c
@@ -6855,7 +6855,7 @@ int iAmMaster(void) {
             (server.cluster_enabled && clusterNodeIsMaster(getMyClusterNode())));
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include "testhelp.h"
 #include "intset.h"  /* Compact integer set structure */
 
@@ -6901,7 +6901,7 @@ int main(int argc, char **argv) {
     int j;
     char config_from_stdin = 0;
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
     monotonicInit(); /* Required for dict tests, that are relying on monotime during dict rehashing. */
     if (argc >= 3 && !strcasecmp(argv[1], "test")) {
         int flags = 0;

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -208,7 +208,7 @@ void SHA1Final(unsigned char digest[20], SHA1_CTX* context)
 }
 /* ================ end of sha1.c ================ */
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #define BUFSIZE 4096
 
 #define UNUSED(x) (void)(x)

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -21,7 +21,7 @@ void SHA1Init(SHA1_CTX* context);
 __attribute__((noinline)) void SHA1Update(SHA1_CTX* context, const unsigned char* data, uint32_t len);
 void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int sha1Test(int argc, char **argv, int flags);
 #endif
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -1375,7 +1375,7 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...) {
     return result;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <assert.h>
 #include <sys/mman.h>
 #include "testhelp.h"

--- a/src/util.h
+++ b/src/util.h
@@ -100,7 +100,7 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...);
 size_t redis_strlcpy(char *dst, const char *src, size_t dsize);
 size_t redis_strlcat(char *dst, const char *src, size_t dsize);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int utilTest(int argc, char **argv, int flags);
 #endif
 

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -1686,7 +1686,7 @@ unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, zip
     return picked;
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include <sys/time.h>
 #include "adlist.h"
 #include "sds.h"

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -67,7 +67,7 @@ void ziplistRandomPairs(unsigned char *zl, unsigned int count, ziplistEntry *key
 unsigned int ziplistRandomPairsUnique(unsigned char *zl, unsigned int count, ziplistEntry *keys, ziplistEntry *vals);
 int ziplistSafeToAdd(unsigned char* zl, size_t add);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int ziplistTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -441,7 +441,7 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
 #undef OUT_OF_RANGE
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 static void zipmapRepr(unsigned char *p) {
     unsigned int l;
 

--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -47,7 +47,7 @@ size_t zipmapBlobLen(unsigned char *zm);
 void zipmapRepr(unsigned char *p);
 int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int zipmapTest(int argc, char *argv[], int flags);
 #endif
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -908,7 +908,7 @@ size_t zmalloc_get_memory_size(void) {
 #endif
 }
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 #include "testhelp.h"
 #include "redisassert.h"
 

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -168,7 +168,7 @@ __attribute__((alloc_size(2),noinline)) void *extend_to_usable(void *ptr, size_t
 
 int get_proc_stat_ll(int i, long long *res);
 
-#ifdef REDIS_TEST
+#ifdef SERVER_TEST
 int zmalloc_test(int argc, char **argv, int flags);
 #endif
 


### PR DESCRIPTION
The test flag `REDIS_TEST` has already be changed to `SERVER_TEST` in `.github/workflows/daily.yml`, the name in the src directory need to be changed as well.

```shell
 run: |
        sudo apt-get update && sudo apt-get install libc6-dev-i386
        make 32bit SERVER_CFLAGS='-Werror -DSERVER_TEST'
```