### PR TITLE
Rename function redis-check-rdb -> valkey-check-rdb, redis-check-aof -> valkey-check-aof

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -93,7 +93,7 @@ void rdbReportError(int corruption_error, int linenum, char *reason, ...) {
             rdbCheckError("Cannot check RDB that is a FIFO: %s", argv[1]);
             return;
         }
-        redis_check_rdb_main(2,argv,NULL);
+        valkey_check_rdb_main(2, argv, NULL);
     } else if (corruption_error) {
         /* In diskless loading, in case of corrupt file, log and exit. */
         serverLog(LL_WARNING, "%s. Failure loading rdb format", msg);

--- a/src/server.c
+++ b/src/server.c
@@ -6998,18 +6998,18 @@ int main(int argc, char **argv) {
      * the program main. However the program is part of the Redis executable
      * so that we can easily execute an RDB check on loading errors. */
     if (strstr(exec_name,"valkey-check-rdb") != NULL)
-        redis_check_rdb_main(argc,argv,NULL);
+        valkey_check_rdb_main(argc, argv, NULL);
     else if (strstr(exec_name,"valkey-check-aof") != NULL)
-        redis_check_aof_main(argc,argv);
+        valkey_check_aof_main(argc, argv);
     
     /* If enable USE_REDIS_SYMLINKS, valkey may install symlinks like 
      * redis-server -> valkey-server, redis-check-rdb -> valkey-check-rdb,
      * redis-check-aof -> valkey-check-aof, etc. */
 #ifdef USE_REDIS_SYMLINKS
     if (strstr(exec_name,"redis-check-rdb") != NULL)
-        redis_check_rdb_main(argc, argv, NULL);
+        valkey_check_rdb_main(argc, argv, NULL);
     else if (strstr(exec_name,"redis-check-aof") != NULL)
-        redis_check_aof_main(argc,argv);
+        valkey_check_aof_main(argc, argv);
 #endif
 
     if (argc >= 2) {

--- a/src/server.h
+++ b/src/server.h
@@ -3377,10 +3377,10 @@ void sentinelInfoCommand(client *c);
 void sentinelPublishCommand(client *c);
 void sentinelRoleCommand(client *c);
 
-/* redis-check-rdb & aof */
-int redis_check_rdb(char *rdbfilename, FILE *fp);
-int redis_check_rdb_main(int argc, char **argv, FILE *fp);
-int redis_check_aof_main(int argc, char **argv);
+/* valkey-check-rdb & aof */
+int valkey_check_rdb(char *rdbfilename, FILE *fp);
+int valkey_check_rdb_main(int argc, char **argv, FILE *fp);
+int valkey_check_aof_main(int argc, char **argv);
 
 /* Scripting */
 void scriptingInit(int setup);

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -246,7 +246,7 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
 
     if (preamble) {
         char *argv[2] = {NULL, aof_filepath};
-        if (redis_check_rdb_main(2, argv, fp) == C_ERR) {
+        if (valkey_check_rdb_main(2, argv, fp) == C_ERR) {
             printf("RDB preamble of AOF file is not sane, aborting.\n");
             exit(1);
         } else {
@@ -515,7 +515,7 @@ void checkOldStyleAof(char *filepath, int fix, int preamble) {
     printAofStyle(ret, filepath, (char *)"AOF");
 }
 
-int redis_check_aof_main(int argc, char **argv) {
+int valkey_check_aof_main(int argc, char **argv) {
     char *filepath;
     char temp_filepath[PATH_MAX + 1];
     char *dirpath;

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -192,7 +192,7 @@ void rdbCheckSetupSignals(void) {
  * 1 is returned.
  * The file is specified as a filename in 'rdbfilename' if 'fp' is NULL,
  * otherwise the already open file 'fp' is checked. */
-int redis_check_rdb(char *rdbfilename, FILE *fp) {
+int valkey_check_rdb(char *rdbfilename, FILE *fp) {
     uint64_t dbid;
     int selected_dbid = -1;
     int type, rdbver;
@@ -396,8 +396,8 @@ err:
     return 1;
 }
 
-/* RDB check main: called form server.c when Redis is executed with the
- * redis-check-rdb alias, on during RDB loading errors.
+/* RDB check main: called form server.c when Valkey is executed with the
+ * valkey-check-rdb alias, on during RDB loading errors.
  *
  * The function works in two ways: can be called with argc/argv as a
  * standalone executable, or called with a non NULL 'fp' argument if we
@@ -408,7 +408,7 @@ err:
  * status code according to success (RDB is sane) or error (RDB is corrupted).
  * Otherwise if called with a non NULL fp, the function returns C_OK or
  * C_ERR depending on the success or failure. */
-int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
+int valkey_check_rdb_main(int argc, char **argv, FILE *fp) {
     struct timeval tv;
 
     if (argc != 2 && fp == NULL) {
@@ -434,7 +434,7 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     rdbCheckMode = 1;
     rdbCheckInfo("Checking RDB file %s", argv[1]);
     rdbCheckSetupSignals();
-    int retval = redis_check_rdb(argv[1],fp);
+    int retval = valkey_check_rdb(argv[1], fp);
     if (retval == 0) {
         rdbCheckInfo("\\o/ RDB looks OK! \\o/");
         rdbShowGenericInfo();


### PR DESCRIPTION
Just rename the function name 
- `redis_check_rdb_main` to  `valkey_check_rdb_main`
- `redis_check_rdb` to `valkeyr_check_rdb`
- `redis_check_aof_main` to `valkey_check_aof_main`