### PR TITLE
Wait for cluster fully online in cluster_config_consistent

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1450,6 +1450,10 @@ int clusterNodeFailureReportsCount(clusterNode *node) {
     return listLength(node->fail_reports);
 }
 
+static int clusterNodeNameComparator(const void *node1, const void *node2) {
+    return strncasecmp((*(clusterNode **)node1)->name, (*(clusterNode **)node2)->name, CLUSTER_NAMELEN);
+}
+
 int clusterNodeRemoveSlave(clusterNode *master, clusterNode *slave) {
     int j;
 
@@ -1479,6 +1483,7 @@ int clusterNodeAddSlave(clusterNode *master, clusterNode *slave) {
         sizeof(clusterNode*)*(master->numslaves+1));
     master->slaves[master->numslaves] = slave;
     master->numslaves++;
+    qsort(master->slaves, master->numslaves, sizeof(clusterNode *), clusterNodeNameComparator);
     master->flags |= CLUSTER_NODE_MIGRATE_TO;
     return C_OK;
 }

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -182,8 +182,21 @@ proc cluster_write_test {id} {
 }
 
 # Check if cluster configuration is consistent.
+# All the nodes in the cluster should show same slots configuration and have health
+# state "online" to be considered as consistent.
 proc cluster_config_consistent {} {
     for {set j 0} {$j < $::cluster_master_nodes + $::cluster_replica_nodes} {incr j} {
+        # Check if all the nodes are online
+        set shards_cfg [R $j CLUSTER SHARDS]
+        foreach shard_cfg $shards_cfg {
+            set nodes [dict get $shard_cfg nodes]
+            foreach node $nodes {
+                if {[dict get $node health] ne "online"} {
+                    return 0
+                }
+            }
+        }
+
         if {$j == 0} {
             set base_cfg [R $j cluster slots]
         } else {
@@ -199,7 +212,7 @@ proc cluster_config_consistent {} {
 
 # Wait for cluster configuration to propagate and be consistent across nodes.
 proc wait_for_cluster_propagation {} {
-    wait_for_condition 50 100 {
+    wait_for_condition 1000 50 {
         [cluster_config_consistent] eq 1
     } else {
         fail "cluster config did not reach a consistent state"


### PR DESCRIPTION
Wait for cluster to be in a fully consistent and online state in `cluster_config_consistent`. We expect the `start_server` to create the desired primaries and replicas before the start of the tests. With the current setup, the replicas may not complete the sync with primaries and can be in loading state. In some cases, the role of replicas can still be master with the delay of propagation of replicate command. The tests can show flaky behavior in such cases. Add a check that verifies the nodes health status 'online' for the cluster consistency. Leverage the deterministic order of `CLUSTER SLOTS` to consider the cluster as consistent along with the nodes health status.