### PR TITLE
Add sharded-pubsub tcl test to test_helper all test set

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -105,6 +105,7 @@ set ::all_tests {
     unit/cluster/links
     unit/cluster/cluster-response-tls
     unit/cluster/failure-marking
+    unit/cluster/sharded-pubsub
 }
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0


### PR DESCRIPTION
Maybe we could support listing all files via glob/regex pattern and we could just pass unit/* and avoid this issue. Adding the test to the `all_tests` set manually for now.