### PR TITLE
Introduce Thread-local storage variable to reduce atomic contention when update used_memory metrics.

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -676,12 +676,12 @@ int performEvictions(void) {
              * AOF and Output buffer memory will be freed eventually so
              * we only care about memory used by the key space. */
             enterExecutionUnit(1, 0);
-            delta = (long long)zmalloc_used_memory();
+            delta = (long long)zmalloc_used_memory_with_thread_delta();
             latencyStartMonitor(eviction_latency);
             dbGenericDelete(db, keyobj, server.lazyfree_lazy_eviction, DB_FLAG_KEY_EVICTED);
             latencyEndMonitor(eviction_latency);
             latencyAddSampleIfNeeded("eviction-del", eviction_latency);
-            delta -= (long long)zmalloc_used_memory();
+            delta -= (long long)zmalloc_used_memory_with_thread_delta();
             mem_freed += delta;
             server.stat_evictedkeys++;
             signalModifiedKey(NULL, db, keyobj);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -52,6 +52,7 @@ void zlibc_free(void *ptr) {
 #include <string.h>
 #include "zmalloc.h"
 #include <stdatomic.h>
+#include <threads.h>
 
 #define UNUSED(x) ((void)(x))
 
@@ -88,7 +89,7 @@ void zlibc_free(void *ptr) {
 #endif
 
 static _Atomic int64_t used_memory = 0;
-static __thread int64_t thread_used_memory_delta = 0;
+static thread_local int64_t thread_used_memory_delta = 0;
 
 #define THREAD_MEM_MAX_DELTA (1024 * 1024)
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -52,7 +52,6 @@ void zlibc_free(void *ptr) {
 #include <string.h>
 #include "zmalloc.h"
 #include <stdatomic.h>
-#include <threads.h>
 
 #define UNUSED(x) ((void)(x))
 
@@ -86,6 +85,12 @@ void zlibc_free(void *ptr) {
 #define free(ptr) je_free(ptr)
 #define mallocx(size, flags) je_mallocx(size, flags)
 #define dallocx(ptr, flags) je_dallocx(ptr, flags)
+#endif
+
+#if __STDC_NO_THREADS__
+#define thread_local __thread
+#else
+#include <threads.h>
 #endif
 
 static _Atomic int64_t used_memory = 0;

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -126,6 +126,7 @@ void *ztrycalloc_usable(size_t size, size_t *usable);
 void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable);
 __attribute__((malloc)) char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
+size_t zmalloc_used_memory_with_thread_delta(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));
 size_t zmalloc_get_rss(void);
 int zmalloc_get_allocator_info(size_t *allocated,


### PR DESCRIPTION
#### Description 
This patch try to introduce Thread-local storage variable to replace atomic for `zmalloc` to reduce unnecessary contention. 

#### Problem Statement
 `zmalloc` and `zfree` related functions will update the `used_memory` for each operation, and they are called very frequency.  From the benchmark of [memtier_benchmark-1Mkeys-load-stream-5-fields-with-100B-values-pipeline-10.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-stream-5-fields-with-100B-values-pipeline-10.yml) , the cycles ratio of `zmalloc` and `zfree` are high, they are wrappers for the lower allocator library, it should not take too much cycles. And most of the cycles are contributed by `lock add` and `lock sub` , they are expensive instructions. From the profiling, the metrics' update mainly come from the main thread, use a TLS will reduce a lot of contention. 

![image](https://github.com/valkey-io/valkey/assets/698621/7d319967-b21e-4dc2-86ff-eb126b4ceec8)

![image](https://github.com/valkey-io/valkey/assets/698621/04238abe-2e67-4e41-bc99-7f794ac8e2a3)

#### Performance Impact
##### Test Env

- OS: CentOS Stream 8
- Kernel: 6.2.0
- Platform: Intel Xeon Platinum 8380
- Server and Client in same socket

##### Start Server 
`taskset -c 0 ~/valkey/src/valkey-server /tmp/valkey_1.conf`
```
port 9001
bind * -::*
daemonize yes
protected-mode no
save ""
```

By using the benchmark [memtier_benchmark-1Mkeys-load-stream-5-fields-with-100B-values-pipeline-10.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-stream-5-fields-with-100B-values-pipeline-10.yml).
`memtier_benchmark -s 127.0.0.1 -p 9001  "--pipeline" "10" "--data-size" "100" --command "XADD __key__ MAXLEN ~ 1 * field __data__" --command-key-pattern="P" --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram`

We can observe more than **6%** QPS gain.  

For the other benchmarks SET/GET, using the commands like:
`taskset -c 6-9  ~/valkey/src/valkey-benchmark -p 9001 -t set,get -d 100 -r 1000000 -n 1000000 -c 50 --threads 4`

No perf gain and regression.

With pipeline enabled,  I can observe 4% perf gain with [test case](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-100B-values-pipeline-10.yml).
`taskset -c 4-7 memtier_benchmark -s 127.0.0.1 -p 9001 "--pipeline" "10" "--data-size" "100" --ratio 1:0 --key-pattern P:P --key-minimum=1 --key-maximum 1000000 --test-time 180 -c 50 -t 4 --hide-histogram`
