### PR TITLE
Replace "redis" with "valkey" test code

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -318,8 +318,8 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
     UNUSED(tls_flag);
 #endif
 
-    const char *scheme = "valkey://";
-    const char *tlsscheme = "valkeys://";
+    const char *scheme = "redis://";
+    const char *tlsscheme = "rediss://";
     const char *curr = uri;
     const char *end = uri + strlen(uri);
     const char *userinfo, *username, *port, *host, *path;
@@ -330,7 +330,7 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
         *tls_flag = 1;
         curr += strlen(tlsscheme);
 #else
-        fprintf(stderr,"valkeys:// is only supported when %s is compiled with OpenSSL\n", tool_name);
+        fprintf(stderr,"rediss:// is only supported when %s is compiled with OpenSSL\n", tool_name);
         exit(1);
 #endif
     } else if (!strncasecmp(scheme, curr, strlen(scheme))) {

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -318,8 +318,8 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
     UNUSED(tls_flag);
 #endif
 
-    const char *scheme = "redis://";
-    const char *tlsscheme = "rediss://";
+    const char *scheme = "valkey://";
+    const char *tlsscheme = "valkeys://";
     const char *curr = uri;
     const char *end = uri + strlen(uri);
     const char *userinfo, *username, *port, *host, *path;
@@ -330,7 +330,7 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
         *tls_flag = 1;
         curr += strlen(tlsscheme);
 #else
-        fprintf(stderr,"rediss:// is only supported when %s is compiled with OpenSSL\n", tool_name);
+        fprintf(stderr,"valkeys:// is only supported when %s is compiled with OpenSSL\n", tool_name);
         exit(1);
 #endif
     } else if (!strncasecmp(scheme, curr, strlen(scheme))) {

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -87,7 +87,7 @@ proc cluster_allocate_slots {n} {
 # Check that cluster nodes agree about "state", or raise an error.
 proc assert_cluster_state {state} {
     foreach_valkey_id id {
-        if {[instance_is_killed redis $id]} continue
+        if {[instance_is_killed valkey $id]} continue
         wait_for_condition 1000 50 {
             [CI $id cluster_state] eq $state
         } else {
@@ -101,7 +101,7 @@ proc assert_cluster_state {state} {
 proc cluster_find_available_slave {first} {
     foreach_valkey_id id {
         if {$id < $first} continue
-        if {[instance_is_killed redis $id]} continue
+        if {[instance_is_killed valkey $id]} continue
         set me [get_myself $id]
         if {[dict get $me slaveof] eq {-}} {return $id}
     }
@@ -170,7 +170,7 @@ proc set_cluster_node_timeout {to} {
 # as a starting point to talk with the cluster.
 proc cluster_write_test {id} {
     set prefix [randstring 20 20 alpha]
-    set port [get_instance_attrib redis $id port]
+    set port [get_instance_attrib valkey $id port]
     set cluster [redis_cluster 127.0.0.1:$port]
     for {set j 0} {$j < 100} {incr j} {
         $cluster set key.$j $prefix.$j

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -86,7 +86,7 @@ proc cluster_allocate_slots {n} {
 
 # Check that cluster nodes agree about "state", or raise an error.
 proc assert_cluster_state {state} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {[instance_is_killed redis $id]} continue
         wait_for_condition 1000 50 {
             [CI $id cluster_state] eq $state
@@ -99,7 +99,7 @@ proc assert_cluster_state {state} {
 # Search the first node starting from ID $first that is not
 # already configured as a slave.
 proc cluster_find_available_slave {first} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id < $first} continue
         if {[instance_is_killed redis $id]} continue
         set me [get_myself $id]
@@ -161,7 +161,7 @@ proc cluster_create_with_continuous_slots {masters slaves} {
 
 # Set the cluster node-timeout to all the reachalbe nodes.
 proc set_cluster_node_timeout {to} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         catch {R $id CONFIG SET cluster-node-timeout $to}
     }
 }

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -12,7 +12,7 @@ set ::tlsdir "../../tls"
 
 proc main {} {
     parse_options
-    spawn_instance redis $::redis_base_port $::instances_count {
+    spawn_instance valkey $::valkey_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
         "enable-protected-configs yes"

--- a/tests/cluster/tests/00-base.tcl
+++ b/tests/cluster/tests/00-base.tcl
@@ -11,7 +11,7 @@ if {$::simulate_error} {
 test "Different nodes have different IDs" {
     set ids {}
     set numnodes 0
-    foreach_redis_id id {
+    foreach_valkey_id id {
         incr numnodes
         # Every node should just know itself.
         set nodeid [dict get [get_myself $id] id]
@@ -31,7 +31,7 @@ test "After the join, every node gets a different config epoch" {
     while {[incr trynum -1] != 0} {
         # We check that this condition is true for *all* the nodes.
         set ok 1 ; # Will be set to 0 every time a node is not ok.
-        foreach_redis_id id {
+        foreach_valkey_id id {
             set epochs {}
             foreach n [get_cluster_nodes $id] {
                 lappend epochs [dict get $n config_epoch]

--- a/tests/cluster/tests/01-faildet.tcl
+++ b/tests/cluster/tests/01-faildet.tcl
@@ -11,8 +11,8 @@ test "Cluster should start ok" {
 }
 
 test "Killing two slave nodes" {
-    kill_instance redis 5
-    kill_instance redis 6
+    kill_instance valkey 5
+    kill_instance valkey 6
 }
 
 test "Cluster should be still up" {
@@ -20,7 +20,7 @@ test "Cluster should be still up" {
 }
 
 test "Killing one master node" {
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 # Note: the only slave of instance 0 is already down so no
@@ -30,7 +30,7 @@ test "Cluster should be down now" {
 }
 
 test "Restarting master node" {
-    restart_instance redis 0
+    restart_instance valkey 0
 }
 
 test "Cluster should be up again" {

--- a/tests/cluster/tests/02-failover.tcl
+++ b/tests/cluster/tests/02-failover.tcl
@@ -29,7 +29,7 @@ test "Instance #5 synced with the master" {
 set current_epoch [CI 1 cluster_current_epoch]
 
 test "Killing one master node" {
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 test "Wait for failover" {
@@ -53,7 +53,7 @@ test "Instance #5 is now a master" {
 }
 
 test "Restarting the previously killed master node" {
-    restart_instance redis 0
+    restart_instance valkey 0
 }
 
 test "Instance #0 gets converted into a slave" {

--- a/tests/cluster/tests/03-failover-loop.tcl
+++ b/tests/cluster/tests/03-failover-loop.tcl
@@ -25,7 +25,7 @@ while {[incr iterations -1]} {
     if {$role eq {master}} {
         set slave {}
         set myid [dict get [get_myself $tokill] id]
-        foreach_redis_id id {
+        foreach_valkey_id id {
             if {$id == $tokill} continue
             if {[dict get [get_myself $id] slaveof] eq $myid} {
                 set slave $id
@@ -111,7 +111,7 @@ while {[incr iterations -1]} {
 }
 
 test "Post condition: current_epoch >= my_epoch everywhere" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         assert {[CI $id cluster_current_epoch] >= [CI $id cluster_my_epoch]}
     }
 }

--- a/tests/cluster/tests/03-failover-loop.tcl
+++ b/tests/cluster/tests/03-failover-loop.tcl
@@ -14,7 +14,7 @@ test "Cluster is up" {
 }
 
 set iterations 20
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 while {[incr iterations -1]} {
     set tokill [randomInt 10]
@@ -64,7 +64,7 @@ while {[incr iterations -1]} {
     test "Terminating node #$tokill" {
         # Stop AOF so that an initial AOFRW won't prevent the instance from terminating
         R $tokill config set appendonly no
-        kill_instance redis $tokill
+        kill_instance valkey $tokill
     }
 
     if {$role eq {master}} {
@@ -89,7 +89,7 @@ while {[incr iterations -1]} {
     }
 
     test "Restarting node #$tokill" {
-        restart_instance redis $tokill
+        restart_instance valkey $tokill
     }
 
     test "Instance #$tokill is now a slave" {

--- a/tests/cluster/tests/04-resharding.tcl
+++ b/tests/cluster/tests/04-resharding.tcl
@@ -54,11 +54,11 @@ proc process_is_running {pid} {
 
 set numkeys 50000
 set numops 200000
-set start_node_port [get_instance_attrib redis 0 port]
+set start_node_port [get_instance_attrib valkey 0 port]
 set cluster [redis_cluster 127.0.0.1:$start_node_port]
 if {$::tls} {
     # setup a non-TLS cluster client to the TLS cluster
-    set plaintext_port [get_instance_attrib redis 0 plaintext-port]
+    set plaintext_port [get_instance_attrib valkey 0 plaintext-port]
     set cluster_plaintext [redis_cluster 127.0.0.1:$plaintext_port 0]
     puts "Testing TLS cluster on start node 127.0.0.1:$start_node_port, plaintext port $plaintext_port"
 } else {
@@ -85,7 +85,7 @@ test "Cluster consistency during live resharding" {
             set target [dict get [get_myself [randomInt 5]] id]
             set tribpid [lindex [exec \
                 ../../../src/valkey-cli --cluster reshard \
-                127.0.0.1:[get_instance_attrib redis 0 port] \
+                127.0.0.1:[get_instance_attrib valkey 0 port] \
                 --cluster-from all \
                 --cluster-to $target \
                 --cluster-slots 100 \
@@ -141,8 +141,8 @@ test "Terminate and restart all the instances" {
     foreach_valkey_id id {
         # Stop AOF so that an initial AOFRW won't prevent the instance from terminating
         R $id config set appendonly no
-        kill_instance redis $id
-        restart_instance redis $id
+        kill_instance valkey $id
+        restart_instance valkey $id
     }
 }
 
@@ -171,7 +171,7 @@ test "Verify slaves consistency" {
         set role [R $id role]
         lassign $role myrole myoffset slaves
         if {$myrole eq {slave}} continue
-        set masterport [get_instance_attrib redis $id port]
+        set masterport [get_instance_attrib valkey $id port]
         set masterdigest [R $id debug digest]
         foreach_valkey_id sid {
             set srole [R $sid role]

--- a/tests/cluster/tests/05-slave-selection.tcl
+++ b/tests/cluster/tests/05-slave-selection.tcl
@@ -34,7 +34,7 @@ test "CLUSTER SLAVES and CLUSTER REPLICAS output is consistent" {
 }
 
 test {Slaves of #0 are instance #5 and #10 as expected} {
-    set port0 [get_instance_attrib redis 0 port]
+    set port0 [get_instance_attrib valkey 0 port]
     assert {[lindex [R 5 role] 2] == $port0}
     assert {[lindex [R 10 role] 2] == $port0}
 }
@@ -48,7 +48,7 @@ test "Instance #5 and #10 synced with the master" {
     }
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 test "Slaves are both able to receive and acknowledge writes" {
     for {set j 0} {$j < 100} {incr j} {
@@ -80,7 +80,7 @@ test "Write data while slave #10 is paused and can't receive it" {
     assert {[R 10 read] eq {OK OK}}
 
     # Kill the master so that a reconnection will not be possible.
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 test "Wait for instance #5 (and not #10) to turn into a master" {
@@ -100,7 +100,7 @@ test "Cluster should eventually be up again" {
 }
 
 test "Node #10 should eventually replicate node #5" {
-    set port5 [get_instance_attrib redis 5 port]
+    set port5 [get_instance_attrib valkey 5 port]
     wait_for_condition 1000 50 {
         ([lindex [R 10 role] 2] == $port5) &&
         ([lindex [R 10 role] 3] eq {connected})
@@ -130,7 +130,7 @@ test "The first master has actually 5 slaves" {
 }
 
 test {Slaves of #0 are instance #3, #6, #9, #12 and #15 as expected} {
-    set port0 [get_instance_attrib redis 0 port]
+    set port0 [get_instance_attrib valkey 0 port]
     assert {[lindex [R 3 role] 2] == $port0}
     assert {[lindex [R 6 role] 2] == $port0}
     assert {[lindex [R 9 role] 2] == $port0}
@@ -179,7 +179,7 @@ test "New Master down consecutively" {
 
         set instances [dict remove $instances $master_id]
 
-        kill_instance redis $master_id
+        kill_instance valkey $master_id
         wait_for_condition 1000 50 {
             [master_detected $instances]
         } else {

--- a/tests/cluster/tests/06-slave-stop-cond.tcl
+++ b/tests/cluster/tests/06-slave-stop-cond.tcl
@@ -22,7 +22,7 @@ test "The first master has actually one slave" {
 }
 
 test {Slaves of #0 is instance #5 as expected} {
-    set port0 [get_instance_attrib redis 0 port]
+    set port0 [get_instance_attrib valkey 0 port]
     assert {[lindex [R 5 role] 2] == $port0}
 }
 
@@ -60,7 +60,7 @@ test "Break master-slave link and prevent further reconnections" {
     assert {[R 5 read] eq {OK OK}}
 
     # Kill the master so that a reconnection will not be possible.
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 test "Slave #5 is reachable and alive" {

--- a/tests/cluster/tests/07-replica-migration.tcl
+++ b/tests/cluster/tests/07-replica-migration.tcl
@@ -27,10 +27,10 @@ test "Each master should have two replicas attached" {
 }
 
 test "Killing all the slaves of master #0 and #1" {
-    kill_instance redis 5
-    kill_instance redis 10
-    kill_instance redis 6
-    kill_instance redis 11
+    kill_instance valkey 5
+    kill_instance valkey 10
+    kill_instance valkey 6
+    kill_instance valkey 11
     after 4000
 }
 
@@ -62,13 +62,13 @@ test "Cluster is up" {
 }
 
 test "Kill slave #7 of master #2. Only slave left is #12 now" {
-    kill_instance redis 7
+    kill_instance valkey 7
 }
 
 set current_epoch [CI 1 cluster_current_epoch]
 
 test "Killing master node #2, #12 should failover" {
-    kill_instance redis 2
+    kill_instance valkey 2
 }
 
 test "Wait for failover" {

--- a/tests/cluster/tests/07-replica-migration.tcl
+++ b/tests/cluster/tests/07-replica-migration.tcl
@@ -15,7 +15,7 @@ test "Cluster is up" {
 }
 
 test "Each master should have two replicas attached" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
                 [llength [lindex [R $id role] 2]] == 2
@@ -34,7 +34,7 @@ test "Killing all the slaves of master #0 and #1" {
     after 4000
 }
 
-foreach_redis_id id {
+foreach_valkey_id id {
     if {$id < 5} {
         test "Master #$id should have at least one replica" {
             wait_for_condition 1000 50 {

--- a/tests/cluster/tests/08-update-msg.tcl
+++ b/tests/cluster/tests/08-update-msg.tcl
@@ -38,7 +38,7 @@ test "Instance #5 synced with the master" {
 set current_epoch [CI 1 cluster_current_epoch]
 
 test "Killing one master node" {
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 test "Wait for failover" {
@@ -62,7 +62,7 @@ test "Instance #5 is now a master" {
 }
 
 test "Killing the new master #5" {
-    kill_instance redis 5
+    kill_instance valkey 5
 }
 
 test "Cluster should be down now" {
@@ -70,7 +70,7 @@ test "Cluster should be down now" {
 }
 
 test "Restarting the old master node" {
-    restart_instance redis 0
+    restart_instance valkey 0
 }
 
 test "Instance #0 gets converted into a slave" {
@@ -82,7 +82,7 @@ test "Instance #0 gets converted into a slave" {
 }
 
 test "Restarting the new master node" {
-    restart_instance redis 5
+    restart_instance valkey 5
 }
 
 test "Cluster is up again" {

--- a/tests/cluster/tests/10-manual-failover.tcl
+++ b/tests/cluster/tests/10-manual-failover.tcl
@@ -30,7 +30,7 @@ set current_epoch [CI 1 cluster_current_epoch]
 
 set numkeys 50000
 set numops 10000
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset content}
 array set content {}
 

--- a/tests/cluster/tests/11-manual-takeover.tcl
+++ b/tests/cluster/tests/11-manual-takeover.tcl
@@ -23,9 +23,9 @@ foreach id $replica_ids {
 }
 
 test "Killing majority of master nodes" {
-    kill_instance redis 0
-    kill_instance redis 1
-    kill_instance redis 2
+    kill_instance valkey 0
+    kill_instance valkey 1
+    kill_instance valkey 2
 }
 
 foreach id $replica_ids {
@@ -57,9 +57,9 @@ test "Instance #5, #6, #7 are now masters" {
 }
 
 test "Restarting the previously killed master nodes" {
-    restart_instance redis 0
-    restart_instance redis 1
-    restart_instance redis 2
+    restart_instance valkey 0
+    restart_instance valkey 1
+    restart_instance valkey 2
 }
 
 test "Instance #0, #1, #2 gets converted into a slaves" {

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -18,7 +18,7 @@ test "Cluster is up" {
 }
 
 test "Each master should have at least two replicas attached" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
                 [llength [lindex [R $id role] 2]] >= 2
@@ -30,7 +30,7 @@ test "Each master should have at least two replicas attached" {
 }
 
 test "Set allow-replica-migration yes" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         R $id CONFIG SET cluster-allow-replica-migration yes
     }
 }

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -39,7 +39,7 @@ set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
         ../../../src/valkey-cli --cluster rebalance \
-        127.0.0.1:[get_instance_attrib redis 0 port] \
+        127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]
 
@@ -60,7 +60,7 @@ test "Resharding back some slot to master #0" {
     after 10000
     set output [exec \
         ../../../src/valkey-cli --cluster rebalance \
-        127.0.0.1:[get_instance_attrib redis 0 port] \
+        127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=.01 \
         --cluster-use-empty-masters  >@ stdout]

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -38,7 +38,7 @@ set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
         ../../../src/valkey-cli --cluster rebalance \
-        127.0.0.1:[get_instance_attrib redis 0 port] \
+        127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]
 }

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -17,7 +17,7 @@ test "Cluster is up" {
 }
 
 test "Each master should have at least two replicas attached" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
                 [llength [lindex [R $id role] 2]] >= 2
@@ -29,7 +29,7 @@ test "Each master should have at least two replicas attached" {
 }
 
 test "Set allow-replica-migration no" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         R $id CONFIG SET cluster-allow-replica-migration no
     }
 }
@@ -52,7 +52,7 @@ test "Master #0 still should have its replicas" {
 }
 
 test "Each master should have at least two replicas attached" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id < 5} {
             wait_for_condition 1000 50 {
                 [llength [lindex [R $id role] 2]] >= 2

--- a/tests/cluster/tests/13-no-failover-option.tcl
+++ b/tests/cluster/tests/13-no-failover-option.tcl
@@ -32,7 +32,7 @@ test "Instance #5 synced with the master" {
 test "The nofailover flag is propagated" {
     set slave5_id [dict get [get_myself 5] id]
 
-    foreach_redis_id id {
+    foreach_valkey_id id {
         wait_for_condition 1000 50 {
             [has_flag [get_node_by_id $id $slave5_id] nofailover]
         } else {

--- a/tests/cluster/tests/13-no-failover-option.tcl
+++ b/tests/cluster/tests/13-no-failover-option.tcl
@@ -44,7 +44,7 @@ test "The nofailover flag is propagated" {
 set current_epoch [CI 1 cluster_current_epoch]
 
 test "Killing one master node" {
-    kill_instance redis 0
+    kill_instance valkey 0
 }
 
 test "Cluster should be still down after some time" {
@@ -57,5 +57,5 @@ test "Instance #5 is still a slave" {
 }
 
 test "Restarting the previously killed master node" {
-    restart_instance redis 0
+    restart_instance valkey 0
 }

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -31,13 +31,13 @@ proc get_one_of_my_replica {id} {
         fail "replicas didn't connect"
     }
     set replica_port [lindex [lindex [lindex [R $id role] 2] 0] 1]
-    set replica_id_num [get_instance_id_by_port redis $replica_port]
+    set replica_id_num [get_instance_id_by_port valkey $replica_port]
     return $replica_id_num
 }
 
 proc cluster_write_keys_with_expire {id ttl} {
     set prefix [randstring 20 20 alpha]
-    set port [get_instance_attrib redis $id port]
+    set port [get_instance_attrib valkey $id port]
     set cluster [redis_cluster 127.0.0.1:$port]
     for {set j 100} {$j < 200} {incr j} {
         $cluster setex key_expire.$j $ttl $prefix.$j
@@ -93,7 +93,7 @@ proc test_slave_load_expired_keys {aof} {
         }
 
         # kill the replica (would stay down until re-started)
-        kill_instance redis $replica_id
+        kill_instance valkey $replica_id
 
         # Make sure the master doesn't do active expire (sending DELs to the replica)
         R $master_id DEBUG SET-ACTIVE-EXPIRE 0
@@ -102,7 +102,7 @@ proc test_slave_load_expired_keys {aof} {
         after [expr $data_ttl*1000]
 
         # start the replica again (loading an RDB or AOF file)
-        restart_instance redis $replica_id
+        restart_instance valkey $replica_id
 
         # make sure the keys are still there
         set replica_dbsize_3 [R $replica_id dbsize]

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -15,7 +15,7 @@ test "Cluster is writable" {
 
 proc find_non_empty_master {} {
     set master_id_no {}
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {[RI $id role] eq {master} && [R $id dbsize] > 0} {
             set master_id_no $id
             break

--- a/tests/cluster/tests/15-cluster-slots.tcl
+++ b/tests/cluster/tests/15-cluster-slots.tcl
@@ -44,13 +44,13 @@ test "client do not break when cluster slot" {
 }
 
 test "client can handle keys with hash tag" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     $cluster set foo{tag} bar
     $cluster close
 }
 
 test "slot migration is valid from primary to another primary" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     set key order1
     set slot [$cluster cluster keyslot $key]
     array set nodefrom [$cluster masternode_for_slot $slot]
@@ -61,7 +61,7 @@ test "slot migration is valid from primary to another primary" {
 }
 
 test "slot migration is invalid from primary to replica" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     set key order1
     set slot [$cluster cluster keyslot $key]
     array set nodefrom [$cluster masternode_for_slot $slot]
@@ -117,9 +117,9 @@ proc count_bound_slots {n} {
 if {$::tls} {
     test {CLUSTER SLOTS from non-TLS client in TLS cluster} {
         set slots_tls [R 0 cluster slots]
-        set host [get_instance_attrib redis 0 host]
-        set plaintext_port [get_instance_attrib redis 0 plaintext-port]
-        set client_plain [redis $host $plaintext_port 0 0]
+        set host [get_instance_attrib valkey 0 host]
+        set plaintext_port [get_instance_attrib valkey 0 plaintext-port]
+        set client_plain [valkey $host $plaintext_port 0 0]
         set slots_plain [$client_plain cluster slots]
         $client_plain close
         # Compare the ports in the first row

--- a/tests/cluster/tests/16-transactions-on-replica.tcl
+++ b/tests/cluster/tests/16-transactions-on-replica.tcl
@@ -58,7 +58,7 @@ test "MULTI-EXEC with write operations is MOVED" {
 }
 
 test "read-only blocking operations from replica" {
-    set rd [valkey_deferring_client redis 1]
+    set rd [valkey_deferring_client valkey 1]
     $rd readonly
     $rd read
     $rd XREAD BLOCK 0 STREAMS k 0

--- a/tests/cluster/tests/17-diskless-load-swapdb.tcl
+++ b/tests/cluster/tests/17-diskless-load-swapdb.tcl
@@ -42,7 +42,7 @@ test "Main db not affected when fail to diskless load" {
 
     # Save an RDB and kill the replica
     $replica save
-    kill_instance redis $replica_id
+    kill_instance valkey $replica_id
 
     # Delete the key from master
     $master del $slot0_key
@@ -51,7 +51,7 @@ test "Main db not affected when fail to diskless load" {
     # backlog size is very small, and dumping rdb will cost several seconds.
     set num 10000
     set value [string repeat A 1024]
-    set rd [valkey_deferring_client redis $master_id]
+    set rd [valkey_deferring_client valkey $master_id]
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
     }
@@ -60,7 +60,7 @@ test "Main db not affected when fail to diskless load" {
     }
 
     # Start the replica again
-    restart_instance redis $replica_id
+    restart_instance valkey $replica_id
     $replica READONLY
 
     # Start full sync, wait till after db started loading in background
@@ -71,7 +71,7 @@ test "Main db not affected when fail to diskless load" {
     }
 
     # Kill master, abort full sync
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
 
     # Start full sync, wait till the replica detects the disconnection
     wait_for_condition 500 10 {

--- a/tests/cluster/tests/20-half-migrated-slot.tcl
+++ b/tests/cluster/tests/20-half-migrated-slot.tcl
@@ -21,7 +21,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/21-many-slot-migration.tcl
+++ b/tests/cluster/tests/21-many-slot-migration.tcl
@@ -21,7 +21,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
+++ b/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
@@ -8,10 +8,10 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 proc get_addr_replica_serving_slot slot {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     array set node [$cluster masternode_for_slot $slot]
 
     set replicanodeinfo [$cluster cluster replicas $node(id)]

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -6,7 +6,7 @@ test "Create a 3 nodes cluster" {
     cluster_create_with_continuous_slots 3 3
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 test "Pub/Sub shard basics" {
 
     set slot [$cluster cluster keyslot "channel.0"]

--- a/tests/cluster/tests/29-slot-migration-response.tcl
+++ b/tests/cluster/tests/29-slot-migration-response.tcl
@@ -12,7 +12,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib redis 0 port]]
+set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -1,7 +1,7 @@
 # Initialization tests -- most units will start including this.
 
 test "(init) Restart killed instances" {
-    foreach type {redis} {
+    foreach type {valkey} {
         foreach_${type}_id id {
             if {[get_instance_attrib $type $id pid] == -1} {
                 puts -nonewline "$type/$id "
@@ -59,7 +59,7 @@ proc join_nodes_in_cluster {} {
     for {set j 0} {$j < [expr [llength $ids]-1]} {incr j} {
         set a [lindex $ids $j]
         set b [lindex $ids [expr $j+1]]
-        set b_port [get_instance_attrib redis $b port]
+        set b_port [get_instance_attrib valkey $b port]
         R $a cluster meet 127.0.0.1 $b_port
     }
 

--- a/tests/cluster/tests/includes/init-tests.tcl
+++ b/tests/cluster/tests/includes/init-tests.tcl
@@ -13,7 +13,7 @@ test "(init) Restart killed instances" {
 }
 
 test "Cluster nodes are reachable" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         # Every node should be reachable.
         wait_for_condition 1000 50 {
             ([catch {R $id ping} ping_reply] == 0) &&
@@ -26,7 +26,7 @@ test "Cluster nodes are reachable" {
 }
 
 test "Cluster nodes hard reset" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$::valgrind} {
             set node_timeout 10000
         } else {
@@ -55,7 +55,7 @@ proc join_nodes_in_cluster {} {
     # If auto-discovery works all nodes will know every other node
     # eventually.
     set ids {}
-    foreach_redis_id id {lappend ids $id}
+    foreach_valkey_id id {lappend ids $id}
     for {set j 0} {$j < [expr [llength $ids]-1]} {incr j} {
         set a [lindex $ids $j]
         set b [lindex $ids [expr $j+1]]
@@ -63,7 +63,7 @@ proc join_nodes_in_cluster {} {
         R $a cluster meet 127.0.0.1 $b_port
     }
 
-    foreach_redis_id id {
+    foreach_valkey_id id {
         wait_for_condition 1000 50 {
             [llength [get_cluster_nodes $id connected]] == [llength $ids]
         } else {

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -1,7 +1,7 @@
 source "../../../tests/support/cli.tcl"
 
 proc config_set_all_nodes {keyword value} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         R $id config set $keyword $value
     }
 }

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -27,7 +27,7 @@ proc fix_cluster {addr} {
 proc wait_cluster_stable {} {
     wait_for_condition 1000 50 {
         [catch {exec ../../../src/valkey-cli --cluster \
-            check 127.0.0.1:[get_instance_attrib redis 0 port] \
+            check 127.0.0.1:[get_instance_attrib valkey 0 port] \
             {*}[valkeycli_tls_config "../../../tests"] \
             }] == 0
     } else {

--- a/tests/helpers/bg_block_op.tcl
+++ b/tests/helpers/bg_block_op.tcl
@@ -11,7 +11,7 @@ set ::tlsdir "tests/tls"
 # unlikely that lists and zsets just get more data without ever causing
 # blocking.
 proc bg_block_op {host port db ops tls} {
-    set r [redis $host $port 0 $tls]
+    set r [valkey $host $port 0 $tls]
     $r client setname LOAD_HANDLER
     $r select $db
 

--- a/tests/helpers/bg_complex_data.tcl
+++ b/tests/helpers/bg_complex_data.tcl
@@ -4,7 +4,7 @@ source tests/support/util.tcl
 set ::tlsdir "tests/tls"
 
 proc bg_complex_data {host port db ops tls} {
-    set r [redis $host $port 0 $tls]
+    set r [valkey $host $port 0 $tls]
     $r client setname LOAD_HANDLER
     $r select $db
     createComplexDataset $r $ops

--- a/tests/helpers/gen_write_load.tcl
+++ b/tests/helpers/gen_write_load.tcl
@@ -4,7 +4,7 @@ set ::tlsdir "tests/tls"
 
 proc gen_write_load {host port seconds tls} {
     set start_time [clock seconds]
-    set r [redis $host $port 1 $tls]
+    set r [valkey $host $port 1 $tls]
     $r client setname LOAD_HANDLER
     $r select 9
     while 1 {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -25,7 +25,7 @@ set ::dont_clean 0
 set ::simulate_error 0
 set ::failed 0
 set ::sentinel_instances {}
-set ::redis_instances {}
+set ::valkey_instances {}
 set ::global_config {}
 set ::sentinel_base_port 20000
 set ::redis_base_port 30000
@@ -345,7 +345,7 @@ proc pause_on_error {} {
         } elseif {$cmd eq {show-redis-logs}} {
             set count 10
             if {[lindex $argv 1] ne {}} {set count [lindex $argv 1]}
-            foreach_redis_id id {
+            foreach_valkey_id id {
                 puts "=== REDIS $id ===="
                 puts [exec tail -$count redis_$id/log.txt]
                 puts "---------------------\n"
@@ -359,7 +359,7 @@ proc pause_on_error {} {
                 puts "---------------------\n"
             }
         } elseif {$cmd eq {ls}} {
-            foreach_redis_id id {
+            foreach_valkey_id id {
                 puts -nonewline "Redis $id"
                 set errcode [catch {
                     set str {}
@@ -530,7 +530,7 @@ proc S {n args} {
 # Example:
 #     [Rn 0] info
 proc Rn {n} {
-    return [dict get [lindex $::redis_instances $n] link]
+    return [dict get [lindex $::valkey_instances $n] link]
 }
 
 # Like R but to chat with server instances.
@@ -588,8 +588,8 @@ proc foreach_sentinel_id {idvar code} {
     return -code $errcode $result
 }
 
-proc foreach_redis_id {idvar code} {
-    set errcode [catch {uplevel 1 [list foreach_instance_id $::redis_instances $idvar $code]} result]
+proc foreach_valkey_id {idvar code} {
+    set errcode [catch {uplevel 1 [list foreach_instance_id $::valkey_instances $idvar $code]} result]
     return -code $errcode $result
 }
 
@@ -608,8 +608,8 @@ proc set_instance_attrib {type id attrib newval} {
 # Create a master-slave cluster of the given number of total instances.
 # The first instance "0" is the master, all others are configured as
 # slaves.
-proc create_redis_master_slave_cluster n {
-    foreach_redis_id id {
+proc create_valkey_master_slave_cluster n {
+    foreach_valkey_id id {
         if {$id == 0} {
             # Our master.
             R $id slaveof no one

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -294,7 +294,7 @@ tags {"external:skip"} {
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
 
             assert_equal OK [$client set k1 v1]
             assert_equal v1 [$client get k1]
@@ -332,7 +332,7 @@ tags {"external:skip"} {
 
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -364,7 +364,7 @@ tags {"external:skip"} {
 
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -395,7 +395,7 @@ tags {"external:skip"} {
 
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -406,7 +406,7 @@ tags {"external:skip"} {
         clean_aof_persistence $aof_dirpath
     }
 
-    test {Multi Part AOF can load data from old version redis (rdb preamble no)} {
+    test {Multi Part AOF can load data from old version valkey (rdb preamble no)} {
         create_aof $server_path $aof_old_name_old_path {
             append_to_aof [formatCommand set k1 v1]
             append_to_aof [formatCommand set k2 v2]
@@ -416,7 +416,7 @@ tags {"external:skip"} {
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -452,12 +452,12 @@ tags {"external:skip"} {
         clean_aof_persistence $aof_dirpath
     }
 
-    test {Multi Part AOF can load data from old version redis (rdb preamble yes)} {
+    test {Multi Part AOF can load data from old version valkey (rdb preamble yes)} {
         exec cp tests/assets/rdb-preamble.aof $aof_old_name_old_path
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # k1 k2 in rdb header and k3 in AOF tail
@@ -509,7 +509,7 @@ tags {"external:skip"} {
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal v1 [$client get k1]
@@ -548,7 +548,7 @@ tags {"external:skip"} {
         start_server_aof [list dir $server_path] {
             assert_equal 1 [is_alive [srv pid]]
 
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 0 [$client exists k1]
@@ -604,10 +604,10 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            set redis1 [redis [srv host] [srv port] 0 $::tls]
+            set redis1 [valkey [srv host] [srv port] 0 $::tls]
 
             start_server [list overrides [list dir $server_path appendonly yes appendfilename appendonly.aof2]] {
-                set redis2 [redis [srv host] [srv port] 0 $::tls]
+                set redis2 [valkey [srv host] [srv port] 0 $::tls]
 
                 test "Multi Part AOF can upgrade when when two servers share the same server dir (server1)" {
                     wait_done_loading $redis1
@@ -679,21 +679,21 @@ tags {"external:skip"} {
         start_server [list overrides [list appendonly yes appendfilename "\" file seq \\n\\n.aof \""]] {
             set dir [get_redis_dir]
             set aof_manifest_name [format "%s/%s/%s%s" $dir "appendonlydir" " file seq \n\n.aof " $::manifest_suffix]
-            set redis [redis [srv host] [srv port] 0 $::tls]
+            set valkey [valkey [srv host] [srv port] 0 $::tls]
 
-            assert_equal OK [$redis set k1 v1]
+            assert_equal OK [$valkey set k1 v1]
 
-            $redis bgrewriteaof
-            waitForBgrewriteaof $redis
+            $valkey bgrewriteaof
+            waitForBgrewriteaof $valkey
 
             assert_aof_manifest_content $aof_manifest_name {
                 {file " file seq \n\n.aof .2.base.rdb" seq 2 type b}
                 {file " file seq \n\n.aof .2.incr.aof" seq 2 type i}
             }
 
-            set d1 [$redis debug digest]
-            $redis debug loadaof
-            set d2 [$redis debug digest]
+            set d1 [$valkey debug digest]
+            $valkey debug loadaof
+            set d2 [$valkey debug digest]
             assert {$d1 eq $d2}
         }
 
@@ -702,7 +702,7 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can create BASE (RDB format) when server starts from empty} {
         start_server_aof [list dir $server_path] {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.1${::base_aof_sufix}${::rdb_format_suffix}"]
@@ -725,7 +725,7 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can create BASE (AOF format) when server starts from empty} {
         start_server_aof [list dir $server_path aof-use-rdb-preamble no] {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             assert_equal 1 [check_file_exist $aof_dirpath "${aof_basename}.1${::base_aof_sufix}${::aof_format_suffix}"]

--- a/tests/integration/aof-race.tcl
+++ b/tests/integration/aof-race.tcl
@@ -7,7 +7,7 @@ tags {"aof external:skip"} {
     # cleaned after a child responsible for an AOF rewrite exited. This buffer
     # was subsequently appended to the new AOF, resulting in duplicate commands.
     start_server_aof [list dir $server_path] {
-        set client [redis [srv host] [srv port] 0 $::tls]
+        set client [valkey [srv host] [srv port] 0 $::tls]
         set bench [open "|src/valkey-benchmark -q -s [srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
 
         wait_for_condition 100 1 {
@@ -30,7 +30,7 @@ tags {"aof external:skip"} {
 
     # Restart server to replay AOF
     start_server_aof [list dir $server_path] {
-        set client [redis [srv host] [srv port] 0 $::tls]
+        set client [valkey [srv host] [srv port] 0 $::tls]
         wait_done_loading $client
         assert_equal 20000 [$client get foo]
     }

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -43,7 +43,7 @@ tags {"aof external:skip"} {
         }
 
         test "Truncated AOF loaded: we expect foo to be equal to 5" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert {[$client get foo] eq "5"}
         }
@@ -60,7 +60,7 @@ tags {"aof external:skip"} {
         }
 
         test "Truncated AOF loaded: we expect foo to be equal to 6 now" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert {[$client get foo] eq "6"}
         }
@@ -136,7 +136,7 @@ tags {"aof external:skip"} {
         }
 
         test "Fixed AOF: Keyspace should contain values that were parseable" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal "hello" [$client get foo]
             assert_equal "" [$client get bar]
@@ -156,7 +156,7 @@ tags {"aof external:skip"} {
         }
 
         test "AOF+SPOP: Set should have 1 member" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
@@ -176,7 +176,7 @@ tags {"aof external:skip"} {
         }
 
         test "AOF+SPOP: Set should have 1 member" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 1 [$client scard set]
         }
@@ -195,7 +195,7 @@ tags {"aof external:skip"} {
         }
 
         test "AOF+EXPIRE: List should be empty" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
             assert_equal 0 [$client llen list]
         }
@@ -272,8 +272,8 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+LMPOP/BLMPOP: pop elements from the list" {
-            set client [redis [srv host] [srv port] 0 $::tls]
-            set client2 [redis [srv host] [srv port] 1 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            set client2 [valkey [srv host] [srv port] 1 $::tls]
             wait_done_loading $client
 
             # Pop all elements from mylist, should be blmpop delete mylist.
@@ -299,7 +299,7 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+LMPOP/BLMPOP: after pop elements from the list" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # mylist and mylist2 no longer exist.
@@ -319,8 +319,8 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+ZMPOP/BZMPOP: pop elements from the zset" {
-            set client [redis [srv host] [srv port] 0 $::tls]
-            set client2 [redis [srv host] [srv port] 1 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
+            set client2 [valkey [srv host] [srv port] 1 $::tls]
             wait_done_loading $client
 
             # Pop all elements from myzset, should be bzmpop delete myzset.
@@ -346,7 +346,7 @@ tags {"aof external:skip"} {
 
     start_server_aof [list dir $server_path aof-load-truncated no] {
         test "AOF+ZMPOP/BZMPOP: after pop elements from the zset" {
-            set client [redis [srv host] [srv port] 0 $::tls]
+            set client [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $client
 
             # myzset and myzset2 no longer exist.
@@ -387,7 +387,7 @@ tags {"aof external:skip"} {
     }
     start_server_aof [list dir $server_path] {
         test {Successfully load AOF which has timestamp annotations inside} {
-            set c [redis [srv host] [srv port] 0 $::tls]
+            set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -399,7 +399,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217473
         exec src/valkey-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [srv host] [srv port] 0 $::tls]
+            set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -409,7 +409,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217471
         exec src/valkey-check-aof --truncate-to-timestamp 1628217471 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [srv host] [srv port] 0 $::tls]
+            set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "bar2" [$c get foo2]
@@ -419,7 +419,7 @@ tags {"aof external:skip"} {
         # truncate to timestamp 1628217470
         exec src/valkey-check-aof --truncate-to-timestamp 1628217470 $aof_manifest_file
         start_server_aof [list dir $server_path] {
-            set c [redis [srv host] [srv port] 0 $::tls]
+            set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
             assert_equal "bar1" [$c get foo1]
             assert_equal "" [$c get foo2]

--- a/tests/integration/psync2-pingoff.tcl
+++ b/tests/integration/psync2-pingoff.tcl
@@ -1,5 +1,5 @@
 # These tests were added together with the meaningful offset implementation
-# in redis OSS 6.0.0, which was later abandoned in 6.0.4, they used to test that
+# in valkey OSS 6.0.0, which was later abandoned in 6.0.4, they used to test that
 # servers are able to PSYNC with replicas even if the replication stream has
 # PINGs at the end which present in one sever and missing on another.
 # We keep these tests just because they reproduce edge cases in the replication

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -11,8 +11,8 @@ proc common_bench_setup {cmd} {
     r flushall
     if {[catch { exec {*}$cmd } error]} {
         set first_line [lindex [split $error "\n"] 0]
-        puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
-        fail "redis-benchmark non zero code. first line: $first_line"
+        puts [colorstr red "valkey-benchmark non zero code. first line: $first_line"]
+        fail "valkey-benchmark non zero code. first line: $first_line"
     }
 }
 
@@ -164,8 +164,8 @@ tags {"benchmark network external:skip logreqres:skip"} {
                             puts "Skipping test, TLSv1.3 not supported."
                         }
                     } else {
-                        puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
-                        fail "redis-benchmark non zero code. first line: $first_line"
+                        puts [colorstr red "valkey-benchmark non zero code. first line: $first_line"]
+                        fail "valkey-benchmark non zero code. first line: $first_line"
                     }
                 }
                 if {$ciphersuites_supported} {

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -19,7 +19,7 @@ proc main {} {
         "enable-debug-command yes"
     } "../tests/includes/sentinel.conf"
 
-    spawn_instance redis $::redis_base_port $::instances_count {
+    spawn_instance valkey $::valkey_base_port $::instances_count {
         "enable-protected-configs yes"
         "enable-debug-command yes"
         "save ''"

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -79,7 +79,7 @@ test "Basic failover works if the master is down" {
     set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
     foreach_sentinel_id id {
         S $id sentinel debug ping-period 500
         S $id sentinel debug ask-period 500  
@@ -89,9 +89,9 @@ test "Basic failover works if the master is down" {
             fail "At least one Sentinel did not receive failover info"
         }
     }
-    restart_instance redis $master_id
+    restart_instance valkey $master_id
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 }
 
 test "New master [join $addr {:}] role matches" {
@@ -125,12 +125,12 @@ test "ODOWN is not possible without N (quorum) Sentinels reports" {
     set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
 
     # Make sure failover did not happened.
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
-    restart_instance redis $master_id
+    restart_instance valkey $master_id
 }
 
 test "Failover is not possible without majority agreement" {
@@ -144,12 +144,12 @@ test "Failover is not possible without majority agreement" {
     }
 
     # Kill the current master
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
 
     # Make sure failover did not happened.
     set addr [S $quorum SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
-    restart_instance redis $master_id
+    restart_instance valkey $master_id
 
     # Cleanup: restart Sentinels to monitor the master.
     for {set id 0} {$id < $quorum} {incr id} {
@@ -171,7 +171,7 @@ test "Failover works if we configure for absolute agreement" {
         }
     }
 
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
 
     foreach_sentinel_id id {
         wait_for_condition 1000 100 {
@@ -180,9 +180,9 @@ test "Failover works if we configure for absolute agreement" {
             fail "At least one Sentinel did not receive failover info"
         }
     }
-    restart_instance redis $master_id
+    restart_instance valkey $master_id
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 
     # Set the min ODOWN agreement back to strict majority.
     foreach_sentinel_id id {

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -99,7 +99,7 @@ test "New master [join $addr {:}] role matches" {
 }
 
 test "All the other slaves now point to the new master" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -10,7 +10,7 @@ test "We can failover with Sentinel 1 crashed" {
     # Crash Sentinel 1
     kill_instance sentinel 1
 
-    kill_instance redis $master_id
+    kill_instance valkey $master_id
     foreach_sentinel_id id {
         if {$id != 1} {
             wait_for_condition 1000 50 {
@@ -20,9 +20,9 @@ test "We can failover with Sentinel 1 crashed" {
             }
         }
     }
-    restart_instance redis $master_id
+    restart_instance valkey $master_id
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 }
 
 test "After Sentinel 1 is restarted, its config gets updated" {

--- a/tests/sentinel/tests/02-slaves-reconf.tcl
+++ b/tests/sentinel/tests/02-slaves-reconf.tcl
@@ -11,7 +11,7 @@ proc 02_test_slaves_replication {} {
     uplevel 1 {
         test "Check that slaves replicate from current master" {
             set master_port [RPort $master_id]
-            foreach_redis_id id {
+            foreach_valkey_id id {
                 if {$id == $master_id} continue
                 if {[instance_is_killed redis $id]} continue
                 wait_for_condition 1000 50 {
@@ -58,7 +58,7 @@ foreach_sentinel_id id {
 02_test_slaves_replication
 
 test "Kill a slave instance" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id == $master_id} continue
         set killed_slave_id $id
         kill_instance redis $id

--- a/tests/sentinel/tests/02-slaves-reconf.tcl
+++ b/tests/sentinel/tests/02-slaves-reconf.tcl
@@ -13,7 +13,7 @@ proc 02_test_slaves_replication {} {
             set master_port [RPort $master_id]
             foreach_valkey_id id {
                 if {$id == $master_id} continue
-                if {[instance_is_killed redis $id]} continue
+                if {[instance_is_killed valkey $id]} continue
                 wait_for_condition 1000 50 {
                     ([RI $id master_port] == $master_port) &&
                     ([RI $id master_link_status] eq {up})
@@ -31,7 +31,7 @@ proc 02_crash_and_failover {} {
             set old_port [RPort $master_id]
             set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
             assert {[lindex $addr 1] == $old_port}
-            kill_instance redis $master_id
+            kill_instance valkey $master_id
             foreach_sentinel_id id {
                 wait_for_condition 1000 50 {
                     [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
@@ -39,9 +39,9 @@ proc 02_crash_and_failover {} {
                     fail "At least one Sentinel did not receive failover info"
                 }
             }
-            restart_instance redis $master_id
+            restart_instance valkey $master_id
             set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-            set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+            set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
         }
     }
 }
@@ -61,7 +61,7 @@ test "Kill a slave instance" {
     foreach_valkey_id id {
         if {$id == $master_id} continue
         set killed_slave_id $id
-        kill_instance redis $id
+        kill_instance valkey $id
         break
     }
 }
@@ -83,7 +83,7 @@ test "Wait for failover to end" {
 }
 
 test "Restart killed slave and test replication of slaves again..." {
-    restart_instance redis $killed_slave_id
+    restart_instance valkey $killed_slave_id
 }
 
 # Now we check if the slave rejoining the partition is reconfigured even

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -6,7 +6,7 @@ set ::user "testuser"
 set ::password "secret"
 
 proc server_set_password {} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         assert_equal {OK} [R $id CONFIG SET requirepass $::password]
         assert_equal {OK} [R $id AUTH $::password]
         assert_equal {OK} [R $id CONFIG SET masterauth $::password]
@@ -14,7 +14,7 @@ proc server_set_password {} {
 }
 
 proc server_reset_password {} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         assert_equal {OK} [R $id CONFIG SET requirepass ""]
         assert_equal {OK} [R $id CONFIG SET masterauth ""]
     }
@@ -116,7 +116,7 @@ test "Sentinels (re)connection following master ACL change" {
     assert_equal {OK} [S $sent2up SENTINEL SET mymaster auth-user $::user]
     assert_equal {OK} [S $sent2up SENTINEL SET mymaster auth-pass $::password]
 
-    foreach_redis_id id {
+    foreach_valkey_id id {
         server_set_acl $id
     }
 
@@ -153,7 +153,7 @@ test "Sentinels (re)connection following master ACL change" {
     wait_for_sentinels_connect_servers
 
     # remove requirepass and verify sentinels manage to connect servers
-    foreach_redis_id id {
+    foreach_valkey_id id {
         server_reset_acl $id
     }
 

--- a/tests/sentinel/tests/05-manual.tcl
+++ b/tests/sentinel/tests/05-manual.tcl
@@ -43,7 +43,7 @@ test "New master [join $addr {:}] role matches" {
 }
 
 test "All the other slaves now point to the new master" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]

--- a/tests/sentinel/tests/05-manual.tcl
+++ b/tests/sentinel/tests/05-manual.tcl
@@ -35,7 +35,7 @@ test "Manual failover works" {
         }
     }
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 }
 
 test "New master [join $addr {:}] role matches" {

--- a/tests/sentinel/tests/07-down-conditions.tcl
+++ b/tests/sentinel/tests/07-down-conditions.tcl
@@ -46,9 +46,9 @@ test "Crash the majority of Sentinels to prevent failovers for this unit" {
 test "SDOWN is triggered by non-responding but not crashed instance" {
     ensure_master_up
     set master_addr [S $::alive_sentinel SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $master_addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $master_addr 1]]
 
-    set pid [get_instance_attrib redis $master_id pid]
+    set pid [get_instance_attrib valkey $master_id pid]
     pause_process $pid
     ensure_master_down
     resume_process $pid
@@ -58,9 +58,9 @@ test "SDOWN is triggered by non-responding but not crashed instance" {
 test "SDOWN is triggered by crashed instance" {
     lassign [S $::alive_sentinel SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] host port
     ensure_master_up
-    kill_instance redis 0
+    kill_instance valkey 0
     ensure_master_down
-    restart_instance redis 0
+    restart_instance valkey 0
     ensure_master_up
 }
 

--- a/tests/sentinel/tests/08-hostname-conf.tcl
+++ b/tests/sentinel/tests/08-hostname-conf.tcl
@@ -1,7 +1,7 @@
 source "../tests/includes/utils.tcl"
 
 proc set_redis_announce_ip {addr} {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         R $id config set replica-announce-ip $addr
     }
 }
@@ -16,7 +16,7 @@ proc set_all_instances_hostname {hostname} {
     foreach_sentinel_id id {
         set_instance_attrib sentinel $id host $hostname
     }
-    foreach_redis_id id {
+    foreach_valkey_id id {
         set_instance_attrib redis $id host $hostname
     }
 }

--- a/tests/sentinel/tests/08-hostname-conf.tcl
+++ b/tests/sentinel/tests/08-hostname-conf.tcl
@@ -17,7 +17,7 @@ proc set_all_instances_hostname {hostname} {
         set_instance_attrib sentinel $id host $hostname
     }
     foreach_valkey_id id {
-        set_instance_attrib redis $id host $hostname
+        set_instance_attrib valkey $id host $hostname
     }
 }
 

--- a/tests/sentinel/tests/10-replica-priority.tcl
+++ b/tests/sentinel/tests/10-replica-priority.tcl
@@ -51,7 +51,7 @@ proc 10_set_replica_announced {master_id announced n_replicas} {
         set i 0
         foreach_valkey_id id {
             if {$id == $master_id} continue
-            #puts "set replica-announce=$announced on redis #$id"
+            #puts "set replica-announce=$announced on valkey #$id"
             R $id CONFIG SET replica-announced "$announced"
             incr i
             if { $n_replicas!="all" && $i >= $n_replicas } { break }

--- a/tests/sentinel/tests/10-replica-priority.tcl
+++ b/tests/sentinel/tests/10-replica-priority.tcl
@@ -1,7 +1,7 @@
 source "../tests/includes/init-tests.tcl"
 
 test "Check acceptable replica-priority values" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id == $master_id} continue
 
         # ensure replica-announced accepts yes and no
@@ -49,7 +49,7 @@ proc 10_test_number_of_replicas {n_replicas_expected} {
 proc 10_set_replica_announced {master_id announced n_replicas} {
     test "Set replica-announced=$announced on $n_replicas replicas" {
         set i 0
-        foreach_redis_id id {
+        foreach_valkey_id id {
             if {$id == $master_id} continue
             #puts "set replica-announce=$announced on redis #$id"
             R $id CONFIG SET replica-announced "$announced"

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -29,7 +29,7 @@ proc reboot_instance {type id} {
     }
 
     # Connect with it with a fresh link
-    set link [redis 127.0.0.1 $port 0 $::tls]
+    set link [valkey 127.0.0.1 $port 0 $::tls]
     $link reconnect 1
     set_instance_attrib $type $id link $link
 }
@@ -52,8 +52,8 @@ test "Master reboot in very short time" {
         S $id sentinel debug ask-period 500 
     }
 
-    kill_instance redis $master_id
-    reboot_instance redis $master_id
+    kill_instance valkey $master_id
+    reboot_instance valkey $master_id
     
     foreach_sentinel_id id {        
         wait_for_condition 1000 100 {
@@ -64,7 +64,7 @@ test "Master reboot in very short time" {
     }
 
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port redis [lindex $addr 1]]
+    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 
     # Make sure the instance load all the dataset
     while 1 {

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -83,7 +83,7 @@ test "New master [join $addr {:}] role matches" {
 }
 
 test "All the other slaves now point to the new master" {
-    foreach_redis_id id {
+    foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -22,8 +22,8 @@ test "(init) Sentinels can start monitoring a master" {
     set quorum [expr {$sentinels/2+1}]
     foreach_sentinel_id id {
         S $id SENTINEL MONITOR mymaster \
-              [get_instance_attrib redis $master_id host] \
-              [get_instance_attrib redis $master_id port] $quorum
+              [get_instance_attrib valkey $master_id host] \
+              [get_instance_attrib valkey $master_id port] $quorum
     }
     foreach_sentinel_id id {
         assert {[S $id sentinel master mymaster] ne {}}

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -13,7 +13,7 @@ test "(init) Remove old master entry from sentinels" {
 
 set redis_slaves [expr $::instances_count - 1]
 test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances" {
-    create_redis_master_slave_cluster [expr {$redis_slaves+1}]
+    create_valkey_master_slave_cluster [expr {$redis_slaves+1}]
 }
 set master_id 0
 

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -1,5 +1,5 @@
 proc restart_killed_instances {} {
-    foreach type {redis sentinel} {
+    foreach type {valkey sentinel} {
         foreach_${type}_id id {
             if {[get_instance_attrib $type $id pid] == -1} {
                 puts -nonewline "$type/$id "

--- a/tests/support/benchmark.tcl
+++ b/tests/support/benchmark.tcl
@@ -19,14 +19,14 @@ proc redisbenchmark {host port {opts {}}} {
 }
 
 proc redisbenchmarkuri {host port {opts {}}} {
-    set cmd [list src/valkey-benchmark -u redis://$host:$port]
+    set cmd [list src/valkey-benchmark -u valkey://$host:$port]
     lappend cmd {*}[redisbenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
 }
 
 proc redisbenchmarkuriuserpass {host port user pass {opts {}}} {
-    set cmd [list src/valkey-benchmark -u redis://$user:$pass@$host:$port]
+    set cmd [list src/valkey-benchmark -u valkey://$user:$pass@$host:$port]
     lappend cmd {*}[redisbenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd

--- a/tests/support/benchmark.tcl
+++ b/tests/support/benchmark.tcl
@@ -19,14 +19,14 @@ proc redisbenchmark {host port {opts {}}} {
 }
 
 proc redisbenchmarkuri {host port {opts {}}} {
-    set cmd [list src/valkey-benchmark -u valkey://$host:$port]
+    set cmd [list src/valkey-benchmark -u redis://$host:$port]
     lappend cmd {*}[redisbenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
 }
 
 proc redisbenchmarkuriuserpass {host port user pass {opts {}}} {
-    set cmd [list src/valkey-benchmark -u valkey://$user:$pass@$host:$port]
+    set cmd [list src/valkey-benchmark -u redis://$user:$pass@$host:$port]
     lappend cmd {*}[redisbenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -69,7 +69,7 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
         set tls $::redis_cluster::tls($id)
         if {[catch {
             set r {}
-            set r [redis $start_host $start_port 0 $tls]
+            set r [valkey $start_host $start_port 0 $tls]
             set nodes_descr [$r cluster nodes]
             $r close
         } e]} {
@@ -115,7 +115,7 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
         # Connect to the node
         set link {}
         set tls $::redis_cluster::tls($id)
-        catch {set link [redis $host $port 0 $tls]}
+        catch {set link [valkey $host $port 0 $tls]}
 
         # Build this node description as an hash.
         set node [dict create \

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -265,7 +265,7 @@ proc ::redis::redis_readnl {fd len} {
     return $buf
 }
 
-proc ::redis::redis_bulk_read {fd} {
+proc ::redis::valkey_bulk_read {fd} {
     set count [redis_read_line $fd]
     if {$count == -1} return {}
     set buf [redis_readnl $fd $count]
@@ -335,7 +335,7 @@ proc ::redis::redis_read_double {id fd} {
 }
 
 proc ::redis::redis_read_verbatim_str fd {
-    set v [redis_bulk_read $fd]
+    set v [valkey_bulk_read $fd]
     # strip the first 4 chars ("txt:")
     return [string range $v 4 end]
 }
@@ -356,7 +356,7 @@ proc ::redis::redis_read_reply_logic {id fd} {
             # {return [redis_read_bool $fd]}
             = {return [redis_read_verbatim_str $fd]}
             - {return -code error [redis_read_line $fd]}
-            $ {return [redis_bulk_read $fd]}
+            $ {return [valkey_bulk_read $fd]}
             > -
             ~ -
             * {return [redis_multi_bulk_read $id $fd]}

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -4,7 +4,7 @@
 #
 # Example usage:
 #
-# set r [redis 127.0.0.1 6379]
+# set r [valkey 127.0.0.1 6379]
 # $r lpush mylist foo
 # $r lpush mylist bar
 # $r lrange mylist 0 -1
@@ -26,30 +26,30 @@
 # vwait forever
 
 package require Tcl 8.5
-package provide redis 0.1
+package provide valkey 0.1
 
 source [file join [file dirname [info script]] "response_transformers.tcl"]
 
-namespace eval redis {}
-set ::redis::id 0
-array set ::redis::fd {}
-array set ::redis::addr {}
-array set ::redis::blocking {}
-array set ::redis::deferred {}
-array set ::redis::readraw {}
-array set ::redis::attributes {} ;# Holds the RESP3 attributes from the last call
-array set ::redis::reconnect {}
-array set ::redis::tls {}
-array set ::redis::callback {}
-array set ::redis::state {} ;# State in non-blocking reply reading
-array set ::redis::statestack {} ;# Stack of states, for nested mbulks
-array set ::redis::curr_argv {} ;# Remember the current argv, to be used in response_transformers.tcl
-array set ::redis::testing_resp3 {} ;# Indicating if the current client is using RESP3 (only if the test is trying to test RESP3 specific behavior. It won't be on in case of force_resp3)
+namespace eval valkey {}
+set ::valkey::id 0
+array set ::valkey::fd {}
+array set ::valkey::addr {}
+array set ::valkey::blocking {}
+array set ::valkey::deferred {}
+array set ::valkey::readraw {}
+array set ::valkey::attributes {} ;# Holds the RESP3 attributes from the last call
+array set ::valkey::reconnect {}
+array set ::valkey::tls {}
+array set ::valkey::callback {}
+array set ::valkey::state {} ;# State in non-blocking reply reading
+array set ::valkey::statestack {} ;# Stack of states, for nested mbulks
+array set ::valkey::curr_argv {} ;# Remember the current argv, to be used in response_transformers.tcl
+array set ::valkey::testing_resp3 {} ;# Indicating if the current client is using RESP3 (only if the test is trying to test RESP3 specific behavior. It won't be on in case of force_resp3)
 
 set ::force_resp3 0
 set ::log_req_res 0
 
-proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {readraw 0}} {
+proc valkey {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {readraw 0}} {
     if {$tls} {
         package require tls
         ::tls::init \
@@ -62,23 +62,23 @@ proc redis {{server 127.0.0.1} {port 6379} {defer 0} {tls 0} {tlsoptions {}} {re
         set fd [socket $server $port]
     }
     fconfigure $fd -translation binary
-    set id [incr ::redis::id]
-    set ::redis::fd($id) $fd
-    set ::redis::addr($id) [list $server $port]
-    set ::redis::blocking($id) 1
-    set ::redis::deferred($id) $defer
-    set ::redis::readraw($id) $readraw
-    set ::redis::reconnect($id) 0
-    set ::redis::curr_argv($id) 0
-    set ::redis::testing_resp3($id) 0
-    set ::redis::tls($id) $tls
-    ::redis::redis_reset_state $id
-    interp alias {} ::redis::redisHandle$id {} ::redis::__dispatch__ $id
+    set id [incr ::valkey::id]
+    set ::valkey::fd($id) $fd
+    set ::valkey::addr($id) [list $server $port]
+    set ::valkey::blocking($id) 1
+    set ::valkey::deferred($id) $defer
+    set ::valkey::readraw($id) $readraw
+    set ::valkey::reconnect($id) 0
+    set ::valkey::curr_argv($id) 0
+    set ::valkey::testing_resp3($id) 0
+    set ::valkey::tls($id) $tls
+    ::valkey::redis_reset_state $id
+    interp alias {} ::valkey::redisHandle$id {} ::valkey::__dispatch__ $id
 }
 
 # On recent versions of tcl-tls/OpenSSL, reading from a dropped connection
 # results with an error we need to catch and mimic the old behavior.
-proc ::redis::redis_safe_read {fd len} {
+proc ::valkey::redis_safe_read {fd len} {
     if {$len == -1} {
         set err [catch {set val [read $fd]} msg]
     } else {
@@ -93,7 +93,7 @@ proc ::redis::redis_safe_read {fd len} {
     error $msg
 }
 
-proc ::redis::redis_safe_gets {fd} {
+proc ::valkey::redis_safe_gets {fd} {
     if {[catch {set val [gets $fd]} msg]} {
         if {[string match "*connection abort*" $msg]} {
             return {}
@@ -105,40 +105,40 @@ proc ::redis::redis_safe_gets {fd} {
 
 # This is a wrapper to the actual dispatching procedure that handles
 # reconnection if needed.
-proc ::redis::__dispatch__ {id method args} {
-    set errorcode [catch {::redis::__dispatch__raw__ $id $method $args} retval]
-    if {$errorcode && $::redis::reconnect($id) && $::redis::fd($id) eq {}} {
+proc ::valkey::__dispatch__ {id method args} {
+    set errorcode [catch {::valkey::__dispatch__raw__ $id $method $args} retval]
+    if {$errorcode && $::valkey::reconnect($id) && $::valkey::fd($id) eq {}} {
         # Try again if the connection was lost.
         # FIXME: we don't re-select the previously selected DB, nor we check
         # if we are inside a transaction that needs to be re-issued from
         # scratch.
-        set errorcode [catch {::redis::__dispatch__raw__ $id $method $args} retval]
+        set errorcode [catch {::valkey::__dispatch__raw__ $id $method $args} retval]
     }
     return -code $errorcode $retval
 }
 
-proc ::redis::__dispatch__raw__ {id method argv} {
-    set fd $::redis::fd($id)
+proc ::valkey::__dispatch__raw__ {id method argv} {
+    set fd $::valkey::fd($id)
 
     # Reconnect the link if needed.
     if {$fd eq {} && $method ne {close}} {
-        lassign $::redis::addr($id) host port
-        if {$::redis::tls($id)} {
-            set ::redis::fd($id) [::tls::socket $host $port]
+        lassign $::valkey::addr($id) host port
+        if {$::valkey::tls($id)} {
+            set ::valkey::fd($id) [::tls::socket $host $port]
         } else {
-            set ::redis::fd($id) [socket $host $port]
+            set ::valkey::fd($id) [socket $host $port]
         }
-        fconfigure $::redis::fd($id) -translation binary
-        set fd $::redis::fd($id)
+        fconfigure $::valkey::fd($id) -translation binary
+        set fd $::valkey::fd($id)
     }
 
     # Transform HELLO 2 to HELLO 3 if force_resp3
     # All set the connection var testing_resp3 in case of HELLO 3
     if {[llength $argv] > 0 && [string compare -nocase $method "HELLO"] == 0} {
         if {[lindex $argv 0] == 3} {
-            set ::redis::testing_resp3($id) 1
+            set ::valkey::testing_resp3($id) 1
         } else {
-            set ::redis::testing_resp3($id) 0
+            set ::valkey::testing_resp3($id) 0
             if {$::force_resp3} {
                 # If we are in force_resp3 we run HELLO 3 instead of HELLO 2
                 lset argv 0 3
@@ -146,8 +146,8 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         }
     }
 
-    set blocking $::redis::blocking($id)
-    set deferred $::redis::deferred($id)
+    set blocking $::valkey::blocking($id)
+    set deferred $::valkey::deferred($id)
     if {$blocking == 0} {
         if {[llength $argv] == 0} {
             error "Please provide a callback in non-blocking mode"
@@ -155,124 +155,124 @@ proc ::redis::__dispatch__raw__ {id method argv} {
         set callback [lindex $argv end]
         set argv [lrange $argv 0 end-1]
     }
-    if {[info command ::redis::__method__$method] eq {}} {
-        catch {unset ::redis::attributes($id)}
+    if {[info command ::valkey::__method__$method] eq {}} {
+        catch {unset ::valkey::attributes($id)}
         set cmd "*[expr {[llength $argv]+1}]\r\n"
         append cmd "$[string length $method]\r\n$method\r\n"
         foreach a $argv {
             append cmd "$[string length $a]\r\n$a\r\n"
         }
-        ::redis::redis_write $fd $cmd
+        ::valkey::redis_write $fd $cmd
         if {[catch {flush $fd}]} {
             catch {close $fd}
-            set ::redis::fd($id) {}
+            set ::valkey::fd($id) {}
             return -code error "I/O error reading reply"
         }
 
-        set ::redis::curr_argv($id) [concat $method $argv]
+        set ::valkey::curr_argv($id) [concat $method $argv]
         if {!$deferred} {
             if {$blocking} {
-                ::redis::redis_read_reply $id $fd
+                ::valkey::redis_read_reply $id $fd
             } else {
                 # Every well formed reply read will pop an element from this
                 # list and use it as a callback. So pipelining is supported
                 # in non blocking mode.
-                lappend ::redis::callback($id) $callback
-                fileevent $fd readable [list ::redis::redis_readable $fd $id]
+                lappend ::valkey::callback($id) $callback
+                fileevent $fd readable [list ::valkey::redis_readable $fd $id]
             }
         }
     } else {
-        uplevel 1 [list ::redis::__method__$method $id $fd] $argv
+        uplevel 1 [list ::valkey::__method__$method $id $fd] $argv
     }
 }
 
-proc ::redis::__method__blocking {id fd val} {
-    set ::redis::blocking($id) $val
+proc ::valkey::__method__blocking {id fd val} {
+    set ::valkey::blocking($id) $val
     fconfigure $fd -blocking $val
 }
 
-proc ::redis::__method__reconnect {id fd val} {
-    set ::redis::reconnect($id) $val
+proc ::valkey::__method__reconnect {id fd val} {
+    set ::valkey::reconnect($id) $val
 }
 
-proc ::redis::__method__read {id fd} {
-    ::redis::redis_read_reply $id $fd
+proc ::valkey::__method__read {id fd} {
+    ::valkey::redis_read_reply $id $fd
 }
 
-proc ::redis::__method__rawread {id fd {len -1}} {
+proc ::valkey::__method__rawread {id fd {len -1}} {
     return [redis_safe_read $fd $len]
 }
 
-proc ::redis::__method__write {id fd buf} {
-    ::redis::redis_write $fd $buf
+proc ::valkey::__method__write {id fd buf} {
+    ::valkey::redis_write $fd $buf
 }
 
-proc ::redis::__method__flush {id fd} {
+proc ::valkey::__method__flush {id fd} {
     flush $fd
 }
 
-proc ::redis::__method__close {id fd} {
+proc ::valkey::__method__close {id fd} {
     catch {close $fd}
-    catch {unset ::redis::fd($id)}
-    catch {unset ::redis::addr($id)}
-    catch {unset ::redis::blocking($id)}
-    catch {unset ::redis::deferred($id)}
-    catch {unset ::redis::readraw($id)}
-    catch {unset ::redis::attributes($id)}
-    catch {unset ::redis::reconnect($id)}
-    catch {unset ::redis::tls($id)}
-    catch {unset ::redis::state($id)}
-    catch {unset ::redis::statestack($id)}
-    catch {unset ::redis::callback($id)}
-    catch {unset ::redis::curr_argv($id)}
-    catch {unset ::redis::testing_resp3($id)}
-    catch {interp alias {} ::redis::redisHandle$id {}}
+    catch {unset ::valkey::fd($id)}
+    catch {unset ::valkey::addr($id)}
+    catch {unset ::valkey::blocking($id)}
+    catch {unset ::valkey::deferred($id)}
+    catch {unset ::valkey::readraw($id)}
+    catch {unset ::valkey::attributes($id)}
+    catch {unset ::valkey::reconnect($id)}
+    catch {unset ::valkey::tls($id)}
+    catch {unset ::valkey::state($id)}
+    catch {unset ::valkey::statestack($id)}
+    catch {unset ::valkey::callback($id)}
+    catch {unset ::valkey::curr_argv($id)}
+    catch {unset ::valkey::testing_resp3($id)}
+    catch {interp alias {} ::valkey::redisHandle$id {}}
 }
 
-proc ::redis::__method__channel {id fd} {
+proc ::valkey::__method__channel {id fd} {
     return $fd
 }
 
-proc ::redis::__method__deferred {id fd val} {
-    set ::redis::deferred($id) $val
+proc ::valkey::__method__deferred {id fd val} {
+    set ::valkey::deferred($id) $val
 }
 
-proc ::redis::__method__readraw {id fd val} {
-    set ::redis::readraw($id) $val
+proc ::valkey::__method__readraw {id fd val} {
+    set ::valkey::readraw($id) $val
 }
 
-proc ::redis::__method__readingraw {id fd} {
-    return $::redis::readraw($id)
+proc ::valkey::__method__readingraw {id fd} {
+    return $::valkey::readraw($id)
 }
 
-proc ::redis::__method__attributes {id fd} {
-    set _ $::redis::attributes($id)
+proc ::valkey::__method__attributes {id fd} {
+    set _ $::valkey::attributes($id)
 }
 
-proc ::redis::redis_write {fd buf} {
+proc ::valkey::redis_write {fd buf} {
     puts -nonewline $fd $buf
 }
 
-proc ::redis::redis_writenl {fd buf} {
+proc ::valkey::redis_writenl {fd buf} {
     redis_write $fd $buf
     redis_write $fd "\r\n"
     flush $fd
 }
 
-proc ::redis::redis_readnl {fd len} {
+proc ::valkey::redis_readnl {fd len} {
     set buf [redis_safe_read $fd $len]
     redis_safe_read $fd 2 ; # discard CR LF
     return $buf
 }
 
-proc ::redis::valkey_bulk_read {fd} {
+proc ::valkey::valkey_bulk_read {fd} {
     set count [redis_read_line $fd]
     if {$count == -1} return {}
     set buf [redis_readnl $fd $count]
     return $buf
 }
 
-proc ::redis::redis_multi_bulk_read {id fd} {
+proc ::valkey::redis_multi_bulk_read {id fd} {
     set count [redis_read_line $fd]
     if {$count == -1} return {}
     set l {}
@@ -288,7 +288,7 @@ proc ::redis::redis_multi_bulk_read {id fd} {
     return $l
 }
 
-proc ::redis::redis_read_map {id fd} {
+proc ::valkey::redis_read_map {id fd} {
     set count [redis_read_line $fd]
     if {$count == -1} return {}
     set d {}
@@ -306,23 +306,23 @@ proc ::redis::redis_read_map {id fd} {
     return $d
 }
 
-proc ::redis::redis_read_line fd {
+proc ::valkey::redis_read_line fd {
     string trim [redis_safe_gets $fd]
 }
 
-proc ::redis::redis_read_null fd {
+proc ::valkey::redis_read_null fd {
     redis_safe_gets $fd
     return {}
 }
 
-proc ::redis::redis_read_bool fd {
+proc ::valkey::redis_read_bool fd {
     set v [redis_read_line $fd]
     if {$v == "t"} {return 1}
     if {$v == "f"} {return 0}
     return -code error "Bad protocol, '$v' as bool type"
 }
 
-proc ::redis::redis_read_double {id fd} {
+proc ::valkey::redis_read_double {id fd} {
     set v [redis_read_line $fd]
     # unlike many other DTs, there is a textual difference between double and a string with the same value,
     # so we need to transform to double if we are testing RESP3 (i.e. some tests check that a
@@ -334,14 +334,14 @@ proc ::redis::redis_read_double {id fd} {
     }
 }
 
-proc ::redis::redis_read_verbatim_str fd {
+proc ::valkey::redis_read_verbatim_str fd {
     set v [valkey_bulk_read $fd]
     # strip the first 4 chars ("txt:")
     return [string range $v 4 end]
 }
 
-proc ::redis::redis_read_reply_logic {id fd} {
-    if {$::redis::readraw($id)} {
+proc ::valkey::redis_read_reply_logic {id fd} {
+    if {$::valkey::readraw($id)} {
         return [redis_read_line $fd]
     }
 
@@ -363,13 +363,13 @@ proc ::redis::redis_read_reply_logic {id fd} {
             % {return [redis_read_map $id $fd]}
             | {
                 set attrib [redis_read_map $id $fd]
-                set ::redis::attributes($id) $attrib
+                set ::valkey::attributes($id) $attrib
                 continue
             }
             default {
                 if {$type eq {}} {
                     catch {close $fd}
-                    set ::redis::fd($id) {}
+                    set ::valkey::fd($id) {}
                     return -code error "I/O error reading reply"
                 }
                 return -code error "Bad protocol, '$type' as reply type byte"
@@ -378,31 +378,31 @@ proc ::redis::redis_read_reply_logic {id fd} {
     }
 }
 
-proc ::redis::redis_read_reply {id fd} {
+proc ::valkey::redis_read_reply {id fd} {
     set response [redis_read_reply_logic $id $fd]
-    ::response_transformers::transform_response_if_needed $id $::redis::curr_argv($id) $response
+    ::response_transformers::transform_response_if_needed $id $::valkey::curr_argv($id) $response
 }
 
-proc ::redis::redis_reset_state id {
-    set ::redis::state($id) [dict create buf {} mbulk -1 bulk -1 reply {}]
-    set ::redis::statestack($id) {}
+proc ::valkey::redis_reset_state id {
+    set ::valkey::state($id) [dict create buf {} mbulk -1 bulk -1 reply {}]
+    set ::valkey::statestack($id) {}
 }
 
-proc ::redis::redis_call_callback {id type reply} {
-    set cb [lindex $::redis::callback($id) 0]
-    set ::redis::callback($id) [lrange $::redis::callback($id) 1 end]
-    uplevel #0 $cb [list ::redis::redisHandle$id $type $reply]
-    ::redis::redis_reset_state $id
+proc ::valkey::redis_call_callback {id type reply} {
+    set cb [lindex $::valkey::callback($id) 0]
+    set ::valkey::callback($id) [lrange $::valkey::callback($id) 1 end]
+    uplevel #0 $cb [list ::valkey::redisHandle$id $type $reply]
+    ::valkey::redis_reset_state $id
 }
 
 # Read a reply in non-blocking mode.
-proc ::redis::redis_readable {fd id} {
+proc ::valkey::redis_readable {fd id} {
     if {[eof $fd]} {
         redis_call_callback $id eof {}
-        ::redis::__method__close $id $fd
+        ::valkey::__method__close $id $fd
         return
     }
-    if {[dict get $::redis::state($id) bulk] == -1} {
+    if {[dict get $::valkey::state($id) bulk] == -1} {
         set line [gets $fd]
         if {$line eq {}} return ;# No complete line available, return
         switch -exact -- [string index $line 0] {
@@ -411,19 +411,19 @@ proc ::redis::redis_readable {fd id} {
             - {redis_call_callback $id err [string range $line 1 end-1]}
             ( {redis_call_callback $id reply [string range $line 1 end-1]}
             $ {
-                dict set ::redis::state($id) bulk \
+                dict set ::valkey::state($id) bulk \
                     [expr [string range $line 1 end-1]+2]
-                if {[dict get $::redis::state($id) bulk] == 1} {
+                if {[dict get $::valkey::state($id) bulk] == 1} {
                     # We got a $-1, hack the state to play well with this.
-                    dict set ::redis::state($id) bulk 2
-                    dict set ::redis::state($id) buf "\r\n"
-                    ::redis::redis_readable $fd $id
+                    dict set ::valkey::state($id) bulk 2
+                    dict set ::valkey::state($id) buf "\r\n"
+                    ::valkey::redis_readable $fd $id
                 }
             }
             * {
-                dict set ::redis::state($id) mbulk [string range $line 1 end-1]
+                dict set ::valkey::state($id) mbulk [string range $line 1 end-1]
                 # Handle *-1
-                if {[dict get $::redis::state($id) mbulk] == -1} {
+                if {[dict get $::valkey::state($id) mbulk] == -1} {
                     redis_call_callback $id reply {}
                 }
             }
@@ -433,27 +433,27 @@ proc ::redis::redis_readable {fd id} {
             }
         }
     } else {
-        set totlen [dict get $::redis::state($id) bulk]
-        set buflen [string length [dict get $::redis::state($id) buf]]
+        set totlen [dict get $::valkey::state($id) bulk]
+        set buflen [string length [dict get $::valkey::state($id) buf]]
         set toread [expr {$totlen-$buflen}]
         set data [read $fd $toread]
         set nread [string length $data]
-        dict append ::redis::state($id) buf $data
+        dict append ::valkey::state($id) buf $data
         # Check if we read a complete bulk reply
-        if {[string length [dict get $::redis::state($id) buf]] ==
-            [dict get $::redis::state($id) bulk]} {
-            if {[dict get $::redis::state($id) mbulk] == -1} {
+        if {[string length [dict get $::valkey::state($id) buf]] ==
+            [dict get $::valkey::state($id) bulk]} {
+            if {[dict get $::valkey::state($id) mbulk] == -1} {
                 redis_call_callback $id reply \
-                    [string range [dict get $::redis::state($id) buf] 0 end-2]
+                    [string range [dict get $::valkey::state($id) buf] 0 end-2]
             } else {
-                dict with ::redis::state($id) {
+                dict with ::valkey::state($id) {
                     lappend reply [string range $buf 0 end-2]
                     incr mbulk -1
                     set bulk -1
                 }
-                if {[dict get $::redis::state($id) mbulk] == 0} {
+                if {[dict get $::valkey::state($id) mbulk] == 0} {
                     redis_call_callback $id reply \
-                        [dict get $::redis::state($id) reply]
+                        [dict get $::valkey::state($id) reply]
                 }
             }
         }
@@ -461,6 +461,6 @@ proc ::redis::redis_readable {fd id} {
 }
 
 # when forcing resp3 some tests that rely on resp2 can fail, so we have to translate the resp3 response to resp2
-proc ::redis::should_transform_to_resp2 {id} {
-    return [expr {$::force_resp3 && !$::redis::testing_resp3($id)}]
+proc ::valkey::should_transform_to_resp2 {id} {
+    return [expr {$::force_resp3 && !$::valkey::testing_resp3($id)}]
 }

--- a/tests/support/response_transformers.tcl
+++ b/tests/support/response_transformers.tcl
@@ -90,7 +90,7 @@ set ::transformer_funcs {
 }
 
 proc ::response_transformers::transform_response_if_needed {id argv response} {
-    if {![::redis::should_transform_to_resp2 $id] || $::redis::readraw($id)} {
+    if {![::valkey::should_transform_to_resp2 $id] || $::valkey::readraw($id)} {
         return $response
     }
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -347,7 +347,7 @@ proc run_external_server_test {code overrides} {
     set srv {}
     dict set srv "host" $::host
     dict set srv "port" $::port
-    set client [redis $::host $::port 0 $::tls]
+    set client [valkey $::host $::port 0 $::tls]
     dict set srv "client" $client
     if {!$::singledb} {
         $client select 9

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -195,7 +195,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
     set ::cur_test "$name in $::curfile"
     if {$::external} {
         catch {
-            set r [redis [srv 0 host] [srv 0 port] 0 $::tls]
+            set r [valkey [srv 0 host] [srv 0 port] 0 $::tls]
             catch {
                 $r debug log "### Starting test $::cur_test"
             }

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -942,7 +942,7 @@ proc read_from_aof {fp} {
     set res {}
     for {set j 0} {$j < $count} {incr j} {
         read $fp 1
-        set arg [::redis::valkey_bulk_read $fp]
+        set arg [::valkey::valkey_bulk_read $fp]
         if {$j == 0} {set arg [string tolower $arg]}
         lappend res $arg
     }
@@ -1009,7 +1009,7 @@ proc get_nonloopback_addr {} {
 }
 
 proc get_nonloopback_client {} {
-    return [redis [get_nonloopback_addr] [srv 0 "port"] 0 $::tls]
+    return [valkey [get_nonloopback_addr] [srv 0 "port"] 0 $::tls]
 }
 
 # The following functions and variables are used only when running large-memory

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -942,7 +942,7 @@ proc read_from_aof {fp} {
     set res {}
     for {set j 0} {$j < $count} {incr j} {
         read $fp 1
-        set arg [::redis::redis_bulk_read $fp]
+        set arg [::redis::valkey_bulk_read $fp]
         if {$j == 0} {set arg [string tolower $arg]}
         lappend res $arg
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -877,7 +877,7 @@ proc read_from_replication_stream {s} {
     set res {}
     for {set j 0} {$j < $count} {incr j} {
         read $s 1
-        set arg [::redis::redis_bulk_read $s]
+        set arg [::redis::valkey_bulk_read $s]
         if {$j == 0} {set arg [string tolower $arg]}
         lappend res $arg
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -240,7 +240,7 @@ proc reconnect {args} {
     set host [dict get $srv "host"]
     set port [dict get $srv "port"]
     set config [dict get $srv "config"]
-    set client [redis $host $port 0 $::tls]
+    set client [valkey $host $port 0 $::tls]
     if {[dict exists $srv "client"]} {
         set old [dict get $srv "client"]
         $old close
@@ -264,7 +264,7 @@ proc valkey_deferring_client {args} {
     }
 
     # create client that defers reading reply
-    set client [redis [srv $level "host"] [srv $level "port"] 1 $::tls]
+    set client [valkey [srv $level "host"] [srv $level "port"] 1 $::tls]
 
     # select the right db and read the response (OK)
     if {!$::singledb} {
@@ -286,7 +286,7 @@ proc valkey_client {args} {
     }
 
     # create client that won't defers reading reply
-    set client [redis [srv $level "host"] [srv $level "port"] 0 $::tls]
+    set client [valkey [srv $level "host"] [srv $level "port"] 0 $::tls]
 
     # select the right db and read the response (OK), or at least ping
     # the server if we're in a singledb mode.
@@ -628,8 +628,8 @@ proc print_help_screen {} {
         "--skipfile <file>  Name of a file containing test names or regexp patterns (if <test> starts with '/') that should be skipped (one per line). This option can be repeated."
         "--skiptest <test>  Test name or regexp pattern (if <test> starts with '/') to skip. This option can be repeated."
         "--tags <tags>      Run only tests having specified tags or not having '-' prefixed tags."
-        "--dont-clean       Don't delete redis log files after the run."
-        "--dont-pre-clean   Don't delete existing redis log files before the run."
+        "--dont-clean       Don't delete valkey log files after the run."
+        "--dont-pre-clean   Don't delete existing valkey log files before the run."
         "--no-latency       Skip latency measurements and validation by some tests."
         "--stop             Blocks once the first test fails."
         "--loop             Execute the specified set of tests forever."
@@ -640,8 +640,8 @@ proc print_help_screen {} {
         "--tls-module       Run tests in TLS mode with Redis module."
         "--host <addr>      Run tests against an external host."
         "--port <port>      TCP port to use against external host."
-        "--baseport <port>  Initial port number for spawned redis servers."
-        "--portcount <num>  Port range for spawned redis servers."
+        "--baseport <port>  Initial port number for spawned valkey servers."
+        "--portcount <num>  Port range for spawned valkey servers."
         "--singledb         Use a single database, avoid SELECT."
         "--cluster-mode     Run tests in cluster protocol compatible mode."
         "--ignore-encoding  Don't validate object encoding."
@@ -877,7 +877,7 @@ proc read_from_replication_stream {s} {
     set res {}
     for {set j 0} {$j < $count} {incr j} {
         read $s 1
-        set arg [::redis::valkey_bulk_read $s]
+        set arg [::valkey::valkey_bulk_read $s]
         if {$j == 0} {set arg [string tolower $arg]}
         lappend res $arg
     }

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -31,14 +31,14 @@ start_server {tags {"auth external:skip"} overrides {requirepass foobar}} {
     } {101}
 
     test {For unauthenticated clients multibulk and bulk length are limited} {
-        set rr [redis [srv "host"] [srv "port"] 0 $::tls]
+        set rr [valkey [srv "host"] [srv "port"] 0 $::tls]
         $rr write "*100\r\n"
         $rr flush
         catch {[$rr read]} e
         assert_match {*unauthenticated multibulk length*} $e
         $rr close
 
-        set rr [redis [srv "host"] [srv "port"] 0 $::tls]
+        set rr [valkey [srv "host"] [srv "port"] 0 $::tls]
         $rr write "*1\r\n\$100000000\r\n"
         $rr flush
         catch {[$rr read]} e

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -269,7 +269,7 @@ test {Migrate the last slot away from a node using valkey-cli} {
         catch { $newnode_r get foo } e
         assert_match "MOVED $slot *" $e
         lassign [split [lindex $e 2] :] owner_host owner_port
-        set owner_r [redis $owner_host $owner_port 0 $::tls]
+        set owner_r [valkey $owner_host $owner_port 0 $::tls]
         set owner_id [$owner_r CLUSTER MYID]
 
         # Move slot to new node using plain commands

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -384,7 +384,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT SETINFO invalid args} {
         assert_error {*wrong number of arguments*} {r CLIENT SETINFO lib-name}
-        assert_error {*cannot contain spaces*} {r CLIENT SETINFO lib-name "redis py"}
+        assert_error {*cannot contain spaces*} {r CLIENT SETINFO lib-name "valkey py"}
         assert_error {*newlines*} {r CLIENT SETINFO lib-name "redis.py\n"}
         assert_error {*Unrecognized*} {r CLIENT SETINFO badger hamster}
         # test that all of these didn't affect the previously set values

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -169,7 +169,7 @@ run_solo {defrag} {
                 # since the AOF contains simple (fast) SET commands (and the cron during loading runs every 1024 commands),
                 # it'll still not block the loading for long periods of time.
                 if {!$::no_latency} {
-                    assert {$max_latency <= 40}
+                    assert {$max_latency <= 65}
                 }
             }
             } ;# Active defrag - AOF loading

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -169,7 +169,7 @@ run_solo {defrag} {
                 # since the AOF contains simple (fast) SET commands (and the cron during loading runs every 1024 commands),
                 # it'll still not block the loading for long periods of time.
                 if {!$::no_latency} {
-                    assert {$max_latency <= 65}
+                    assert {$max_latency <= 40}
                 }
             }
             } ;# Active defrag - AOF loading

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -20,7 +20,7 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         assert { [string match "*cmdstat_module*" $info] }
     }
 
-    test {test redis version} {
+    test {test valkey version} {
         assert_equal [s valkey_version] [r test.serverversion]
     }
 

--- a/tests/unit/moduleapi/usercall.tcl
+++ b/tests/unit/moduleapi/usercall.tcl
@@ -12,7 +12,7 @@ start_server {tags {"modules usercall"}} {
     r module load $testmodule
 
     # baseline test that module isn't doing anything weird
-    test {test module check regular redis command without user/acl} {
+    test {test module check regular valkey command without user/acl} {
         assert_equal [r usercall.reset_user] OK
         assert_equal [r usercall.add_to_acl "~* &* +@all -set"] OK
         assert_equal [r usercall.call_without_user set x 5] OK
@@ -20,7 +20,7 @@ start_server {tags {"modules usercall"}} {
     }
 
     # call with user with acl set on it, but without testing the acl
-    test {test module check regular redis command with user} {
+    test {test module check regular valkey command with user} {
         assert_equal [r set x 5] OK
 
         assert_equal [r usercall.reset_user] OK
@@ -36,7 +36,7 @@ start_server {tags {"modules usercall"}} {
     }
 
     # call with user with acl set on it, but with testing the acl in rm_call (for cmd itself)
-    test {test module check regular redis command with user and acl} {
+    test {test module check regular valkey command with user and acl} {
         assert_equal [r set x 5] OK
 
         r ACL LOG RESET
@@ -62,7 +62,7 @@ start_server {tags {"modules usercall"}} {
     }
 
     # call with user with acl set on it, but with testing the acl in rm_call (for cmd itself)
-    test {test module check regular redis command with user and acl from blocked background thread} {
+    test {test module check regular valkey command with user and acl from blocked background thread} {
         assert_equal [r set x 5] OK
 
         r ACL LOG RESET

--- a/tests/unit/networking.tcl
+++ b/tests/unit/networking.tcl
@@ -6,10 +6,10 @@ test {CONFIG SET port number} {
 
         # available port
         set avail_port [find_available_port $::baseport $::portcount]
-        set rd [redis [srv 0 host] [srv 0 port] 0 $::tls]
+        set rd [valkey [srv 0 host] [srv 0 port] 0 $::tls]
         $rd CONFIG SET $port_cfg $avail_port
         $rd close
-        set rd [redis [srv 0 host] $avail_port 0 $::tls]
+        set rd [valkey [srv 0 host] $avail_port 0 $::tls]
         $rd PING
 
         # already inuse port
@@ -18,7 +18,7 @@ test {CONFIG SET port number} {
         $rd close
 
         # make sure server still listening on the previous port
-        set rd [redis [srv 0 host] $avail_port 0 $::tls]
+        set rd [valkey [srv 0 host] $avail_port 0 $::tls]
         $rd PING
         $rd close
     }
@@ -31,7 +31,7 @@ test {CONFIG SET bind address} {
         assert_match {*Failed to bind to specified addresses*} $e
 
         # make sure server still bound to the previous address
-        set rd [redis [srv 0 host] [srv 0 port] 0 $::tls]
+        set rd [valkey [srv 0 host] [srv 0 port] 0 $::tls]
         $rd PING
         $rd close
     }
@@ -154,18 +154,18 @@ start_server {config "minimal.conf" tags {"external:skip"}} {
 
             # Setting a password should disable protected mode
             assert_equal {OK} [r config set requirepass "secret"]
-            set r2 [redis $myaddr [srv 0 "port"] 0 $::tls]
+            set r2 [valkey $myaddr [srv 0 "port"] 0 $::tls]
             assert_equal {OK} [$r2 auth secret]
             assert_equal {PONG} [$r2 ping]
 
             # Clearing the password re-enables protected mode
             assert_equal {OK} [r config set requirepass ""]
-            set r2 [redis $myaddr [srv 0 "port"] 0 $::tls]
+            set r2 [valkey $myaddr [srv 0 "port"] 0 $::tls]
             assert_match {*DENIED*} $err
 
             # Explicitly disabling protected-mode works
             assert_equal {OK} [r config set protected-mode no]
-            set r2 [redis $myaddr [srv 0 "port"] 0 $::tls]
+            set r2 [valkey $myaddr [srv 0 "port"] 0 $::tls]
             assert_equal {PONG} [$r2 ping]
         }
     }

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1,7 +1,7 @@
 foreach is_eval {0 1} {
 foreach script_compatibility_api {server redis} {
 
-# We run the tests using both the server APIs, e.g. server.call(), and redis APIs, e.g. redis.call(),
+# We run the tests using both the server APIs, e.g. server.call(), and valkey APIs, e.g. redis.call(),
 # in order to ensure compatibility.
 if {$script_compatibility_api eq "server"} {
     proc replace_script_redis_api_with_server {args} {
@@ -1055,7 +1055,7 @@ start_server {tags {"scripting"}} {
     test "Try trick global protection 3" {
         catch {
             run_script {
-                redis = function() return 1 end
+                valkey = function() return 1 end
             } 0
         } e
         set _ $e

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -3,34 +3,34 @@ start_server {tags {"tls"}} {
         package require tls
 
         test {TLS: Not accepting non-TLS connections on a TLS port} {
-            set s [redis [srv 0 host] [srv 0 port]]
+            set s [valkey [srv 0 host] [srv 0 port]]
             catch {$s PING} e
             set e
         } {*I/O error*}
 
         test {TLS: Verify tls-auth-clients behaves as expected} {
-            set s [redis [srv 0 host] [srv 0 port]]
+            set s [valkey [srv 0 host] [srv 0 port]]
             ::tls::import [$s channel]
             catch {$s PING} e
             assert_match {*error*} $e
 
             r CONFIG SET tls-auth-clients no
 
-            set s [redis [srv 0 host] [srv 0 port]]
+            set s [valkey [srv 0 host] [srv 0 port]]
             ::tls::import [$s channel]
             catch {$s PING} e
             assert_match {PONG} $e
 
             r CONFIG SET tls-auth-clients optional
 
-            set s [redis [srv 0 host] [srv 0 port]]
+            set s [valkey [srv 0 host] [srv 0 port]]
             ::tls::import [$s channel]
             catch {$s PING} e
             assert_match {PONG} $e
 
             r CONFIG SET tls-auth-clients yes
 
-            set s [redis [srv 0 host] [srv 0 port]]
+            set s [valkey [srv 0 host] [srv 0 port]]
             ::tls::import [$s channel]
             catch {$s PING} e
             assert_match {*error*} $e
@@ -39,11 +39,11 @@ start_server {tags {"tls"}} {
         test {TLS: Verify tls-protocols behaves as expected} {
             r CONFIG SET tls-protocols TLSv1.2
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-tls1.2 0}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-tls1.2 0}]
             catch {$s PING} e
             assert_match {*I/O error*} $e
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-tls1.2 1}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-tls1.2 1}]
             catch {$s PING} e
             assert_match {PONG} $e
 
@@ -54,17 +54,17 @@ start_server {tags {"tls"}} {
             r CONFIG SET tls-protocols TLSv1.2
             r CONFIG SET tls-ciphers "DEFAULT:-AES128-SHA256"
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES128-SHA256"}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES128-SHA256"}]
             catch {$s PING} e
             assert_match {*I/O error*} $e
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES256-SHA256"}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES256-SHA256"}]
             catch {$s PING} e
             assert_match {PONG} $e
 
             r CONFIG SET tls-ciphers "DEFAULT"
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES128-SHA256"}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-cipher "-ALL:AES128-SHA256"}]
             catch {$s PING} e
             assert_match {PONG} $e
 
@@ -76,7 +76,7 @@ start_server {tags {"tls"}} {
             r CONFIG SET tls-protocols TLSv1.2
             r CONFIG SET tls-ciphers "AES128-SHA256:AES256-SHA256"
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-cipher "AES256-SHA256:AES128-SHA256"}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-cipher "AES256-SHA256:AES128-SHA256"}]
             catch {$s PING} e
             assert_match {PONG} $e
 
@@ -84,7 +84,7 @@ start_server {tags {"tls"}} {
 
             r CONFIG SET tls-prefer-server-ciphers yes
 
-            set s [redis [srv 0 host] [srv 0 port] 0 1 {-cipher "AES256-SHA256:AES128-SHA256"}]
+            set s [valkey [srv 0 host] [srv 0 port] 0 1 {-cipher "AES256-SHA256:AES128-SHA256"}]
             catch {$s PING} e
             assert_match {PONG} $e
 
@@ -119,7 +119,7 @@ start_server {tags {"tls"}} {
             set srv_port [srv 0 port]
 
             # TLS
-            set rd [redis [srv 0 host] $srv_port 0 1]
+            set rd [valkey [srv 0 host] $srv_port 0 1]
             $rd PING
 
             # TCP
@@ -127,7 +127,7 @@ start_server {tags {"tls"}} {
             $rd CONFIG SET port $srv_port
             $rd close
 
-            set rd [redis [srv 0 host] $srv_port 0 0]
+            set rd [valkey [srv 0 host] $srv_port 0 0]
             $rd PING
 
             # TLS
@@ -135,7 +135,7 @@ start_server {tags {"tls"}} {
             $rd CONFIG SET tls-port $srv_port
             $rd close
 
-            set rd [redis [srv 0 host] $srv_port 0 1]
+            set rd [valkey [srv 0 host] $srv_port 0 1]
             $rd PING
             $rd close
         }

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -362,7 +362,7 @@ tags {"wait aof network external:skip"} {
 
             test {WAITAOF master client didn't send any command} {
                 $master config set repl-ping-replica-period 1
-                set client [redis [srv -1 "host"] [srv -1 "port"] 0 $::tls]
+                set client [valkey [srv -1 "host"] [srv -1 "port"] 0 $::tls]
                 after 1200 ;# wait for PING
                 assert_equal [$master waitaof 1 1 0] {1 1}
                 $client close


### PR DESCRIPTION
Occurrences of "redis" in TCL test suites and helpers, such as TCL client used in tests, are replaced with "valkey".

Occurrences of uppercase "Redis" are not changed in this PR.

No files are renamed in this PR.