### PR TITLE
Split valkey.log and audit.log

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -626,7 +626,7 @@ void loadServerConfigFromString(char *config) {
         fclose(audit_logfp);
 
         /* Edit verbosity if audit-logfile is defined. Default LL_NOTICE. */
-        if server.verbosity > LL_VERBOSE {
+        if (server.verbosity > LL_VERBOSE) {
             server.verbosity = LL_VERBOSE;
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -3133,6 +3133,7 @@ standardConfig static_configs[] = {
     createStringConfig("proc-title-template", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.proc_title_template, CONFIG_DEFAULT_PROC_TITLE_TEMPLATE, isValidProcTitleTemplate, updateProcTitleTemplate),
     createStringConfig("bind-source-addr", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.bind_source_addr, NULL, NULL, NULL),
     createStringConfig("logfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.logfile, "", NULL, NULL),
+    createStringConfig("audit-logfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.audit_logfile, "", NULL, NULL),
 #ifdef LOG_REQ_RES
     createStringConfig("req-res-logfile", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, EMPTY_STRING_IS_NULL, server.req_res_logfile, NULL, NULL, NULL),
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -615,6 +615,8 @@ void loadServerConfigFromString(char *config) {
     if (server.audit_logfile[0] != '\0') {
         FILE *audit_logfp;
 
+        /* Test if we are able to open the file. The server will not
+         * be able to abort just for this problem later... */
         audit_logfp = fopen(server.audit_logfile,"a");
         if (audit_logfp == NULL) {
             err = sdscatprintf(sdsempty(),
@@ -622,6 +624,11 @@ void loadServerConfigFromString(char *config) {
             goto loaderr;
         }
         fclose(audit_logfp);
+
+        /* Edit verbosity if audit-logfile is defined. Default LL_NOTICE. */
+        if server.verbosity > LL_VERBOSE {
+            server.verbosity = LL_VERBOSE;
+        }
     }
 
     /* Sanity checks. */

--- a/src/config.c
+++ b/src/config.c
@@ -612,6 +612,18 @@ void loadServerConfigFromString(char *config) {
         fclose(logfp);
     }
 
+    if (server.audit_logfile[0] != '\0') {
+        FILE *audit_logfp;
+
+        audit_logfp = fopen(server.audit_logfile,"a");
+        if (audit_logfp == NULL) {
+            err = sdscatprintf(sdsempty(),
+                               "Can't open the audit log file: %s", strerror(errno));
+            goto loaderr;
+        }
+        fclose(audit_logfp);
+    }
+
     /* Sanity checks. */
     if (server.cluster_enabled && server.masterhost) {
         err = "replicaof directive not allowed in cluster mode";

--- a/src/server.c
+++ b/src/server.c
@@ -121,7 +121,9 @@ void serverLogRaw(int level, const char *msg) {
     level &= 0xff; /* clear flags */
     if (level < server.verbosity) return;
 
-    fp = log_to_stdout ? stdout : fopen(server.logfile,"a");
+    fp = log_to_stdout ? stdout :
+                         (server.verbosity <= LL_VERBOSE ? fopen(server.audit_logfile,"a") :
+                                                           fopen(server.logfile,"a"));
     if (!fp) return;
 
     if (rawmode) {

--- a/src/server.c
+++ b/src/server.c
@@ -122,7 +122,7 @@ void serverLogRaw(int level, const char *msg) {
     if (level < server.verbosity) return;
 
     fp = log_to_stdout ? stdout :
-                         (server.verbosity <= LL_VERBOSE ? fopen(server.audit_logfile,"a") :
+                         (server.verbosity == LL_VERBOSE ? fopen(server.audit_logfile,"a") :
                                                            fopen(server.logfile,"a"));
     if (!fp) return;
 

--- a/src/server.c
+++ b/src/server.c
@@ -122,8 +122,9 @@ void serverLogRaw(int level, const char *msg) {
     if (level < server.verbosity) return;
 
     fp = log_to_stdout ? stdout :
-                         (server.verbosity == LL_VERBOSE ? fopen(server.audit_logfile,"a") :
-                                                           fopen(server.logfile,"a"));
+                         ((level == server.verbosity && server.verbosity == LL_VERBOSE)
+                             ? fopen(server.audit_logfile,"a")
+                             : fopen(server.logfile,"a"));
     if (!fp) return;
 
     if (rawmode) {

--- a/src/server.h
+++ b/src/server.h
@@ -1848,6 +1848,7 @@ struct valkeyServer {
     int replication_allowed;        /* Are we allowed to replicate? */
     /* Logging */
     char *logfile;                  /* Path of log file */
+    char *audit_logfile;            /* Path of audit log file*/
     int syslog_enabled;             /* Is syslog enabled? */
     char *syslog_ident;             /* Syslog ident */
     int syslog_facility;            /* Syslog facility */


### PR DESCRIPTION
fix #260 

## what have been changed
- Add config parameter "audit-logfile", usage is same as "logfile".
- If "audit-logfile" is not empty and `server.verbosity` bigger than `LL_VERBOSE`, edit it as `LL_VERBOSE`.
- If `loglevel == LL_VERBOSE` and `server.verbosity == LL_VERBOSE`, print it to "audit-logfile", not "logfile".

### results
![image](https://github.com/valkey-io/valkey/assets/38001238/e4956434-165a-4942-acf8-974acc66fa4d)

with valkey.conf as below:
``` bash
# valkey.conf
logfile "./valkey.log"
audit-logfile "./audit.log"
```


## Note
- also wrote in #260 
- `LL_DEBUG` is not included in this change: not affected by this change.
  - It's intended because DEBUG is literally debug.
- I would like to add more log levels: like splitting client connection logs with other verbose logs.
  - But this is a quite big change, so I didn't do it right now.
- testfile is not ready cause it is just a concept of change. I'll work on it when this change is suitable for Valkey.