### PR TITLE
Rename redis in install_server.sh file

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -29,15 +29,15 @@
 #
 # To run this script non-interactively (for automation/provisioning purposes),
 # feed the variables into the script. Any missing variables will be prompted!
-# Tip: Environment variables also support command substitution (see REDIS_EXECUTABLE)
+# Tip: Environment variables also support command substitution (see SERVER_EXECUTABLE)
 #
 # Example:
 #
-# sudo REDIS_PORT=1234 \
-# 		 REDIS_CONFIG_FILE=/etc/redis/1234.conf \
-# 		 REDIS_LOG_FILE=/var/log/redis_1234.log \
-# 		 REDIS_DATA_DIR=/var/lib/redis/1234 \
-# 		 REDIS_EXECUTABLE=`command -v valkey-server` ./utils/install_server.sh
+# sudo SERVER_PORT=1234 \
+# 		 SERVER_CONFIG_FILE=/etc/valkey/1234.conf \
+# 		 SERVER_LOG_FILE=/var/log/valkey_1234.log \
+# 		 SERVER_DATA_DIR=/var/lib/valkey/1234 \
+# 		 SERVER_EXECUTABLE=`command -v valkey-server` ./utils/install_server.sh
 #
 # This generates a server config file and an /etc/init.d script, and installs them.
 #
@@ -60,11 +60,11 @@ SCRIPT=$(readlink -f $0)
 SCRIPTPATH=$(dirname $SCRIPT)
 
 #Initial defaults
-_REDIS_PORT=6379
+_SERVER_PORT=6379
 _MANUAL_EXECUTION=false
 
-echo "Welcome to the redis service installer"
-echo "This script will help you easily set up a running redis server"
+echo "Welcome to the valkey service installer"
+echo "This script will help you easily set up a running valkey server"
 echo
 
 #check for root user
@@ -83,93 +83,93 @@ then
 fi
 unset _pid_1_exe
 
-if ! echo $REDIS_PORT | egrep -q '^[0-9]+$' ; then
+if ! echo $SERVER_PORT | egrep -q '^[0-9]+$' ; then
 	_MANUAL_EXECUTION=true
 	#Read the server port
-	read  -p "Please select the redis port for this instance: [$_REDIS_PORT] " REDIS_PORT
-	if ! echo $REDIS_PORT | egrep -q '^[0-9]+$' ; then
-		echo "Selecting default: $_REDIS_PORT"
-		REDIS_PORT=$_REDIS_PORT
+	read  -p "Please select the server port for this instance: [$_SERVER_PORT] " SERVER_PORT
+	if ! echo $SERVER_PORT | egrep -q '^[0-9]+$' ; then
+		echo "Selecting default: $_SERVER_PORT"
+		SERVER_PORT=$_SERVER_PORT
 	fi
 fi
 
-if [ -z "$REDIS_CONFIG_FILE" ] ; then
+if [ -z "$SERVER_CONFIG_FILE" ] ; then
 	_MANUAL_EXECUTION=true
 	#read the server config file
-	_REDIS_CONFIG_FILE="/etc/redis/$REDIS_PORT.conf"
-	read -p "Please select the redis config file name [$_REDIS_CONFIG_FILE] " REDIS_CONFIG_FILE
-	if [ -z "$REDIS_CONFIG_FILE" ] ; then
-		REDIS_CONFIG_FILE=$_REDIS_CONFIG_FILE
-		echo "Selected default - $REDIS_CONFIG_FILE"
+	_SERVER_CONFIG_FILE="/etc/valkey/$SERVER_PORT.conf"
+	read -p "Please select the valkey config file name [$_SERVER_CONFIG_FILE] " SERVER_CONFIG_FILE
+	if [ -z "$SERVER_CONFIG_FILE" ] ; then
+		SERVER_CONFIG_FILE=$_SERVER_CONFIG_FILE
+		echo "Selected default - $SERVER_CONFIG_FILE"
 	fi
 fi
 
-if [ -z "$REDIS_LOG_FILE" ] ; then
+if [ -z "$SERVER_LOG_FILE" ] ; then
 	_MANUAL_EXECUTION=true
 	#read the server log file path
