### PR TITLE
Use epoll_pwait2() if available

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,6 +55,14 @@ else
 	STD+=-std=c99
 endif
 
+# Check for epoll_pwait2 support.
+EPOLL_PWAIT2_SUPPORT := $(shell echo '$(NUMBER_SIGN_CHAR)include <sys/epoll.h>\n$(NUMBER_SIGN_CHAR)include <time.h>\n \
+	int main() { struct timespec ts; epoll_pwait2(0, NULL, 0, &ts, NULL); return 0; }' | \
+	$(CC) $(CFLAGS) -x c - -o /dev/null $(LDFLAGS) 2>/dev/null && echo 1 || echo 0)
+ifeq ($(EPOLL_PWAIT2_SUPPORT),1)
+	REDIS_CFLAGS+= -DHAVE_EPOLL_PWAIT2
+endif
+
 PREFIX?=/usr/local
 INSTALL_BIN=$(PREFIX)/bin
 INSTALL=install

--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -110,8 +110,15 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
     aeApiState *state = eventLoop->apidata;
     int retval, numevents = 0;
 
+#ifdef HAVE_EPOLL_PWAIT2
+    struct timespec ts = {0, 0};
+    if (tvp != NULL) TIMEVAL_TO_TIMESPEC(tvp, &ts);
+    retval = epoll_pwait2(state->epfd, state->events, eventLoop->setsize, tvp ? &ts : NULL, NULL);
+#else
     retval = epoll_wait(state->epfd,state->events,eventLoop->setsize,
             tvp ? (tvp->tv_sec*1000 + (tvp->tv_usec + 999)/1000) : -1);
+#endif
+
     if (retval > 0) {
         int j;
 


### PR DESCRIPTION
`epoll_pwait2()` was introduced in Linux kernel 5.11, it extends `epoll_wait()`/`epoll_pwait()` by allowing the `timeout` to be specified with a higher resolution, as a `timespec` type, providing nanosecond precision.

By using `epoll_pwait2()`, we can resolve the problem in https://github.com/redis/redis/pull/8764 faultlessly, once and for all. Furthermore, it would also offer the possibility for us to handle timers in a higher resolution in the future: from microseconds to nanoseconds (if necessary).