### PR TITLE
Rename redis_init_script file and its content

### DIFF
--- a/utils/install_server.sh
+++ b/utils/install_server.sh
@@ -167,7 +167,7 @@ mkdir -p "$SERVER_DATA_DIR" || die "Could not create valkey data directory"
 #render the templates
 TMP_FILE="/tmp/${SERVER_PORT}.conf"
 DEFAULT_CONFIG="${SCRIPTPATH}/../valkey.conf"
-INIT_TPL_FILE="${SCRIPTPATH}/redis_init_script.tpl"
+INIT_TPL_FILE="${SCRIPTPATH}/valkey_init_script.tpl"
 INIT_SCRIPT_DEST="/etc/init.d/valkey_${SERVER_PORT}"
 PIDFILE="/var/run/valkey_${SERVER_PORT}.pid"
 
@@ -197,17 +197,17 @@ rm -f $TMP_FILE
 
 #we hard code the configs here to avoid issues with templates containing env vars
 #kinda lame but works!
-REDIS_INIT_HEADER=\
+VALKEY_INIT_HEADER=\
 "#!/bin/sh\n
 #Configurations injected by install_server below....\n\n
 EXEC=$SERVER_EXECUTABLE\n
 CLIEXEC=$CLI_EXEC\n
 PIDFILE=\"$PIDFILE\"\n
 CONF=\"$SERVER_CONFIG_FILE\"\n\n
-REDISPORT=\"$SERVER_PORT\"\n\n
+VALKEYPORT=\"$SERVER_PORT\"\n\n
 ###############\n\n"
 
-REDIS_CHKCONFIG_INFO=\
+VALKEY_CHKCONFIG_INFO=\
 "# REDHAT chkconfig header\n\n
 # chkconfig: - 58 74\n
 # description: valkey_${SERVER_PORT} is the valkey daemon.\n
@@ -220,15 +220,15 @@ REDIS_CHKCONFIG_INFO=\
 # Should-Start: \$syslog \$named\n
 # Should-Stop: \$syslog \$named\n
 # Short-Description: start and stop valkey_${SERVER_PORT}\n
-# Description: Redis daemon\n
+# Description: Valkey daemon\n
 ### END INIT INFO\n\n"
 
 if command -v chkconfig >/dev/null; then
 	#if we're a box with chkconfig on it we want to include info for chkconfig
-	echo "$REDIS_INIT_HEADER" "$REDIS_CHKCONFIG_INFO" > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
+	echo "$VALKEY_INIT_HEADER" "$VALKEY_CHKCONFIG_INFO" > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 else
 	#combine the header and the template (which is actually a static footer)
-	echo "$REDIS_INIT_HEADER" > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
+	echo "$VALKEY_INIT_HEADER" > $TMP_FILE && cat $INIT_TPL_FILE >> $TMP_FILE || die "Could not write init script to $TMP_FILE"
 fi
 
 ###
@@ -246,7 +246,7 @@ EXEC=$SERVER_EXECUTABLE
 CLIEXEC=$CLI_EXEC
 PIDFILE=$PIDFILE
 CONF="$SERVER_CONFIG_FILE"
-REDISPORT="$SERVER_PORT"
+VALKEYPORT="$SERVER_PORT"
 ###############
 # SysV Init Information
 # chkconfig: - 58 74
@@ -260,7 +260,7 @@ REDISPORT="$SERVER_PORT"
 # Should-Start: \$syslog \$named
 # Should-Stop: \$syslog \$named
 # Short-Description: start and stop valkey_${SERVER_PORT}
-# Description: Redis daemon
+# Description: Valkey daemon
 ### END INIT INFO
 
 EOT

--- a/utils/valkey_init_script
+++ b/utils/valkey_init_script
@@ -4,19 +4,19 @@
 # as it does use of the /proc filesystem.
 
 ### BEGIN INIT INFO
-# Provides:     redis_6379
+# Provides:     valkey_6379
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
-# Short-Description:    Redis data structure server
-# Description:          Redis data structure server. See https://redis.io
+# Short-Description:    Valkey data structure server
+# Description:          Valkey data structure server. See https://valkey.io
 ### END INIT INFO
 
-REDISPORT=6379
-EXEC=/usr/local/bin/redis-server
-CLIEXEC=/usr/local/bin/redis-cli
+VALKEYPORT=6379
+EXEC=/usr/local/bin/valkey-server
+CLIEXEC=/usr/local/bin/valkey-cli
 
-PIDFILE=/var/run/redis_${REDISPORT}.pid
-CONF="/etc/redis/${REDISPORT}.conf"
+PIDFILE=/var/run/valkey_${VALKEYPORT}.pid
+CONF="/etc/valkey/${VALKEYPORT}.conf"
 
 case "$1" in
     start)
@@ -24,7 +24,7 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
-                echo "Starting Redis server..."
+                echo "Starting Valkey server..."
                 $EXEC $CONF
         fi
         ;;
@@ -35,13 +35,13 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
-                $CLIEXEC -p $REDISPORT shutdown
+                $CLIEXEC -p $VALKEYPORT shutdown
                 while [ -x /proc/${PID} ]
                 do
-                    echo "Waiting for Redis to shutdown ..."
+                    echo "Waiting for Valkey to shutdown ..."
                     sleep 1
                 done
-                echo "Redis stopped"
+                echo "Valkey stopped"
         fi
         ;;
     *)

--- a/utils/valkey_init_script.tpl
+++ b/utils/valkey_init_script.tpl
@@ -5,7 +5,7 @@ case "$1" in
         then
             echo "$PIDFILE exists, process is already running or crashed"
         else
-            echo "Starting Redis server..."
+            echo "Starting Valkey server..."
             $EXEC $CONF
         fi
         ;;
@@ -16,22 +16,22 @@ case "$1" in
         else
             PID=$(cat $PIDFILE)
             echo "Stopping ..."
-            $CLIEXEC -p $REDISPORT shutdown
+            $CLIEXEC -p $VALKEYPORT shutdown
             while [ -x /proc/${PID} ]
             do
-                echo "Waiting for Redis to shutdown ..."
+                echo "Waiting for Valkey to shutdown ..."
                 sleep 1
             done
-            echo "Redis stopped"
+            echo "Valkey stopped"
         fi
         ;;
     status)
         PID=$(cat $PIDFILE)
         if [ ! -x /proc/${PID} ]
         then
-            echo 'Redis is not running'
+            echo 'Valkey is not running'
         else
-            echo "Redis is running ($PID)"
+            echo "Valkey is running ($PID)"
         fi
         ;;
     restart)


### PR DESCRIPTION
Rename the init script and a related `.tpl` file and rename variable names inside (redis to valkey). Update variables in `utils/install_server.sh`.

Fixes #354