### PR TITLE
Correcting the installed redis symlinks in 7.2.4-rc1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -374,6 +374,7 @@ else
 	GEN_COMMANDS_FLAGS=
 endif
 
+ENGINE_NAME=valkey
 REDIS_SERVER_NAME=valkey-server$(PROG_SUFFIX)
 REDIS_SENTINEL_NAME=valkey-sentinel$(PROG_SUFFIX)
 REDIS_SERVER_OBJ=adlist.o quicklist.o ae.o anet.o dict.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o crc16.o endianconv.o slowlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script_lua.o script.o functions.o function_lua.o commands.o strl.o connection.o unix.o logreqres.o


### PR DESCRIPTION
This is a PR directly to the 7.2 branch.

The make variable `ENGINE_NAME` (from 38632278fd06fe186f7707e4fa099f666d805547) was lost during branching of `7.2` and tag `7.2.4-rc1` 
resulting in the creation of faulty symlinks:
```
      INSTALL SYMLINK valkey-serverredis -> valkey-server
      INSTALL SYMLINK valkey-cliredis -> valkey-cli
      INSTALL SYMLINK valkey-benchmarkredis -> valkey-benchmark
      INSTALL SYMLINK valkey-check-rdbredis -> valkey-check-rdb
      INSTALL SYMLINK valkey-check-aofredis -> valkey-check-aof
      INSTALL SYMLINK valkey-sentinelredis -> valkey-sentinel
```

By just adding the variable we get a minimal diff compared to unstable.