### PR TITLE
Remove unused REDIS_TEST_MAIN dead code in crc64.c

### DIFF
--- a/src/crc64.c
+++ b/src/crc64.c
@@ -152,10 +152,3 @@ int crc64Test(int argc, char *argv[], int flags) {
 }
 
 #endif
-
-#ifdef REDIS_TEST_MAIN
-int main(int argc, char *argv[]) {
-    return crc64Test(argc, argv);
-}
-
-#endif


### PR DESCRIPTION
We use `#ifdef SERVER_TEST` to run the relavent tests, we can now remove the dead code `#ifdef REDIS_TEST_MAIN`.

Now we are using in `src/crc64.c`:
```c
/* Test main */
#ifdef SERVER_TEST
#include <stdio.h>

#define UNUSED(x) (void)(x)
int crc64Test(int argc, char *argv[], int flags) {
    UNUSED(argc);
    UNUSED(argv);
    UNUSED(flags);
    crc64_init();
    printf("[calcula]: e9c6d914c4b8d9ca == %016" PRIx64 "\n",
           (uint64_t)_crc64(0, "123456789", 9));
    printf("[64speed]: e9c6d914c4b8d9ca == %016" PRIx64 "\n",
           (uint64_t)crc64(0, (unsigned char*)"123456789", 9));
    char li[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed "
                "do eiusmod tempor incididunt ut labore et dolore magna "
                "aliqua. Ut enim ad minim veniam, quis nostrud exercitation "
                "ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis "
                "aute irure dolor in reprehenderit in voluptate velit esse "
                "cillum dolore eu fugiat nulla pariatur. Excepteur sint "
                "occaecat cupidatat non proident, sunt in culpa qui officia "
                "deserunt mollit anim id est laborum.";
    printf("[calcula]: c7794709e69683b3 == %016" PRIx64 "\n",
           (uint64_t)_crc64(0, li, sizeof(li)));
    printf("[64speed]: c7794709e69683b3 == %016" PRIx64 "\n",
           (uint64_t)crc64(0, (unsigned char*)li, sizeof(li)));
    return 0;
}

#endif
```
