### PR TITLE
Input output traffic stats and command process count for each client.

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -107,6 +107,7 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int had_err
     const ustime_t total_cmd_duration = c->duration + blocked_us + reply_us;
     c->lastcmd->microseconds += total_cmd_duration;
     c->lastcmd->calls++;
+    c->commands_processed++;
     server.stat_numcommands++;
     if (had_errors)
         c->lastcmd->failed_calls++;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1992,9 +1992,9 @@ int writeToClient(client *c, int handler_installed) {
     if (getClientType(c) == CLIENT_TYPE_SLAVE) {
         atomicIncr(server.stat_net_repl_output_bytes, totwritten);
     } else {
-        c->net_output_bytes += totwritten;
         atomicIncr(server.stat_net_output_bytes, totwritten);
     }
+    c->net_output_bytes += totwritten;
 
     if (nwritten == -1) {
         if (connGetState(c->conn) != CONN_STATE_CONNECTED) {
@@ -2720,9 +2720,9 @@ void readQueryFromClient(connection *conn) {
         c->read_reploff += nread;
         atomicIncr(server.stat_net_repl_input_bytes, nread);
     } else {
-        c->net_input_bytes += nread;
         atomicIncr(server.stat_net_input_bytes, nread);
     }
+    c->net_input_bytes += nread;
 
     if (!(c->flags & CLIENT_MASTER) &&
         /* The commands cached in the MULTI/EXEC queue have not been executed yet,

--- a/src/networking.c
+++ b/src/networking.c
@@ -2880,8 +2880,8 @@ sds catClientInfoString(sds s, client *client) {
         " resp=%i", client->resp,
         " lib-name=%s", client->lib_name ? (char*)client->lib_name->ptr : "",
         " lib-ver=%s", client->lib_ver ? (char*)client->lib_ver->ptr : "",
-        " tot-input=%U", client->net_input_bytes,
-        " tot-output=%U", client->net_output_bytes,
+        " tot-net-in=%U", client->net_input_bytes,
+        " tot-net-out=%U", client->net_output_bytes,
         " tot-cmds=%U", client->commands_processed));
     return ret;
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -214,6 +214,9 @@ client *createClient(connection *conn) {
     c->mem_usage_bucket_node = NULL;
     if (conn) linkClient(c);
     initClientMultiState(c);
+    c->net_input_bytes = 0;
+    c->net_output_bytes = 0;
+    c->commands_processed = 0;
     return c;
 }
 
@@ -1989,6 +1992,7 @@ int writeToClient(client *c, int handler_installed) {
     if (getClientType(c) == CLIENT_TYPE_SLAVE) {
         atomicIncr(server.stat_net_repl_output_bytes, totwritten);
     } else {
+        c->net_output_bytes += totwritten;
         atomicIncr(server.stat_net_output_bytes, totwritten);
     }
 
@@ -2716,6 +2720,7 @@ void readQueryFromClient(connection *conn) {
         c->read_reploff += nread;
         atomicIncr(server.stat_net_repl_input_bytes, nread);
     } else {
+        c->net_input_bytes += nread;
         atomicIncr(server.stat_net_input_bytes, nread);
     }
 
@@ -2874,7 +2879,10 @@ sds catClientInfoString(sds s, client *client) {
         " redir=%I", (client->flags & CLIENT_TRACKING) ? (long long) client->client_tracking_redirection : -1,
         " resp=%i", client->resp,
         " lib-name=%s", client->lib_name ? (char*)client->lib_name->ptr : "",
-        " lib-ver=%s", client->lib_ver ? (char*)client->lib_ver->ptr : ""));
+        " lib-ver=%s", client->lib_ver ? (char*)client->lib_ver->ptr : "",
+        " tot-input=%U", client->net_input_bytes,
+        " tot-output=%U", client->net_output_bytes,
+        " tot-cmds=%U", client->commands_processed));
     return ret;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3717,7 +3717,11 @@ void call(client *c, int flags) {
     }
 
     if (!(c->flags & CLIENT_BLOCKED)) {
-        server.current_client->commands_processed++;
+        /* Modules may call commands in cron, in which case server.current_client
+         * is not set. */
+        if (server.current_client) {
+            server.current_client->commands_processed++;
+        }
         server.stat_numcommands++;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -3716,8 +3716,10 @@ void call(client *c, int flags) {
         }
     }
 
-    if (!(c->flags & CLIENT_BLOCKED))
+    if (!(c->flags & CLIENT_BLOCKED)) {
+        c->commands_processed++;
         server.stat_numcommands++;
+    }
 
     /* Record peak memory after each command and before the eviction that runs
      * before the next command. */

--- a/src/server.c
+++ b/src/server.c
@@ -3717,7 +3717,7 @@ void call(client *c, int flags) {
     }
 
     if (!(c->flags & CLIENT_BLOCKED)) {
-        c->commands_processed++;
+        server.current_client->commands_processed++;
         server.stat_numcommands++;
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1282,9 +1282,9 @@ typedef struct client {
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
-    unsigned long long net_input_bytes;
-    unsigned long long net_output_bytes;
-    unsigned long long commands_processed;
+    unsigned long long net_input_bytes;    /* Total network input bytes read from this client. */
+    unsigned long long net_output_bytes;   /* Total network output bytes sent to this client. */
+    unsigned long long commands_processed; /* Total count of commands this client executed. */
 } client;
 
 /* ACL information */

--- a/src/server.h
+++ b/src/server.h
@@ -1282,6 +1282,9 @@ typedef struct client {
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
+    unsigned long long net_input_bytes;
+    unsigned long long net_output_bytes;
+    unsigned long long commands_processed;
 } client;
 
 /* ACL information */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -79,6 +79,13 @@ start_server {tags {"introspection"}} {
         assert_equal [expr $output4+23] $output5
         assert_equal [expr $cmd4+1] $cmd5
         $rd close
+        # test recursive command
+        set info [r client info]
+        set cmd6 [get_field_in_client_info $info "tot-cmds"]
+        r eval "server.call('ping')" 0
+        set info [r client info]
+        set cmd7 [get_field_in_client_info $info "tot-cmds"]
+        assert_equal [expr $cmd6+3] $cmd7
     }
 
     test {CLIENT KILL with illegal arguments} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* tot-input=* tot-output=* tot-cmds=*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,33 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* tot-input=* tot-output=* tot-cmds=*}
+
+    proc get_field_in_client_info {info field} {
+        set info [string trim $info]
+        foreach item [split $info " "] {
+            set kv [split $item "="]
+            set k [lindex $kv 0]
+            if {[string match $field $k]} {
+                return [lindex $kv 1]   
+            }
+        }
+        return ""
+    }
+
+    test {client input output and command process statistics} {
+        set info1 [r client info]
+        set input1 [get_field_in_client_info $info1 "tot-input"]
+        set output1 [get_field_in_client_info $info1 "tot-output"]
+        set cmd1 [get_field_in_client_info $info1 "tot-cmds"]
+        set info2 [r client info]
+        set input2 [get_field_in_client_info $info2 "tot-input"]
+        set output2 [get_field_in_client_info $info2 "tot-output"]
+        set cmd2 [get_field_in_client_info $info2 "tot-cmds"]
+        assert_equal [expr $input1+26] $input2
+        assert {[expr $output1+300] < $output2}
+        assert_equal [expr $cmd1+1] $cmd2
+    }
 
     test {CLIENT KILL with illegal arguments} {
         assert_error "ERR wrong number of arguments for 'client|kill' command" {r client kill}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -7,7 +7,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT LIST} {
         r client list
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* tot-cmds=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|list user=* redir=-1 resp=* lib-name=* lib-ver=* tot-net-in=* tot-net-out=* tot-cmds=*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -17,7 +17,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-input=* tot-output=* tot-cmds=*}
+    } {id=* addr=*:* laddr=*:* fd=* name=* age=* idle=* flags=N db=* sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=26 qbuf-free=* argv-mem=* multi-mem=0 rbs=* rbp=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client|info user=* redir=-1 resp=* lib-name=* lib-ver=* tot-net-in=* tot-net-out=* tot-cmds=*}
 
     proc get_field_in_client_info {info field} {
         set info [string trim $info]
@@ -33,12 +33,12 @@ start_server {tags {"introspection"}} {
 
     test {client input output and command process statistics} {
         set info1 [r client info]
-        set input1 [get_field_in_client_info $info1 "tot-input"]
-        set output1 [get_field_in_client_info $info1 "tot-output"]
+        set input1 [get_field_in_client_info $info1 "tot-net-in"]
+        set output1 [get_field_in_client_info $info1 "tot-net-out"]
         set cmd1 [get_field_in_client_info $info1 "tot-cmds"]
         set info2 [r client info]
-        set input2 [get_field_in_client_info $info2 "tot-input"]
-        set output2 [get_field_in_client_info $info2 "tot-output"]
+        set input2 [get_field_in_client_info $info2 "tot-net-in"]
+        set output2 [get_field_in_client_info $info2 "tot-net-out"]
         set cmd2 [get_field_in_client_info $info2 "tot-cmds"]
         assert_equal [expr $input1+26] $input2
         assert {[expr $output1+300] < $output2}


### PR DESCRIPTION
We already have global stats for input traffic, output traffic and how many commands have been executed.

However, some users have the difficulty of locating the IP(s) which have heavy network traffic. So here some stats for single client are introduced.
```              
tot-net-in   // Total network input bytes read from the client
tot-net-out  // Total network output bytes sent to the client
tot-cmds     // Total commands the client has executed     
```                             
These three stats are shown in `CLIENT LIST` and `CLIENT INFO`.

Though the metrics are handled in hot paths of the code, personally I don't think it will slow down the server. Considering all other complex operations handled nearby, this is only a small and simple operation.

However we do need to be cautious when adding more and more metrics, as discussed in redis/redis#12640, we may need to find a way to tell whether this has obvious performance degradation.