### PR TITLE
Add links for security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 
 If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
 Please *DO NOT* create an issue.
-We follow a responsible disclore procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publically.
+We follow a responsible disclore procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
 If you would like to be added to our list of vendors, please reach out to the Valkey team at maintainers@lists.valkey.io.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,6 @@
-# Security Policy
-
-Valkey is under development, more information will become available.
-
 ## Reporting a Vulnerability
 
-If you believe you've discovered a serious vulnerability, please contact Madelyn
-at placeholderkv@gmail.com
+If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
+Please *DO NOT* create an issue.
+We follow a responsible disclore procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publically.
+If you would like to be added to our list of vendors, please reach out to the Valkey team at maintainers@lists.valkey.io.


### PR DESCRIPTION
Add an initial security release page. In the fullness of time I would like to also include our version support here, but until that has been decided I would like to keep this simple and just include links.