### PR TITLE
Rename remaining test procedures missed in `#287`

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -403,7 +403,7 @@ sds createLatencyReport(void) {
             "  1) Lower the system load.\n"
             "  2) Use a computer / VM just for Redis if you are running other software in the same system.\n"
             "  3) Check if you have a \"noisy neighbour\" problem.\n"
-            "  4) Check with 'valkey-cli --intrinsic-latency 100' what is the intrinsic latency in your system.\n"
+            "  4) Check with 'redis-cli --intrinsic-latency 100' what is the intrinsic latency in your system.\n"
             "  5) Check if the problem is allocator-related by recompiling Redis with MALLOC=libc, if you are using Jemalloc. However this may create fragmentation problems.\n");
         }
 

--- a/src/latency.c
+++ b/src/latency.c
@@ -403,7 +403,7 @@ sds createLatencyReport(void) {
             "  1) Lower the system load.\n"
             "  2) Use a computer / VM just for Redis if you are running other software in the same system.\n"
             "  3) Check if you have a \"noisy neighbour\" problem.\n"
-            "  4) Check with 'redis-cli --intrinsic-latency 100' what is the intrinsic latency in your system.\n"
+            "  4) Check with 'valkey-cli --intrinsic-latency 100' what is the intrinsic latency in your system.\n"
             "  5) Check if the problem is allocator-related by recompiling Redis with MALLOC=libc, if you are using Jemalloc. However this may create fragmentation problems.\n");
         }
 

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -171,7 +171,7 @@ proc set_cluster_node_timeout {to} {
 proc cluster_write_test {id} {
     set prefix [randstring 20 20 alpha]
     set port [get_instance_attrib valkey $id port]
-    set cluster [redis_cluster 127.0.0.1:$port]
+    set cluster [valkey_cluster 127.0.0.1:$port]
     for {set j 0} {$j < 100} {incr j} {
         $cluster set key.$j $prefix.$j
     }

--- a/tests/cluster/tests/03-failover-loop.tcl
+++ b/tests/cluster/tests/03-failover-loop.tcl
@@ -14,7 +14,7 @@ test "Cluster is up" {
 }
 
 set iterations 20
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 while {[incr iterations -1]} {
     set tokill [randomInt 10]

--- a/tests/cluster/tests/04-resharding.tcl
+++ b/tests/cluster/tests/04-resharding.tcl
@@ -55,11 +55,11 @@ proc process_is_running {pid} {
 set numkeys 50000
 set numops 200000
 set start_node_port [get_instance_attrib valkey 0 port]
-set cluster [redis_cluster 127.0.0.1:$start_node_port]
+set cluster [valkey_cluster 127.0.0.1:$start_node_port]
 if {$::tls} {
     # setup a non-TLS cluster client to the TLS cluster
     set plaintext_port [get_instance_attrib valkey 0 plaintext-port]
-    set cluster_plaintext [redis_cluster 127.0.0.1:$plaintext_port 0]
+    set cluster_plaintext [valkey_cluster 127.0.0.1:$plaintext_port 0]
     puts "Testing TLS cluster on start node 127.0.0.1:$start_node_port, plaintext port $plaintext_port"
 } else {
     set cluster_plaintext $cluster

--- a/tests/cluster/tests/05-slave-selection.tcl
+++ b/tests/cluster/tests/05-slave-selection.tcl
@@ -48,7 +48,7 @@ test "Instance #5 and #10 synced with the master" {
     }
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 test "Slaves are both able to receive and acknowledge writes" {
     for {set j 0} {$j < 100} {incr j} {

--- a/tests/cluster/tests/10-manual-failover.tcl
+++ b/tests/cluster/tests/10-manual-failover.tcl
@@ -30,7 +30,7 @@ set current_epoch [CI 1 cluster_current_epoch]
 
 set numkeys 50000
 set numops 10000
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset content}
 array set content {}
 

--- a/tests/cluster/tests/14-consistency-check.tcl
+++ b/tests/cluster/tests/14-consistency-check.tcl
@@ -38,7 +38,7 @@ proc get_one_of_my_replica {id} {
 proc cluster_write_keys_with_expire {id ttl} {
     set prefix [randstring 20 20 alpha]
     set port [get_instance_attrib valkey $id port]
-    set cluster [redis_cluster 127.0.0.1:$port]
+    set cluster [valkey_cluster 127.0.0.1:$port]
     for {set j 100} {$j < 200} {incr j} {
         $cluster setex key_expire.$j $ttl $prefix.$j
     }

--- a/tests/cluster/tests/15-cluster-slots.tcl
+++ b/tests/cluster/tests/15-cluster-slots.tcl
@@ -44,13 +44,13 @@ test "client do not break when cluster slot" {
 }
 
 test "client can handle keys with hash tag" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+    set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     $cluster set foo{tag} bar
     $cluster close
 }
 
 test "slot migration is valid from primary to another primary" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+    set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     set key order1
     set slot [$cluster cluster keyslot $key]
     array set nodefrom [$cluster masternode_for_slot $slot]
@@ -61,7 +61,7 @@ test "slot migration is valid from primary to another primary" {
 }
 
 test "slot migration is invalid from primary to replica" {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+    set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     set key order1
     set slot [$cluster cluster keyslot $key]
     array set nodefrom [$cluster masternode_for_slot $slot]

--- a/tests/cluster/tests/20-half-migrated-slot.tcl
+++ b/tests/cluster/tests/20-half-migrated-slot.tcl
@@ -21,7 +21,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/21-many-slot-migration.tcl
+++ b/tests/cluster/tests/21-many-slot-migration.tcl
@@ -21,7 +21,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
+++ b/tests/cluster/tests/25-pubsubshard-slot-migration.tcl
@@ -8,10 +8,10 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 
 proc get_addr_replica_serving_slot slot {
-    set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+    set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
     array set node [$cluster masternode_for_slot $slot]
 
     set replicanodeinfo [$cluster cluster replicas $node(id)]

--- a/tests/cluster/tests/26-pubsubshard.tcl
+++ b/tests/cluster/tests/26-pubsubshard.tcl
@@ -6,7 +6,7 @@ test "Create a 3 nodes cluster" {
     cluster_create_with_continuous_slots 3 3
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 test "Pub/Sub shard basics" {
 
     set slot [$cluster cluster keyslot "channel.0"]

--- a/tests/cluster/tests/29-slot-migration-response.tcl
+++ b/tests/cluster/tests/29-slot-migration-response.tcl
@@ -12,7 +12,7 @@ test "Cluster is up" {
     assert_cluster_state ok
 }
 
-set cluster [redis_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
+set cluster [valkey_cluster 127.0.0.1:[get_instance_attrib valkey 0 port]]
 catch {unset nodefrom}
 catch {unset nodeto}
 

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -11,7 +11,7 @@ proc fix_cluster {addr} {
         exec ../../../src/valkey-cli {*}[valkeycli_tls_config "../../../tests"] --cluster fix $addr << yes
     } result]
     if {$code != 0} {
-        puts "redis-cli --cluster fix returns non-zero exit code, output below:\n$result"
+        puts "valkey-cli --cluster fix returns non-zero exit code, output below:\n$result"
     }
     # Note: valkey-cli --cluster fix may return a non-zero exit code if nodes don't agree,
     # but we can ignore that and rely on the check below.
@@ -19,7 +19,7 @@ proc fix_cluster {addr} {
     wait_for_condition 100 100 {
         [catch {exec ../../../src/valkey-cli {*}[valkeycli_tls_config "../../../tests"] --cluster check $addr} result] == 0
     } else {
-        puts "redis-cli --cluster check returns non-zero exit code, output below:\n$result"
+        puts "valkey-cli --cluster check returns non-zero exit code, output below:\n$result"
         fail "Cluster could not settle with configuration"
     }
 }

--- a/tests/integration/aof-multi-part.tcl
+++ b/tests/integration/aof-multi-part.tcl
@@ -604,71 +604,71 @@ tags {"external:skip"} {
         }
 
         start_server_aof [list dir $server_path] {
-            set redis1 [valkey [srv host] [srv port] 0 $::tls]
+            set valkey1 [valkey [srv host] [srv port] 0 $::tls]
 
             start_server [list overrides [list dir $server_path appendonly yes appendfilename appendonly.aof2]] {
-                set redis2 [valkey [srv host] [srv port] 0 $::tls]
+                set valkey2 [valkey [srv host] [srv port] 0 $::tls]
 
                 test "Multi Part AOF can upgrade when when two servers share the same server dir (server1)" {
-                    wait_done_loading $redis1
-                    assert_equal v1 [$redis1 get k1]
-                    assert_equal v2 [$redis1 get k2]
-                    assert_equal v3 [$redis1 get k3]
+                    wait_done_loading $valkey1
+                    assert_equal v1 [$valkey1 get k1]
+                    assert_equal v2 [$valkey1 get k2]
+                    assert_equal v3 [$valkey1 get k3]
 
-                    assert_equal 0 [$redis1 exists k4]
-                    assert_equal 0 [$redis1 exists k5]
-                    assert_equal 0 [$redis1 exists k6]
+                    assert_equal 0 [$valkey1 exists k4]
+                    assert_equal 0 [$valkey1 exists k5]
+                    assert_equal 0 [$valkey1 exists k6]
 
                     assert_aof_manifest_content $aof_manifest_file  {
                         {file appendonly.aof seq 1 type b}
                         {file appendonly.aof.1.incr.aof seq 1 type i}
                     }
 
-                    $redis1 bgrewriteaof
-                    waitForBgrewriteaof $redis1
+                    $valkey1 bgrewriteaof
+                    waitForBgrewriteaof $valkey1
 
-                    assert_equal OK [$redis1 set k v]
+                    assert_equal OK [$valkey1 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file {
                         {file appendonly.aof.2.base.rdb seq 2 type b}
                         {file appendonly.aof.2.incr.aof seq 2 type i}
                     }
 
-                    set d1 [$redis1 debug digest]
-                    $redis1 debug loadaof
-                    set d2 [$redis1 debug digest]
+                    set d1 [$valkey1 debug digest]
+                    $valkey1 debug loadaof
+                    set d2 [$valkey1 debug digest]
                     assert {$d1 eq $d2}
                 }
 
                 test "Multi Part AOF can upgrade when when two servers share the same server dir (server2)" {
-                    wait_done_loading $redis2
+                    wait_done_loading $valkey2
 
-                    assert_equal 0 [$redis2 exists k1]
-                    assert_equal 0 [$redis2 exists k2]
-                    assert_equal 0 [$redis2 exists k3]
+                    assert_equal 0 [$valkey2 exists k1]
+                    assert_equal 0 [$valkey2 exists k2]
+                    assert_equal 0 [$valkey2 exists k3]
 
-                    assert_equal v4 [$redis2 get k4]
-                    assert_equal v5 [$redis2 get k5]
-                    assert_equal v6 [$redis2 get k6]
+                    assert_equal v4 [$valkey2 get k4]
+                    assert_equal v5 [$valkey2 get k5]
+                    assert_equal v6 [$valkey2 get k6]
 
                     assert_aof_manifest_content $aof_manifest_file2  {
                         {file appendonly.aof2 seq 1 type b}
                         {file appendonly.aof2.1.incr.aof seq 1 type i}
                     }
 
-                    $redis2 bgrewriteaof
-                    waitForBgrewriteaof $redis2
+                    $valkey2 bgrewriteaof
+                    waitForBgrewriteaof $valkey2
 
-                    assert_equal OK [$redis2 set k v]
+                    assert_equal OK [$valkey2 set k v]
 
                     assert_aof_manifest_content $aof_manifest_file2 {
                         {file appendonly.aof2.2.base.rdb seq 2 type b}
                         {file appendonly.aof2.2.incr.aof seq 2 type i}
                     }
 
-                    set d1 [$redis2 debug digest]
-                    $redis2 debug loadaof
-                    set d2 [$redis2 debug digest]
+                    set d1 [$valkey2 debug digest]
+                    $valkey2 debug loadaof
+                    set d2 [$valkey2 debug digest]
                     assert {$d1 eq $d2}
                 }
             }
@@ -677,7 +677,7 @@ tags {"external:skip"} {
 
     test {Multi Part AOF can handle appendfilename contains whitespaces} {
         start_server [list overrides [list appendonly yes appendfilename "\" file seq \\n\\n.aof \""]] {
-            set dir [get_redis_dir]
+            set dir [get_valkey_dir]
             set aof_manifest_name [format "%s/%s/%s%s" $dir "appendonlydir" " file seq \n\n.aof " $::manifest_suffix]
             set valkey [valkey [srv host] [srv port] 0 $::tls]
 
@@ -756,7 +756,7 @@ tags {"external:skip"} {
 
 
     start_server {tags {"Multi Part AOF"} overrides {aof-use-rdb-preamble {yes} appendonly {no} save {}}} {
-        set dir [get_redis_dir]
+        set dir [get_valkey_dir]
         set aof_basename "appendonly.aof"
         set aof_dirname "appendonlydir"
         set aof_dirpath "$dir/$aof_dirname"
@@ -1174,7 +1174,7 @@ tags {"external:skip"} {
         }
 
         start_server {overrides {aof-use-rdb-preamble {yes} appendonly {no} save {}}} {
-            set dir [get_redis_dir]
+            set dir [get_valkey_dir]
             set aof_basename "appendonly.aof"
             set aof_dirname "appendonlydir"
             set aof_dirpath "$dir/$aof_dirname"

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -444,7 +444,7 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         r acl deluser clitest
     }
     
-    proc test_redis_cli_rdb_dump {functions_only} {
+    proc test_valkey_cli_rdb_dump {functions_only} {
         r flushdb
         r function flush
 
@@ -480,12 +480,12 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
     test "Dumping an RDB - functions only: $functions_only" {
         # Disk-based master
         assert_match "OK" [r config set repl-diskless-sync no]
-        test_redis_cli_rdb_dump $functions_only
+        test_valkey_cli_rdb_dump $functions_only
 
         # Disk-less master
         assert_match "OK" [r config set repl-diskless-sync yes]
         assert_match "OK" [r config set repl-diskless-sync-delay 0]
-        test_redis_cli_rdb_dump $functions_only
+        test_valkey_cli_rdb_dump $functions_only
     } {} {needs:repl needs:debug}
 
     } ;# foreach functions_only
@@ -504,12 +504,12 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         assert_equal {key:2} [run_cli --scan --quoted-pattern {"*:\x32"}]
     }
 
-    proc test_redis_cli_repl {} {
+    proc test_valkey_cli_repl {} {
         set fd [open_cli "--replica"]
         wait_for_condition 500 100 {
             [string match {*slave0:*state=online*} [r info]]
         } else {
-            fail "redis-cli --replica did not connect"
+            fail "valkey-cli --replica did not connect"
         }
 
         for {set i 0} {$i < 100} {incr i} {
@@ -519,7 +519,7 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         wait_for_condition 500 100 {
             [string match {*test-value-99*} [read_cli $fd]]
         } else {
-            fail "redis-cli --replica didn't read commands"
+            fail "valkey-cli --replica didn't read commands"
         }
 
         fconfigure $fd -blocking true
@@ -531,12 +531,12 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
     test "Connecting as a replica" {
         # Disk-based master
         assert_match "OK" [r config set repl-diskless-sync no]
-        test_redis_cli_repl
+        test_valkey_cli_repl
 
         # Disk-less master
         assert_match "OK" [r config set repl-diskless-sync yes]
         assert_match "OK" [r config set repl-diskless-sync-delay 0]
-        test_redis_cli_repl
+        test_valkey_cli_repl
     } {} {needs:repl}
 
     test "Piping raw protocol" {

--- a/tests/support/aofmanifest.tcl
+++ b/tests/support/aofmanifest.tcl
@@ -12,7 +12,7 @@ proc join_path {dir1 dir2} {
     return [format "%s/%s" $dir1 $dir2]
 }
 
-proc get_redis_dir {} {
+proc get_valkey_dir {} {
     set config [srv config]
     set _ [dict get $config "dir"]
 }

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -4,25 +4,25 @@
 #
 # Example usage:
 #
-# set c [redis_cluster {127.0.0.1:6379 127.0.0.1:6380}]
+# set c [valkey_cluster {127.0.0.1:6379 127.0.0.1:6380}]
 # $c set foo
 # $c get foo
 # $c close
 
 package require Tcl 8.5
-package provide redis_cluster 0.1
+package provide valkey_cluster 0.1
 
-namespace eval redis_cluster {}
-set ::redis_cluster::internal_id 0
-set ::redis_cluster::id 0
-array set ::redis_cluster::startup_nodes {}
-array set ::redis_cluster::nodes {}
-array set ::redis_cluster::slots {}
-array set ::redis_cluster::tls {}
+namespace eval valkey_cluster {}
+set ::valkey_cluster::internal_id 0
+set ::valkey_cluster::id 0
+array set ::valkey_cluster::startup_nodes {}
+array set ::valkey_cluster::nodes {}
+array set ::valkey_cluster::slots {}
+array set ::valkey_cluster::tls {}
 
 # List of "plain" commands, which are commands where the sole key is always
 # the first argument.
-set ::redis_cluster::plain_commands {
+set ::valkey_cluster::plain_commands {
     get set setnx setex psetex append strlen exists setbit getbit
     setrange getrange substr incr decr rpush lpush rpushx lpushx
     linsert rpop lpop brpop llen lindex lset lrange ltrim lrem
@@ -39,34 +39,34 @@ set ::redis_cluster::plain_commands {
 
 # Create a cluster client. The nodes are given as a list of host:port. The TLS
 # parameter (1 or 0) is optional and defaults to the global $::tls.
-proc redis_cluster {nodes {tls -1}} {
-    set id [incr ::redis_cluster::id]
-    set ::redis_cluster::startup_nodes($id) $nodes
-    set ::redis_cluster::nodes($id) {}
-    set ::redis_cluster::slots($id) {}
-    set ::redis_cluster::tls($id) [expr $tls == -1 ? $::tls : $tls]
-    set handle [interp alias {} ::redis_cluster::instance$id {} ::redis_cluster::__dispatch__ $id]
+proc valkey_cluster {nodes {tls -1}} {
+    set id [incr ::valkey_cluster::id]
+    set ::valkey_cluster::startup_nodes($id) $nodes
+    set ::valkey_cluster::nodes($id) {}
+    set ::valkey_cluster::slots($id) {}
+    set ::valkey_cluster::tls($id) [expr $tls == -1 ? $::tls : $tls]
+    set handle [interp alias {} ::valkey_cluster::instance$id {} ::valkey_cluster::__dispatch__ $id]
     $handle refresh_nodes_map
     return $handle
 }
 
 # Totally reset the slots / nodes state for the client, calls
 # CLUSTER NODES in the first startup node available, populates the
-# list of nodes ::redis_cluster::nodes($id) with an hash mapping node
+# list of nodes ::valkey_cluster::nodes($id) with an hash mapping node
 # ip:port to a representation of the node (another hash), and finally
-# maps ::redis_cluster::slots($id) with an hash mapping slot numbers
+# maps ::valkey_cluster::slots($id) with an hash mapping slot numbers
 # to node IDs.
 #
 # This function is called when a new Cluster client is initialized
 # and every time we get a -MOVED redirection error.
-proc ::redis_cluster::__method__refresh_nodes_map {id} {
+proc ::valkey_cluster::__method__refresh_nodes_map {id} {
     # Contact the first responding startup node.
     set idx 0; # Index of the node that will respond.
     set errmsg {}
-    foreach start_node $::redis_cluster::startup_nodes($id) {
+    foreach start_node $::valkey_cluster::startup_nodes($id) {
         set ip_port [lindex [split $start_node @] 0]
         lassign [split $ip_port :] start_host start_port
-        set tls $::redis_cluster::tls($id)
+        set tls $::valkey_cluster::tls($id)
         if {[catch {
             set r {}
             set r [valkey $start_host $start_port 0 $tls]
@@ -84,18 +84,18 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
         }
     }
 
-    if {$idx == [llength $::redis_cluster::startup_nodes($id)]} {
+    if {$idx == [llength $::valkey_cluster::startup_nodes($id)]} {
         error "No good startup node found. $errmsg"
     }
 
     # Put the node that responded as first in the list if it is not
     # already the first.
     if {$idx != 0} {
-        set l $::redis_cluster::startup_nodes($id)
+        set l $::valkey_cluster::startup_nodes($id)
         set left [lrange $l 0 [expr {$idx-1}]]
         set right [lrange $l [expr {$idx+1}] end]
         set l [concat [lindex $l $idx] $left $right]
-        set ::redis_cluster::startup_nodes($id) $l
+        set ::valkey_cluster::startup_nodes($id) $l
     }
 
     # Parse CLUSTER NODES output to populate the nodes description.
@@ -114,7 +114,7 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
 
         # Connect to the node
         set link {}
-        set tls $::redis_cluster::tls($id)
+        set tls $::valkey_cluster::tls($id)
         catch {set link [valkey $host $port 0 $tls]}
 
         # Build this node description as an hash.
@@ -130,17 +130,17 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
             link $link \
         ]
         dict set nodes $addr $node
-        lappend ::redis_cluster::startup_nodes($id) $addr
+        lappend ::valkey_cluster::startup_nodes($id) $addr
     }
 
     # Close all the existing links in the old nodes map, and set the new
     # map as current.
-    foreach n $::redis_cluster::nodes($id) {
+    foreach n $::valkey_cluster::nodes($id) {
         catch {
             [dict get $n link] close
         }
     }
-    set ::redis_cluster::nodes($id) $nodes
+    set ::valkey_cluster::nodes($id) $nodes
 
     # Populates the slots -> nodes map.
     dict for {addr node} $nodes {
@@ -148,47 +148,47 @@ proc ::redis_cluster::__method__refresh_nodes_map {id} {
             lassign [split $slotrange -] start end
             if {$end == {}} {set end $start}
             for {set j $start} {$j <= $end} {incr j} {
-                dict set ::redis_cluster::slots($id) $j $addr
+                dict set ::valkey_cluster::slots($id) $j $addr
             }
         }
     }
 
     # Only retain unique entries in the startup nodes list
-    set ::redis_cluster::startup_nodes($id) [lsort -unique $::redis_cluster::startup_nodes($id)]
+    set ::valkey_cluster::startup_nodes($id) [lsort -unique $::valkey_cluster::startup_nodes($id)]
 }
 
-# Free a redis_cluster handle.
-proc ::redis_cluster::__method__close {id} {
+# Free a valkey_cluster handle.
+proc ::valkey_cluster::__method__close {id} {
     catch {
-        set nodes $::redis_cluster::nodes($id)
+        set nodes $::valkey_cluster::nodes($id)
         dict for {addr node} $nodes {
             catch {
                 [dict get $node link] close
             }
         }
     }
-    catch {unset ::redis_cluster::startup_nodes($id)}
-    catch {unset ::redis_cluster::nodes($id)}
-    catch {unset ::redis_cluster::slots($id)}
-    catch {unset ::redis_cluster::tls($id)}
-    catch {interp alias {} ::redis_cluster::instance$id {}}
+    catch {unset ::valkey_cluster::startup_nodes($id)}
+    catch {unset ::valkey_cluster::nodes($id)}
+    catch {unset ::valkey_cluster::slots($id)}
+    catch {unset ::valkey_cluster::tls($id)}
+    catch {interp alias {} ::valkey_cluster::instance$id {}}
 }
 
-proc ::redis_cluster::__method__masternode_for_slot {id slot} {
+proc ::valkey_cluster::__method__masternode_for_slot {id slot} {
     # Get the node mapped to this slot.
-    set node_addr [dict get $::redis_cluster::slots($id) $slot]
+    set node_addr [dict get $::valkey_cluster::slots($id) $slot]
     if {$node_addr eq {}} {
         error "No mapped node for slot $slot."
     }
-    return [dict get $::redis_cluster::nodes($id) $node_addr]
+    return [dict get $::valkey_cluster::nodes($id) $node_addr]
 }
 
-proc ::redis_cluster::__method__masternode_notfor_slot {id slot} {
+proc ::valkey_cluster::__method__masternode_notfor_slot {id slot} {
     # Get a node that is not mapped to this slot.
-    set node_addr [dict get $::redis_cluster::slots($id) $slot]
-    set addrs [dict keys $::redis_cluster::nodes($id)]
+    set node_addr [dict get $::valkey_cluster::slots($id) $slot]
+    set addrs [dict keys $::valkey_cluster::nodes($id)]
     foreach addr [lshuffle $addrs] {
-        set node [dict get $::redis_cluster::nodes($id) $addr]
+        set node [dict get $::valkey_cluster::nodes($id) $addr]
         if {$node_addr ne $addr && [dict get $node slaveof] eq "-"} {
             return $node
         }
@@ -196,22 +196,22 @@ proc ::redis_cluster::__method__masternode_notfor_slot {id slot} {
     error "Slot $slot is everywhere"
 }
 
-proc ::redis_cluster::__dispatch__ {id method args} {
-    if {[info command ::redis_cluster::__method__$method] eq {}} {
+proc ::valkey_cluster::__dispatch__ {id method args} {
+    if {[info command ::valkey_cluster::__method__$method] eq {}} {
         # Get the keys from the command.
-        set keys [::redis_cluster::get_keys_from_command $method $args]
+        set keys [::valkey_cluster::get_keys_from_command $method $args]
         if {$keys eq {}} {
-            error "Redis command '$method' is not supported by redis_cluster."
+            error "Redis command '$method' is not supported by valkey_cluster."
         }
 
         # Resolve the keys in the corresponding hash slot they hash to.
-        set slot [::redis_cluster::get_slot_from_keys $keys]
+        set slot [::valkey_cluster::get_slot_from_keys $keys]
         if {$slot eq {}} {
             error "Invalid command: multiple keys not hashing to the same slot."
         }
 
         # Get the node mapped to this slot.
-        set node_addr [dict get $::redis_cluster::slots($id) $slot]
+        set node_addr [dict get $::valkey_cluster::slots($id) $slot]
         if {$node_addr eq {}} {
             error "No mapped node for slot $slot."
         }
@@ -221,7 +221,7 @@ proc ::redis_cluster::__dispatch__ {id method args} {
         set asking 0
         while {[incr retry -1]} {
             if {$retry < 5} {after 100}
-            set node [dict get $::redis_cluster::nodes($id) $node_addr]
+            set node [dict get $::valkey_cluster::nodes($id) $node_addr]
             set link [dict get $node link]
             if {$asking} {
                 $link ASKING
@@ -233,8 +233,8 @@ proc ::redis_cluster::__dispatch__ {id method args} {
                     [string range $e 0 2] eq {I/O} \
                 } {
                     # MOVED redirection.
-                    ::redis_cluster::__method__refresh_nodes_map $id
-                    set node_addr [dict get $::redis_cluster::slots($id) $slot]
+                    ::valkey_cluster::__method__refresh_nodes_map $id
+                    set node_addr [dict get $::valkey_cluster::slots($id) $slot]
                     continue
                 } elseif {[string range $e 0 2] eq {ASK}} {
                     # ASK redirection.
@@ -252,14 +252,14 @@ proc ::redis_cluster::__dispatch__ {id method args} {
         }
         error "Too many redirections or failures contacting Redis Cluster."
     } else {
-        uplevel 1 [list ::redis_cluster::__method__$method $id] $args
+        uplevel 1 [list ::valkey_cluster::__method__$method $id] $args
     }
 }
 
-proc ::redis_cluster::get_keys_from_command {cmd argv} {
+proc ::valkey_cluster::get_keys_from_command {cmd argv} {
     set cmd [string tolower $cmd]
     # Most commands get just one key as first argument.
-    if {[lsearch -exact $::redis_cluster::plain_commands $cmd] != -1} {
+    if {[lsearch -exact $::valkey_cluster::plain_commands $cmd] != -1} {
         return [list [lindex $argv 0]]
     }
 
@@ -277,7 +277,7 @@ proc ::redis_cluster::get_keys_from_command {cmd argv} {
 
 # Returns the CRC16 of the specified string.
 # The CRC parameters are described in the Cluster specification.
-set ::redis_cluster::XMODEMCRC16Lookup {
+set ::valkey_cluster::XMODEMCRC16Lookup {
     0x0000 0x1021 0x2042 0x3063 0x4084 0x50a5 0x60c6 0x70e7
     0x8108 0x9129 0xa14a 0xb16b 0xc18c 0xd1ad 0xe1ce 0xf1ef
     0x1231 0x0210 0x3273 0x2252 0x52b5 0x4294 0x72f7 0x62d6
@@ -312,19 +312,19 @@ set ::redis_cluster::XMODEMCRC16Lookup {
     0x6e17 0x7e36 0x4e55 0x5e74 0x2e93 0x3eb2 0x0ed1 0x1ef0
 }
 
-proc ::redis_cluster::crc16 {s} {
+proc ::valkey_cluster::crc16 {s} {
     set s [encoding convertto ascii $s]
     set crc 0
     foreach char [split $s {}] {
         scan $char %c byte
-        set crc [expr {(($crc<<8)&0xffff) ^ [lindex $::redis_cluster::XMODEMCRC16Lookup [expr {(($crc>>8)^$byte) & 0xff}]]}]
+        set crc [expr {(($crc<<8)&0xffff) ^ [lindex $::valkey_cluster::XMODEMCRC16Lookup [expr {(($crc>>8)^$byte) & 0xff}]]}]
     }
     return $crc
 }
 
 # Hash a single key returning the slot it belongs to, Implemented hash
 # tags as described in the Cluster specification.
-proc ::redis_cluster::hash {key} {
+proc ::valkey_cluster::hash {key} {
     set keylen [string length $key]
     set s {}
     set e {}
@@ -353,10 +353,10 @@ proc ::redis_cluster::hash {key} {
 # Return the slot the specified keys hash to.
 # If the keys hash to multiple slots, an empty string is returned to
 # signal that the command can't be run in Cluster.
-proc ::redis_cluster::get_slot_from_keys {keys} {
+proc ::valkey_cluster::get_slot_from_keys {keys} {
     set slot {}
     foreach k $keys {
-        set s [::redis_cluster::hash $k]
+        set s [::valkey_cluster::hash $k]
         if {$slot eq {}} {
             set slot $s
         } elseif {$slot != $s} {

--- a/tests/unit/cluster/cluster-response-tls.tcl
+++ b/tests/unit/cluster/cluster-response-tls.tcl
@@ -27,7 +27,7 @@ proc cluster_response_tls {tls_cluster} {
     test "CLUSTER SLOTS with different connection type -- tls-cluster $tls_cluster" {
         set slots1 [R 0 cluster slots]
         set pport [srv 0 pport]
-        set cluster_client [redis_cluster 127.0.0.1:$pport 0]
+        set cluster_client [valkey_cluster 127.0.0.1:$pport 0]
         set slots2 [$cluster_client cluster slots]
         $cluster_client close
         # Compare the ports in the first row
@@ -38,15 +38,15 @@ proc cluster_response_tls {tls_cluster} {
         set nodes [R 0 cluster nodes]
         set port1 [get_port_from_node_info [lindex [split $nodes "\r\n"] 0]]
         set pport [srv 0 pport]
-        set cluster_client [redis_cluster 127.0.0.1:$pport 0]
+        set cluster_client [valkey_cluster 127.0.0.1:$pport 0]
         set nodes [$cluster_client cluster nodes]
         set port2 [get_port_from_node_info [lindex [split $nodes "\r\n"] 0]]
         $cluster_client close
         assert_not_equal $port1 $port2
     }
 
-    set cluster [redis_cluster 127.0.0.1:[srv 0 port]]
-    set cluster_pport [redis_cluster 127.0.0.1:[srv 0 pport] 0]
+    set cluster [valkey_cluster 127.0.0.1:[srv 0 port]]
+    set cluster_pport [valkey_cluster 127.0.0.1:[srv 0 pport] 0]
     $cluster refresh_nodes_map
 
     test "Set many keys in the cluster -- tls-cluster $tls_cluster" {


### PR DESCRIPTION
Renamed below procedures and variables as follows.

redis_cluster             ->     valkey_cluster
redis1                    ->     valkey1
redis2                    ->     valkey2
get_redis_dir             ->     get_valkey_dir
test_redis_cli_rdb_dump   ->     test_valkey_cli_rdb_dump
test_redis_cli_repl       ->     test_valkey_cli_repl
redis-cli                 ->     valkey-cli
redis_reset_state         ->     valkey_reset_state
redisHandle               ->     valkeyHandle
redis_safe_read           ->     valkey_safe_read
redis_safe_gets           ->     valkey_safe_gets
redis_write               ->     valkey_write
redis_read_reply          ->     valkey_read_reply
redis_readable            ->     valkey_readable
redis_readnl              ->     valkey_readnl
redis_writenl             ->     valkey_writenl
redis_read_map            ->     valkey_read_map
redis_read_line           ->     valkey_read_line
redis_read_null           ->     valkey_read_null
redis_read_bool           ->     valkey_read_bool
redis_read_double         ->     valkey_read_double
redis_read_verbatim_str   ->     valkey_read_verbatim_str
redis_call_callback       ->     valkey_call_callback