### PR TITLE
Initial PR outlining the governance for the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,6 @@ Welcome and thank you for wanting to contribute!
 
 The Valkey project is led by a Technical Steering Committee, whose responsibilities are laid out in [GOVERNANCE.md](GOVERNANCE.md).
 
-# IMPORTANT: HOW TO USE VALKEY GITHUB ISSUES
-
 ## Get started
 
 * Have a question? Ask it on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,12 @@ Contributing to Valkey
 
 Welcome and thank you for wanting to contribute!
 
+# Project governance
+
+The Valkey project is led by a Technical Steering Committee, whose responsibilities are laid out in [GOVERNANCE.md](GOVERNANCE.md).
+
+# IMPORTANT: HOW TO USE VALKEY GITHUB ISSUES
+
 ## Get started
 
 * Have a question? Ask it on

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,17 +1,17 @@
 # Project Governance
 
-The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
+The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of the Valkey repository.
 The Valkey project includes all of the current and future repositories under the Valkey-io organization.
-Maintainers are defined as individuals with full commit access to a repository, which should be in sync with the MAINTAINERS.md file in a given projects repository.
+Maintainers are defined as individuals with full commit access to a repository, which shall be in sync with the MAINTAINERS.md file in a given projects repository.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
 ## Technical Steering Committee
 
-The TSC will be responsible for oversight of all technical, project, approval, and policy matters for Valkey.
+The TSC is responsible for oversight of all technical, project, approval, and policy matters for Valkey.
 
 The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the Valkey repository.
 Maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
-The TSC will appoint a Chair responsible for organizing TSC meetings.
+The TSC shall appoint a Chair responsible for organizing TSC meetings.
 If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
 The TSC can amend this governance document by no less than a 2/3 affirmative vote.
 
@@ -20,13 +20,13 @@ The TSC may, at its discretion, add or remove maintainers from other repositorie
 
 ## Voting
 
-The TSC will strive for all decisions to be made by consensus.
+The TSC shall strive for all decisions to be made by consensus.
 While explicit agreement of the entire TSC is preferred, it is not required for consensus.
-Rather, the TSC will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the TSC and nature of support and objections.
-The TSC will document evidence of consensus in accordance with these requirements.
-If consensus cannot be reached, the TSC will make the decision by a vote.
+Rather, the TSC shall determine consensus based on their good faith consideration of a number of factors, including the dominant view of the TSC and nature of support and objections.
+The TSC shall document evidence of consensus in accordance with these requirements.
+If consensus cannot be reached, the TSC shall make the decision by a vote.
 
-A vote will also be called when an issue or pull request is marked as a major decision, which are decisions that have significant impact on the Valkey architecture or design.
+A vote shall also be called when an issue or pull request is marked as a major decision, which are decisions that have a significant impact on the Valkey architecture or design.
 Examples of major decisions:
     * Fundamental changes to the Valkey core datastructures
     * Adding a new data structure or API
@@ -40,9 +40,9 @@ Examples of major decisions:
 
 Any member of the TSC can call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.
-The discussion will be open to the public, with the notable exception of discussions involving embargoed security issues or the addition or removal of maintainers, which will be private.
+The discussion shall be open to the public, with the notable exception of discussions involving embargoed security issues or the addition or removal of maintainers, which will be private.
 In any vote, each voting TSC member will have one vote.
-The TSC will give at least two weeks for all members to submit their vote.
+The TSC shall give at least two weeks for all members to submit their vote.
 Except as specifically noted elsewhere in this document, decisions by vote require a simple majority vote of all voting members.
 It is the responsibility of the TSC chair to help facilitate the voting process as needed to make sure it completes within the voting period.
 
@@ -52,13 +52,13 @@ A maintainer's access (and accordingly, their position on the TSC) will be remov
 
 * Resignation: Written notice of resignation to the TSC.
 * TSC Vote: 2/3 affirmative vote of the TSC to remove a member
-* Unreachable Member: If a member is unresponsive for more than six months, the remaining active members of the TSC may vote to remove to unreachable member by simple majority.
+* Unreachable Member: If a member is unresponsive for more than six months, the remaining active members of the TSC may vote to remove the unreachable member by a simple majority.
 
 ## Technical direction for other Valkey projects
 
-The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for that project.
-Delegation of decision making for a project is considered a major decision, and should happen with an explicit vote.
-Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repository.
+The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for those projects.
+Delegation of decision making for a project is considered a major decision, and shall happen with an explicit vote.
+Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repositories.
 
 The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
 The Valkey project includes all of the current and future repositories under the Valkey-io organization.
-Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the [MAINTAINERS.md](MAINTAINERS.md) file.
+Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the MAINTAINERS.md file in a given projects repository.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
 ## Technical Steering Committee

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Project Governance
 
 The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
-The Valkey project includes all of the repositories under the Valkey-io organization.
+The Valkey project includes all of the current and future repositories under the Valkey-io organization.
 Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the [MAINTAINERS.md](MAINTAINERS.md) file.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
@@ -10,7 +10,7 @@ Maintainers of other repositories within the Valkey project are not members of t
 The TSC will be responsible for oversight of all technical, project, approval, and policy matters for Valkey.
 
 The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the Valkey repository.
-New maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
+Maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
 The TSC will appoint a Chair responsible for organizing TSC meetings.
 If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
 The TSC can amend this governance document by no less than a 2/3 affirmative vote.
@@ -33,13 +33,16 @@ Examples of major decisions:
     * Changes that affect backward compatibility
     * New user visible fields that need to be maintained
     * Modifications to the TSC or other governance documents
+    * Adding members to other roles within the Valkey project
+    * Delegation of maintainership for projects to other groups or individuals
 
-The TSC Chair will call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
+Any member of the TSC can call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.
 The discussion will be open to the public, with the notable exception of discussions involving embargoed security issues or the addition or removal of maintainers, which will be private.
 In any vote, each voting TSC member will have one vote.
-The TSC members will give at least two weeks for all members to submit their vote.
+The TSC will give at least two weeks for all members to submit their vote.
 Except as specifically noted elsewhere in this document, decisions by vote require a simple majority vote of all voting members.
+It is the responsibility of the TSC chair to help facilitate the voting process as needed to make sure it completes within the voting period.
 
 ## Termination of Membership
 
@@ -52,6 +55,7 @@ A maintainer's access (and accordingly, their position on the TSC) will be remov
 ## Technical direction for other Valkey projects
 
 The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for that project.
+Delegation of decision making for a project is considered a major decision, and should happen with an explicit vote.
 Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repository.
 
 The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,6 +32,7 @@ Examples of major decisions:
     * Adding a new data structure or API
     * Changes that affect backward compatibility
     * New user visible fields that need to be maintained
+    * Modifications to the TSC or other governance documents
 
 The TSC Chair will call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,61 @@
