### PR TITLE
Update crash wording to include our repo

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2382,10 +2382,10 @@ void bugReportEnd(int killViaSignal, int sig) {
     serverLogRawFromHandler(LL_WARNING|LL_RAW,
 "\n=== REDIS BUG REPORT END. Make sure to include from START to END. ===\n\n"
 "       Please report the crash by opening an issue on github:\n\n"
-"           http://github.com/redis/redis/issues\n\n"
-"  If a Redis module was involved, please open in the module's repo instead.\n\n"
-"  Suspect RAM error? Use redis-server --test-memory to verify it.\n\n"
-"  Some other issues could be detected by redis-server --check-system\n"
+"           http://github.com/valkey-io/valkey/issues\n\n"
+"  If a module was involved, please open in the module's repo instead.\n\n"
+"  Suspect RAM error? Use valkey-server --test-memory to verify it.\n\n"
+"  Some other issues could be detected by valkey-server --check-system\n"
 );
 
     /* free(messages); Don't call free() with possibly corrupted memory. */


### PR DESCRIPTION
Update the wording in the crash log to point to Valkey repo instead of Redis repo.