### PR TITLE
Fix typo in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 
 If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
 Please *DO NOT* create an issue.
-We follow a responsible disclore procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
+We follow a responsible disclosure procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
 If you would like to be added to our list of vendors, please reach out to the Valkey team at maintainers@lists.valkey.io.


### PR DESCRIPTION
Fix typo: "disclore" to "disclosure" in SECURITY.md 