-	_REDIS_LOG_FILE="/var/log/redis_$REDIS_PORT.log"
-	read -p "Please select the redis log file name [$_REDIS_LOG_FILE] " REDIS_LOG_FILE
-	if [ -z "$REDIS_LOG_FILE" ] ; then
-		REDIS_LOG_FILE=$_REDIS_LOG_FILE
-		echo "Selected default - $REDIS_LOG_FILE"
+	_SERVER_LOG_FILE="/var/log/valkey_$SERVER_PORT.log"
+	read -p "Please select the server log file name [$_SERVER_LOG_FILE] " SERVER_LOG_FILE
+	if [ -z "$SERVER_LOG_FILE" ] ; then
+		SERVER_LOG_FILE=$_SERVER_LOG_FILE
+		echo "Selected default - $SERVER_LOG_FILE"
 	fi
 fi
 
-if [ -z "$REDIS_DATA_DIR" ] ; then
+if [ -z "$SERVER_DATA_DIR" ] ; then
 	_MANUAL_EXECUTION=true
 	#get the server data directory
-	_REDIS_DATA_DIR="/var/lib/redis/$REDIS_PORT"
-	read -p "Please select the data directory for this instance [$_REDIS_DATA_DIR] " REDIS_DATA_DIR
-	if [ -z "$REDIS_DATA_DIR" ] ; then
-		REDIS_DATA_DIR=$_REDIS_DATA_DIR
-		echo "Selected default - $REDIS_DATA_DIR"
+	_SERVER_DATA_DIR="/var/lib/valkey/$SERVER_PORT"
+	read -p "Please select the data directory for this instance [$_SERVER_DATA_DIR] " SERVER_DATA_DIR
+	if [ -z "$SERVER_DATA_DIR" ] ; then
+		SERVER_DATA_DIR=$_SERVER_DATA_DIR
+		echo "Selected default - $SERVER_DATA_DIR"
 	fi
 fi
 
-if [ ! -x "$REDIS_EXECUTABLE" ] ; then
+if [ ! -x "$SERVER_EXECUTABLE" ] ; then
 	_MANUAL_EXECUTION=true
 	#get the server executable path
-	_REDIS_EXECUTABLE=`command -v redis-server`
-	read -p "Please select the redis executable path [$_REDIS_EXECUTABLE] " REDIS_EXECUTABLE
-	if [ ! -x "$REDIS_EXECUTABLE" ] ; then
-		REDIS_EXECUTABLE=$_REDIS_EXECUTABLE
+	_SERVER_EXECUTABLE=`command -v valkey-server`
+	read -p "Please select the valkey executable path [$_SERVER_EXECUTABLE] " SERVER_EXECUTABLE
+	if [ ! -x "$SERVER_EXECUTABLE" ] ; then
+		SERVER_EXECUTABLE=$_SERVER_EXECUTABLE
 
-		if [ ! -x "$REDIS_EXECUTABLE" ] ; then
-			echo "Mmmmm...  it seems like you don't have a redis executable. Did you run make install yet?"
+		if [ ! -x "$SERVER_EXECUTABLE" ] ; then
+			echo "Mmmmm...  it seems like you don't have a valkey executable. Did you run make install yet?"
 			exit 1
 		fi
 	fi
 fi
 
 #check the default for valkey cli
-CLI_EXEC=`command -v redis-cli`
+CLI_EXEC=`command -v valkey-cli`
 if [ -z "$CLI_EXEC" ] ; then
-	CLI_EXEC=`dirname $REDIS_EXECUTABLE`"/redis-cli"
+	CLI_EXEC=`dirname $SERVER_EXECUTABLE`"/valkey-cli"
 fi
 
 echo "Selected config:"
 
