### PR TITLE
Fix two typos that were flagged in the 7.2 build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -342,7 +342,7 @@ else
     endef
 endif
 
-# Determine install/unstall Redis symlinks for compatibility when 
+# Determine install/uninstall Redis symlinks for compatibility when 
 # installing/uninstalling Valkey binaries (defaulting to `yes`)
 USE_REDIS_SYMLINKS?=yes
 ifeq ($(USE_REDIS_SYMLINKS),yes)

--- a/src/eval.c
+++ b/src/eval.c
@@ -30,7 +30,7 @@
 /*
  * This file initializes the global LUA object and registers functions to call Valkey API from within the LUA language. 
  * It heavily invokes LUA's C API documented at https://www.lua.org/pil/24.html. There are 2 entrypoint functions in this file: 
- * 1. evalCommand() - Gets invoked everytime a user runs LUA script via eval command on Valkey. 
+ * 1. evalCommand() - Gets invoked every time a user runs LUA script via eval command on Valkey. 
  * 2. scriptingInit() - initServer() function from server.c invokes this to initialize LUA at startup. 
  *                      It is also invoked between 2 eval invocations to reset Lua. 
  */


### PR DESCRIPTION
These were flagged on the 7.2 build system, which is using the old spell check. I think we should consider re-adding it as it missed some typos. 

Relevant: https://github.com/valkey-io/valkey/pull/72