### PR TITLE
Revert the default PID file back to the real default

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -329,7 +329,7 @@ daemonize no
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/valkey.pid".
+# is used even if not specified, defaulting to "/var/run/redis.pid".
 #
 # Creating a pid file is best effort: if the server is not able to create it
 # nothing bad happens, the server will start and run normally.


### PR DESCRIPTION
The default pid file is created at /var/run/redis.pid based on the code at https://github.com/valkey-io/valkey/blob/da831c0d2242251be84a5d7f14f954c6c7fa8ee8/src/server.h#L132. Until we update it, we should reflect that in the conf file.