-echo "Port           : $REDIS_PORT"
-echo "Config file    : $REDIS_CONFIG_FILE"
-echo "Log file       : $REDIS_LOG_FILE"
-echo "Data dir       : $REDIS_DATA_DIR"
-echo "Executable     : $REDIS_EXECUTABLE"
+echo "Port           : $SERVER_PORT"
+echo "Config file    : $SERVER_CONFIG_FILE"
+echo "Log file       : $SERVER_LOG_FILE"
+echo "Data dir       : $SERVER_DATA_DIR"
+echo "Executable     : $SERVER_EXECUTABLE"
 echo "Cli Executable : $CLI_EXEC"
 
 if $_MANUAL_EXECUTION == true ; then
 	read -p "Is this ok? Then press ENTER to go on or Ctrl-C to abort." _UNUSED_
 fi
 
-mkdir -p `dirname "$REDIS_CONFIG_FILE"` || die "Could not create redis config directory"
-mkdir -p `dirname "$REDIS_LOG_FILE"` || die "Could not create redis log dir"
-mkdir -p "$REDIS_DATA_DIR" || die "Could not create redis data directory"
+mkdir -p `dirname "$SERVER_CONFIG_FILE"` || die "Could not create valkey config directory"
+mkdir -p `dirname "$SERVER_LOG_FILE"` || die "Could not create valkey log dir"
+mkdir -p "$SERVER_DATA_DIR" || die "Could not create valkey data directory"
 
 #render the templates
-TMP_FILE="/tmp/${REDIS_PORT}.conf"
+TMP_FILE="/tmp/${SERVER_PORT}.conf"
 DEFAULT_CONFIG="${SCRIPTPATH}/../valkey.conf"
 INIT_TPL_FILE="${SCRIPTPATH}/redis_init_script.tpl"
-INIT_SCRIPT_DEST="/etc/init.d/redis_${REDIS_PORT}"
-PIDFILE="/var/run/redis_${REDIS_PORT}.pid"
+INIT_SCRIPT_DEST="/etc/init.d/valkey_${SERVER_PORT}"
+PIDFILE="/var/run/valkey_${SERVER_PORT}.pid"
 
 if [ ! -f "$DEFAULT_CONFIG" ]; then
 	echo "Mmmmm... the default config is missing. Did you switch to the utils directory?"
@@ -181,16 +181,16 @@ fi
 echo "## Generated by install_server.sh ##" > $TMP_FILE
 
 read -r SED_EXPR <<-EOF
-s#^port .\+#port ${REDIS_PORT}#; \
-s#^logfile .\+#logfile ${REDIS_LOG_FILE}#; \
-s#^dir .\+#dir ${REDIS_DATA_DIR}#; \
+s#^port .\+#port ${SERVER_PORT}#; \
+s#^logfile .\+#logfile ${SERVER_LOG_FILE}#; \
+s#^dir .\+#dir ${SERVER_DATA_DIR}#; \
 s#^pidfile .\+#pidfile ${PIDFILE}#; \
 s#^daemonize no#daemonize yes#;
 EOF
 sed "$SED_EXPR" $DEFAULT_CONFIG >> $TMP_FILE
 
 #cat $TPL_FILE | while read line; do eval "echo \"$line\"" >> $TMP_FILE; done
-cp $TMP_FILE $REDIS_CONFIG_FILE || die "Could not write redis config file $REDIS_CONFIG_FILE"
+cp $TMP_FILE $SERVER_CONFIG_FILE || die "Could not write valkey config file $SERVER_CONFIG_FILE"
 
 #Generate sample script from template file
 rm -f $TMP_FILE
@@ -200,26 +200,26 @@ rm -f $TMP_FILE
 REDIS_INIT_HEADER=\
 "#!/bin/sh\n
 #Configurations injected by install_server below....\n\n
-EXEC=$REDIS_EXECUTABLE\n
+EXEC=$SERVER_EXECUTABLE\n
 CLIEXEC=$CLI_EXEC\n
 PIDFILE=\"$PIDFILE\"\n
-CONF=\"$REDIS_CONFIG_FILE\"\n\n
-REDISPORT=\"$REDIS_PORT\"\n\n
+CONF=\"$SERVER_CONFIG_FILE\"\n\n
+REDISPORT=\"$SERVER_PORT\"\n\n
 ###############\n\n"
 
 REDIS_CHKCONFIG_INFO=\
 "# REDHAT chkconfig header\n\n
 # chkconfig: - 58 74\n
