### PR TITLE
Replace Valkey in runtest scripts error prints

### DIFF
--- a/runtest
+++ b/runtest
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis test"
+    echo "You need tcl 8.5 or newer in order to run the Valkey test"
     exit 1
 fi
 $TCLSH tests/test_helper.tcl "${@}"

--- a/runtest-cluster
+++ b/runtest-cluster
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis Cluster test"
+    echo "You need tcl 8.5 or newer in order to run the Valkey Cluster test"
     exit 1
 fi
 $TCLSH tests/cluster/run.tcl $*

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -9,7 +9,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis ModuleApi test"
+    echo "You need tcl 8.5 or newer in order to run the Valkey ModuleApi test"
     exit 1
 fi
 

--- a/runtest-sentinel
+++ b/runtest-sentinel
@@ -8,7 +8,7 @@ done
 
 if [ -z $TCLSH ]
 then
-    echo "You need tcl 8.5 or newer in order to run the Redis Sentinel test"
+    echo "You need tcl 8.5 or newer in order to run the Valkey Sentinel test"
     exit 1
 fi
 $TCLSH tests/sentinel/run.tcl $*


### PR DESCRIPTION
Replaced Redis with Valkey in runtest script's error prints.