### PR TITLE
change redis tls cert files name to valkey tls cert files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,7 @@ release.h
 src/transfer.sh
 src/configs
 redis.ds
-src/redis.conf
-src/nodes.conf
+src/*.conf
 deps/lua/src/lua
 deps/lua/src/luac
 deps/lua/src/liblua.a

--- a/TLS.md
+++ b/TLS.md
@@ -40,6 +40,9 @@ For TLS built-in mode:
     ./src/valkey-server --tls-port 6379 --port 0 \
         --tls-cert-file ./tests/tls/valkey.crt \
         --tls-key-file ./tests/tls/valkey.key \
+    ./src/redis-server --tls-port 6379 --port 0 \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt
 
 For TLS module mode:

--- a/TLS.md
+++ b/TLS.md
@@ -40,9 +40,6 @@ For TLS built-in mode:
     ./src/valkey-server --tls-port 6379 --port 0 \
         --tls-cert-file ./tests/tls/valkey.crt \
         --tls-key-file ./tests/tls/valkey.key \
-    ./src/redis-server --tls-port 6379 --port 0 \
-        --tls-cert-file ./tests/tls/valkey.crt \
-        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt
 
 For TLS module mode:

--- a/TLS.md
+++ b/TLS.md
@@ -38,22 +38,22 @@ invoked so sample certificates/keys are available):
 
 For TLS built-in mode:
     ./src/redis-server --tls-port 6379 --port 0 \
-        --tls-cert-file ./tests/tls/redis.crt \
-        --tls-key-file ./tests/tls/redis.key \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt
 
 For TLS module mode:
     ./src/redis-server --tls-port 6379 --port 0 \
-        --tls-cert-file ./tests/tls/redis.crt \
-        --tls-key-file ./tests/tls/redis.key \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt \
         --loadmodule src/redis-tls.so
 
 To connect to this Redis server with `redis-cli`:
 
     ./src/redis-cli --tls \
-        --cert ./tests/tls/redis.crt \
-        --key ./tests/tls/redis.key \
+        --cert ./tests/tls/valkey.crt \
+        --key ./tests/tls/valkey.key \
         --cacert ./tests/tls/ca.crt
 
 This will disable TCP and enable TLS on port 6379. It's also possible to have

--- a/TLS.md
+++ b/TLS.md
@@ -37,21 +37,21 @@ To manually run a Redis server with TLS mode (assuming `gen-test-certs.sh` was
 invoked so sample certificates/keys are available):
 
 For TLS built-in mode:
-    ./src/redis-server --tls-port 6379 --port 0 \
+    ./src/valkey-server --tls-port 6379 --port 0 \
         --tls-cert-file ./tests/tls/valkey.crt \
         --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt
 
 For TLS module mode:
-    ./src/redis-server --tls-port 6379 --port 0 \
+    ./src/valkey-server --tls-port 6379 --port 0 \
         --tls-cert-file ./tests/tls/valkey.crt \
         --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt \
         --loadmodule src/redis-tls.so
 
-To connect to this Redis server with `redis-cli`:
+To connect to this valkey server with `redis-cli`:
 
-    ./src/redis-cli --tls \
+    ./src/valkey-cli --tls \
         --cert ./tests/tls/valkey.crt \
         --key ./tests/tls/valkey.key \
         --cacert ./tests/tls/ca.crt
@@ -60,7 +60,7 @@ This will disable TCP and enable TLS on port 6379. It's also possible to have
 both TCP and TLS available, but you'll need to assign different ports.
 
 To make a Replica connect to the master using TLS, use `--tls-replication yes`,
-and to make Redis Cluster use TLS across nodes use `--tls-cluster yes`.
+and to make valkey Cluster use TLS across nodes use `--tls-cluster yes`.
 
 Connections
 -----------
@@ -90,7 +90,7 @@ To-Do List
   directly manipulating sockets for most actions. This will need to be cleaned
   up for proper TLS support. The best approach is probably to migrate to hiredis
   async mode.
-- [ ] redis-cli `--slave` and `--rdb` support.
+- [ ] valkey-cli `--slave` and `--rdb` support.
 
 Multi-port
 ----------

--- a/deps/hiredis/test.sh
+++ b/deps/hiredis/test.sh
@@ -23,8 +23,8 @@ SOCK_FILE=${tmpdir}/hiredis-test-redis.sock
 if [ "$TEST_SSL" = "1" ]; then
     SSL_CA_CERT=${tmpdir}/ca.crt
     SSL_CA_KEY=${tmpdir}/ca.key
-    SSL_CERT=${tmpdir}/redis.crt
-    SSL_KEY=${tmpdir}/redis.key
+    SSL_CERT=${tmpdir}/valkey.crt
+    SSL_KEY=${tmpdir}/valkey.key
 
     openssl genrsa -out ${tmpdir}/ca.key 4096
     openssl req \

--- a/redis.conf
+++ b/redis.conf
@@ -199,8 +199,8 @@ tcp-keepalive 300
 # server to connected clients, masters or cluster peers.  These files should be
 # PEM formatted.
 #
-# tls-cert-file redis.crt
-# tls-key-file redis.key
+# tls-cert-file valkey.crt
+# tls-key-file valkey.key
 #
 # If the key file is encrypted using a passphrase, it can be included here
 # as well.
@@ -228,7 +228,7 @@ tcp-keepalive 300
 # required by older versions of OpenSSL (<3.0). Newer versions do not require
 # this configuration and recommend against it.
 #
-# tls-dh-params-file redis.dh
+# tls-dh-params-file valkey.dh
 
 # Configure a CA certificate(s) bundle or directory to authenticate TLS/SSL
 # clients and peers.  Redis requires an explicit configuration of at least one

--- a/redis.conf
+++ b/redis.conf
@@ -231,7 +231,7 @@ tcp-keepalive 300
 # tls-dh-params-file valkey.dh
 
 # Configure a CA certificate(s) bundle or directory to authenticate TLS/SSL
-# clients and peers.  Redis requires an explicit configuration of at least one
+# clients and peers.  Valkey requires an explicit configuration of at least one
 # of these, and will not implicitly use the system wide configuration.
 #
 # tls-ca-cert-file ca.crt

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -146,7 +146,7 @@ sentinel down-after-milliseconds mymaster 30000
 #
 # For more information about ACL configuration please refer to the Redis
 # website at https://redis.io/topics/acl and redis server configuration 
-# template redis.conf.
+# template valkey.conf.
 
 # ACL LOG
 #
@@ -164,7 +164,7 @@ acllog-max-len 128
 # ACL file, the server will refuse to start.
 #
 # The format of the external ACL user file is exactly the same as the
-# format that is used inside redis.conf to describe users.
+# format that is used inside valkey.conf to describe users.
 #
 # aclfile /etc/redis/sentinel-users.acl
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -64,7 +64,7 @@ static unsigned long nextid = 0; /* Next command id that has not been assigned *
 struct ACLCategoryItem {
     char *name;
     uint64_t flag;
-} ACLDefaultCommandCategories[] = { /* See redis.conf for details on each category. */
+} ACLDefaultCommandCategories[] = { /* See valkey.conf for details on each category. */
     {"keyspace", ACL_CATEGORY_KEYSPACE},
     {"read", ACL_CATEGORY_READ},
     {"write", ACL_CATEGORY_WRITE},
@@ -2272,7 +2272,7 @@ int ACLLoadConfiguredUsers(void) {
 
 /* This function loads the ACL from the specified filename: every line
  * is validated and should be either empty or in the format used to specify
- * users in the redis.conf configuration or in the ACL file, that is:
+ * users in the valkey.conf or in the ACL file, that is:
  *
  *  user <username> ... rules ...
  *
@@ -2566,7 +2566,7 @@ cleanup:
 
 /* This function is called once the server is already running, modules are
  * loaded, and we are ready to start, in order to load the ACLs either from
- * the pending list of users defined in redis.conf, or from the ACL file.
+ * the pending list of users defined in valkey.conf, or from the ACL file.
  * The function will just exit with an error if the user is trying to mix
  * both the loading methods. */
 void ACLLoadUsersAtStartup(void) {

--- a/src/aof.c
+++ b/src/aof.c
@@ -1481,7 +1481,7 @@ int loadSingleAppendOnlyFile(char *filename) {
         robj **argv;
         char buf[AOF_ANNOTATION_LINE_MAX_LEN];
         sds argsds;
-        struct redisCommand *cmd;
+        struct serverCommand *cmd;
 
         /* Serve the clients from time to time */
         if (!(loops++ % 1024)) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -990,7 +990,7 @@ void clusterCommand(client *c) {
  *
  * CLUSTER_REDIR_DOWN_STATE and CLUSTER_REDIR_DOWN_RO_STATE if the cluster is
  * down but the user attempts to execute a command that addresses one or more keys. */
-clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *error_code) {
+clusterNode *getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *error_code) {
     clusterNode *myself = getMyClusterNode();
     clusterNode *n = NULL;
     robj *firstkey = NULL;
@@ -1039,7 +1039,7 @@ clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, in
     /* Check that all the keys are in the same hash slot, and obtain this
      * slot and the node associated. */
     for (i = 0; i < ms->count; i++) {
-        struct redisCommand *mcmd;
+        struct serverCommand *mcmd;
         robj **margv;
         int margc, numkeys, j;
         keyReference *keyindex;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -105,7 +105,7 @@ long long clusterNodeReplOffset(clusterNode *node);
 clusterNode *clusterLookupNode(const char *name, int length);
 
 /* functions with shared implementations */
-clusterNode *getNodeByQuery(client *c, struct redisCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
+clusterNode *getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
 int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);

--- a/src/commands.c
+++ b/src/commands.c
@@ -3,7 +3,7 @@
 
 #define MAKE_CMD(name,summary,complexity,since,doc_flags,replaced,deprecated,group,group_enum,history,num_history,tips,num_tips,function,arity,flags,acl,key_specs,key_specs_num,get_keys,numargs) name,summary,complexity,since,doc_flags,replaced,deprecated,group_enum,history,num_history,tips,num_tips,function,arity,flags,acl,key_specs,key_specs_num,get_keys,numargs
 #define MAKE_ARG(name,type,key_spec_index,token,summary,since,flags,numsubargs,deprecated_since) name,type,key_spec_index,token,summary,since,flags,deprecated_since,numsubargs
-#define COMMAND_STRUCT redisCommand
+#define COMMAND_STRUCT serverCommand
 #define COMMAND_ARG redisCommandArg
 
 #ifdef LOG_REQ_RES

--- a/src/commands.def
+++ b/src/commands.def
@@ -5,7 +5,7 @@
  * the fantastic
  * Redis Command Table! */
 
-/* Must match redisCommandGroup */
+/* Must match serverCommandGroup */
 const char *COMMAND_GROUP_STR[] = {
     "generic",
     "string",

--- a/src/config.c
+++ b/src/config.c
@@ -537,7 +537,7 @@ void loadServerConfigFromString(char *config) {
         if (!strcasecmp(argv[0],"include") && argc == 2) {
             loadServerConfig(argv[1], 0, NULL);
         } else if (!strcasecmp(argv[0],"rename-command") && argc == 3) {
-            struct redisCommand *cmd = lookupCommandBySds(argv[1]);
+            struct serverCommand *cmd = lookupCommandBySds(argv[1]);
             int retval;
 
             if (!cmd) {

--- a/src/config.c
+++ b/src/config.c
@@ -1275,7 +1275,7 @@ int rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *optio
 }
 
 /* Write the long long 'bytes' value as a string in a way that is parsable
- * inside redis.conf. If possible uses the GB, MB, KB notation. */
+ * inside valkey.conf. If possible uses the GB, MB, KB notation. */
 int rewriteConfigFormatMemory(char *buf, size_t len, long long bytes) {
     int gb = 1024*1024*1024;
     int mb = 1024*1024;
@@ -1473,7 +1473,7 @@ void rewriteConfigReplicaOfOption(standardConfig *config, const char *name, stru
 
     /* If this is a master, we want all the slaveof config options
      * in the file to be removed. Note that if this is a cluster instance
-     * we don't want a slaveof directive inside redis.conf. */
+     * we don't want a slaveof directive inside valkey.conf. */
     if (server.cluster_enabled || server.masterhost == NULL) {
         rewriteConfigMarkAsProcessed(state, name);
         return;

--- a/src/crc64.c
+++ b/src/crc64.c
@@ -152,10 +152,3 @@ int crc64Test(int argc, char *argv[], int flags) {
 }
 
 #endif
-
-#ifdef REDIS_TEST_MAIN
-int main(int argc, char *argv[]) {
-    return crc64Test(argc, argv);
-}
-
-#endif

--- a/src/db.c
+++ b/src/db.c
@@ -2149,7 +2149,7 @@ int doesCommandHaveKeys(struct redisCommand *cmd) {
 /* A simplified channel spec table that contains all of the redis commands
  * and which channels they have and how they are accessed. */
 typedef struct ChannelSpecs {
-    redisCommandProc *proc; /* Command procedure to match against */
+    serverCommandProc *proc; /* Command procedure to match against */
     uint64_t flags;         /* CMD_CHANNEL_* flags for this command */
     int start;              /* The initial position of the first channel */
     int count;              /* The number of channels, or -1 if all remaining

--- a/src/evict.c
+++ b/src/evict.c
@@ -69,7 +69,7 @@ static struct evictionPoolEntry *EvictionPoolLRU;
 
 /* Return the LRU clock, based on the clock resolution. This is a time
  * in a reduced-bits format that can be used to set and check the
- * object->lru field of redisObject structures. */
+ * object->lru field of serverObject structures. */
 unsigned int getLRUClock(void) {
     return (mstime()/LRU_CLOCK_RESOLUTION) & LRU_CLOCK_MAX;
 }

--- a/src/latency.c
+++ b/src/latency.c
@@ -493,10 +493,10 @@ void fillCommandCDF(client *c, struct hdr_histogram* histogram) {
 void latencyAllCommandsFillCDF(client *c, dict *commands, int *command_with_data) {
     dictIterator *di = dictGetSafeIterator(commands);
     dictEntry *de;
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
 
     while((de = dictNext(di)) != NULL) {
-        cmd = (struct redisCommand *) dictGetVal(de);
+        cmd = (struct serverCommand *) dictGetVal(de);
         if (cmd->latency_histogram) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             fillCommandCDF(c, cmd->latency_histogram);
@@ -516,7 +516,7 @@ void latencySpecificCommandsFillCDF(client *c) {
     void *replylen = addReplyDeferredLen(c);
     int command_with_data = 0;
     for (int j = 2; j < c->argc; j++){
-        struct redisCommand *cmd = lookupCommandBySds(c->argv[j]->ptr);
+        struct serverCommand *cmd = lookupCommandBySds(c->argv[j]->ptr);
         /* If the command does not exist we skip the reply */
         if (cmd == NULL) {
             continue;
@@ -533,7 +533,7 @@ void latencySpecificCommandsFillCDF(client *c) {
             dictIterator *di = dictGetSafeIterator(cmd->subcommands_dict);
 
             while ((de = dictNext(di)) != NULL) {
-                struct redisCommand *sub = dictGetVal(de);
+                struct serverCommand *sub = dictGetVal(de);
                 if (sub->latency_histogram) {
                     addReplyBulkCBuffer(c, sub->fullname, sdslen(sub->fullname));
                     fillCommandCDF(c, sub->latency_histogram);

--- a/src/module.c
+++ b/src/module.c
@@ -430,7 +430,7 @@ typedef struct RedisModuleUser {
 
 /* This is a structure used to export some meta-information such as dbid to the module. */
 typedef struct RedisModuleKeyOptCtx {
-    struct redisObject *from_key, *to_key; /* Optional name of key processed, NULL when unknown. 
+    struct serverObject *from_key, *to_key; /* Optional name of key processed, NULL when unknown. 
                                               In most cases, only 'from_key' is valid, but in callbacks 
                                               such as `copy2`, both 'from_key' and 'to_key' are valid. */
     int from_dbid, to_dbid;                /* The dbid of the key being processed, -1 when unknown.
@@ -13430,7 +13430,7 @@ const char *RM_GetCurrentCommandName(RedisModuleCtx *ctx) {
 struct RedisModuleDefragCtx {
     long long int endtime;
     unsigned long *cursor;
-    struct redisObject *key; /* Optional name of key processed, NULL when unknown. */
+    struct serverObject *key; /* Optional name of key processed, NULL when unknown. */
     int dbid;                /* The dbid of the key being processed, -1 when unknown. */
 };
 

--- a/src/module.c
+++ b/src/module.c
@@ -238,7 +238,7 @@ typedef void (*RedisModuleDisconnectFunc) (RedisModuleCtx *ctx, struct RedisModu
 struct RedisModuleCommand {
     struct RedisModule *module;
     RedisModuleCmdFunc func;
-    struct redisCommand *rediscmd;
+    struct serverCommand *rediscmd;
 };
 typedef struct RedisModuleCommand RedisModuleCommand;
 
@@ -959,7 +959,7 @@ void RedisModuleCommandDispatcher(client *c) {
  * In order to accomplish its work, the module command is called, flagging
  * the context in a way that the command can recognize this is a special
  * "get keys" call by calling RedisModule_IsKeysPositionRequest(ctx). */
-int moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+int moduleGetCommandKeysViaAPI(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     RedisModuleCommand *cp = cmd->module_cmd;
     RedisModuleCtx ctx;
     moduleCreateContext(&ctx, cp->module, REDISMODULE_CTX_KEYS_POS_REQUEST);
@@ -979,7 +979,7 @@ int moduleGetCommandKeysViaAPI(struct redisCommand *cmd, robj **argv, int argc, 
 /* This function returns the list of channels, with the same interface as
  * moduleGetCommandKeysViaAPI, for modules that declare "getchannels-api"
  * during registration. Unlike keys, this is the only way to declare channels. */
-int moduleGetCommandChannelsViaAPI(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result) {
+int moduleGetCommandChannelsViaAPI(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *result) {
     RedisModuleCommand *cp = cmd->module_cmd;
     RedisModuleCtx ctx;
     moduleCreateContext(&ctx, cp->module, REDISMODULE_CTX_CHANNELS_POS_REQUEST);
@@ -1301,7 +1301,7 @@ int RM_CreateCommand(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc c
  * Function will take the ownership of both 'declared_name' and 'fullname' SDS.
  */
 RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds declared_name, sds fullname, RedisModuleCmdFunc cmdfunc, int64_t flags, int firstkey, int lastkey, int keystep) {
-    struct redisCommand *rediscmd;
+    struct serverCommand *rediscmd;
     RedisModuleCommand *cp;
 
     /* Create a command "proxy", which is a structure that is referenced
@@ -1352,7 +1352,7 @@ RedisModuleCommand *moduleCreateCommandProxy(struct RedisModule *module, sds dec
  * * The command doesn't belong to the calling module
  */
 RedisModuleCommand *RM_GetCommand(RedisModuleCtx *ctx, const char *name) {
-    struct redisCommand *cmd = lookupCommandByCString(name);
+    struct serverCommand *cmd = lookupCommandByCString(name);
 
     if (!cmd || !(cmd->flags & CMD_MODULE))
         return NULL;
@@ -1399,7 +1399,7 @@ int RM_CreateSubcommand(RedisModuleCommand *parent, const char *name, RedisModul
     if ((flags & CMD_MODULE_NO_CLUSTER) && server.cluster_enabled)
         return REDISMODULE_ERR;
 
-    struct redisCommand *parent_cmd = parent->rediscmd;
+    struct serverCommand *parent_cmd = parent->rediscmd;
 
     if (parent_cmd->parent)
         return REDISMODULE_ERR; /* We don't allow more than one level of subcommands */
@@ -1553,7 +1553,7 @@ int RM_SetCommandACLCategories(RedisModuleCommand *command, const char *aclflags
     if (!command || !command->module || !command->module->onload) return REDISMODULE_ERR;
     int64_t categories_flags = aclflags ? categoryFlagsFromString((char*)aclflags) : 0;
     if (categories_flags == -1) return REDISMODULE_ERR;
-    struct redisCommand *rcmd = command->rediscmd;
+    struct serverCommand *rcmd = command->rediscmd;
     rcmd->acl_categories = categories_flags; /* ACL categories flags for module command */
     command->module->num_commands_with_acl_categories++;
     return REDISMODULE_OK;
@@ -1866,7 +1866,7 @@ int RM_SetCommandInfo(RedisModuleCommand *command, const RedisModuleCommandInfo 
         return REDISMODULE_ERR;
     }
 
-    struct redisCommand *cmd = command->rediscmd;
+    struct serverCommand *cmd = command->rediscmd;
 
     /* Check if any info has already been set. Overwriting info involves freeing
      * the old info, which is not implemented. */
@@ -2038,7 +2038,7 @@ static int moduleValidateCommandInfo(const RedisModuleCommandInfo *info) {
                 moduleCmdKeySpecAt(version, info->key_specs, j);
             if (j >= INT_MAX) {
                 serverLog(LL_WARNING, "Invalid command info: Too many key specs");
-                return 0; /* redisCommand.key_specs_num is an int. */
+                return 0; /* serverCommand.key_specs_num is an int. */
             }
 
             /* Flags. Exactly one flag in a group is set if and only if the
@@ -2256,7 +2256,7 @@ void *moduleGetHandleByName(char *modulename) {
 }
 
 /* Returns 1 if `cmd` is a command of the module `modulename`. 0 otherwise. */
-int moduleIsModuleCommand(void *module_handle, struct redisCommand *cmd) {
+int moduleIsModuleCommand(void *module_handle, struct serverCommand *cmd) {
     if (cmd->proc != RedisModuleCommandDispatcher)
         return 0;
     if (module_handle == NULL)
@@ -3578,7 +3578,7 @@ int RM_ReplyWithLongDouble(RedisModuleCtx *ctx, long double ld) {
  * The command returns REDISMODULE_ERR if the format specifiers are invalid
  * or the command name does not belong to a known command. */
 int RM_Replicate(RedisModuleCtx *ctx, const char *cmdname, const char *fmt, ...) {
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
     robj **argv = NULL;
     int argc = 0, flags = 0, j;
     va_list ap;
@@ -6773,7 +6773,7 @@ const char *moduleTypeModuleName(moduleType *mt) {
 }
 
 /* Return the module name from a module command */
-const char *moduleNameFromCommand(struct redisCommand *cmd) {
+const char *moduleNameFromCommand(struct serverCommand *cmd) {
     serverAssert(cmd->proc == RedisModuleCommandDispatcher);
 
     RedisModuleCommand *cp = cmd->module_cmd;
@@ -7528,7 +7528,7 @@ int RM_GetDbIdFromDigest(RedisModuleDigest *dig) {
  * handling is performed by Redis itself. */
 void RM_EmitAOF(RedisModuleIO *io, const char *cmdname, const char *fmt, ...) {
     if (io->error) return;
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
     robj **argv = NULL;
     int argc = 0, flags = 0, j;
     va_list ap;
@@ -9722,7 +9722,7 @@ RedisModuleUser *RM_GetModuleUserFromUserName(RedisModuleString *name) {
  */
 int RM_ACLCheckCommandPermissions(RedisModuleUser *user, RedisModuleString **argv, int argc) {
     int keyidxptr;
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
 
     /* Find command */
     if ((cmd = lookupCommand(argv, argc)) == NULL) {
@@ -12154,7 +12154,7 @@ void moduleFreeArgs(struct redisCommandArg *args, int num_args) {
  * Note that caller needs to handle the deletion of the command table dict,
  * and after that needs to free the command->fullname and the command itself.
  */
-int moduleFreeCommand(struct RedisModule *module, struct redisCommand *cmd) {
+int moduleFreeCommand(struct RedisModule *module, struct serverCommand *cmd) {
     if (cmd->proc != RedisModuleCommandDispatcher)
         return C_ERR;
 
@@ -12193,7 +12193,7 @@ int moduleFreeCommand(struct RedisModule *module, struct redisCommand *cmd) {
         dictEntry *de;
         dictIterator *di = dictGetSafeIterator(cmd->subcommands_dict);
         while ((de = dictNext(di)) != NULL) {
-            struct redisCommand *sub = dictGetVal(de);
+            struct serverCommand *sub = dictGetVal(de);
             if (moduleFreeCommand(module, sub) != C_OK) continue;
 
             serverAssert(dictDelete(cmd->subcommands_dict, sub->declared_name) == DICT_OK);
@@ -12213,7 +12213,7 @@ void moduleUnregisterCommands(struct RedisModule *module) {
     dictIterator *di = dictGetSafeIterator(server.commands);
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
-        struct redisCommand *cmd = dictGetVal(de);
+        struct serverCommand *cmd = dictGetVal(de);
         if (moduleFreeCommand(module, cmd) != C_OK) continue;
 
         serverAssert(dictDelete(server.commands, cmd->fullname) == DICT_OK);
@@ -13363,7 +13363,7 @@ int RM_ModuleTypeReplaceValue(RedisModuleKey *key, moduleType *mt, void *new_val
  */
 int *RM_GetCommandKeysWithFlags(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys, int **out_flags) {
     UNUSED(ctx);
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
     int *res = NULL;
 
     /* Find command */

--- a/src/module.c
+++ b/src/module.c
@@ -8703,7 +8703,7 @@ void moduleReleaseGIL(void) {
  * used to send anything to the client, and has the db number where the event
  * occurred as its selected db number.
  *
- * Notice that it is not necessary to enable notifications in redis.conf for
+ * Notice that it is not necessary to enable notifications in valkey.conf for
  * module notifications to work.
  *
  * Warning: the notification callbacks are performed in a synchronous manner,

--- a/src/multi.c
+++ b/src/multi.c
@@ -149,7 +149,7 @@ void execCommand(client *c) {
     int j;
     robj **orig_argv;
     int orig_argc, orig_argv_len;
-    struct redisCommand *orig_cmd;
+    struct serverCommand *orig_cmd;
 
     if (!(c->flags & CLIENT_MULTI)) {
         addReplyError(c,"EXEC without MULTI");

--- a/src/multi.c
+++ b/src/multi.c
@@ -390,7 +390,7 @@ void touchWatchedKey(serverDb *db, robj *key) {
     /* Check if we are already watching for this key */
     listRewind(clients,&li);
     while((ln = listNext(&li))) {
-        watchedKey *wk = redis_member2struct(watchedKey, node, ln);
+        watchedKey *wk = server_member2struct(watchedKey, node, ln);
         client *c = wk->client;
 
         if (wk->expired) {
@@ -443,7 +443,7 @@ void touchAllWatchedKeysInDb(serverDb *emptied, serverDb *replaced_with) {
             if (!clients) continue;
             listRewind(clients,&li);
             while((ln = listNext(&li))) {
-                watchedKey *wk = redis_member2struct(watchedKey, node, ln);
+                watchedKey *wk = server_member2struct(watchedKey, node, ln);
                 if (wk->expired) {
                     if (!replaced_with || !dbFind(replaced_with, key->ptr)) {
                         /* Expired key now deleted. No logical change. Clear the

--- a/src/networking.c
+++ b/src/networking.c
@@ -2075,7 +2075,7 @@ int handleClientsWithPendingWrites(void) {
 
 /* resetClient prepare the client to process the next command */
 void resetClient(client *c) {
-    redisCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
+    serverCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
 
     freeClientArgv(c);
     c->cur_script = NULL;

--- a/src/networking.c
+++ b/src/networking.c
@@ -385,7 +385,7 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
 /* The subscribe / unsubscribe command family has a push as a reply,
  * or in other words, it responds with a push (or several of them
  * depending on how many arguments it got), and has no reply. */
-int cmdHasPushAsReply(struct redisCommand *cmd) {
+int cmdHasPushAsReply(struct serverCommand *cmd) {
     if (!cmd) return 0;
     return cmd->proc == subscribeCommand  || cmd->proc == unsubscribeCommand ||
            cmd->proc == psubscribeCommand || cmd->proc == punsubscribeCommand ||

--- a/src/rio.h
+++ b/src/rio.h
@@ -175,8 +175,8 @@ size_t rioWriteBulkString(rio *r, const char *buf, size_t len);
 size_t rioWriteBulkLongLong(rio *r, long long l);
 size_t rioWriteBulkDouble(rio *r, double d);
 
-struct redisObject;
-int rioWriteBulkObject(rio *r, struct redisObject *obj);
+struct serverObject;
+int rioWriteBulkObject(rio *r, struct serverObject *obj);
 
 void rioGenericUpdateChecksum(rio *r, const void *buf, size_t len);
 void rioSetAutoSync(rio *r, off_t bytes);

--- a/src/script.c
+++ b/src/script.c
@@ -319,7 +319,7 @@ void scriptKill(client *c, int is_eval) {
     addReply(c, shared.ok);
 }
 
-static int scriptVerifyCommandArity(struct redisCommand *cmd, int argc, sds *err) {
+static int scriptVerifyCommandArity(struct serverCommand *cmd, int argc, sds *err) {
     if (!cmd || ((cmd->arity > 0 && cmd->arity != argc) || (argc < -cmd->arity))) {
         if (cmd)
             *err = sdsnew("Wrong number of args calling Redis command from script");
@@ -541,7 +541,7 @@ void scriptCall(scriptRunCtx *run_ctx, sds *err) {
     /* Process module hooks */
     moduleCallCommandFilters(c);
 
-    struct redisCommand *cmd = lookupCommand(c->argv, c->argc);
+    struct serverCommand *cmd = lookupCommand(c->argv, c->argc);
     c->cmd = c->lastcmd = c->realcmd = cmd;
     if (scriptVerifyCommandArity(cmd, c->argc, err) != C_OK) {
         goto error;

--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1143,7 +1143,7 @@ static int luaRedisAclCheckCmdPermissionsCommand(lua_State *lua) {
     if (argv == NULL) return luaError(lua);
 
     /* Find command */
-    struct redisCommand *cmd;
+    struct serverCommand *cmd;
     if ((cmd = lookupCommand(argv, argc)) == NULL) {
         luaPushError(lua, "Invalid command passed to redis.acl_check_cmd()");
         raise_error = 1;

--- a/src/server.c
+++ b/src/server.c
@@ -4246,11 +4246,11 @@ void incrementErrorCount(const char *fullerr, size_t namelen) {
             return;
         }
 
-        struct redisError *error = zmalloc(sizeof(*error));
+        struct serverError *error = zmalloc(sizeof(*error));
         error->count = 1;
         raxInsert(server.errors,(unsigned char*)fullerr,namelen,error,NULL);
     } else {
-        struct redisError *error = result;
+        struct serverError *error = result;
         error->count++;
     }
 }
@@ -6071,10 +6071,10 @@ sds genRedisInfoString(dict *section_dict, int all_sections, int everything) {
         raxIterator ri;
         raxStart(&ri,server.errors);
         raxSeek(&ri,"^",NULL,0);
-        struct redisError *e;
+        struct serverError *e;
         while(raxNext(&ri)) {
             char *tmpsafe;
-            e = (struct redisError *) ri.data;
+            e = (struct serverError *) ri.data;
             info = sdscatprintf(info,
                 "errorstat_%.*s:count=%lld\r\n",
                 (int)ri.key_len, getSafeInfoString((char *) ri.key, ri.key_len, &tmpsafe), e->count);

--- a/src/server.c
+++ b/src/server.c
@@ -2142,7 +2142,7 @@ void initServerConfig(void) {
 
     /* Command table -- we initialize it here as it is part of the
      * initial configuration, since command names may be changed via
-     * redis.conf using the rename-command directive. */
+     * valkey.conf using the rename-command directive. */
     server.commands = dictCreate(&commandTableDictType);
     server.orig_commands = dictCreate(&commandTableDictType);
     populateCommandTable();
@@ -3081,7 +3081,7 @@ void populateCommandTable(void) {
 
         retval1 = dictAdd(server.commands, sdsdup(c->fullname), c);
         /* Populate an additional dictionary that will be unaffected
-         * by rename-command statements in redis.conf. */
+         * by rename-command statements in valkey.conf. */
         retval2 = dictAdd(server.orig_commands, sdsdup(c->fullname), c);
         serverAssert(retval1 == DICT_OK && retval2 == DICT_OK);
     }
@@ -3236,7 +3236,7 @@ struct serverCommand *lookupCommandByCString(const char *s) {
 
 /* Lookup the command in the current table, if not found also check in
  * the original table containing the original command names unaffected by
- * redis.conf rename-command statement.
+ * valkey.conf rename-command statement.
  *
  * This is used by functions rewriting the argument vector such as
  * rewriteClientCommandVector() in order to set client->cmd pointer
@@ -6275,7 +6275,7 @@ sds getVersion(void) {
 }
 
 void usage(void) {
-    fprintf(stderr,"Usage: ./redis-server [/path/to/redis.conf] [options] [-]\n");
+    fprintf(stderr,"Usage: ./redis-server [/path/to/valkey.conf] [options] [-]\n");
     fprintf(stderr,"       ./redis-server - (read config from stdin)\n");
     fprintf(stderr,"       ./redis-server -v or --version\n");
     fprintf(stderr,"       ./redis-server -h or --help\n");
@@ -6285,11 +6285,11 @@ void usage(void) {
     fprintf(stderr,"Examples:\n");
     fprintf(stderr,"       ./redis-server (run the server with default conf)\n");
     fprintf(stderr,"       echo 'maxmemory 128mb' | ./redis-server -\n");
-    fprintf(stderr,"       ./redis-server /etc/redis/6379.conf\n");
+    fprintf(stderr,"       ./redis-server /etc/valkey/6379.conf\n");
     fprintf(stderr,"       ./redis-server --port 7777\n");
     fprintf(stderr,"       ./redis-server --port 7777 --replicaof 127.0.0.1 8888\n");
-    fprintf(stderr,"       ./redis-server /etc/myredis.conf --loglevel verbose -\n");
-    fprintf(stderr,"       ./redis-server /etc/myredis.conf --loglevel verbose\n\n");
+    fprintf(stderr,"       ./redis-server /etc/myvalkey.conf --loglevel verbose -\n");
+    fprintf(stderr,"       ./redis-server /etc/myvalkey.conf --loglevel verbose\n\n");
     fprintf(stderr,"Sentinel mode:\n");
     fprintf(stderr,"       ./redis-server /etc/sentinel.conf --sentinel\n");
     exit(1);
@@ -6306,7 +6306,7 @@ void redisAsciiArt(void) {
 
     /* Show the ASCII logo if: log file is stdout AND stdout is a
      * tty AND syslog logging is disabled. Also show logo if the user
-     * forced us to do so via redis.conf. */
+     * forced us to do so via valkey.conf. */
     int show_logo = ((!server.syslog_enabled &&
                       server.logfile[0] == '\0' &&
                       isatty(fileno(stdout))) ||
@@ -6700,7 +6700,7 @@ void redisOutOfMemoryHandler(size_t allocation_size) {
         allocation_size);
 }
 
-/* Callback for sdstemplate on proc-title-template. See redis.conf for
+/* Callback for sdstemplate on proc-title-template. See valkey.conf for
  * supported variables.
  */
 static sds redisProcTitleGetVariable(const sds varname, void *arg)

--- a/src/server.c
+++ b/src/server.c
@@ -2906,7 +2906,7 @@ void InitServerLast(void) {
  * because anyway the legacy (first,last,step) spec is to be deprecated
  * and one should use the new key specs scheme.
  */
-void populateCommandLegacyRangeSpec(struct redisCommand *c) {
+void populateCommandLegacyRangeSpec(struct serverCommand *c) {
     memset(&c->legacy_range_key_spec, 0, sizeof(c->legacy_range_key_spec));
 
     /* Set the movablekeys flag if we have a GETKEYS flag for modules.
@@ -2985,7 +2985,7 @@ sds catSubCommandFullname(const char *parent_name, const char *sub_name) {
     return sdscatfmt(sdsempty(), "%s|%s", parent_name, sub_name);
 }
 
-void commandAddSubcommand(struct redisCommand *parent, struct redisCommand *subcommand, const char *declared_name) {
+void commandAddSubcommand(struct serverCommand *parent, struct serverCommand *subcommand, const char *declared_name) {
     if (!parent->subcommands_dict)
         parent->subcommands_dict = dictCreate(&commandTableDictType);
 
@@ -2996,8 +2996,8 @@ void commandAddSubcommand(struct redisCommand *parent, struct redisCommand *subc
 }
 
 /* Set implicit ACl categories (see comment above the definition of
- * struct redisCommand). */
-void setImplicitACLCategories(struct redisCommand *c) {
+ * struct serverCommand). */
+void setImplicitACLCategories(struct serverCommand *c) {
     if (c->flags & CMD_WRITE)
         c->acl_categories |= ACL_CATEGORY_WRITE;
     /* Exclude scripting commands from the RO category. */
@@ -3021,7 +3021,7 @@ void setImplicitACLCategories(struct redisCommand *c) {
  *
  * On success, the function return C_OK. Otherwise C_ERR is returned and we won't
  * add this command in the commands dict. */
-int populateCommandStructure(struct redisCommand *c) {
+int populateCommandStructure(struct serverCommand *c) {
     /* If the command marks with CMD_SENTINEL, it exists in sentinel. */
     if (!(c->flags & CMD_SENTINEL) && server.sentinel_mode)
         return C_ERR;
@@ -3047,7 +3047,7 @@ int populateCommandStructure(struct redisCommand *c) {
     /* Handle subcommands */
     if (c->subcommands) {
         for (int j = 0; c->subcommands[j].declared_name; j++) {
-            struct redisCommand *sub = c->subcommands+j;
+            struct serverCommand *sub = c->subcommands+j;
 
             sub->fullname = catSubCommandFullname(c->declared_name, sub->declared_name);
             if (populateCommandStructure(sub) == C_ERR)
@@ -3060,13 +3060,13 @@ int populateCommandStructure(struct redisCommand *c) {
     return C_OK;
 }
 
-extern struct redisCommand redisCommandTable[];
+extern struct serverCommand redisCommandTable[];
 
 /* Populates the Redis Command Table dict from the static table in commands.c
  * which is auto generated from the json files in the commands folder. */
 void populateCommandTable(void) {
     int j;
-    struct redisCommand *c;
+    struct serverCommand *c;
 
     for (j = 0;; j++) {
         c = redisCommandTable + j;
@@ -3088,13 +3088,13 @@ void populateCommandTable(void) {
 }
 
 void resetCommandTableStats(dict* commands) {
-    struct redisCommand *c;
+    struct serverCommand *c;
     dictEntry *de;
     dictIterator *di;
 
     di = dictGetSafeIterator(commands);
     while((de = dictNext(di)) != NULL) {
-        c = (struct redisCommand *) dictGetVal(de);
+        c = (struct serverCommand *) dictGetVal(de);
         c->microseconds = 0;
         c->calls = 0;
         c->rejected_calls = 0;
@@ -3156,12 +3156,12 @@ void serverOpArrayFree(serverOpArray *oa) {
 /* ====================== Commands lookup and execution ===================== */
 
 int isContainerCommandBySds(sds s) {
-    struct redisCommand *base_cmd = dictFetchValue(server.commands, s);
+    struct serverCommand *base_cmd = dictFetchValue(server.commands, s);
     int has_subcommands = base_cmd && base_cmd->subcommands_dict;
     return has_subcommands;
 }
 
-struct redisCommand *lookupSubcommand(struct redisCommand *container, sds sub_name) {
+struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_name) {
     return dictFetchValue(container->subcommands_dict, sub_name);
 }
 
@@ -3173,8 +3173,8 @@ struct redisCommand *lookupSubcommand(struct redisCommand *container, sds sub_na
  * name (e.g. in COMMAND INFO) rather than to find the command
  * a user requested to execute (in processCommand).
  */
-struct redisCommand *lookupCommandLogic(dict *commands, robj **argv, int argc, int strict) {
-    struct redisCommand *base_cmd = dictFetchValue(commands, argv[0]->ptr);
+struct serverCommand *lookupCommandLogic(dict *commands, robj **argv, int argc, int strict) {
+    struct serverCommand *base_cmd = dictFetchValue(commands, argv[0]->ptr);
     int has_subcommands = base_cmd && base_cmd->subcommands_dict;
     if (argc == 1 || !has_subcommands) {
         if (strict && argc != 1)
@@ -3189,11 +3189,11 @@ struct redisCommand *lookupCommandLogic(dict *commands, robj **argv, int argc, i
     }
 }
 
-struct redisCommand *lookupCommand(robj **argv, int argc) {
+struct serverCommand *lookupCommand(robj **argv, int argc) {
     return lookupCommandLogic(server.commands,argv,argc,0);
 }
 
-struct redisCommand *lookupCommandBySdsLogic(dict *commands, sds s) {
+struct serverCommand *lookupCommandBySdsLogic(dict *commands, sds s) {
     int argc, j;
     sds *strings = sdssplitlen(s,sdslen(s),"|",1,&argc);
     if (strings == NULL)
@@ -3212,17 +3212,17 @@ struct redisCommand *lookupCommandBySdsLogic(dict *commands, sds s) {
         argv[j] = &objects[j];
     }
 
-    struct redisCommand *cmd = lookupCommandLogic(commands,argv,argc,1);
+    struct serverCommand *cmd = lookupCommandLogic(commands,argv,argc,1);
     sdsfreesplitres(strings,argc);
     return cmd;
 }
 
-struct redisCommand *lookupCommandBySds(sds s) {
+struct serverCommand *lookupCommandBySds(sds s) {
     return lookupCommandBySdsLogic(server.commands,s);
 }
 
-struct redisCommand *lookupCommandByCStringLogic(dict *commands, const char *s) {
-    struct redisCommand *cmd;
+struct serverCommand *lookupCommandByCStringLogic(dict *commands, const char *s) {
+    struct serverCommand *cmd;
     sds name = sdsnew(s);
 
     cmd = lookupCommandBySdsLogic(commands,name);
@@ -3230,7 +3230,7 @@ struct redisCommand *lookupCommandByCStringLogic(dict *commands, const char *s) 
     return cmd;
 }
 
-struct redisCommand *lookupCommandByCString(const char *s) {
+struct serverCommand *lookupCommandByCString(const char *s) {
     return lookupCommandByCStringLogic(server.commands,s);
 }
 
@@ -3241,8 +3241,8 @@ struct redisCommand *lookupCommandByCString(const char *s) {
  * This is used by functions rewriting the argument vector such as
  * rewriteClientCommandVector() in order to set client->cmd pointer
  * correctly even if the command was renamed. */
-struct redisCommand *lookupCommandOrOriginal(robj **argv ,int argc) {
-    struct redisCommand *cmd = lookupCommandLogic(server.commands, argv, argc, 0);
+struct serverCommand *lookupCommandOrOriginal(robj **argv ,int argc) {
+    struct serverCommand *cmd = lookupCommandLogic(server.commands, argv, argc, 0);
 
     if (!cmd) cmd = lookupCommandLogic(server.orig_commands, argv, argc, 0);
     return cmd;
@@ -3352,7 +3352,7 @@ void preventCommandReplication(client *c) {
 }
 
 /* Log the last command a client executed into the slowlog. */
-void slowlogPushCurrentCommand(client *c, struct redisCommand *cmd, ustime_t duration) {
+void slowlogPushCurrentCommand(client *c, struct serverCommand *cmd, ustime_t duration) {
     /* Some commands may contain sensitive data that should not be available in the slowlog. */
     if (cmd->flags & CMD_SKIP_SLOWLOG)
         return;
@@ -3459,7 +3459,7 @@ void postExecutionUnitOperations(void) {
  * twice, its possible to pass a NULL cmd value to indicate that the error was counted elsewhere.
  *
  * The function returns true if stats was updated and false if not. */
-int incrCommandStatsOnError(struct redisCommand *cmd, int flags) {
+int incrCommandStatsOnError(struct serverCommand *cmd, int flags) {
     /* hold the prev error count captured on the last command execution */
     static long long prev_err_count = 0;
     int res = 0;
@@ -3516,7 +3516,7 @@ int incrCommandStatsOnError(struct redisCommand *cmd, int flags) {
 void call(client *c, int flags) {
     long long dirty;
     uint64_t client_old_flags = c->flags;
-    struct redisCommand *real_cmd = c->realcmd;
+    struct serverCommand *real_cmd = c->realcmd;
     client *prev_client = server.executing_client;
     server.executing_client = c;
 
@@ -4640,7 +4640,7 @@ void addReplyCommandFlags(client *c, uint64_t flags, replyFlagNames *replyFlags)
     }
 }
 
-void addReplyFlagsForCommand(client *c, struct redisCommand *cmd) {
+void addReplyFlagsForCommand(client *c, struct serverCommand *cmd) {
     replyFlagNames flagNames[] = {
         {CMD_WRITE,             "write"},
         {CMD_READONLY,          "readonly"},
@@ -4672,7 +4672,7 @@ void addReplyFlagsForCommand(client *c, struct redisCommand *cmd) {
     addReplyCommandFlags(c, cmd->flags, flagNames);
 }
 
-void addReplyDocFlagsForCommand(client *c, struct redisCommand *cmd) {
+void addReplyDocFlagsForCommand(client *c, struct serverCommand *cmd) {
     replyFlagNames docFlagNames[] = {
         {CMD_DOC_DEPRECATED,         "deprecated"},
         {CMD_DOC_SYSCMD,             "syscmd"},
@@ -4818,7 +4818,7 @@ void addReplyJson(client *c, struct jsonObject *rs) {
 
 #endif
 
-void addReplyCommandHistory(client *c, struct redisCommand *cmd) {
+void addReplyCommandHistory(client *c, struct serverCommand *cmd) {
     addReplySetLen(c, cmd->num_history);
     for (int j = 0; j<cmd->num_history; j++) {
         addReplyArrayLen(c, 2);
@@ -4827,14 +4827,14 @@ void addReplyCommandHistory(client *c, struct redisCommand *cmd) {
     }
 }
 
-void addReplyCommandTips(client *c, struct redisCommand *cmd) {
+void addReplyCommandTips(client *c, struct serverCommand *cmd) {
     addReplySetLen(c, cmd->num_tips);
     for (int j = 0; j<cmd->num_tips; j++) {
         addReplyBulkCString(c, cmd->tips[j]);
     }
 }
 
-void addReplyCommandKeySpecs(client *c, struct redisCommand *cmd) {
+void addReplyCommandKeySpecs(client *c, struct serverCommand *cmd) {
     addReplySetLen(c, cmd->key_specs_num);
     for (int i = 0; i < cmd->key_specs_num; i++) {
         int maplen = 3;
@@ -4931,7 +4931,7 @@ void addReplyCommandKeySpecs(client *c, struct redisCommand *cmd) {
 }
 
 /* Reply with an array of sub-command using the provided reply callback. */
-void addReplyCommandSubCommands(client *c, struct redisCommand *cmd, void (*reply_function)(client*, struct redisCommand*), int use_map) {
+void addReplyCommandSubCommands(client *c, struct serverCommand *cmd, void (*reply_function)(client*, struct serverCommand*), int use_map) {
     if (!cmd->subcommands_dict) {
         addReplySetLen(c, 0);
         return;
@@ -4944,7 +4944,7 @@ void addReplyCommandSubCommands(client *c, struct redisCommand *cmd, void (*repl
     dictEntry *de;
     dictIterator *di = dictGetSafeIterator(cmd->subcommands_dict);
     while((de = dictNext(di)) != NULL) {
-        struct redisCommand *sub = (struct redisCommand *)dictGetVal(de);
+        struct serverCommand *sub = (struct serverCommand *)dictGetVal(de);
         if (use_map)
             addReplyBulkCBuffer(c, sub->fullname, sdslen(sub->fullname));
         reply_function(c, sub);
@@ -4953,7 +4953,7 @@ void addReplyCommandSubCommands(client *c, struct redisCommand *cmd, void (*repl
 }
 
 /* Output the representation of a Redis command. Used by the COMMAND command and COMMAND INFO. */
-void addReplyCommandInfo(client *c, struct redisCommand *cmd) {
+void addReplyCommandInfo(client *c, struct serverCommand *cmd) {
     if (!cmd) {
         addReplyNull(c);
     } else {
@@ -4981,7 +4981,7 @@ void addReplyCommandInfo(client *c, struct redisCommand *cmd) {
 }
 
 /* Output the representation of a Redis command. Used by the COMMAND DOCS. */
-void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
+void addReplyCommandDocs(client *c, struct serverCommand *cmd) {
     /* Count our reply len so we don't have to use deferred reply. */
     long maplen = 1;
     if (cmd->summary) maplen++;
@@ -5054,7 +5054,7 @@ void addReplyCommandDocs(client *c, struct redisCommand *cmd) {
 
 /* Helper for COMMAND GETKEYS and GETKEYSANDFLAGS */
 void getKeysSubcommandImpl(client *c, int with_flags) {
-    struct redisCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
+    struct serverCommand *cmd = lookupCommand(c->argv+2,c->argc-2);
     getKeysResult result = GETKEYS_RESULT_INIT;
     int j;
 
@@ -5138,7 +5138,7 @@ typedef struct {
     } cache;
 } commandListFilter;
 
-int shouldFilterFromCommandList(struct redisCommand *cmd, commandListFilter *filter) {
+int shouldFilterFromCommandList(struct serverCommand *cmd, commandListFilter *filter) {
     switch (filter->type) {
         case (COMMAND_LIST_FILTER_MODULE):
             if (!filter->cache.valid) {
@@ -5170,7 +5170,7 @@ void commandListWithFilter(client *c, dict *commands, commandListFilter filter, 
     dictIterator *di = dictGetIterator(commands);
 
     while ((de = dictNext(di)) != NULL) {
-        struct redisCommand *cmd = dictGetVal(de);
+        struct serverCommand *cmd = dictGetVal(de);
         if (!shouldFilterFromCommandList(cmd,&filter)) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             (*numcmds)++;
@@ -5189,7 +5189,7 @@ void commandListWithoutFilter(client *c, dict *commands, int *numcmds) {
     dictIterator *di = dictGetIterator(commands);
 
     while ((de = dictNext(di)) != NULL) {
-        struct redisCommand *cmd = dictGetVal(de);
+        struct serverCommand *cmd = dictGetVal(de);
         addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
         (*numcmds)++;
 
@@ -5273,7 +5273,7 @@ void commandDocsCommand(client *c) {
         addReplyMapLen(c, dictSize(server.commands));
         di = dictGetIterator(server.commands);
         while ((de = dictNext(di)) != NULL) {
-            struct redisCommand *cmd = dictGetVal(de);
+            struct serverCommand *cmd = dictGetVal(de);
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             addReplyCommandDocs(c, cmd);
         }
@@ -5283,7 +5283,7 @@ void commandDocsCommand(client *c) {
         int numcmds = 0;
         void *replylen = addReplyDeferredLen(c);
         for (i = 2; i < c->argc; i++) {
-            struct redisCommand *cmd = lookupCommandBySds(c->argv[i]->ptr);
+            struct serverCommand *cmd = lookupCommandBySds(c->argv[i]->ptr);
             if (!cmd)
                 continue;
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
@@ -5405,13 +5405,13 @@ const char *getSafeInfoString(const char *s, size_t len, char **tmp) {
 }
 
 sds genRedisInfoStringCommandStats(sds info, dict *commands) {
-    struct redisCommand *c;
+    struct serverCommand *c;
     dictEntry *de;
     dictIterator *di;
     di = dictGetSafeIterator(commands);
     while((de = dictNext(di)) != NULL) {
         char *tmpsafe;
-        c = (struct redisCommand *) dictGetVal(de);
+        c = (struct serverCommand *) dictGetVal(de);
         if (c->calls || c->failed_calls || c->rejected_calls) {
             info = sdscatprintf(info,
                 "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
@@ -5445,13 +5445,13 @@ sds genRedisInfoStringACLStats(sds info) {
 }
 
 sds genRedisInfoStringLatencyStats(sds info, dict *commands) {
-    struct redisCommand *c;
+    struct serverCommand *c;
     dictEntry *de;
     dictIterator *di;
     di = dictGetSafeIterator(commands);
     while((de = dictNext(di)) != NULL) {
         char *tmpsafe;
-        c = (struct redisCommand *) dictGetVal(de);
+        c = (struct serverCommand *) dictGetVal(de);
         if (c->latency_histogram) {
             info = fillPercentileDistributionLatencies(info,
                 getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe),

--- a/src/server.c
+++ b/src/server.c
@@ -3117,7 +3117,7 @@ void resetErrorTableStats(void) {
 
 /* ========================== Redis OP Array API ============================ */
 
-int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target) {
+int serverOpArrayAppend(serverOpArray *oa, int dbid, robj **argv, int argc, int target) {
     redisOp *op;
     int prev_capacity = oa->capacity;
 
@@ -3138,7 +3138,7 @@ int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int ta
     return oa->numops;
 }
 
-void redisOpArrayFree(redisOpArray *oa) {
+void serverOpArrayFree(serverOpArray *oa) {
     while(oa->numops) {
         int j;
         redisOp *op;
@@ -3322,7 +3322,7 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target) {
         argvcopy[j] = argv[j];
         incrRefCount(argv[j]);
     }
-    redisOpArrayAppend(&server.also_propagate,dbid,argvcopy,argc,target);
+    serverOpArrayAppend(&server.also_propagate,dbid,argvcopy,argc,target);
 }
 
 /* It is possible to call the function forceCommandPropagation() inside a
@@ -3419,7 +3419,7 @@ static void propagatePendingCommands(void) {
         propagateNow(-1,&shared.exec,1,PROPAGATE_AOF|PROPAGATE_REPL);
     }
 
-    redisOpArrayFree(&server.also_propagate);
+    serverOpArrayFree(&server.also_propagate);
 }
 
 /* Performs operations that should be performed after an execution unit ends.

--- a/src/server.h
+++ b/src/server.h
@@ -81,7 +81,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #include "connection.h" /* Connection abstraction */
 
 #define REDISMODULE_CORE 1
-typedef struct redisObject robj;
+typedef struct serverObject robj;
 #include "redismodule.h"    /* Redis modules API defines. */
 
 /* Following includes allow test functions to be called from Redis main() */
@@ -750,14 +750,14 @@ typedef void *(*moduleTypeLoadFunc)(struct RedisModuleIO *io, int encver);
 typedef void (*moduleTypeSaveFunc)(struct RedisModuleIO *io, void *value);
 typedef int (*moduleTypeAuxLoadFunc)(struct RedisModuleIO *rdb, int encver, int when);
 typedef void (*moduleTypeAuxSaveFunc)(struct RedisModuleIO *rdb, int when);
-typedef void (*moduleTypeRewriteFunc)(struct RedisModuleIO *io, struct redisObject *key, void *value);
+typedef void (*moduleTypeRewriteFunc)(struct RedisModuleIO *io, struct serverObject *key, void *value);
 typedef void (*moduleTypeDigestFunc)(struct RedisModuleDigest *digest, void *value);
 typedef size_t (*moduleTypeMemUsageFunc)(const void *value);
 typedef void (*moduleTypeFreeFunc)(void *value);
-typedef size_t (*moduleTypeFreeEffortFunc)(struct redisObject *key, const void *value);
-typedef void (*moduleTypeUnlinkFunc)(struct redisObject *key, void *value);
-typedef void *(*moduleTypeCopyFunc)(struct redisObject *fromkey, struct redisObject *tokey, const void *value);
-typedef int (*moduleTypeDefragFunc)(struct RedisModuleDefragCtx *ctx, struct redisObject *key, void **value);
+typedef size_t (*moduleTypeFreeEffortFunc)(struct serverObject *key, const void *value);
+typedef void (*moduleTypeUnlinkFunc)(struct serverObject *key, void *value);
+typedef void *(*moduleTypeCopyFunc)(struct serverObject *fromkey, struct serverObject *tokey, const void *value);
+typedef int (*moduleTypeDefragFunc)(struct RedisModuleDefragCtx *ctx, struct serverObject *key, void **value);
 typedef size_t (*moduleTypeMemUsageFunc2)(struct RedisModuleKeyOptCtx *ctx, const void *value, size_t sample_size);
 typedef void (*moduleTypeFreeFunc2)(struct RedisModuleKeyOptCtx *ctx, void *value);
 typedef size_t (*moduleTypeFreeEffortFunc2)(struct RedisModuleKeyOptCtx *ctx, const void *value);
@@ -846,7 +846,7 @@ struct RedisModuleIO {
     moduleType *type;   /* Module type doing the operation. */
     int error;          /* True if error condition happened. */
     struct RedisModuleCtx *ctx; /* Optional context, see RM_GetContextFromIO()*/
-    struct redisObject *key;    /* Optional name of key processed */
+    struct serverObject *key;    /* Optional name of key processed */
     int dbid;            /* The dbid of the key being processed, -1 when unknown. */
     sds pre_flush_buffer; /* A buffer that should be flushed before next write operation
                            * See rdbSaveSingleModuleAux for more details */
@@ -873,7 +873,7 @@ struct RedisModuleIO {
 struct RedisModuleDigest {
     unsigned char o[20];    /* Ordered elements. */
     unsigned char x[20];    /* Xored elements. */
-    struct redisObject *key; /* Optional name of key processed */
+    struct serverObject *key; /* Optional name of key processed */
     int dbid;                /* The dbid of the key being processed */
 };
 
@@ -909,7 +909,7 @@ struct RedisModuleDigest {
 #define OBJ_SHARED_REFCOUNT INT_MAX     /* Global object never destroyed. */
 #define OBJ_STATIC_REFCOUNT (INT_MAX-1) /* Object allocated in the stack. */
 #define OBJ_FIRST_SPECIAL_REFCOUNT OBJ_STATIC_REFCOUNT
-struct redisObject {
+struct serverObject {
     unsigned type:4;
     unsigned encoding:4;
     unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or

--- a/src/server.h
+++ b/src/server.h
@@ -1385,14 +1385,14 @@ typedef struct redisOp {
 /* Defines an array of Redis operations. There is an API to add to this
  * structure in an easy way.
  *
- * int redisOpArrayAppend(redisOpArray *oa, int dbid, robj **argv, int argc, int target);
- * void redisOpArrayFree(redisOpArray *oa);
+ * int serverOpArrayAppend(serverOpArray *oa, int dbid, robj **argv, int argc, int target);
+ * void serverOpArrayFree(serverOpArray *oa);
  */
-typedef struct redisOpArray {
+typedef struct serverOpArray {
     redisOp *ops;
     int numops;
     int capacity;
-} redisOpArray;
+} serverOpArray;
 
 /* This structure is returned by the getMemoryOverheadData() function in
  * order to return memory overhead information. */
@@ -1844,7 +1844,7 @@ struct redisServer {
     int child_info_pipe[2];         /* Pipe used to write the child_info_data. */
     int child_info_nread;           /* Num of bytes of the last read from pipe */
     /* Propagation of commands in AOF / replication */
-    redisOpArray also_propagate;    /* Additional command to propagate. */
+    serverOpArray also_propagate;    /* Additional command to propagate. */
     int replication_allowed;        /* Are we allowed to replicate? */
     /* Logging */
     char *logfile;                  /* Path of log file */
@@ -3065,7 +3065,7 @@ int incrCommandStatsOnError(struct redisCommand *cmd, int flags);
 void call(client *c, int flags);
 void alsoPropagate(int dbid, robj **argv, int argc, int target);
 void postExecutionUnitOperations(void);
-void redisOpArrayFree(redisOpArray *oa);
+void serverOpArrayFree(serverOpArray *oa);
 void forceCommandPropagation(client *c, int flags);
 void preventCommandPropagation(client *c);
 void preventCommandAOF(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -1475,7 +1475,7 @@ struct malloc_stats {
  * TLS Context Configuration
  *----------------------------------------------------------------------------*/
 
-typedef struct redisTLSContextConfig {
+typedef struct serverTLSContextConfig {
     char *cert_file;                /* Server side and optionally client side cert file name */
     char *key_file;                 /* Private key filename for cert_file */
     char *key_file_pass;            /* Optional password for key_file */
@@ -1492,7 +1492,7 @@ typedef struct redisTLSContextConfig {
     int session_caching;
     int session_cache_size;
     int session_cache_timeout;
-} redisTLSContextConfig;
+} serverTLSContextConfig;
 
 /*-----------------------------------------------------------------------------
  * AOF manifest definition
@@ -2050,7 +2050,7 @@ struct redisServer {
     int tls_cluster;
     int tls_replication;
     int tls_auth_clients;
-    redisTLSContextConfig tls_ctx_config;
+    serverTLSContextConfig tls_ctx_config;
     /* cpu affinity */
     char *server_cpulist; /* cpu affinity list of redis server main/io thread. */
     char *bio_cpulist; /* cpu affinity list of bio thread. */

--- a/src/server.h
+++ b/src/server.h
@@ -1734,7 +1734,7 @@ struct redisServer {
     durationStats duration_stats[EL_DURATION_TYPE_NUM];
 
     /* Configuration */
-    int verbosity;                  /* Loglevel in redis.conf */
+    int verbosity;                  /* Loglevel verbosity */
     int maxidletime;                /* Client timeout in seconds */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
@@ -2314,7 +2314,7 @@ typedef int serverGetKeysProc(struct serverCommand *cmd, robj **argv, int argc, 
  *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
- * See redis.conf for the exact meaning of each.
+ * See valkey.conf for the exact meaning of each.
  *
  * @keyspace, @read, @write, @set, @sortedset, @list, @hash, @string, @bitmap,
  * @hyperloglog, @stream, @admin, @fast, @slow, @pubsub, @blocking, @dangerous,

--- a/src/server.h
+++ b/src/server.h
@@ -2386,7 +2386,7 @@ struct serverCommand {
     struct RedisModuleCommand *module_cmd; /* A pointer to the module command data (NULL if native command) */
 };
 
-struct redisError {
+struct serverError {
     long long count;
 };
 

--- a/src/server.h
+++ b/src/server.h
@@ -103,7 +103,7 @@ struct hdr_histogram;
 #define max(a, b) ((a) > (b) ? (a) : (b))
 
 /* Get the pointer of the outer struct from a member address */
-#define redis_member2struct(struct_name, member_name, member_addr) \
+#define server_member2struct(struct_name, member_name, member_addr) \
             ((struct_name *)((char*)member_addr - offsetof(struct_name, member_name)))
 
 /* Error codes */

--- a/src/server.h
+++ b/src/server.h
@@ -2235,7 +2235,7 @@ typedef enum {
     COMMAND_GROUP_STREAM,
     COMMAND_GROUP_BITMAP,
     COMMAND_GROUP_MODULE,
-} redisCommandGroup;
+} serverCommandGroup;
 
 typedef void redisCommandProc(client *c);
 typedef int redisGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
@@ -2343,7 +2343,7 @@ struct redisCommand {
     int doc_flags; /* Flags for documentation (see CMD_DOC_*). */
     const char *replaced_by; /* In case the command is deprecated, this is the successor command. */
     const char *deprecated_since; /* In case the command is deprecated, when did it happen? */
-    redisCommandGroup group; /* Command group */
+    serverCommandGroup group; /* Command group */
     commandHistory *history; /* History of the command */
     int num_history;
     const char **tips; /* An array of strings that are meant to be tips for clients/proxies regarding this command */

--- a/src/server.h
+++ b/src/server.h
@@ -2237,8 +2237,8 @@ typedef enum {
     COMMAND_GROUP_MODULE,
 } serverCommandGroup;
 
-typedef void redisCommandProc(client *c);
-typedef int redisGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+typedef void serverCommandProc(client *c);
+typedef int serverGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 /* Redis command structure.
  *
@@ -2348,7 +2348,7 @@ struct redisCommand {
     int num_history;
     const char **tips; /* An array of strings that are meant to be tips for clients/proxies regarding this command */
     int num_tips;
-    redisCommandProc *proc; /* Command implementation */
+    serverCommandProc *proc; /* Command implementation */
     int arity; /* Number of arguments, it is possible to use -N to say >= N */
     uint64_t flags; /* Command flags, see CMD_*. */
     uint64_t acl_categories; /* ACl categories, see ACL_CATEGORY_*. */
@@ -2356,7 +2356,7 @@ struct redisCommand {
     int key_specs_num;
     /* Use a function to determine keys arguments in a command line.
      * Used for Redis Cluster redirect (may be NULL) */
-    redisGetKeysProc *getkeys_proc;
+    serverGetKeysProc *getkeys_proc;
     int num_args; /* Length of args array. */
     /* Array of subcommands (may be NULL) */
     struct redisCommand *subcommands;

--- a/src/tls.c
+++ b/src/tls.c
@@ -203,7 +203,7 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
 /* Create a *base* SSL_CTX using the SSL configuration provided. The base context
  * includes everything that's common for both client-side and server-side connections.
  */
-static SSL_CTX *createSSLContext(redisTLSContextConfig *ctx_config, int protocols, int client) {
+static SSL_CTX *createSSLContext(serverTLSContextConfig *ctx_config, int protocols, int client) {
     const char *cert_file = client ? ctx_config->client_cert_file : ctx_config->cert_file;
     const char *key_file = client ? ctx_config->client_key_file : ctx_config->key_file;
     const char *key_file_pass = client ? ctx_config->client_key_file_pass : ctx_config->key_file_pass;
@@ -282,12 +282,12 @@ error:
 
 /* Attempt to configure/reconfigure TLS. This operation is atomic and will
  * leave the SSL_CTX unchanged if fails.
- * @priv: config of redisTLSContextConfig.
+ * @priv: config of serverTLSContextConfig.
  * @reconfigure: if true, ignore the previous configure; if false, only
  *               configure from @ctx_config if redis_tls_ctx is NULL.
  */
 static int tlsConfigure(void *priv, int reconfigure) {
-    redisTLSContextConfig *ctx_config = (redisTLSContextConfig *)priv;
+    serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
     char errbuf[256];
     SSL_CTX *ctx = NULL;
     SSL_CTX *client_ctx = NULL;

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -100,7 +100,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             puts $cfg [format "tls-key-file %s/../../tls/server.key" [pwd]]
             puts $cfg [format "tls-client-cert-file %s/../../tls/client.crt" [pwd]]
             puts $cfg [format "tls-client-key-file %s/../../tls/client.key" [pwd]]
-            puts $cfg [format "tls-dh-params-file %s/../../tls/redis.dh" [pwd]]
+            puts $cfg [format "tls-dh-params-file %s/../../tls/valkey.dh" [pwd]]
             puts $cfg [format "tls-ca-cert-file %s/../../tls/ca.crt" [pwd]]
         } else {
             puts $cfg "port $port"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -536,7 +536,7 @@ proc start_server {options {code undefined}} {
     }
 
     # write new configuration to temporary file
-    set config_file [tmpfile redis.conf]
+    set config_file [tmpfile valkey.conf]
     create_server_config_file $config_file $config $config_lines
 
     set stdout [format "%s/%s" [dict get $config "dir"] "stdout"]

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -486,7 +486,7 @@ proc start_server {options {code undefined}} {
         dict set config "tls-key-file" [format "%s/tests/tls/server.key" [pwd]]
         dict set config "tls-client-cert-file" [format "%s/tests/tls/client.crt" [pwd]]
         dict set config "tls-client-key-file" [format "%s/tests/tls/client.key" [pwd]]
-        dict set config "tls-dh-params-file" [format "%s/tests/tls/redis.dh" [pwd]]
+        dict set config "tls-dh-params-file" [format "%s/tests/tls/valkey.dh" [pwd]]
         dict set config "tls-ca-cert-file" [format "%s/tests/tls/ca.crt" [pwd]]
         dict set config "loglevel" "debug"
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -327,7 +327,7 @@ proc run_solo {name code} {
 proc cleanup {} {
     if {!$::quiet} {puts -nonewline "Cleanup: may take some time... "}
     flush stdout
-    catch {exec rm -rf {*}[glob tests/tmp/redis.conf.*]}
+    catch {exec rm -rf {*}[glob tests/tmp/valkey.conf.*]}
     catch {exec rm -rf {*}[glob tests/tmp/server*.*]}
     catch {exec rm -rf {*}[glob tests/tmp/*.acl.*]}
     if {!$::quiet} {puts "OK"}

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -419,7 +419,7 @@ start_server {tags {"other external:skip"}} {
             assert_equal $expect_port [lindex $cmdline 3]
             assert_equal $expect_tls_port [lindex $cmdline 4]
             assert_match "*/tests/tmp/server.*/socket" [lindex $cmdline 5]
-            assert_match "*/tests/tmp/redis.conf.*" [lindex $cmdline 6]
+            assert_match "*/tests/tmp/valkey.conf.*" [lindex $cmdline 6]
 
             # Try setting a bad template
             catch {r config set "proc-title-template" "{invalid-var}"} err

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -100,8 +100,8 @@ start_server {tags {"tls"}} {
             set master_port [srv 0 port]
 
             # Use a non-restricted client/server cert for the replica
-            set redis_crt [format "%s/tests/tls/redis.crt" [pwd]]
-            set redis_key [format "%s/tests/tls/redis.key" [pwd]]
+            set redis_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set redis_key [format "%s/tests/tls/valkey.key" [pwd]]
 
             start_server [list overrides [list tls-cert-file $redis_crt tls-key-file $redis_key] \
                                omit [list tls-client-cert-file tls-client-key-file]] {

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -100,10 +100,10 @@ start_server {tags {"tls"}} {
             set master_port [srv 0 port]
 
             # Use a non-restricted client/server cert for the replica
-            set redis_crt [format "%s/tests/tls/valkey.crt" [pwd]]
-            set redis_key [format "%s/tests/tls/valkey.key" [pwd]]
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
 
-            start_server [list overrides [list tls-cert-file $redis_crt tls-key-file $redis_key] \
+            start_server [list overrides [list tls-cert-file $valkey_crt tls-key-file $valkey_key] \
                                omit [list tls-client-cert-file tls-client-key-file]] {
                 set replica [srv 0 client]
                 $replica replicaof $master_host $master_port

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -28,7 +28,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/valkey-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi
@@ -44,7 +44,7 @@ then
     if [ "$2" == "-f" ]; then
         OPT_ARG="--cluster-yes"
     fi
-    $BIN_PATH/redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS $OPT_ARG
+    $BIN_PATH/valkey-cli --cluster create $HOSTS --cluster-replicas $REPLICAS $OPT_ARG
     exit 0
 fi
 
@@ -53,7 +53,7 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Stopping $PORT"
-        $BIN_PATH/redis-cli -p $PORT shutdown nosave
+        $BIN_PATH/valkey-cli -p $PORT shutdown nosave
     done
     exit 0
 fi
@@ -64,13 +64,13 @@ then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Stopping $PORT"
-        $BIN_PATH/redis-cli -p $PORT shutdown nosave
+        $BIN_PATH/valkey-cli -p $PORT shutdown nosave
     done
     PORT=$OLD_PORT
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
         echo "Starting $PORT"
-        $BIN_PATH/redis-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
+        $BIN_PATH/valkey-server --port $PORT --protected-mode $PROTECTED_MODE --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --appenddirname appendonlydir-${PORT} --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes ${ADDITIONAL_OPTIONS}
     done
     exit 0
 fi
@@ -81,7 +81,7 @@ then
     while [ 1 ]; do
         clear
         date
-        $BIN_PATH/redis-cli -p $PORT cluster nodes | head -30
+        $BIN_PATH/valkey-cli -p $PORT cluster nodes | head -30
         sleep 1
     done
     exit 0
@@ -105,7 +105,7 @@ if [ "$1" == "call" ]
 then
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
-        $BIN_PATH/redis-cli -p $PORT $2 $3 $4 $5 $6 $7 $8 $9
+        $BIN_PATH/valkey-cli -p $PORT $2 $3 $4 $5 $6 $7 $8 $9
     done
     exit 0
 fi
@@ -131,10 +131,10 @@ then
 fi
 
 echo "Usage: $0 [start|create|stop|restart|watch|tail|tailall|clean|clean-logs|call]"
-echo "start       -- Launch Redis Cluster instances."
-echo "create [-f] -- Create a cluster using redis-cli --cluster create."
-echo "stop        -- Stop Redis Cluster instances."
-echo "restart     -- Restart Redis Cluster instances."
+echo "start       -- Launch Valkey Cluster instances."
+echo "create [-f] -- Create a cluster using valkey-cli --cluster create."
+echo "stop        -- Stop Valkey Cluster instances."
+echo "restart     -- Restart Valkey Cluster instances."
 echo "watch       -- Show CLUSTER NODES output (first 30 lines) of first node."
 echo "tail <id>   -- Run tail -f of instance at base port + ID."
 echo "tailall     -- Run tail -f for all the log files at once."

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -3,10 +3,10 @@
 # Generate some test certificates which are used by the regression test suite:
 #
 #   tests/tls/ca.{crt,key}          Self signed CA certificate.
-#   tests/tls/redis.{crt,key}       A certificate with no key usage/policy restrictions.
+#   tests/tls/valkey.{crt,key}      A certificate with no key usage/policy restrictions.
 #   tests/tls/client.{crt,key}      A certificate restricted for SSL client usage.
 #   tests/tls/server.{crt,key}      A certificate restricted for SSL server usage.
-#   tests/tls/valkey.dh              DH Params file.
+#   tests/tls/valkey.dh             DH Params file.
 
 generate_cert() {
     local name=$1

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -6,7 +6,7 @@
 #   tests/tls/redis.{crt,key}       A certificate with no key usage/policy restrictions.
 #   tests/tls/client.{crt,key}      A certificate restricted for SSL client usage.
 #   tests/tls/server.{crt,key}      A certificate restricted for SSL server usage.
-#   tests/tls/redis.dh              DH Params file.
+#   tests/tls/valkey.dh              DH Params file.
 
 generate_cert() {
     local name=$1
@@ -53,6 +53,6 @@ _END_
 
 generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
 generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
-generate_cert redis "Generic-cert"
+generate_cert valkey "Generic-cert"
 
-[ -f tests/tls/redis.dh ] || openssl dhparam -out tests/tls/redis.dh 2048
+[ -f tests/tls/valkey.dh ] || openssl dhparam -out tests/tls/valkey.dh 2048

--- a/utils/generate-command-code.py
+++ b/utils/generate-command-code.py
@@ -578,7 +578,7 @@ with open("%s/%s.def" % (srcdir, commands_filename), "w") as f:
  * the fantastic
  * Redis Command Table! */
 
-/* Must match redisCommandGroup */
+/* Must match serverCommandGroup */
 const char *COMMAND_GROUP_STR[] = {
     "generic",
     "string",

--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -166,7 +166,7 @@ mkdir -p "$REDIS_DATA_DIR" || die "Could not create redis data directory"
 
 #render the templates
 TMP_FILE="/tmp/${REDIS_PORT}.conf"
-DEFAULT_CONFIG="${SCRIPTPATH}/../redis.conf"
+DEFAULT_CONFIG="${SCRIPTPATH}/../valkey.conf"
 INIT_TPL_FILE="${SCRIPTPATH}/redis_init_script.tpl"
 INIT_SCRIPT_DEST="/etc/init.d/redis_${REDIS_PORT}"
 PIDFILE="/var/run/redis_${REDIS_PORT}.pid"

--- a/utils/systemd-redis_server.service
+++ b/utils/systemd-redis_server.service
@@ -24,9 +24,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/redis-server --supervised systemd --daemonize no
+ExecStart=/usr/local/bin/valkey-server --supervised systemd --daemonize no
 ## Alternatively, have redis-server load a configuration file:
-#ExecStart=/usr/local/bin/redis-server /path/to/your/redis.conf
+#ExecStart=/usr/local/bin/valkey-server /path/to/your/valkey.conf
 LimitNOFILE=10032
 NoNewPrivileges=yes
 #OOMScoreAdjust=-900

--- a/valkey.conf
+++ b/valkey.conf
@@ -1,9 +1,9 @@
-# Redis configuration file example.
+# Valkey configuration file example.
 #
-# Note that in order to read the configuration file, Redis must be
+# Note that in order to read the configuration file, the server must be
 # started with the file path as first argument:
 #
-# ./redis-server /path/to/redis.conf
+# ./valkey-server /path/to/valkey.conf
 
 # Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
@@ -20,12 +20,12 @@
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all Redis servers but also need
+# have a standard template that goes to all servers but also need
 # to customize a few per-server settings.  Include files can include
 # other files, so use this wisely.
 #
 # Note that option "include" won't be rewritten by command "CONFIG REWRITE"
-# from admin or Redis Sentinel. Since Redis always uses the last processed
+# from admin or Sentinel. Since the server always uses the last processed
 # line as value of a configuration directive, you'd better put includes
 # at the beginning of this file to avoid overwriting config change at runtime.
 #
@@ -55,11 +55,11 @@
 
 ################################## NETWORK #####################################
 
-# By default, if no "bind" configuration directive is specified, Redis listens
+# By default, if no "bind" configuration directive is specified, the server listens
 # for connections from all available network interfaces on the host machine.
 # It is possible to listen to just one or multiple selected interfaces using
 # the "bind" configuration directive, followed by one or more IP addresses.
-# Each address can be prefixed by "-", which means that redis will not fail to
+# Each address can be prefixed by "-", which means that the server will not fail to
 # start if the address is not available. Being not available only refers to
 # addresses that does not correspond to any network interface. Addresses that
 # are already in use will always fail, and unsupported protocols will always BE
@@ -71,11 +71,11 @@
 # bind 127.0.0.1 ::1              # listens on loopback IPv4 and IPv6
 # bind * -::*                     # like the default, all available interfaces
 #
-# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# ~~~ WARNING ~~~ If the computer running the server is directly exposed to the
 # internet, binding to all the interfaces is dangerous and will expose the
 # instance to everybody on the internet. So by default we uncomment the
-# following bind directive, that will force Redis to listen only on the
-# IPv4 and IPv6 (if available) loopback interface addresses (this means Redis
+# following bind directive, that will force the server to listen only on the
+# IPv4 and IPv6 (if available) loopback interface addresses (this means the server
 # will only be able to accept client connections from the same host that it is
 # running on).
 #
@@ -100,26 +100,26 @@ bind 127.0.0.1 -::1
 # bind-source-addr 10.0.0.1
 
 # Protected mode is a layer of security protection, in order to avoid that
-# Redis instances left open on the internet are accessed and exploited.
+# the server instances left open on the internet are accessed and exploited.
 #
 # When protected mode is on and the default user has no password, the server
 # only accepts local connections from the IPv4 address (127.0.0.1), IPv6 address
 # (::1) or Unix domain sockets.
 #
 # By default protected mode is enabled. You should disable it only if
-# you are sure you want clients from other hosts to connect to Redis
+# you are sure you want clients from other hosts to connect to the server
 # even if no authentication is configured.
 protected-mode yes
 
-# Redis uses default hardened security configuration directives to reduce the
+# The server uses default hardened security configuration directives to reduce the
 # attack surface on innocent users. Therefore, several sensitive configuration
 # directives are immutable, and some potentially-dangerous commands are blocked.
 #
-# Configuration directives that control files that Redis writes to (e.g., 'dir'
+# Configuration directives that control files that the server writes to (e.g., 'dir'
 # and 'dbfilename') and that aren't usually modified during runtime
 # are protected by making them immutable.
 #
-# Commands that can increase the attack surface of Redis and that aren't usually
+# Commands that can increase the attack surface of the server and that aren't usually
 # called by users are blocked by default.
 #
 # These can be exposed to either all connections or just local ones by setting
@@ -135,7 +135,7 @@ protected-mode yes
 # enable-module-command no
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
-# If port 0 is specified Redis will not listen on a TCP socket.
+# If port 0 is specified the server will not listen on a TCP socket.
 port 6379
 
 # TCP listen() backlog.
@@ -150,10 +150,10 @@ tcp-backlog 511
 # Unix socket.
 #
 # Specify the path for the Unix socket that will be used to listen for
-# incoming connections. There is no default, so Redis will not listen
+# incoming connections. There is no default, so the server will not listen
 # on a unix socket when not specified.
 #
-# unixsocket /run/redis.sock
+# unixsocket /run/valkey.sock
 # unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -171,9 +171,6 @@ timeout 0
 # On Linux, the specified value (in seconds) is the period used to send ACKs.
 # Note that to close the connection the double of the time is needed.
 # On other kernels the period depends on the kernel configuration.
-#
-# A reasonable value for this option is 300 seconds, which is the new
-# Redis default starting with Redis 3.2.1.
 tcp-keepalive 300
 
 # Apply OS-specific mechanism to mark the listening socket with the specified
@@ -207,7 +204,7 @@ tcp-keepalive 300
 #
 # tls-key-file-pass secret
 
-# Normally Redis uses the same certificate for both server functions (accepting
+# Normally the server uses the same certificate for both server functions (accepting
 # connections) and client functions (replicating from a master, establishing
 # cluster bus connections, etc.).
 #
@@ -231,7 +228,7 @@ tcp-keepalive 300
 # tls-dh-params-file valkey.dh
 
 # Configure a CA certificate(s) bundle or directory to authenticate TLS/SSL
-# clients and peers.  Valkey requires an explicit configuration of at least one
+# clients and peers. The server requires an explicit configuration of at least one
 # of these, and will not implicitly use the system wide configuration.
 #
 # tls-ca-cert-file ca.crt
@@ -247,14 +244,14 @@ tcp-keepalive 300
 # tls-auth-clients no
 # tls-auth-clients optional
 
-# By default, a Redis replica does not attempt to establish a TLS connection
+# By default, a replica does not attempt to establish a TLS connection
 # with its master.
 #
 # Use the following directive to enable TLS on replication links.
 #
 # tls-replication yes
 
-# By default, the Redis Cluster bus uses a plain TCP connection. To enable
+# By default, the cluster bus uses a plain TCP connection. To enable
 # TLS for the bus protocol, use the following directive:
 #
 # tls-cluster yes
@@ -304,18 +301,18 @@ tcp-keepalive 300
 
 ################################# GENERAL #####################################
 
-# By default Redis does not run as a daemon. Use 'yes' if you need it.
-# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-# When Redis is supervised by upstart or systemd, this parameter has no impact.
+# By default the server does not run as a daemon. Use 'yes' if you need it.
+# Note that the server will write a pid file in /var/run/valkey.pid when daemonized.
+# When the server is supervised by upstart or systemd, this parameter has no impact.
 daemonize no
 
-# If you run Redis from upstart or systemd, Redis can interact with your
+# If you run the server from upstart or systemd, the server can interact with your
 # supervision tree. Options:
 #   supervised no      - no supervision interaction
-#   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#   supervised upstart - signal upstart by putting the server into SIGSTOP mode
 #                        requires "expect stop" in your upstart job config
 #   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
-#                        on startup, and updating Redis status on a regular
+#                        on startup, and updating the server status on a regular
 #                        basis.
 #   supervised auto    - detect upstart or systemd method based on
 #                        UPSTART_JOB or NOTIFY_SOCKET environment variables
@@ -327,19 +324,19 @@ daemonize no
 #
 # supervised auto
 
-# If a pid file is specified, Redis writes it where specified at startup
+# If a pid file is specified, the server writes it where specified at startup
 # and removes it at exit.
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/redis.pid".
+# is used even if not specified, defaulting to "/var/run/valkey.pid".
 #
-# Creating a pid file is best effort: if Redis is not able to create it
+# Creating a pid file is best effort: if the server is not able to create it
 # nothing bad happens, the server will start and run normally.
 #
-# Note that on modern Linux systems "/run/redis.pid" is more conforming
+# Note that on modern Linux systems "/run/valkey.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis_6379.pid
+pidfile /var/run/valkey_6379.pid
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -351,7 +348,7 @@ pidfile /var/run/redis_6379.pid
 loglevel notice
 
 # Specify the log file name. Also the empty string can be used to force
-# Redis to log on the standard output. Note that if you use standard
+# the server to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
 logfile ""
 
@@ -371,7 +368,7 @@ logfile ""
 # crash-log-enabled no
 
 # To disable the fast memory check that's run as part of the crash log, which
-# will possibly let redis terminate sooner, uncomment the following:
+# will possibly let the server terminate sooner, uncomment the following:
 #
 # crash-memcheck-enabled no
 
@@ -380,7 +377,7 @@ logfile ""
 # dbid is a number between 0 and 'databases'-1
 databases 16
 
-# By default Redis shows an ASCII art logo only when started to log to the
+# By default the server shows an ASCII art logo only when started to log to the
 # standard output and if the standard output is a TTY and syslog logging is
 # disabled. Basically this means that normally a logo is displayed only in
 # interactive sessions.
@@ -389,12 +386,12 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
-# By default, Redis modifies the process title (as seen in 'top' and 'ps') to
+# By default, the server modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave
 # the process name as executed by setting the following to no.
 set-proc-title yes
 
-# When changing the process title, Redis uses the following template to construct
+# When changing the process title, the server uses the following template to construct
 # the modified title.
 #
 # Template variables are specified in curly brackets. The following variables are
@@ -422,7 +419,7 @@ locale-collate ""
 #
 # save <seconds> <changes> [<seconds> <changes> ...]
 #
-# Redis will save the DB if the given number of seconds elapsed and it
+# The server will save the DB if the given number of seconds elapsed and it
 # surpassed the given number of write operations against the DB.
 #
 # Snapshotting can be completely disabled with a single empty string argument
@@ -430,7 +427,7 @@ locale-collate ""
 #
 # save ""
 #
-# Unless specified otherwise, by default Redis will save the DB:
+# Unless specified otherwise, by default the server will save the DB:
 #   * After 3600 seconds (an hour) if at least 1 change was performed
 #   * After 300 seconds (5 minutes) if at least 100 changes were performed
 #   * After 60 seconds if at least 10000 changes were performed
@@ -439,17 +436,17 @@ locale-collate ""
 #
 # save 3600 1 300 100 60 10000
 
-# By default Redis will stop accepting writes if RDB snapshots are enabled
+# By default the server will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
 # This will make the user aware (in a hard way) that data is not persisting
 # on disk properly, otherwise chances are that no one will notice and some
 # disaster will happen.
 #
-# If the background saving process will start working again Redis will
+# If the background saving process will start working again, the server will
 # automatically allow writes again.
 #
-# However if you have setup your proper monitoring of the Redis server
-# and persistence, you may want to disable this feature so that Redis will
+# However if you have setup your proper monitoring of the server
+# and persistence, you may want to disable this feature so that the server will
 # continue to work as usual even if there are problems with disk,
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
@@ -512,18 +509,18 @@ dir ./
 
 ################################# REPLICATION #################################
 
-# Master-Replica replication. Use replicaof to make a Redis instance a copy of
-# another Redis server. A few things to understand ASAP about Redis replication.
+# Master-Replica replication. Use replicaof to make a server a copy of
+# another server. A few things to understand ASAP about replication.
 #
 #   +------------------+      +---------------+
 #   |      Master      | ---> |    Replica    |
 #   | (receive writes) |      |  (exact copy) |
 #   +------------------+      +---------------+
 #
-# 1) Redis replication is asynchronous, but you can configure a master to
+# 1) Replication is asynchronous, but you can configure a master to
 #    stop accepting writes if it appears to be not connected with at least
 #    a given number of replicas.
-# 2) Redis replicas are able to perform a partial resynchronization with the
+# 2) Replicas are able to perform a partial resynchronization with the
 #    master if the replication link is lost for a relatively small amount of
 #    time. You may want to configure the replication backlog size (see the next
 #    sections of this file) with a sensible value depending on your needs.
@@ -540,8 +537,8 @@ dir ./
 #
 # masterauth <master-password>
 #
-# However this is not enough if you are using Redis ACLs (for Redis version
-# 6 or greater), and the default user is not capable of running the PSYNC
+# However this is not enough if you are using ACLs
+# and the default user is not capable of running the PSYNC
 # command and/or other commands needed for replication. In this case it's
 # better to configure a special user to use with replication, and specify the
 # masteruser configuration as such:
@@ -573,7 +570,7 @@ replica-serve-stale-data yes
 # may also cause problems if clients are writing to it because of a
 # misconfiguration.
 #
-# Since Redis 2.6 by default replicas are read-only.
+# By default, replicas are read-only.
 #
 # Note: read only replicas are not designed to be exposed to untrusted clients
 # on the internet. It's just a protection layer against misuse of the instance.
@@ -592,10 +589,10 @@ replica-read-only yes
 #
 # The transmission can happen in two different ways:
 #
-# 1) Disk-backed: The Redis master creates a new process that writes the RDB
+# 1) Disk-backed: The master creates a new process that writes the RDB
 #                 file on disk. Later the file is transferred by the parent
 #                 process to the replicas incrementally.
-# 2) Diskless: The Redis master creates a new process that directly writes the
+# 2) Diskless: The master creates a new process that directly writes the
 #              RDB file to replica sockets, without touching the disk at all.
 #
 # With disk-backed replication, while the RDB file is generated, more replicas
@@ -627,13 +624,13 @@ repl-diskless-sync-delay 5
 # When diskless replication is enabled with a delay, it is possible to let
 # the replication start before the maximum delay is reached if the maximum
 # number of replicas expected have connected. Default of 0 means that the
-# maximum is not defined and Redis will wait the full delay.
+# maximum is not defined and the server will wait the full delay.
 repl-diskless-sync-max-replicas 0
 
 # -----------------------------------------------------------------------------
 # WARNING: Since in this setup the replica does not immediately store an RDB on
-# disk, it may cause data loss during failovers. RDB diskless load + Redis
-# modules not handling I/O reads may cause Redis to abort in case of I/O errors
+# disk, it may cause data loss during failovers. RDB diskless load + server
+# modules not handling I/O reads may cause the server to abort in case of I/O errors
 # during the initial synchronization stage with the master.
 # -----------------------------------------------------------------------------
 #
@@ -683,7 +680,7 @@ repl-diskless-load disabled
 
 # Disable TCP_NODELAY on the replica socket after SYNC?
 #
-# If you select "yes" Redis will use a smaller number of TCP packets and
+# If you select "yes", the server will use a smaller number of TCP packets and
 # less bandwidth to send data to replicas. But this can add a delay for
 # the data to appear on the replica side, up to 40 milliseconds with
 # Linux kernels using a default configuration.
@@ -722,8 +719,8 @@ repl-disable-tcp-nodelay no
 #
 # repl-backlog-ttl 3600
 
-# The replica priority is an integer number published by Redis in the INFO
-# output. It is used by Redis Sentinel in order to select a replica to promote
+# The replica priority is an integer number published by the server in the INFO
+# output. It is used by Sentinel in order to select a replica to promote
 # into a master if the master is no longer working correctly.
 #
 # A replica with a low priority number is considered better for promotion, so
@@ -732,18 +729,15 @@ repl-disable-tcp-nodelay no
 #
 # However a special priority of 0 marks the replica as not able to perform the
 # role of master, so a replica with priority of 0 will never be selected by
-# Redis Sentinel for promotion.
+# Sentinel for promotion.
 #
 # By default the priority is 100.
 replica-priority 100
 
-# The propagation error behavior controls how Redis will behave when it is
+# The propagation error behavior controls how the server will behave when it is
 # unable to handle a command being processed in the replication stream from a master
 # or processed while reading from an AOF file. Errors that occur during propagation
-# are unexpected, and can cause data inconsistency. However, there are edge cases
-# in earlier versions of Redis where it was possible for the server to replicate or persist
-# commands that would fail on future versions. For this reason the default behavior
-# is to ignore such errors and continue processing commands.
+# are unexpected, and can cause data inconsistency. 
 #
 # If an application wants to ensure there is no data divergence, this configuration
 # should be set to 'panic' instead. The value can also be set to 'panic-on-replicas'
@@ -756,17 +750,15 @@ replica-priority 100
 # Replica ignore disk write errors controls the behavior of a replica when it is
 # unable to persist a write command received from its master to disk. By default,
 # this configuration is set to 'no' and will crash the replica in this condition.
-# It is not recommended to change this default, however in order to be compatible
-# with older versions of Redis this config can be toggled to 'yes' which will just
-# log a warning and execute the write command it got from the master.
+# It is not recommended to change this default.
 #
 # replica-ignore-disk-write-errors no
 
 # -----------------------------------------------------------------------------
-# By default, Redis Sentinel includes all replicas in its reports. A replica
-# can be excluded from Redis Sentinel's announcements. An unannounced replica
+# By default, Sentinel includes all replicas in its reports. A replica
+# can be excluded from Sentinel's announcements. An unannounced replica
 # will be ignored by the 'sentinel replicas <master>' command and won't be
-# exposed to Redis Sentinel's clients.
+# exposed to Sentinel's clients.
 #
 # This option does not change the behavior of replica-priority. Even with
 # replica-announced set to 'no', the replica can be promoted to master. To
@@ -796,10 +788,10 @@ replica-priority 100
 # By default min-replicas-to-write is set to 0 (feature disabled) and
 # min-replicas-max-lag is set to 10.
 
-# A Redis master is able to list the address and port of the attached
+# A master is able to list the address and port of the attached
 # replicas in different ways. For example the "INFO replication" section
 # offers this information, which is used, among other tools, by
-# Redis Sentinel in order to discover replica instances.
+# Sentinel in order to discover replica instances.
 # Another place where this info is available is in the output of the
 # "ROLE" command of a master.
 #
@@ -827,7 +819,7 @@ replica-priority 100
 
 ############################### KEYS TRACKING #################################
 
-# Redis implements server assisted support for client side caching of values.
+# The client side caching of values is assisted via server-side support.
 # This is implemented using an invalidation table that remembers, using
 # a radix key indexed by key name, what clients have which keys. In turn
 # this is used in order to send invalidation messages to clients. Please
@@ -836,22 +828,22 @@ replica-priority 100
 #   https://redis.io/topics/client-side-caching
 #
 # When tracking is enabled for a client, all the read only queries are assumed
-# to be cached: this will force Redis to store information in the invalidation
+# to be cached: this will force the server to store information in the invalidation
 # table. When keys are modified, such information is flushed away, and
 # invalidation messages are sent to the clients. However if the workload is
-# heavily dominated by reads, Redis could use more and more memory in order
+# heavily dominated by reads, the server could use more and more memory in order
 # to track the keys fetched by many clients.
 #
 # For this reason it is possible to configure a maximum fill value for the
 # invalidation table. By default it is set to 1M of keys, and once this limit
-# is reached, Redis will start to evict keys in the invalidation table
+# is reached, the server will start to evict keys in the invalidation table
 # even if they were not modified, just to reclaim memory: this will in turn
 # force the clients to invalidate the cached values. Basically the table
 # maximum size is a trade off between the memory you want to spend server
 # side to track information about who cached what, and the ability of clients
 # to retain cached objects in memory.
 #
-# If you set the value to 0, it means there are no limits, and Redis will
+# If you set the value to 0, it means there are no limits, and the server will
 # retain as many keys as needed in the invalidation table.
 # In the "stats" INFO section, you can find information about the number of
 # keys in the invalidation table at every given moment.
@@ -863,7 +855,7 @@ replica-priority 100
 
 ################################## SECURITY ###################################
 
-# Warning: since Redis is pretty fast, an outside user can try up to
+# Warning: since the server is pretty fast, an outside user can try up to
 # 1 million passwords per second against a modern box. This means that you
 # should use very strong passwords, otherwise they will be very easy to break.
 # Note that because the password is really a shared secret between the client
@@ -871,7 +863,7 @@ replica-priority 100
 # can be easily a long string from /dev/urandom or whatever, so by using a
 # long and unguessable password no brute force attack will be possible.
 
-# Redis ACL users are defined in the following format:
+# ACL users are defined in the following format:
 #
 #   user <username> ... acl rules ...
 #
@@ -902,7 +894,7 @@ replica-priority 100
 #  +@<category> Allow the execution of all the commands in such category
 #               with valid categories are like @admin, @set, @sortedset, ...
 #               and so forth, see the full list in the server.c file where
-#               the Redis command table is described and defined.
+#               the server command table is described and defined.
 #               The special category @all means all the commands, but currently
 #               present in the server, and that will be loaded in the future
 #               via modules.
@@ -1011,7 +1003,7 @@ replica-priority 100
 # * stream - Data type: streams related.
 #
 # For more information about ACL configuration please refer to
-# the Redis web site at https://redis.io/topics/acl
+# the Valkey web site at https://redis.io/topics/acl
 
 # ACL LOG
 #
@@ -1029,11 +1021,11 @@ acllog-max-len 128
 # ACL file, the server will refuse to start.
 #
 # The format of the external ACL user file is exactly the same as the
-# format that is used inside redis.conf to describe users.
+# format that is used inside valkey.conf to describe users.
 #
-# aclfile /etc/redis/users.acl
+# aclfile /etc/valkey/users.acl
 
-# IMPORTANT NOTE: starting with Redis 6 "requirepass" is just a compatibility
+# IMPORTANT NOTE: "requirepass" is just a compatibility
 # layer on top of the new ACL system. The option effect will be just setting
 # the password for the default user. Clients will still authenticate using
 # AUTH <password> as usually, or more explicitly with AUTH default <password>
@@ -1044,16 +1036,13 @@ acllog-max-len 128
 #
 # requirepass foobared
 
-# New users are initialized with restrictive permissions by default, via the
-# equivalent of this ACL rule 'off resetkeys -@all'. Starting with Redis 6.2, it
-# is possible to manage access to Pub/Sub channels with ACL rules as well. The
-# default Pub/Sub channels permission if new users is controlled by the
+# The default Pub/Sub channels permission for new users is controlled by the
 # acl-pubsub-default configuration directive, which accepts one of these values:
 #
 # allchannels: grants access to all Pub/Sub channels
 # resetchannels: revokes access to all Pub/Sub channels
 #
-# From Redis 7.0, acl-pubsub-default defaults to 'resetchannels' permission.
+# acl-pubsub-default defaults to 'resetchannels' permission.
 #
 # acl-pubsub-default resetchannels
 
@@ -1085,15 +1074,15 @@ acllog-max-len 128
 ################################### CLIENTS ####################################
 
 # Set the max number of connected clients at the same time. By default
-# this limit is set to 10000 clients, however if the Redis server is not
+# this limit is set to 10000 clients, however if the server is not
 # able to configure the process file limit to allow for the specified limit
 # the max number of allowed clients is set to the current file limit
-# minus 32 (as Redis reserves a few file descriptors for internal uses).
+# minus 32 (as the server reserves a few file descriptors for internal uses).
 #
-# Once the limit is reached Redis will close all the new connections sending
+# Once the limit is reached the server will close all the new connections sending
 # an error 'max number of clients reached'.
 #
-# IMPORTANT: When Redis Cluster is used, the max number of connections is also
+# IMPORTANT: With a cluster-enabled setup, the max number of connections is also
 # shared with the cluster bus: every node in the cluster will use two
 # connections, one incoming and another outgoing. It is important to size the
 # limit accordingly in case of very large clusters.
@@ -1103,15 +1092,15 @@ acllog-max-len 128
 ############################## MEMORY MANAGEMENT ################################
 
 # Set a memory usage limit to the specified amount of bytes.
-# When the memory limit is reached Redis will try to remove keys
+# When the memory limit is reached the server will try to remove keys
 # according to the eviction policy selected (see maxmemory-policy).
 #
-# If Redis can't remove keys according to the policy, or if the policy is
-# set to 'noeviction', Redis will start to reply with errors to commands
+# If the server can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', the server will start to reply with errors to commands
 # that would use more memory, like SET, LPUSH, and so on, and will continue
 # to reply to read-only commands like GET.
 #
-# This option is usually useful when using Redis as an LRU or LFU cache, or to
+# This option is usually useful when using the server as an LRU or LFU cache, or to
 # set a hard memory limit for an instance (using the 'noeviction' policy).
 #
 # WARNING: If you have replicas attached to an instance with maxmemory on,
@@ -1127,7 +1116,7 @@ acllog-max-len 128
 #
 # maxmemory <bytes>
 
-# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# MAXMEMORY POLICY: how the server will select what to remove when maxmemory
 # is reached. You can select one from the following behaviors:
 #
 # volatile-lru -> Evict using approximated LRU, only keys with an expire set.
@@ -1146,7 +1135,7 @@ acllog-max-len 128
 # randomized algorithms.
 #
 # Note: with any of the above policies, when there are no suitable keys for
-# eviction, Redis will return an error on write operations that require
+# eviction, the server will return an error on write operations that require
 # more memory. These are usually commands that create new keys, add data or
 # modify existing keys. A few examples are: SET, INCR, HSET, LPUSH, SUNIONSTORE,
 # SORT (due to the STORE argument), and EXEC (if the transaction includes any
@@ -1158,7 +1147,7 @@ acllog-max-len 128
 
 # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or
-# accuracy. By default Redis will check five keys and pick the one that was
+# accuracy. By default the server will check five keys and pick the one that was
 # used least recently, you can change the sample size using the following
 # configuration directive.
 #
@@ -1176,7 +1165,7 @@ acllog-max-len 128
 #
 # maxmemory-eviction-tenacity 10
 
-# Starting from Redis 5, by default a replica will ignore its maxmemory setting
+# By default a replica will ignore its maxmemory setting
 # (unless it is promoted to master after a failover or manually). It means
 # that the eviction of keys will be just handled by the master, sending the
 # DEL commands to the replica as keys evict in the master side.
@@ -1196,7 +1185,7 @@ acllog-max-len 128
 #
 # replica-ignore-maxmemory yes
 
-# Redis reclaims expired keys in two ways: upon access when those keys are
+# The server reclaims expired keys in two ways: upon access when those keys are
 # found to be expired, and also in background, in what is called the
 # "active expire key". The key space is slowly and interactively scanned
 # looking for expired keys to reclaim, so that it is possible to free memory
@@ -1215,16 +1204,16 @@ acllog-max-len 128
 
 ############################# LAZY FREEING ####################################
 
-# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# The server has two primitives to delete keys. One is called DEL and is a blocking
 # deletion of the object. It means that the server stops processing new commands
 # in order to reclaim all the memory associated with an object in a synchronous
 # way. If the key deleted is associated with a small object, the time needed
 # in order to execute the DEL command is very small and comparable to most other
-# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# O(1) or O(log_N) commands in the server. However if the key is associated with an
 # aggregated value containing millions of elements, the server can block for
 # a long time (even seconds) in order to complete the operation.
 #
-# For the above reasons Redis also offers non blocking deletion primitives
+# For the above reasons the server also offers non blocking deletion primitives
 # such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
 # FLUSHDB commands, in order to reclaim memory in background. Those commands
 # are executed in constant time. Another thread will incrementally free the
@@ -1232,9 +1221,9 @@ acllog-max-len 128
 #
 # DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
 # It's up to the design of the application to understand when it is a good
-# idea to use one or the other. However the Redis server sometimes has to
+# idea to use one or the other. However the server sometimes has to
 # delete keys or flush the whole database as a side effect of other operations.
-# Specifically Redis deletes objects independently of a user call in the
+# Specifically the server deletes objects independently of a user call in the
 # following scenarios:
 #
 # 1) On eviction, because of the maxmemory and maxmemory policy configurations,
@@ -1278,21 +1267,21 @@ lazyfree-lazy-user-flush no
 
 ################################ THREADED I/O #################################
 
-# Redis is mostly single threaded, however there are certain threaded
+# The server is mostly single threaded, however there are certain threaded
 # operations such as UNLINK, slow I/O accesses and other things that are
 # performed on side threads.
 #
-# Now it is also possible to handle Redis clients socket reads and writes
+# Now it is also possible to handle the server clients socket reads and writes
 # in different I/O threads. Since especially writing is so slow, normally
-# Redis users use pipelining in order to speed up the Redis performances per
+# users use pipelining in order to speed up the server performances per
 # core, and spawn multiple instances in order to scale more. Using I/O
-# threads it is possible to easily speedup two times Redis without resorting
+# threads it is possible to easily speedup two times the server without resorting
 # to pipelining nor sharding of the instance.
 #
 # By default threading is disabled, we suggest enabling it only in machines
 # that have at least 4 or more cores, leaving at least one spare core.
 # Using more than 8 threads is unlikely to help much. We also recommend using
-# threaded I/O only if you actually have performance problems, with Redis
+# threaded I/O only if you actually have performance problems, with 
 # instances being able to use a quite big percentage of CPU time, otherwise
 # there is no point in using this feature.
 #
@@ -1317,9 +1306,9 @@ lazyfree-lazy-user-flush no
 # CONFIG SET. Also, this feature currently does not work when SSL is
 # enabled.
 #
-# NOTE 2: If you want to test the Redis speedup using redis-benchmark, make
+# NOTE 2: If you want to test the server speedup using valkey-benchmark, make
 # sure you also run the benchmark itself in threaded mode, using the
-# --threads option to match the number of Redis threads, otherwise you'll not
+# --threads option to match the number of server threads, otherwise you'll not
 # be able to notice the improvements.
 
 ############################ KERNEL OOM CONTROL ##############################
@@ -1327,12 +1316,12 @@ lazyfree-lazy-user-flush no
 # On Linux, it is possible to hint the kernel OOM killer on what processes
 # should be killed first when out of memory.
 #
-# Enabling this feature makes Redis actively control the oom_score_adj value
+# Enabling this feature makes the server actively control the oom_score_adj value
 # for all its processes, depending on their role. The default scores will
 # attempt to have background child processes killed before all others, and
 # replicas killed before masters.
 #
-# Redis supports these options:
+# The server supports these options:
 #
 # no:       Don't make changes to oom-score-adj (default).
 # yes:      Alias to "relative" see below.
@@ -1359,7 +1348,7 @@ oom-score-adj-values 0 200 800
 # Usually the kernel Transparent Huge Pages control is set to "madvise" or
 # or "never" by default (/sys/kernel/mm/transparent_hugepage/enabled), in which
 # case this config has no effect. On systems in which it is set to "always",
-# redis will attempt to disable it specifically for the redis process in order
+# the server will attempt to disable it specifically for the server process in order
 # to avoid latency problems specifically with fork(2) and CoW.
 # If for some reason you prefer to keep it enabled, you can set this config to
 # "no" and the kernel global to "always".
@@ -1368,20 +1357,20 @@ disable-thp yes
 
 ############################## APPEND ONLY MODE ###############################
 
-# By default Redis asynchronously dumps the dataset on disk. This mode is
-# good enough in many applications, but an issue with the Redis process or
+# By default the server asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the server process or
 # a power outage may result into a few minutes of writes lost (depending on
 # the configured save points).
 #
 # The Append Only File is an alternative persistence mode that provides
 # much better durability. For instance using the default data fsync policy
-# (see later in the config file) Redis can lose just one second of writes in a
+# (see later in the config file) the server can lose just one second of writes in a
 # dramatic event like a server power outage, or a single write if something
-# wrong with the Redis process itself happens, but the operating system is
+# wrong with the process itself happens, but the operating system is
 # still running correctly.
 #
 # AOF and RDB persistence can be enabled at the same time without problems.
-# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# If the AOF is enabled on startup the server will load the AOF, that is the file
 # with the better durability guarantees.
 #
 # Note that changing this value in a config file of an existing database and
@@ -1394,7 +1383,7 @@ appendonly no
 
 # The base name of the append only file.
 #
-# Redis 7 and newer use a set of append-only files to persist the dataset
+# The server uses a set of append-only files to persist the dataset
 # and changes applied to it. There are two basic types of files in use:
 #
 # - Base files, which are a snapshot representing the complete state of the
@@ -1406,7 +1395,7 @@ appendonly no
 # In addition, manifest files are used to track the files and the order in
 # which they were created and should be applied.
 #
-# Append-only file names are created by Redis following a specific pattern.
+# Append-only file names are created by the server following a specific pattern.
 # The file name's prefix is based on the 'appendfilename' configuration
 # parameter, followed by additional information about the sequence and type.
 #
@@ -1419,7 +1408,7 @@ appendonly no
 
 appendfilename "appendonly.aof"
 
-# For convenience, Redis stores all persistent append-only files in a dedicated
+# For convenience, the server stores all persistent append-only files in a dedicated
 # directory. The name of the directory is determined by the appenddirname
 # configuration parameter.
 
@@ -1429,7 +1418,7 @@ appenddirname "appendonlydir"
 # instead of waiting for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
-# Redis supports three different modes:
+# The server supports three different modes:
 #
 # no: don't fsync, just let the OS flush the data when it wants. Faster.
 # always: fsync after every write to the append only log. Slow, Safest.
@@ -1455,7 +1444,7 @@ appendfsync everysec
 # When the AOF fsync policy is set to always or everysec, and a background
 # saving process (a background save or AOF log background rewriting) is
 # performing a lot of I/O against the disk, in some Linux configurations
-# Redis may block too long on the fsync() call. Note that there is no fix for
+# the server may block too long on the fsync() call. Note that there is no fix for
 # this currently, as even performing fsync in a different thread will block
 # our synchronous write(2) call.
 #
@@ -1463,7 +1452,7 @@ appendfsync everysec
 # that will prevent fsync() from being called in the main process while a
 # BGSAVE or BGREWRITEAOF is in progress.
 #
-# This means that while another child is saving, the durability of Redis is
+# This means that while another child is saving, the durability of the server is
 # the same as "appendfsync no". In practical terms, this means that it is
 # possible to lose up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
@@ -1474,10 +1463,10 @@ appendfsync everysec
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
-# Redis is able to automatically rewrite the log file implicitly calling
+# The server is able to automatically rewrite the log file implicitly calling
 # BGREWRITEAOF when the AOF log size grows by the specified percentage.
 #
-# This is how it works: Redis remembers the size of the AOF file after the
+# This is how it works: The server remembers the size of the AOF file after the
 # latest rewrite (if no rewrite has happened since the restart, the size of
 # the AOF at startup is used).
 #
@@ -1493,36 +1482,36 @@ no-appendfsync-on-rewrite no
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 
-# An AOF file may be found to be truncated at the end during the Redis
+# An AOF file may be found to be truncated at the end during the server
 # startup process, when the AOF data gets loaded back into memory.
-# This may happen when the system where Redis is running
+# This may happen when the system where the server is running
 # crashes, especially when an ext4 filesystem is mounted without the
-# data=ordered option (however this can't happen when Redis itself
+# data=ordered option (however this can't happen when the server itself
 # crashes or aborts but the operating system still works correctly).
 #
-# Redis can either exit with an error when this happens, or load as much
+# The server can either exit with an error when this happens, or load as much
 # data as possible (the default now) and start if the AOF file is found
 # to be truncated at the end. The following option controls this behavior.
 #
 # If aof-load-truncated is set to yes, a truncated AOF file is loaded and
-# the Redis server starts emitting a log to inform the user of the event.
+# the server starts emitting a log to inform the user of the event.
 # Otherwise if the option is set to no, the server aborts with an error
 # and refuses to start. When the option is set to no, the user requires
-# to fix the AOF file using the "redis-check-aof" utility before to restart
+# to fix the AOF file using the "valkey-check-aof" utility before to restart
 # the server.
 #
 # Note that if the AOF file will be found to be corrupted in the middle
 # the server will still exit with an error. This option only applies when
-# Redis will try to read more data from the AOF file but not enough bytes
+# the server will try to read more data from the AOF file but not enough bytes
 # will be found.
 aof-load-truncated yes
 
-# Redis can create append-only base files in either RDB or AOF formats. Using
+# The server can create append-only base files in either RDB or AOF formats. Using
 # the RDB format is always faster and more efficient, and disabling it is only
 # supported for backward compatibility purposes.
 aof-use-rdb-preamble yes
 
-# Redis supports recording timestamp annotations in the AOF to support restoring
+# The server supports recording timestamp annotations in the AOF to support restoring
 # the data from a specific point-in-time. However, using this capability changes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
@@ -1541,7 +1530,7 @@ aof-timestamp-enabled no
 #
 # shutdown-timeout 10
 
-# When Redis receives a SIGINT or SIGTERM, shutdown is initiated and by default
+# When the server receives a SIGINT or SIGTERM, shutdown is initiated and by default
 # an RDB snapshot is written to disk in a blocking operation if save points are configured.
 # The options used on signaled shutdown can include the following values:
 # default:  Saves RDB snapshot only if save points are configured.
@@ -1560,12 +1549,12 @@ aof-timestamp-enabled no
 ################ NON-DETERMINISTIC LONG BLOCKING COMMANDS #####################
 
 # Maximum time in milliseconds for EVAL scripts, functions and in some cases
-# modules' commands before Redis can start processing or rejecting other clients.
+# modules' commands before the server can start processing or rejecting other clients.
 #
-# If the maximum execution time is reached Redis will start to reply to most
+# If the maximum execution time is reached the server will start to reply to most
 # commands with a BUSY error.
 #
-# In this state Redis will only allow a handful of commands to be executed.
+# In this state the server will only allow a handful of commands to be executed.
 # For instance, SCRIPT KILL, FUNCTION KILL, SHUTDOWN NOSAVE and possibly some
 # module specific 'allow-busy' commands.
 #
@@ -1581,17 +1570,17 @@ aof-timestamp-enabled no
 # lua-time-limit 5000
 # busy-reply-threshold 5000
 
-################################ REDIS CLUSTER  ###############################
+################################ VALKEY CLUSTER  ###############################
 
-# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
-# started as cluster nodes can. In order to start a Redis instance as a
+# Normal server instances can't be part of a cluster; only nodes that are
+# started as cluster nodes can. In order to start a server instance as a
 # cluster node enable the cluster support uncommenting the following:
 #
 # cluster-enabled yes
 
 # Every cluster node has a cluster configuration file. This file is not
-# intended to be edited by hand. It is created and updated by Redis nodes.
-# Every Redis Cluster node requires a different cluster configuration file.
+# intended to be edited by hand. It is created and updated by each node.
+# Every cluster node requires a different cluster configuration file.
 # Make sure that instances running in the same system do not have
 # overlapping cluster configuration file names.
 #
@@ -1681,7 +1670,7 @@ aof-timestamp-enabled no
 #
 # cluster-allow-replica-migration yes
 
-# By default Redis Cluster nodes stop accepting queries if they detect there
+# By default cluster nodes stop accepting queries if they detect there
 # is at least a hash slot uncovered (no available node is serving it).
 # This way if the cluster is partially down (for example a range of hash slots
 # are no longer covered) all the cluster becomes, eventually, unavailable.
@@ -1776,11 +1765,11 @@ aof-timestamp-enabled no
 
 ########################## CLUSTER DOCKER/NAT support  ########################
 
-# In certain deployments, Redis Cluster nodes address discovery fails, because
+# In certain deployments, cluster node's address discovery fails, because
 # addresses are NAT-ted or because ports are forwarded (the typical case is
 # Docker and other containers).
 #
-# In order to make Redis Cluster working in such environments, a static
+# In order to make a cluster work in such environments, a static
 # configuration where each node knows its public address is needed. The
 # following four options are used for this scope, and are:
 #
@@ -1798,7 +1787,7 @@ aof-timestamp-enabled no
 # to zero, then cluster-announce-port refers to the TLS port. Note also that
 # cluster-announce-tls-port has no effect if tls-cluster is set to no.
 #
-# If the above options are not used, the normal Redis Cluster auto-detection
+# If the above options are not used, the normal cluster auto-detection
 # will be used instead.
 #
 # Note that when remapped, the bus port may not be at the fixed offset of
@@ -1815,14 +1804,14 @@ aof-timestamp-enabled no
 
 ################################## SLOW LOG ###################################
 
-# The Redis Slow Log is a system to log queries that exceeded a specified
+# The server Slow Log is a system to log queries that exceeded a specified
 # execution time. The execution time does not include the I/O operations
 # like talking with the client, sending the reply and so forth,
 # but just the time needed to actually execute the command (this is the only
 # stage of command execution where the thread is blocked and can not serve
 # other requests in the meantime).
 #
-# You can configure the slow log with two parameters: one tells Redis
+# You can configure the slow log with two parameters: one tells the server
 # what is the execution time, in microseconds, to exceed in order for the
 # command to get logged, and the other parameter is the length of the
 # slow log. When a new command is logged the oldest one is removed from the
@@ -1839,9 +1828,9 @@ slowlog-max-len 128
 
 ################################ LATENCY MONITOR ##############################
 
-# The Redis latency monitoring subsystem samples different operations
+# The server latency monitoring subsystem samples different operations
 # at runtime in order to collect data related to possible sources of
-# latency of a Redis instance.
+# latency of a server instance.
 #
 # Via the LATENCY command this information is available to the user that can
 # print graphs and obtain reports.
@@ -1860,7 +1849,7 @@ latency-monitor-threshold 0
 
 ################################ LATENCY TRACKING ##############################
 
-# The Redis extended latency monitoring tracks the per command latencies and enables
+# The server's extended latency monitoring tracks the per command latencies and enables
 # exporting the percentile distribution via the INFO latencystats command,
 # and cumulative latency distributions (histograms) via the LATENCY command.
 #
@@ -1874,7 +1863,7 @@ latency-monitor-threshold 0
 
 ############################# EVENT NOTIFICATION ##############################
 
-# Redis can notify Pub/Sub clients about events happening in the key space.
+# The server can notify Pub/Sub clients about events happening in the key space.
 # This feature is documented at https://redis.io/topics/notifications
 #
 # For instance if keyspace events notification is enabled, and a client
@@ -1884,7 +1873,7 @@ latency-monitor-threshold 0
 # PUBLISH __keyspace@0__:foo del
 # PUBLISH __keyevent@0__:del foo
 #
-# It is possible to select the events that Redis will notify among a set
+# It is possible to select the events that the server will notify among a set
 # of classes. Every class is identified by a single character:
 #
 #  K     Keyspace events, published with __keyspace@<db>__ prefix.
@@ -2009,8 +1998,8 @@ stream-node-max-bytes 4096
 stream-node-max-entries 100
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
-# order to help rehashing the main Redis hash table (the one mapping top-level
-# keys to values). The hash table implementation Redis uses (see dict.c)
+# order to help rehashing the main server hash table (the one mapping top-level
+# keys to values). The hash table implementation the server uses (see dict.c)
 # performs a lazy rehashing: the more operation you run into a hash table
 # that is rehashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
@@ -2021,7 +2010,7 @@ stream-node-max-entries 100
 #
 # If unsure:
 # use "activerehashing no" if you have hard latency requirements and it is
-# not a good thing in your environment that Redis can reply from time to time
+# not a good thing in your environment that the server can reply from time to time
 # to queries with 2 milliseconds delay.
 #
 # use "activerehashing yes" if you don't have such hard requirements but
@@ -2099,21 +2088,21 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # eviction at 5% of maxmemory:
 # maxmemory-clients 5%
 
-# In the Redis protocol, bulk requests, that are, elements representing single
+# In the server protocol, bulk requests, that are, elements representing single
 # strings, are normally limited to 512 mb. However you can change this limit
 # here, but must be 1mb or greater
 #
 # proto-max-bulk-len 512mb
 
-# Redis calls an internal function to perform many background tasks, like
+# The server calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are
 # never requested, and so forth.
 #
-# Not all tasks are performed with the same frequency, but Redis checks for
+# Not all tasks are performed with the same frequency, but the server checks for
 # tasks to perform according to the specified "hz" value.
 #
 # By default "hz" is set to 10. Raising the value will use more CPU when
-# Redis is idle, but at the same time will make Redis more responsive when
+# the server is idle, but at the same time will make the server more responsive when
 # there are many keys expiring at the same time, and timeouts may be
 # handled with more precision.
 #
@@ -2127,7 +2116,7 @@ hz 10
 # avoid too many clients are processed for each background task invocation
 # in order to avoid latency spikes.
 #
-# Since the default HZ value by default is conservatively set to 10, Redis
+# Since the default HZ value by default is conservatively set to 10, the server
 # offers, and enables by default, the ability to use an adaptive HZ value
 # which will temporarily raise when there are many connected clients.
 #
@@ -2144,22 +2133,22 @@ dynamic-hz yes
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
 
-# When redis saves RDB file, if the following option is enabled
+# When the server saves RDB file, if the following option is enabled
 # the file will be fsync-ed every 4 MB of data generated. This is useful
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 rdb-save-incremental-fsync yes
 
-# Redis LFU eviction (see maxmemory setting) can be tuned. However it is a good
+# The server's LFU eviction (see maxmemory setting) can be tuned. However it is a good
 # idea to start with the default settings and only change them after investigating
 # how to improve the performances and how the keys LFU change over time, which
 # is possible to inspect via the OBJECT FREQ command.
 #
-# There are two tunable parameters in the Redis LFU implementation: the
+# There are two tunable parameters in the server LFU implementation: the
 # counter logarithm factor and the counter decay time. It is important to
 # understand what the two parameters mean before changing them.
 #
-# The LFU counter is just 8 bits per key, it's maximum value is 255, so Redis
+# The LFU counter is just 8 bits per key, it's maximum value is 255, so the server
 # uses a probabilistic increment with logarithmic behavior. Given the value
 # of the old counter, when a key is accessed, the counter is incremented in
 # this way:
@@ -2186,8 +2175,8 @@ rdb-save-incremental-fsync yes
 #
 # NOTE: The above table was obtained by running the following commands:
 #
-#   redis-benchmark -n 1000000 incr foo
-#   redis-cli object freq foo
+#   valkey-benchmark -n 1000000 incr foo
+#   valkey-cli object freq foo
 #
 # NOTE 2: The counter initial value is 5 in order to give new objects a chance
 # to accumulate hits.
@@ -2226,7 +2215,7 @@ rdb-save-incremental-fsync yes
 # What is active defragmentation?
 # -------------------------------
 #
-# Active (online) defragmentation allows a Redis server to compact the
+# Active (online) defragmentation allows a server to compact the
 # spaces left between small allocations and deallocations of data in memory,
 # thus allowing to reclaim back memory.
 #
@@ -2234,11 +2223,11 @@ rdb-save-incremental-fsync yes
 # less so with Jemalloc, fortunately) and certain workloads. Normally a server
 # restart is needed in order to lower the fragmentation, or at least to flush
 # away all the data and create it again. However thanks to this feature
-# implemented by Oran Agra for Redis 4.0 this process can happen at runtime
+# implemented by Oran Agra, this process can happen at runtime
 # in a "hot" way, while the server is running.
 #
 # Basically when the fragmentation is over a certain level (see the
-# configuration options below) Redis will start to create new copies of the
+# configuration options below) the server will start to create new copies of the
 # values in contiguous memory regions by exploiting certain specific Jemalloc
 # features (in order to understand if an allocation is causing fragmentation
 # and to allocate it in a better place), and at the same time, will release the
@@ -2247,8 +2236,8 @@ rdb-save-incremental-fsync yes
 #
 # Important things to understand:
 #
-# 1. This feature is disabled by default, and only works if you compiled Redis
-#    to use the copy of Jemalloc we ship with the source code of Redis.
+# 1. This feature is disabled by default, and only works if you compiled the server
+#    to use the copy of Jemalloc we ship with the source code of the server.
 #    This is the default with Linux builds.
 #
 # 2. You never need to enable this feature if you don't have fragmentation
@@ -2288,20 +2277,20 @@ rdb-save-incremental-fsync yes
 # Jemalloc background thread for purging will be enabled by default
 jemalloc-bg-thread yes
 
-# It is possible to pin different threads and processes of Redis to specific
+# It is possible to pin different threads and processes of the server to specific
 # CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different Redis threads in different
-# CPUs, but also in order to make sure that multiple Redis instances running
+# This is useful both in order to pin different server threads in different
+# CPUs, but also in order to make sure that multiple server instances running
 # in the same host will be pinned to different CPUs.
 #
 # Normally you can do this using the "taskset" command, however it is also
-# possible to this via Redis configuration directly, both in Linux and FreeBSD.
+# possible to do this via the server configuration directly, both in Linux and FreeBSD.
 #
 # You can pin the server/IO threads, bio threads, aof rewrite child process, and
 # the bgsave child process. The syntax to specify the cpu list is the same as
 # the taskset command:
 #
-# Set redis server/io threads to cpu affinity 0,2,4,6:
+# Set server/io threads to cpu affinity 0,2,4,6:
 # server-cpulist 0-7:2
 #
 # Set bio threads to cpu affinity 1,3:
@@ -2313,7 +2302,7 @@ jemalloc-bg-thread yes
 # Set bgsave child process to cpu affinity 1,10,11
 # bgsave-cpulist 1,10-11
 
-# In some cases redis will emit warnings and even refuse to start if it detects
+# In some cases the server will emit warnings and even refuse to start if it detects
 # that the system is in bad state, it is possible to suppress these warnings
 # by setting the following config which takes a space delimited list of warnings
 # to suppress


### PR DESCRIPTION
This PR covers changing the redis.crt and redis.key to valkey certs for tls testing.

here are the files generated by the gen-test-certs.sh script.

```
valkey$ ls tests/tls/
ca.crt  ca.key  client.crt  client.key  openssl.cnf  server.crt  server.key  valkey.crt  valkey.dh  valkey.key
```

runtest results for `./runtest --tls`
```

/valkey$ ./runtest --tls
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 2423683
Testing unit/printver
[ready]: 2423684
Testing unit/dump
[ready]: 2423685
Testing unit/auth
[ready]: 2423686
Testing unit/protocol
[ready]: 2423687
Testing unit/keyspace
[ready]: 2423688
Testing unit/scan
[ready]: 2423689
Testing unit/info
[ready]: 2423690
Testing unit/info-command
[ready]: 2423691
Testing unit/type/string
[ready]: 2423692
Testing unit/type/incr
[ready]: 2423693
Testing unit/type/list
[ready]: 2423694
Testing unit/type/list-2
[ready]: 2423695
Testing unit/type/list-3
[ready]: 2423696
Testing unit/type/set
[ready]: 2423697
Testing unit/type/zset
[ready]: 2423698
Testing unit/type/hash
[ok]: DEL against a single item (2 ms)
-------
-------
  5 seconds - unit/cluster/slot-ownership
  8 seconds - unit/cluster/human-announced-nodename
  12 seconds - unit/cluster/hostnames
  42 seconds - unit/scripting
  125 seconds - unit/dump
  12 seconds - unit/cluster/failure-marking
  32 seconds - unit/wait
  28 seconds - unit/client-eviction
  44 seconds - unit/obuf-limits
  20 seconds - unit/cluster/cluster-response-tls
  20 seconds - unit/cluster/links
  61 seconds - unit/introspection
  58 seconds - unit/geo
  78 seconds - unit/hyperloglog
  111 seconds - unit/maxmemory
  189 seconds - integration/replication
  184 seconds - integration/replication-psync
  0 seconds - list-large-memory
  1 seconds - set-large-memory
  0 seconds - bitops-large-memory
  2 seconds - violations
  2 seconds - defrag

\o/ All tests passed without errors!

Cleanup: may take some time... OK

```
Other runtest such as runtest-cluster runtest-moduleapi and runtest-sentinel are also passed.