### PR TITLE
Rename redisCommandProc, redisGetKeysProc to server prefix

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2149,7 +2149,7 @@ int doesCommandHaveKeys(struct redisCommand *cmd) {
 /* A simplified channel spec table that contains all of the redis commands
  * and which channels they have and how they are accessed. */
 typedef struct ChannelSpecs {
-    redisCommandProc *proc; /* Command procedure to match against */
+    serverCommandProc *proc; /* Command procedure to match against */
     uint64_t flags;         /* CMD_CHANNEL_* flags for this command */
     int start;              /* The initial position of the first channel */
     int count;              /* The number of channels, or -1 if all remaining

--- a/src/networking.c
+++ b/src/networking.c
@@ -2075,7 +2075,7 @@ int handleClientsWithPendingWrites(void) {
 
 /* resetClient prepare the client to process the next command */
 void resetClient(client *c) {
-    redisCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
+    serverCommandProc *prevcmd = c->cmd ? c->cmd->proc : NULL;
 
     freeClientArgv(c);
     c->cur_script = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -2237,8 +2237,8 @@ typedef enum {
     COMMAND_GROUP_MODULE,
 } redisCommandGroup;
 
-typedef void redisCommandProc(client *c);
-typedef int redisGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
+typedef void serverCommandProc(client *c);
+typedef int serverGetKeysProc(struct redisCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 /* Redis command structure.
  *
@@ -2348,7 +2348,7 @@ struct redisCommand {
     int num_history;
     const char **tips; /* An array of strings that are meant to be tips for clients/proxies regarding this command */
     int num_tips;
-    redisCommandProc *proc; /* Command implementation */
+    serverCommandProc *proc; /* Command implementation */
     int arity; /* Number of arguments, it is possible to use -N to say >= N */
     uint64_t flags; /* Command flags, see CMD_*. */
     uint64_t acl_categories; /* ACl categories, see ACL_CATEGORY_*. */
@@ -2356,7 +2356,7 @@ struct redisCommand {
     int key_specs_num;
     /* Use a function to determine keys arguments in a command line.
      * Used for Redis Cluster redirect (may be NULL) */
-    redisGetKeysProc *getkeys_proc;
+    serverGetKeysProc *getkeys_proc;
     int num_args; /* Length of args array. */
     /* Array of subcommands (may be NULL) */
     struct redisCommand *subcommands;


### PR DESCRIPTION
https://github.com/valkey-io/valkey/issues/144