### PR TITLE
Remove single node cluster validation check from benchmark

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1787,7 +1787,7 @@ int main(int argc, char **argv) {
             }
             exit(1);
         }
-        if (config.cluster_node_count <= 1) {
+        if (config.cluster_node_count == 0) {
             fprintf(stderr, "Invalid cluster: %d node(s).\n",
                     config.cluster_node_count);
             exit(1);


### PR DESCRIPTION
Before:

```
src/redis-benchmark -n 1 --cluster set k1 v1
Invalid cluster: 1 node(s).
```

After:
```
src/redis-benchmark -n 1 --cluster set k1 v1
Cluster has 1 master nodes:

Master 0: c7adb9ffa6ec89333d2d8df537ca25bec7692d45 127.0.0.1:6379

k1 v1: rps=108250.0 (overall: 108091.1) avg_msec=0.237 (overall: 0.238)
```

Ref: https://github.com/redis/redis/pull/13129