### PR TITLE
Fix LFU/LRU of shared objects.

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1984,9 +1984,9 @@ void createSharedObjects(void) {
     shared.redacted = makeObjectShared(createStringObject("(redacted)",10));
 
     for (j = 0; j < OBJ_SHARED_INTEGERS; j++) {
-        shared.integers[j] =
-            makeObjectShared(createObject(OBJ_STRING,(void*)(long)j));
-        initObjectLRUOrLFU(shared.integers[j]);
+        robj *o = createObject(OBJ_STRING,(void*)(long)j);
+        initObjectLRUOrLFU(o);
+        shared.integers[j] = makeObjectShared(o);
         shared.integers[j]->encoding = OBJ_ENCODING_INT;
     }
     for (j = 0; j < OBJ_SHARED_BULKHDR_LEN; j++) {

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -253,4 +253,4 @@ start_server {tags {"introspection"}} {
         r incr foo
         assert {[getlru foo] > 0}
      } 
-}
+} {} {needs:debug}

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -242,4 +242,15 @@ start_server {tags {"introspection"}} {
         }
     }
 
+    test {lfu/lru value of the shared object key} {
+        r config set maxmemory 0
+        r config set maxmemory-policy allkeys-lfu
+        r incr foo
+        assert {[getlru foo] > 0}
+
+        r del foo
+        r config set maxmemory-policy allkeys-lru
+        r incr foo
+        assert {[getlru foo] > 0}
+     } 
 }


### PR DESCRIPTION
Fix LFU/LRU of shared objects. Initiatlize LRU/LFU information on the objects before marking it as shared.

Related issue: https://github.com/valkey-io/valkey/issues/220