### PR TITLE
Fix typo and rename Redis to Valkey in the utils/lru/README

### DIFF
--- a/utils/lru/README
+++ b/utils/lru/README
@@ -1,8 +1,8 @@
 The test-lru.rb program can be used in order to check the behavior of the
-Redis approximated LRU algorithm against the theoretical output of true
+Valkey approximated LRU algorithm against the theoretical output of true
 LRU algorithm.
 
-In order to use the program you need to recompile Redis setting the define
+In order to use the program you need to recompile Valkey setting the define
 LRU_CLOCK_RESOLUTION to 1, by editing the file server.h.
 This allows to execute the program in a fast way since the 1 ms resolution
 is enough for all the objects to have a different enough time stamp during

--- a/utils/lru/README
+++ b/utils/lru/README
@@ -3,7 +3,7 @@ Redis approximated LRU algorithm against the theoretical output of true
 LRU algorithm.
 
 In order to use the program you need to recompile Redis setting the define
-REDIS_LRU_CLOCK_RESOLUTION to 1, by editing the file server.h.
+LRU_CLOCK_RESOLUTION to 1, by editing the file server.h.
 This allows to execute the program in a fast way since the 1 ms resolution
 is enough for all the objects to have a different enough time stamp during
 the test.


### PR DESCRIPTION
This  utils/lru/README  incorrectly refers to REDIS_LRU_CLOCK_RESOLUTION in server.h to modify the LRU clock resolution. However, the actual constant in server.h has been updated to LRU_CLOCK_RESOLUTION, but the README was not updated to reflect this change. 
<img width="504" alt="valkeyLRU" src="https://github.com/valkey-io/valkey/assets/96312080/712d6612-2079-4a92-b511-69a1927c70ff">

1. Replaced REDIS_LRU_CLOCK_RESOLUTION with LRU_CLOCK_RESOLUTION in the text of utils/lru/README.
2. Updated references from "Redis" to "Valkey" within the same README file as part of the ongoing rebranding efforts:)