+# Project Governance
+
+The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
+The Valkey project includes all of the repositories under the Valkey-io github organization.
+Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the [MAINTAINERS.md](MAINTAINERS.md) file.
+Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
+
+## Technical Steering Committee
+
+The TSC will be responsible for oversight of all technical, project, approval, and policy matters for Valkey.
+
+The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the Valkey repository.
+New maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
+The TSC will appoint a Chair responsible for organizing TSC meetings.
+If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
+The TSC can amend this governance document by no less than a 2/3 affirmative vote.
+
+The TSC may, at its discretion, add or remove members who are not maintainers of the main Valkey repository.
+The TSC may, at its discretion, add or remove maintainers from other repositories within the Valkey project.
+
+## Voting
+
+The TSC will strive for all decisions to be made by consensus.
+While explicit agreement of the entire TSC is preferred, it is not required for consensus.
+Rather, the TSC will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the TSC and nature of support and objections.
+The TSC will document evidence of consensus in accordance with these requirements.
+If consensus cannot be reached, the TSC will make the decision by a vote.
+
+A vote will also be called when an issue or pull request is marked as a major decision, which are decisions that have significant impact on the Valkey architecture or design.
+Examples of major decisions:
+    * Fundamental changes to the Valkey core datastructures
+    * Adding a new data structure or API
+    * Changes that affect backward compatibility
+    * New user visible fields that need to be maintained
+
+The TSC Chair will call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
+Any discussion may be conducted in person or electronically by text, voice, or video.
+The discussion will be open to the public, with the notable exception of discussions involving embargoed security issues or the addition or removal of maintainers, which will be private.
+In any vote, each voting TSC member will have one vote.
+The TSC members will give at least two weeks for all members to submit their vote.
+Except as specifically noted elsewhere in this document, decisions by vote require a simple majority vote of all voting members.
+
+## Termination of Membership
+
+A maintainer's access (and accordingly, their position on the TSC) will be removed if any of the following occur:
+
+* Resignation: Written notice of resignation to the TSC.
+* TSC Vote: 2/3 affirmative vote of the TSC to remove a member
+* Unreachable Member: If a member is unresponsive for more than six months, the remaining active members of the TSC may vote to remove to unreachable member by simple majority.
+
+## Technical direction for other Valkey projects
+
+The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for that project.
+Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repository.
+
+The TSC may, at its discretion, overule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.
+
+## License of this document
+
+This document may be used, modified, and/or distributed under the terms of the
+[Creative Commons Attribution 4.0 International (CC-BY) license](https://creativecommons.org/licenses/by/4.0/legalcode).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Project Governance
 
 The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
-The Valkey project includes all of the repositories under the Valkey-io github organization.
+The Valkey project includes all of the repositories under the Valkey-io organization.
 Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the [MAINTAINERS.md](MAINTAINERS.md) file.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
@@ -53,7 +53,7 @@ A maintainer's access (and accordingly, their position on the TSC) will be remov
 The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for that project.
 Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repository.
 
-The TSC may, at its discretion, overule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.
+The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.
 
 ## License of this document
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 The Valkey project is managed by a Technical Steering Committee (TSC) composed of the maintainers of Valkey repository.
 The Valkey project includes all of the current and future repositories under the Valkey-io organization.
-Maintainers are defined as individuals with full commit access to the Valkey repository as well as additional members defined in the MAINTAINERS.md file in a given projects repository.
+Maintainers are defined as individuals with full commit access to a repository, which should be in sync with the MAINTAINERS.md file in a given projects repository.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
 ## Technical Steering Committee
@@ -35,6 +35,8 @@ Examples of major decisions:
     * Modifications to the TSC or other governance documents
     * Adding members to other roles within the Valkey project
     * Delegation of maintainership for projects to other groups or individuals
+    * Adding or removing a new external library such as a client
+    or module to the project.
 
 Any member of the TSC can call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+## Overview
+
+This document contains a list of maintainers in this repo.
+See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
+
+## Current Maintainers
+
+| Maintainer          | GitHub ID                                       | Affiliation |
+| ------------------- | ----------------------------------------------- | ----------- |
+| Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
+| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Erricson    |
+| Zhu Binbin          | [enjoy-binbin](https://github.com/enjoy-binbin) | Tencent     |
+| Wen Hui             | [hwware](https://github.com/hwware)             | Huawei      |
+| Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |
+| Ping Xie            | [pingxie](https://github.com/pingxie)           | Google      |
+
+
+### Former Maintainers
+
+| Maintainer          | GitHub ID                                       | Affiliation |
+| ------------------- | ----------------------------------------------- | ----------- |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,12 +7,12 @@ See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
 
 | Maintainer          | GitHub ID                                       | Affiliation |
 | ------------------- | ----------------------------------------------- | ----------- |
-| Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
-| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
 | Zhu Binbin          | [enjoy-binbin](https://github.com/enjoy-binbin) | Tencent     |
 | Wen Hui             | [hwware](https://github.com/hwware)             | Huawei      |
-| Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |
+| Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
 | Ping Xie            | [pingxie](https://github.com/pingxie)           | Google      |
+| Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |
+| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
 
 
 ### Former Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
 | Maintainer          | GitHub ID                                       | Affiliation |
 | ------------------- | ----------------------------------------------- | ----------- |
 | Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
-| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Erricson    |
+| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
 | Zhu Binbin          | [enjoy-binbin](https://github.com/enjoy-binbin) | Tencent     |
 | Wen Hui             | [hwware](https://github.com/hwware)             | Huawei      |
 | Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,7 +12,7 @@ See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
 | Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
 | Ping Xie            | [pingxie](https://github.com/pingxie)           | Google      |
 | Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |
-| Viktor Zuiderkwast  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
+| Viktor Söderqvist  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
 
 
 ### Former Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,8 @@ See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
 
 ## Current Maintainers
 
+Maintainers listed in alphabetical order by their github ID.
+
 | Maintainer          | GitHub ID                                       | Affiliation |
 | ------------------- | ----------------------------------------------- | ----------- |
 | Zhu Binbin          | [enjoy-binbin](https://github.com/enjoy-binbin) | Tencent     |
@@ -12,7 +14,7 @@ See [GOVERNANCE.md](GOVERNANCE.md) that explains the function of this file.
 | Madelyn Olson       | [madolson](https://github.com/madolson)         | Amazon      |
 | Ping Xie            | [pingxie](https://github.com/pingxie)           | Google      |
 | Zhao Zhao           | [soloestoy](https://github.com/soloestoy)       | Alibaba     |
-| Viktor Söderqvist  | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
+| Viktor Söderqvist   | [zuiderkwast](https://github.com/zuiderkwast)   | Ericsson    |
 
 
 ### Former Maintainers


### PR DESCRIPTION
Initial PR to add a governance doc outlining permissions for the main Valkey project as well as define responsibilities for sub-projects. 