### PR TITLE
Draft: rename redis.pid to valkey.pid

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -129,7 +129,7 @@ struct hdr_histogram;
 #define RDB_EOF_MARK_SIZE 40
 #define CONFIG_REPL_BACKLOG_MIN_SIZE (1024*16)          /* 16k */
 #define CONFIG_BGSAVE_RETRY_DELAY 5 /* Wait a few secs before trying again. */
-#define CONFIG_DEFAULT_PID_FILE "/var/run/redis.pid"
+#define CONFIG_DEFAULT_PID_FILE "/var/run/valkey.pid"
 #define CONFIG_DEFAULT_BINDADDR_COUNT 2
 #define CONFIG_DEFAULT_BINDADDR { "*", "-::*" }
 #define NET_HOST_STR_LEN 256 /* Longest valid hostname */


### PR DESCRIPTION
fixes: https://github.com/valkey-io/valkey/issues/321 