### PR TITLE
Set permissions for Github Actions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   test-ubuntu-latest:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
     # run weekly new vulnerability was added to the database
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'valkey-io/valkey'
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,8 @@ on:
   - cron: '0 0 * * *'
   # Support manual execution
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   coverity:
     if: github.repository == 'valkey-io/valkey'

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,6 +28,8 @@ on:
         description: 'git branch or sha to use'
         default: 'unstable'
 
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test-external-standalone:
     runs-on: ubuntu-latest

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -32,7 +32,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
-        name: test-external-server-log
+        name: test-external-standalone-log
         path: external-server.log
 
   test-external-cluster:
@@ -84,5 +84,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: test-external-server-log
+          name: test-external-nodebug-log
           path: external-server.log

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'src/commands/*.json'
 
+permissions:
+  contents: read
+
 jobs:
   reply-schemas-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,6 +9,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Spellcheck


### PR DESCRIPTION
This sets the default permission for current CI workflows to only be able to read from the repository (scope: "contents").
When a used Github Action require additional permissions (like CodeQL) we grant that permission on job-level instead.

This means that a compromised action will not be able to modify the repo or even steal secrets since all other permission-scopes are implicit set to "none", i.e. not permitted. This is recommended by [OpenSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).

This PR includes a small fix for the possibility of missing server logs artifacts, found while verifying the permission.
The `upload-artifact@v3` action will replace artifacts which already exists. Since both CI-jobs `test-external-standalone` and `test-external-nodebug` uses the same artifact name, when both jobs fail, we only get logs from the last finished job. This can be avoided by using unique artifact names.

This PR is part of #211

More about permissions and scope can be found here:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions