### PR TITLE
Rename #include guards.

### DIFF
--- a/src/cli_commands.h
+++ b/src/cli_commands.h
@@ -2,8 +2,8 @@
  * It contains alternative structs which omit the parts of the commands table
  * that are not suitable for redis-cli, e.g. the command proc. */
 
-#ifndef __REDIS_CLI_COMMANDS_H
-#define __REDIS_CLI_COMMANDS_H
+#ifndef VALKEY_CLI_COMMANDS_H
+#define VALKEY_CLI_COMMANDS_H
 
 #include <stddef.h>
 #include "commands.h"

--- a/src/commands.h
+++ b/src/commands.h
@@ -1,5 +1,5 @@
-#ifndef __REDIS_COMMANDS_H
-#define __REDIS_COMMANDS_H
+#ifndef VALKEY_COMMANDS_H
+#define VALKEY_COMMANDS_H
 
 /* Must be synced with ARG_TYPE_STR and generate-command-code.py */
 typedef enum {

--- a/src/connection.h
+++ b/src/connection.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __REDIS_CONNECTION_H
-#define __REDIS_CONNECTION_H
+#ifndef VALKEY_CONNECTION_H
+#define VALKEY_CONNECTION_H
 
 #include <errno.h>
 #include <stdio.h>

--- a/src/connhelpers.h
+++ b/src/connhelpers.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __REDIS_CONNHELPERS_H
-#define __REDIS_CONNHELPERS_H
+#ifndef VALKEY_CONNHELPERS_H
+#define VALKEY_CONNHELPERS_H
 
 #include "connection.h"
 
@@ -85,4 +85,4 @@ static inline int callHandler(connection *conn, ConnectionCallbackFunc handler) 
     return 1;
 }
 
-#endif  /* __REDIS_CONNHELPERS_H */
+#endif  /* VALKEY_CONNHELPERS_H */

--- a/src/rand.h
+++ b/src/rand.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef REDIS_RANDOM_H
-#define REDIS_RANDOM_H
+#ifndef VALKEY_RANDOM_H
+#define VALKEY_RANDOM_H
 
 int32_t redisLrand48(void);
 void redisSrand48(int32_t seedval);

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1,5 +1,5 @@
-#ifndef REDISMODULE_H
-#define REDISMODULE_H
+#ifndef VALKEYMODULE_H
+#define VALKEYMODULE_H
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -1692,4 +1692,4 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
 #define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
 
 #endif /* REDISMODULE_CORE */
-#endif /* REDISMODULE_H */
+#endif /* VALKEYMODULE_H */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -1,5 +1,5 @@
-#ifndef VALKEYMODULE_H
-#define VALKEYMODULE_H
+#ifndef REDISMODULE_H
+#define REDISMODULE_H
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -1692,4 +1692,4 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
 #define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
 
 #endif /* REDISMODULE_CORE */
-#endif /* VALKEYMODULE_H */
+#endif /* REDISMODULE_H */

--- a/src/rio.h
+++ b/src/rio.h
@@ -29,8 +29,8 @@
  */
 
 
-#ifndef __REDIS_RIO_H
-#define __REDIS_RIO_H
+#ifndef VALKEY_RIO_H
+#define VALKEY_RIO_H
 
 #include <stdio.h>
 #include <stdint.h>

--- a/src/server.h
+++ b/src/server.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __REDIS_H
-#define __REDIS_H
+#ifndef VALKEY_H
+#define VALKEY_H
 
 #include "fmacros.h"
 #include "config.h"

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -35,8 +35,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __REDIS_ASSERT_H__
-#define __REDIS_ASSERT_H__
+#ifndef VALKEY_ASSERT_H
+#define VALKEY_ASSERT_H
 
 #include "config.h"
 

--- a/src/util.h
+++ b/src/util.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __REDIS_UTIL_H
-#define __REDIS_UTIL_H
+#ifndef VALKEY_UTIL_H
+#define VALKEY_UTIL_H
 
 #include <stdint.h>
 #include "sds.h"


### PR DESCRIPTION
Rename macro guard and remove the leading double underscore.

Fixes #137