### PR TITLE
rename tls cert files to valkey

### DIFF
--- a/TLS.md
+++ b/TLS.md
@@ -33,25 +33,25 @@ To run Redis test suite with TLS, you'll need TLS support for TCL (i.e.
 
 ### Running manually
 
-To manually run a Redis server with TLS mode (assuming `gen-test-certs.sh` was
+To manually run a Valkey server with TLS mode (assuming `gen-test-certs.sh` was
 invoked so sample certificates/keys are available):
 
 For TLS built-in mode:
-    ./src/redis-server --tls-port 6379 --port 0 \
-        --tls-cert-file ./tests/tls/redis.crt \
-        --tls-key-file ./tests/tls/redis.key \
+    ./src/valkey-server --tls-port 6379 --port 0 \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt
 
 For TLS module mode:
-    ./src/redis-server --tls-port 6379 --port 0 \
-        --tls-cert-file ./tests/tls/redis.crt \
-        --tls-key-file ./tests/tls/redis.key \
+    ./src/valkey-server --tls-port 6379 --port 0 \
+        --tls-cert-file ./tests/tls/valkey.crt \
+        --tls-key-file ./tests/tls/valkey.key \
         --tls-ca-cert-file ./tests/tls/ca.crt \
-        --loadmodule src/redis-tls.so
+        --loadmodule src/valkey-tls.so
 
-To connect to this Redis server with `redis-cli`:
+To connect to this Redis server with `valkey-cli`:
 
-    ./src/redis-cli --tls \
+    ./src/valkey-cli --tls \
         --cert ./tests/tls/redis.crt \
         --key ./tests/tls/redis.key \
         --cacert ./tests/tls/ca.crt

--- a/deps/hiredis/test.sh
+++ b/deps/hiredis/test.sh
@@ -23,8 +23,8 @@ SOCK_FILE=${tmpdir}/hiredis-test-redis.sock
 if [ "$TEST_SSL" = "1" ]; then
     SSL_CA_CERT=${tmpdir}/ca.crt
     SSL_CA_KEY=${tmpdir}/ca.key
-    SSL_CERT=${tmpdir}/redis.crt
-    SSL_KEY=${tmpdir}/redis.key
+    SSL_CERT=${tmpdir}/valkey.crt
+    SSL_KEY=${tmpdir}/valkey.key
 
     openssl genrsa -out ${tmpdir}/ca.key 4096
     openssl req \

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -100,7 +100,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             puts $cfg [format "tls-key-file %s/../../tls/server.key" [pwd]]
             puts $cfg [format "tls-client-cert-file %s/../../tls/client.crt" [pwd]]
             puts $cfg [format "tls-client-key-file %s/../../tls/client.key" [pwd]]
-            puts $cfg [format "tls-dh-params-file %s/../../tls/redis.dh" [pwd]]
+            puts $cfg [format "tls-dh-params-file %s/../../tls/valkey.dh" [pwd]]
             puts $cfg [format "tls-ca-cert-file %s/../../tls/ca.crt" [pwd]]
         } else {
             puts $cfg "port $port"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -486,7 +486,7 @@ proc start_server {options {code undefined}} {
         dict set config "tls-key-file" [format "%s/tests/tls/server.key" [pwd]]
         dict set config "tls-client-cert-file" [format "%s/tests/tls/client.crt" [pwd]]
         dict set config "tls-client-key-file" [format "%s/tests/tls/client.key" [pwd]]
-        dict set config "tls-dh-params-file" [format "%s/tests/tls/redis.dh" [pwd]]
+        dict set config "tls-dh-params-file" [format "%s/tests/tls/valkey.dh" [pwd]]
         dict set config "tls-ca-cert-file" [format "%s/tests/tls/ca.crt" [pwd]]
         dict set config "loglevel" "debug"
     }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -100,10 +100,10 @@ start_server {tags {"tls"}} {
             set master_port [srv 0 port]
 
             # Use a non-restricted client/server cert for the replica
-            set redis_crt [format "%s/tests/tls/redis.crt" [pwd]]
-            set redis_key [format "%s/tests/tls/redis.key" [pwd]]
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
 
-            start_server [list overrides [list tls-cert-file $redis_crt tls-key-file $redis_key] \
+            start_server [list overrides [list tls-cert-file $valkey_crt tls-key-file $valkey_key] \
                                omit [list tls-client-cert-file tls-client-key-file]] {
                 set replica [srv 0 client]
                 $replica replicaof $master_host $master_port

--- a/utils/gen-test-certs.sh
+++ b/utils/gen-test-certs.sh
@@ -3,10 +3,10 @@
 # Generate some test certificates which are used by the regression test suite:
 #
 #   tests/tls/ca.{crt,key}          Self signed CA certificate.
-#   tests/tls/redis.{crt,key}       A certificate with no key usage/policy restrictions.
+#   tests/tls/valkey.{crt,key}       A certificate with no key usage/policy restrictions.
 #   tests/tls/client.{crt,key}      A certificate restricted for SSL client usage.
 #   tests/tls/server.{crt,key}      A certificate restricted for SSL server usage.
-#   tests/tls/redis.dh              DH Params file.
+#   tests/tls/valkey.dh              DH Params file.
 
 generate_cert() {
     local name=$1
@@ -53,6 +53,6 @@ _END_
 
 generate_cert server "Server-only" "-extfile tests/tls/openssl.cnf -extensions server_cert"
 generate_cert client "Client-only" "-extfile tests/tls/openssl.cnf -extensions client_cert"
-generate_cert redis "Generic-cert"
+generate_cert valkey "Generic-cert"
 
-[ -f tests/tls/redis.dh ] || openssl dhparam -out tests/tls/redis.dh 2048
+[ -f tests/tls/valkey.dh ] || openssl dhparam -out tests/tls/valkey.dh 2048


### PR DESCRIPTION
This PR covers changing the redis.crt and redis.key to valkey certs for tls testing.

here are the files generated by the gen-test-certs.sh script.

```
valkey$ ls tests/tls/
ca.crt  ca.key  client.crt  client.key  openssl.cnf  server.crt  server.key  valkey.crt  valkey.dh  valkey.key
```

runtest results for `./runtest --tls`
```

/valkey$ ./runtest --tls
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 2423683
Testing unit/printver
[ready]: 2423684
Testing unit/dump
[ready]: 2423685
Testing unit/auth
[ready]: 2423686
Testing unit/protocol
[ready]: 2423687
Testing unit/keyspace
[ready]: 2423688
Testing unit/scan
[ready]: 2423689
Testing unit/info
[ready]: 2423690
Testing unit/info-command
[ready]: 2423691
Testing unit/type/string
[ready]: 2423692
Testing unit/type/incr
[ready]: 2423693
Testing unit/type/list
[ready]: 2423694
Testing unit/type/list-2
[ready]: 2423695
Testing unit/type/list-3
[ready]: 2423696
Testing unit/type/set
[ready]: 2423697
Testing unit/type/zset
[ready]: 2423698
Testing unit/type/hash
[ok]: DEL against a single item (2 ms)
-------
-------
  5 seconds - unit/cluster/slot-ownership
  8 seconds - unit/cluster/human-announced-nodename
  12 seconds - unit/cluster/hostnames
  42 seconds - unit/scripting
  125 seconds - unit/dump
  12 seconds - unit/cluster/failure-marking
  32 seconds - unit/wait
  28 seconds - unit/client-eviction
  44 seconds - unit/obuf-limits
  20 seconds - unit/cluster/cluster-response-tls
  20 seconds - unit/cluster/links
  61 seconds - unit/introspection
  58 seconds - unit/geo
  78 seconds - unit/hyperloglog
  111 seconds - unit/maxmemory
  189 seconds - integration/replication
  184 seconds - integration/replication-psync
  0 seconds - list-large-memory
  1 seconds - set-large-memory
  0 seconds - bitops-large-memory
  2 seconds - violations
  2 seconds - defrag

\o/ All tests passed without errors!

Cleanup: may take some time... OK

```
Other runtest such as runtest-cluster runtest-moduleapi and runtest-sentinel are also passed.
fixes https://github.com/valkey-io/valkey/pull/161 and also covers comments provided