### PR TITLE
Rename redis_client* procedure to valkey_client* in test environment

### DIFF
--- a/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
+++ b/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
@@ -147,7 +147,7 @@ test "Move a replica to another primary, verify client receives sunsubscribe on 
     set replica_addr [get_addr_replica_serving_slot $slot]
     set replica_host [lindex $replica_addr 0]
     set replica_port [lindex $replica_addr 1]
-    set replica_client [redis_client_by_addr $replica_host $replica_port]
+    set replica_client [valkey_client_by_addr $replica_host $replica_port]
     set subscribeclient [valkey_deferring_client_by_addr $replica_host $replica_port]
 
     $subscribeclient deferred 1

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -13,7 +13,7 @@ test "Pub/Sub shard basics" {
     array set publishnode [$cluster masternode_for_slot $slot]
     array set notshardnode [$cluster masternode_notfor_slot $slot]
 
-    set publishclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
+    set publishclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient2 [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set anotherclient [valkey_deferring_client_by_addr $notshardnode(host) $notshardnode(port)]
@@ -57,7 +57,7 @@ test "client can subscribe to multiple shard channels across different slots in 
 }
 
 test "sunsubscribe without specifying any channel would unsubscribe all shard channels subscribed" {
-    set publishclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
+    set publishclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
 
     set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
@@ -77,7 +77,7 @@ test "Verify Pub/Sub and Pub/Sub shard no overlap" {
     array set publishnode [$cluster masternode_for_slot $slot]
     array set notshardnode [$cluster masternode_notfor_slot $slot]
 
-    set publishshardclient [redis_client_by_addr $publishnode(host) $publishnode(port)]
+    set publishshardclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set publishclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeshardclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
@@ -112,7 +112,7 @@ test "PUBSUB channels/shardchannels" {
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient2 [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient3 [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
-    set publishclient [redis_client_by_addr  $publishnode(host) $publishnode(port)]
+    set publishclient [valkey_client_by_addr  $publishnode(host) $publishnode(port)]
 
     ssubscribe $subscribeclient [list "\{channel.0\}1"]
     ssubscribe $subscribeclient2 [list "\{channel.0\}2"]

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -729,14 +729,14 @@ proc valkey_deferring_client_by_addr {host port} {
     return $client
 }
 
-proc redis_client {type id} {
+proc valkey_client {type id} {
     set port [get_instance_attrib $type $id port]
     set host [get_instance_attrib $type $id host]
     set client [redis $host $port 0 $::tls]
     return $client
 }
 
-proc redis_client_by_addr {host port} {
+proc valkey_client_by_addr {host port} {
     set client [redis $host $port 0 $::tls]
     return $client
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -278,7 +278,7 @@ proc valkey_deferring_client {args} {
     return $client
 }
 
-proc redis_client {args} {
+proc valkey_client {args} {
     set level 0
     if {[llength $args] > 0 && [string is integer [lindex $args 0]]} {
         set level [lindex $args 0]

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -1,5 +1,5 @@
 start_server {tags {"acl external:skip"}} {
-    set r2 [redis_client]
+    set r2 [valkey_client]
     test {Test basic multiple selectors} {
         r ACL SETUSER selector-1 on -@all resetkeys nopass
         $r2 auth selector-1 password

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -20,7 +20,7 @@ proc client_exists {name} {
 }
 
 proc gen_client {} {
-    set rr [redis_client]
+    set rr [valkey_client]
     set name "tst_[randstring 4 4 simplealpha]"
     $rr client setname $name
     assert {[client_exists $name]}
@@ -134,7 +134,7 @@ start_server {} {
 
     test "client evicted due to watched key list" {
         r flushdb
-        set rr [redis_client]
+        set rr [valkey_client]
 
         # Since watched key list is a small overhead this test uses a minimal maxmemory-clients config
         set temp_maxmemory_clients 200000
@@ -161,7 +161,7 @@ start_server {} {
         r config set maxmemory-clients $temp_maxmemory_clients
 
         # Test eviction due to pubsub patterns
-        set rr [redis_client]
+        set rr [valkey_client]
         # Add patterns until list maxes out maxmemory clients and causes client eviction
         catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
@@ -172,7 +172,7 @@ start_server {} {
         $rr close
 
         # Test eviction due to pubsub channels
-        set rr [redis_client]
+        set rr [valkey_client]
         # Subscribe to global channels until list maxes out maxmemory clients and causes client eviction
         catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
@@ -183,7 +183,7 @@ start_server {} {
         $rr close
 
         # Test eviction due to sharded pubsub channels
-        set rr [redis_client]
+        set rr [valkey_client]
         # Subscribe to sharded pubsub channels until list maxes out maxmemory clients and causes client eviction
         catch {
             for {set j 0} {$j < $temp_maxmemory_clients} {incr j} {
@@ -199,8 +199,8 @@ start_server {} {
 
     test "client evicted due to tracking redirection" {
         r flushdb
-        set rr [redis_client]
-        set redirected_c [redis_client]
+        set rr [valkey_client]
+        set redirected_c [valkey_client]
         $redirected_c client setname redirected_client
         set redir_id [$redirected_c client id]
         $redirected_c SUBSCRIBE __redis__:invalidate
@@ -232,7 +232,7 @@ start_server {} {
 
     test "client evicted due to client tracking prefixes" {
         r flushdb
-        set rr [redis_client]
+        set rr [valkey_client]
 
         # Since tracking prefixes list is a small overhead this test uses a minimal maxmemory-clients config
         set temp_maxmemory_clients 200000
@@ -323,7 +323,7 @@ start_server {} {
         r flushdb
         set obuf_size [expr {$obuf_limit + [mb 1]}]
         r setrange k $obuf_size v
-        set rr1 [redis_client]
+        set rr1 [valkey_client]
         $rr1 client setname "qbuf-client"
         set rr2 [valkey_deferring_client]
         $rr2 client setname "obuf-client1"
@@ -381,7 +381,7 @@ start_server {} {
         # Make multiple clients consume together roughly 1mb less than maxmemory_clients
         set rrs {}
         for {set j 0} {$j < $client_count} {incr j} {
-            set rr [redis_client]
+            set rr [valkey_client]
             lappend rrs $rr
             $rr client setname client$j
             $rr write [join [list "*2\r\n\$$qbsize\r\n" [string repeat v $qbsize]] ""]
@@ -420,7 +420,7 @@ start_server {} {
         set max_client_mem 0
         set rrs {}
         for {set j 0} {$j < $client_count} {incr j} {
-            set rr [redis_client]
+            set rr [valkey_client]
             lappend rrs $rr
             $rr client setname client$j
             $rr write [join [list "*2\r\n\$$client_mem\r\n" [string repeat v $client_mem]] ""]
@@ -486,7 +486,7 @@ start_server {} {
             set size [lindex $sizes $i]
 
             for {set j 0} {$j < $clients_per_size} {incr j} {
-                set rr [redis_client]
+                set rr [valkey_client]
                 lappend rrs $rr
                 $rr client setname client-$i
                 $rr write [join [list "*2\r\n\$$size\r\n" [string repeat v $size]] ""]
@@ -543,7 +543,7 @@ start_server {} {
 
         test "client total memory grows during $type" {
             r setrange k [mb 1] v
-            set rr [redis_client]
+            set rr [valkey_client]
             $rr client setname test_client
             if {$type eq "client no-evict"} {
                 $rr client no-evict on

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -160,8 +160,8 @@ start_multiple_servers 3 [list overrides $base_conf] {
 # Test that functions are propagated on add-node
 start_multiple_servers 5 [list overrides $base_conf] {
 
-    set node4_rd [redis_client -3]
-    set node5_rd [redis_client -4]
+    set node4_rd [valkey_client -3]
+    set node5_rd [valkey_client -4]
 
     test {Functions are added to new node on valkey-cli cluster add-node} {
         exec src/valkey-cli --cluster-yes --cluster create \
@@ -261,7 +261,7 @@ test {Migrate the last slot away from a node using valkey-cli} {
             fail "Cluster doesn't stabilize"
         }
 
-        set newnode_r [redis_client -3]
+        set newnode_r [valkey_client -3]
         set newnode_id [$newnode_r CLUSTER MYID]
 
         # Find out which node has the key "foo" by asking the new node for a

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -424,7 +424,7 @@ start_server {tags {"info" "external:skip"}} {
         }
 
         test {clients: watching clients} {
-            set r2 [redis_client]
+            set r2 [valkey_client]
             assert_equal [s watching_clients] 0
             assert_equal [s total_watched_keys] 0
             assert_match {*watch=0*} [r client info]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -667,7 +667,7 @@ start_server {tags {"introspection"}} {
         }
 
         # Make sure we can still communicate with the server (on the original port)
-        set r1 [redis_client]
+        set r1 [valkey_client]
         assert_equal [$r1 ping] "PONG"
         $r1 close
     }

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -114,7 +114,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
             init_test $client_eviction
 
             for {set j 0} {$j < 20} {incr j} {
-                set rr [redis_client]
+                set rr [valkey_client]
                 lappend clients $rr
             }
 

--- a/tests/unit/moduleapi/commandfilter.tcl
+++ b/tests/unit/moduleapi/commandfilter.tcl
@@ -148,7 +148,7 @@ test {Filtering based on client id} {
     start_server {tags {"modules"}} {
         r module load $testmodule log-key 0
 
-        set rr [redis_client]
+        set rr [valkey_client]
         set cid [$rr client id]
         r unfilter_clientid $cid
 

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -119,7 +119,7 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
     }
 
     test {tracking with rm_call sanity} {
-        set rd_trk [redis_client]
+        set rd_trk [valkey_client]
         $rd_trk HELLO 3
         $rd_trk CLIENT TRACKING on
         r MSET key1{t} 1 key2{t} 1
@@ -134,7 +134,7 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
     }
 
     test {tracking with rm_call with script} {
-        set rd_trk [redis_client]
+        set rd_trk [valkey_client]
         $rd_trk HELLO 3
         $rd_trk CLIENT TRACKING on
         r MSET key1{t} 1 key2{t} 1

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -1,5 +1,5 @@
 proc wait_for_dbsize {size} {
-    set r2 [redis_client]
+    set r2 [valkey_client]
     wait_for_condition 50 100 {
         [$r2 dbsize] == $size
     } else {
@@ -540,7 +540,7 @@ start_server {tags {"multi"}} {
         # check that if MULTI arrives during timeout, it is either refused, or
         # allowed to pass, and we don't end up executing half of the transaction
         set rd1 [valkey_deferring_client]
-        set r2 [redis_client]
+        set r2 [valkey_client]
         r config set lua-time-limit 10
         r set xx 1
         $rd1 eval {while true do end} 0
@@ -565,7 +565,7 @@ start_server {tags {"multi"}} {
         # check that if EXEC arrives during timeout, we don't end up executing
         # half of the transaction, and also that we exit the multi state
         set rd1 [valkey_deferring_client]
-        set r2 [redis_client]
+        set r2 [valkey_client]
         r config set lua-time-limit 10
         r set xx 1
         catch { $r2 multi; } e
@@ -590,7 +590,7 @@ start_server {tags {"multi"}} {
         # check that we don't run an incomplete transaction due to some commands
         # arriving during busy script
         set rd1 [valkey_deferring_client]
-        set r2 [redis_client]
+        set r2 [valkey_client]
         r config set lua-time-limit 10
         r set xx 1
         catch { $r2 multi; } e
@@ -615,7 +615,7 @@ start_server {tags {"multi"}} {
         # check that if EXEC arrives during timeout, we don't end up executing
         # actual commands during busy script, and also that we exit the multi state
         set rd1 [valkey_deferring_client]
-        set r2 [redis_client]
+        set r2 [valkey_client]
         r config set lua-time-limit 10
         r set xx 1
         catch { $r2 multi; } e
@@ -637,7 +637,7 @@ start_server {tags {"multi"}} {
 
     test {exec with write commands and state change} {
         # check that exec that contains write commands fails if server state changed since they were queued
-        set r1 [redis_client]
+        set r1 [valkey_client]
         r set xx 1
         r multi
         r incr xx
@@ -654,7 +654,7 @@ start_server {tags {"multi"}} {
     test {exec with read commands and stale replica state change} {
         # check that exec that contains read commands fails if server state changed since they were queued
         r config set replica-serve-stale-data no
-        set r1 [redis_client]
+        set r1 [valkey_client]
         r set xx 1
 
         # check that GET and PING are disallowed on stale replica, even if the replica becomes stale only after queuing.
@@ -685,7 +685,7 @@ start_server {tags {"multi"}} {
     } {0} {needs:repl cluster:skip}
 
     test {EXEC with only read commands should not be rejected when OOM} {
-        set r2 [redis_client]
+        set r2 [valkey_client]
 
         r set x value
         r multi
@@ -704,7 +704,7 @@ start_server {tags {"multi"}} {
     } {0} {needs:config-maxmemory}
 
     test {EXEC with at least one use-memory command should fail} {
-        set r2 [redis_client]
+        set r2 [valkey_client]
 
         r multi
         r set x 1

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -109,7 +109,7 @@ start_server {config "minimal.conf" tags {"external:skip"}} {
         assert_equal "" [lindex [r CONFIG GET bind] 1]
 
         # No additional clients can connect
-        catch {redis_client} err
+        catch {valkey_client} err
         assert_match {*connection refused*} $err
 
         # CONFIG REWRITE handles empty bindaddr

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -86,7 +86,7 @@ start_server {tags {"pause network"}} {
     test "Test read/admin multi-execs are not blocked by pause RO" {
         r SET FOO BAR
         r client PAUSE 100000 WRITE
-        set rr [redis_client]
+        set rr [valkey_client]
         assert_equal [$rr MULTI] "OK"
         assert_equal [$rr PING] "QUEUED"
         assert_equal [$rr GET FOO] "QUEUED"
@@ -141,7 +141,7 @@ start_server {tags {"pause network"}} {
         }
 
         r client PAUSE 6000000 WRITE
-        set rr [redis_client]
+        set rr [valkey_client]
 
         # test an eval that's for sure not in the script cache
         assert_equal [$rr EVAL {#!lua flags=no-writes
@@ -177,7 +177,7 @@ start_server {tags {"pause network"}} {
     test "Test read-only scripts in multi-exec are not blocked by pause RO" {
         r SET FOO BAR
         r client PAUSE 100000 WRITE
-        set rr [redis_client]
+        set rr [valkey_client]
         assert_equal [$rr MULTI] "OK"
         assert_equal [$rr EVAL {#!lua flags=no-writes
                 return 12

--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -24,7 +24,7 @@ start_server {tags {"querybuf slow"}} {
     # The test will run at least 2s to check if client query
     # buffer will be resized when client idle 2s.
     test "query buffer resized correctly" {
-        set rd [redis_client]
+        set rd [valkey_client]
         $rd client setname test_client
         set orig_test_client_qbuf [client_query_buffer test_client]
         # Make sure query buff has less than the peak resize threshold (PROTO_RESIZE_THRESHOLD) 32k
@@ -45,7 +45,7 @@ start_server {tags {"querybuf slow"}} {
         r debug pause-cron 1
 
         # Memory will increase by more than 32k due to client query buffer.
-        set rd [redis_client]
+        set rd [valkey_client]
         $rd client setname test_client
 
         # Create a large query buffer (more than PROTO_RESIZE_THRESHOLD - 32k)
@@ -73,7 +73,7 @@ start_server {tags {"querybuf slow"}} {
     } {0} {needs:debug}
 
     test "query buffer resized correctly with fat argv" {
-        set rd [redis_client]
+        set rd [valkey_client]
         $rd client setname test_client
         $rd write "*3\r\n\$3\r\nset\r\n\$1\r\na\r\n\$1000000\r\n"
         $rd flush

--- a/tests/unit/replybufsize.tcl
+++ b/tests/unit/replybufsize.tcl
@@ -15,7 +15,7 @@ start_server {tags {"replybufsize"}} {
         r debug replybuffer peak-reset-time 100
         
         # Create a simple idle test client
-        variable tc [redis_client]
+        variable tc [valkey_client]
         $tc client setname test_client
          
         # make sure the client is idle for 1 seconds to make it shrink the reply buffer

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1242,7 +1242,7 @@ start_server {tags {"scripting"}} {
         # create clients, and set one to block waiting for key 'x'
         set rd [valkey_deferring_client]
         set rd2 [valkey_deferring_client]
-        set r3 [redis_client]
+        set r3 [valkey_client]
         $rd2 blpop x 0
         wait_for_blocked_clients_count 1
 
@@ -2058,8 +2058,8 @@ start_server {tags {"scripting"}} {
             # temporarily set the server to master, so it doesn't block the queuing
             # and we can test the evaluation of the flags on exec
             r replicaof no one
-            set rr [redis_client]
-            set rr2 [redis_client]
+            set rr [valkey_client]
+            set rr2 [valkey_client]
             $rr multi
             $rr2 multi
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -14,7 +14,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
 
     # Client to be used for SET and GET commands
     # We don't read this client's buffer
-    set rd_sg [redis_client] 
+    set rd_sg [valkey_client] 
 
     proc clean_all {} {
         uplevel {
@@ -396,7 +396,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
     }
 
     test {BCAST with prefix collisions throw errors} {
-        set r [redis_client] 
+        set r [valkey_client] 
         catch {$r CLIENT TRACKING ON BCAST PREFIX FOOBAR PREFIX FOO} output
         assert_match {ERR Prefix 'FOOBAR'*'FOO'*} $output
 

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1224,7 +1224,7 @@ foreach type {single multiple single_multiple} {
         r multi
         r sadd dstset{t} c
 
-        set r2 [redis_client]
+        set r2 [valkey_client]
         $r2 smove srcset{t} dstset{t} a
 
         # The dstset is actually unchanged, multi should success

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -353,7 +353,7 @@ tags {"wait aof network external:skip"} {
 
             test {WAITAOF master client didn't send any write command} {
                 $master config set repl-ping-replica-period 1
-                set client [redis_client -1]
+                set client [valkey_client -1]
                 after 1200 ;# wait for PING
                 assert_equal [$master waitaof 1 1 0] {1 1}
                 $client close


### PR DESCRIPTION
Renamed redis-client* procedure to valkey_client*