-# description: redis_${REDIS_PORT} is the redis daemon.\n
+# description: valkey_${SERVER_PORT} is the valkey daemon.\n
 ### BEGIN INIT INFO\n
-# Provides: redis_6379\n
+# Provides: valkey_6379\n
 # Required-Start: \$network \$local_fs \$remote_fs\n
 # Required-Stop: \$network \$local_fs \$remote_fs\n
 # Default-Start: 2 3 4 5\n
 # Default-Stop: 0 1 6\n
 # Should-Start: \$syslog \$named\n
 # Should-Stop: \$syslog \$named\n
-# Short-Description: start and stop redis_${REDIS_PORT}\n
+# Short-Description: start and stop valkey_${SERVER_PORT}\n
 # Description: Redis daemon\n
 ### END INIT INFO\n\n"
 
@@ -242,24 +242,24 @@ cat > ${TMP_FILE} <<EOT
 #!/bin/sh
 #Configurations injected by install_server below....
 
-EXEC=$REDIS_EXECUTABLE
+EXEC=$SERVER_EXECUTABLE
 CLIEXEC=$CLI_EXEC
 PIDFILE=$PIDFILE
-CONF="$REDIS_CONFIG_FILE"
-REDISPORT="$REDIS_PORT"
+CONF="$SERVER_CONFIG_FILE"
+REDISPORT="$SERVER_PORT"
 ###############
 # SysV Init Information
 # chkconfig: - 58 74
-# description: redis_${REDIS_PORT} is the redis daemon.
+# description: valkey_${SERVER_PORT} is the valkey daemon.
 ### BEGIN INIT INFO
-# Provides: redis_${REDIS_PORT}
+# Provides: valkey_${SERVER_PORT}
 # Required-Start: \$network \$local_fs \$remote_fs
 # Required-Stop: \$network \$local_fs \$remote_fs
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Should-Start: \$syslog \$named
 # Should-Stop: \$syslog \$named
-# Short-Description: start and stop redis_${REDIS_PORT}
+# Short-Description: start and stop valkey_${SERVER_PORT}
 # Description: Redis daemon
 ### END INIT INFO
 
@@ -268,23 +268,23 @@ cat ${INIT_TPL_FILE} >> ${TMP_FILE}
 
 #copy to /etc/init.d
 cp $TMP_FILE $INIT_SCRIPT_DEST && \
-	chmod +x $INIT_SCRIPT_DEST || die "Could not copy redis init script to  $INIT_SCRIPT_DEST"
+	chmod +x $INIT_SCRIPT_DEST || die "Could not copy valkey init script to  $INIT_SCRIPT_DEST"
 echo "Copied $TMP_FILE => $INIT_SCRIPT_DEST"
 
 #Install the service
 echo "Installing service..."
 if command -v chkconfig >/dev/null 2>&1; then
 	# we're chkconfig, so lets add to chkconfig and put in runlevel 345
-	chkconfig --add redis_${REDIS_PORT} && echo "Successfully added to chkconfig!"
-	chkconfig --level 345 redis_${REDIS_PORT} on && echo "Successfully added to runlevels 345!"
+	chkconfig --add valkey_${SERVER_PORT} && echo "Successfully added to chkconfig!"
+	chkconfig --level 345 valkey_${SERVER_PORT} on && echo "Successfully added to runlevels 345!"
 elif command -v update-rc.d >/dev/null 2>&1; then
 	#if we're not a chkconfig box assume we're able to use update-rc.d
-	update-rc.d redis_${REDIS_PORT} defaults && echo "Success!"
+	update-rc.d valkey_${SERVER_PORT} defaults && echo "Success!"
 else
 	echo "No supported init tool found."
 fi
 
-/etc/init.d/redis_$REDIS_PORT start || die "Failed starting service..."
+/etc/init.d/valkey_$SERVER_PORT start || die "Failed starting service..."
 
 #tada
 echo "Installation successful!"


### PR DESCRIPTION
Readme in github shows that install script will help to install valkey server, However the logs of thescripts and variables in the script still points to redis so renamed redis to valkey/server accordingly. Please review the changes!