### PR TITLE
Bumped version to 7.2.5 for valkey and wrote release notes

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -11,6 +11,25 @@ CRITICAL: There is a critical bug affecting MOST USERS. Upgrade ASAP.
 SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
+================================================================================
+Valkey 7.2.5 RC1  -  Released Fri 12 Apr 2024
+================================================================================
+
+Upgrade urgency LOW: Second release candidate for Valkey with API compatibility
+for OSS Redis 7.2.4. Moving to a release candidate on 7.2.5, to make it clearer
+this is a patch iteration as opposed to an exact copy of OSS Redis. Also includes
+minor bug fixes present in 7.2.4.RC1 and more compatibility changes.
+
+Changes to support Valkey branding
+=========
+* Update README to remove Redis references.
+* Update valkey-server and valkey-cli help info to show only valkey (#222)
+* Add compatibility for lua debugger to user server instead of redis. (#303)
+
+Bug fixes
+=========
+* Fix module event name to maintain Redis compatibility. (#289)
+* Fix issue where redis symlinks were created with the wrong name. (#282)
 
 ================================================================================
 Valkey 7.2.4 RC1  -  Released Tue 09 Apr 2024

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -18,18 +18,18 @@ Valkey 7.2.5 RC1  -  Released Fri 12 Apr 2024
 Upgrade urgency LOW: Second release candidate for Valkey with API compatibility
 for OSS Redis 7.2.4. Moving to a release candidate on 7.2.5, to make it clearer
 this is a patch iteration as opposed to an exact copy of OSS Redis. Also includes
-minor bug fixes present in 7.2.4.RC1 and more compatibility changes.
+fixes to minor bugs present in 7.2.4 RC1 and more compatibility changes.
 
 Changes to support Valkey branding
 =========
 * Update README to remove Redis references.
-* Update valkey-server and valkey-cli help info to show only valkey (#222)
-* Add compatibility for lua debugger to user server instead of redis. (#303)
+* Update valkey-server and valkey-cli help info to show only Valkey (#222)
+* Add compatibility for lua debugger to use 'server' instead of redis. (#303)
 
 Bug fixes
 =========
 * Fix module event name to maintain Redis compatibility. (#289)
-* Fix issue where redis symlinks were created with the wrong name. (#282)
+* Fix issue where Redis symlinks were created with the wrong name. (#282)
 
 ================================================================================
 Valkey 7.2.4 RC1  -  Released Tue 09 Apr 2024

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #define SERVER_NAME "valkey"
-#define VALKEY_VERSION "7.2.4"
-#define VALKEY_VERSION_NUM 0x00070204
+#define VALKEY_VERSION "7.2.5"
+#define VALKEY_VERSION_NUM 0x00070205
 
 /* Redis compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
Release notes for RC2 (really 7.2.5-rc1). Based on conversation, decided to have first release on 7.2.5 to make it clear this was a patch release over Redis. This could be considered a minor release, but we wanted to clearly signal compatibility with Redis OSS.