### PR TITLE
Fixing a lua debugger bug that prevented use of 'server' for server.call invocations.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1677,7 +1677,7 @@ ldbLog(sdsnew("                     next line of code."));
             luaPushError(lua, "script aborted for user request");
             luaError(lua);
         } else if (argc > 1 &&
-                   (!strcasecmp(argv[0],"r") || !strcasecmp(argv[0],"redis"))) {
+                   (!strcasecmp(argv[0],"r") || !strcasecmp(argv[0],REDIS_API_NAME) || !strcasecmp(argv[0],SERVER_API_NAME))) {
             ldbRedis(lua,argv,argc);
             ldbSendLogs();
         } else if ((!strcasecmp(argv[0],"p") || !strcasecmp(argv[0],"print"))) {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1547,6 +1547,19 @@ start_server {tags {"scripting needs:debug external:skip"}} {
         reconnect
         assert_equal [r ping] {PONG}
     }
+    
+    test {Test scripting debug lua server invocations} {
+        r script debug sync
+        r eval {return 'hello'} 0 
+        set cmd "*2\r\n\$6\r\nserver\r\n\$4\r\nping\r\n"
+        r write $cmd
+        r flush
+        set ret [r read]
+        puts $ret
+        assert_match {*PONG*} $ret
+        reconnect 
+        assert_equal [r ping] {PONG}
+    }
 }
 
 start_server {tags {"scripting external:skip"}} {


### PR DESCRIPTION
* Tested it on local instance. This was originally part of https://github.com/valkey-io/valkey/pull/288 but I am pushing this separately, so that we can easily merge it into the upcoming release.

```
lua debugger> server ping
<redis> ping
<reply> "+PONG"
lua debugger> redis ping
<redis> ping
<reply> "+PONG"
```

* I also searched for lua debugger related unit tests to add coverage for this but did not find any relevant test to modify. Leaving it at that for now. 