### PR TITLE
Fix reference to redis-tls module

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -87,7 +87,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
 
         if {$::tls} {
             if {$::tls_module} {
-                puts $cfg [format "loadmodule %s/../../../src/redis-tls.so" [pwd]]
+                puts $cfg [format "loadmodule %s/../../../src/valkey-tls.so" [pwd]]
             }
 
             puts $cfg "tls-port $port"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -480,7 +480,7 @@ proc start_server {options {code undefined}} {
     set config {}
     if {$::tls} {
         if {$::tls_module} {
-            lappend config_lines [list "loadmodule" [format "%s/src/redis-tls.so" [pwd]]]
+            lappend config_lines [list "loadmodule" [format "%s/src/valkey-tls.so" [pwd]]]
         }
         dict set config "tls-cert-file" [format "%s/tests/tls/server.crt" [pwd]]
         dict set config "tls-key-file" [format "%s/tests/tls/server.key" [pwd]]


### PR DESCRIPTION
Update test usage of valkey-tls.so module to use valkey-tls.so instead.

Fixes tests failures like https://github.com/valkey-io/valkey/actions/runs/8592855995/job/23543475478. 