### PR TITLE
removes empty history arrays

### DIFF
--- a/src/commands/acl-dryrun.json
+++ b/src/commands/acl-dryrun.json
@@ -7,7 +7,6 @@
         "arity": -4,
         "container": "ACL",
         "function": "aclCommand",
-        "history": [],
         "command_flags": [
             "ADMIN",
             "NOSCRIPT",

--- a/src/commands/cluster-myshardid.json
+++ b/src/commands/cluster-myshardid.json
@@ -7,7 +7,6 @@
         "arity": 2,
         "container": "CLUSTER",
         "function": "clusterCommand",
-        "history": [],
         "command_flags": [
             "STALE"
         ],

--- a/src/commands/cluster-shards.json
+++ b/src/commands/cluster-shards.json
@@ -7,7 +7,6 @@
         "arity": 2,
         "container": "CLUSTER",
         "function": "clusterCommand",
-        "history": [],
         "command_flags": [
             "LOADING",
             "STALE"

--- a/src/commands/monitor.json
+++ b/src/commands/monitor.json
@@ -5,7 +5,6 @@
         "since": "1.0.0",
         "arity": 1,
         "function": "monitorCommand",
-        "history": [],
         "command_flags": [
             "ADMIN",
             "NOSCRIPT",

--- a/src/commands/rename.json
+++ b/src/commands/rename.json
@@ -6,7 +6,6 @@
         "since": "1.0.0",
         "arity": 3,
         "function": "renameCommand",
-        "history": [],
         "command_flags": [
             "WRITE"
         ],

--- a/src/commands/subscribe.json
+++ b/src/commands/subscribe.json
@@ -6,7 +6,6 @@
         "since": "2.0.0",
         "arity": -2,
         "function": "subscribeCommand",
-        "history": [],
         "command_flags": [
             "PUBSUB",
             "NOSCRIPT",


### PR DESCRIPTION
Fixes #241 

Removes the empty `history` arrays in 6 command JSON files. This normalizes these 6 with the rest of the command JSON which omit the `history` array entirely when there is no history.

This makes parsing these files slightly less annoying in languages where empty arrays are falsey.

