### PR TITLE
Detect accept4() on specific versions of various platforms

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -100,9 +100,9 @@
 /* Test for accept4() */
 #if defined(__linux__) || \
     defined(OpenBSD5_7) || \
-    __DragonFly_version >= 400305 || \
-    (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000) || \
-    (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)
+    (defined(__DragonFly__) && __DragonFly_version >= 400305) || \
+    (defined(__FreeBSD__) && (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000)) || \
+    (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000))
 #define HAVE_ACCEPT4 1
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,8 @@
 #ifndef __CONFIG_H
 #define __CONFIG_H
 
+#include <sys/param.h>
+
 #ifdef __APPLE__
 #include <fcntl.h> // for fcntl(fd, F_FULLFSYNC)
 #include <AvailabilityMacros.h>
@@ -96,7 +98,9 @@
 #endif
 
 /* Test for accept4() */
-#if defined(__linux__) || defined(OpenBSD5_7) || \
+#if defined(__linux__) || \
+    defined(OpenBSD5_7) || \
+    __DragonFly_version >= 400305 || \
     (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000) || \
     (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000)
 #define HAVE_ACCEPT4 1

--- a/src/config.h
+++ b/src/config.h
@@ -99,9 +99,9 @@
 
 /* Test for accept4() */
 #if defined(__linux__) || \
+    defined(__FreeBSD__) || \
     defined(OpenBSD5_7) || \
     (defined(__DragonFly__) && __DragonFly_version >= 400305) || \
-    (defined(__FreeBSD__) && (__FreeBSD__ >= 10 || __FreeBSD_version >= 1000000)) || \
     (defined(__NetBSD__) && (defined(NetBSD8_0) || __NetBSD_Version__ >= 800000000))
 #define HAVE_ACCEPT4 1
 #endif
@@ -320,7 +320,7 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 /* Test for posix_fadvise() */
-#if defined(__linux__) || __FreeBSD__ >= 10
+#if defined(__linux__) || defined(__FreeBSD__)
 #define HAVE_FADVISE
 #endif
 


### PR DESCRIPTION
This PR has mainly done three things:
1. Enable `accept4()` on DragonFlyBSD 4.3+
2. Fix the failures of determining the presence of `accept4()` due to the missing <sys/param.h> on two OSs: NetBSD, OpenBSD
3. Drop the support of FreeBSD <10.0 for `valkey`

### References
- [param.h in DragonFlyBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/7485684fa5c3fadb6c7a1da0d8bb6ea5da4e0f2f/sys/sys/param.h#L129-L257)
- [param.h in FreeBSD](https://github.com/freebsd/freebsd-src/blob/main/sys/sys/param.h#L46-L76)
- [param.h in NetBSD](https://github.com/NetBSD/src/blob/b5f8d2f930b7ef226d4dc1b4f7017e998c0e5cde/sys/sys/param.h#L53-L70)
- [param.h in OpenBSD](https://github.com/openbsd/src/blob/d9c286e032a7cee9baaecdd54eb0d43f658ae696/sys/sys/param.h#L40-L45)

```
Release notes:
Detect accept4() on NetBSD, OpenBSD and DragonFlyBSD.
```