### PR TITLE
Rename redis to valkey in test suite logs and test names.

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -40,7 +40,7 @@ set ::loop 0
 
 if {[catch {cd tmp}]} {
     puts "tmp directory not found."
-    puts "Please run this test from the Redis source root."
+    puts "Please run this test from the Valkey source root."
     exit 1
 }
 
@@ -313,7 +313,7 @@ proc parse_options {} {
             puts "--fail                  Simulate a test failure."
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
-            puts "--tls-module            Run tests in TLS mode with Redis module."
+            puts "--tls-module            Run tests in TLS mode with Valkey module."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
             puts "--stop                  Blocks once the first test fails."
@@ -342,12 +342,12 @@ proc pause_on_error {} {
         set cmd [lindex $argv 0]
         if {$cmd eq {continue}} {
             break
-        } elseif {$cmd eq {show-redis-logs}} {
+        } elseif {$cmd eq {show-valkey-logs}} {
             set count 10
             if {[lindex $argv 1] ne {}} {set count [lindex $argv 1]}
             foreach_valkey_id id {
-                puts "=== REDIS $id ===="
-                puts [exec tail -$count redis_$id/log.txt]
+                puts "=== VALKEY $id ===="
+                puts [exec tail -$count valkey_$id/log.txt]
                 puts "---------------------\n"
             }
         } elseif {$cmd eq {show-sentinel-logs}} {
@@ -360,7 +360,7 @@ proc pause_on_error {} {
             }
         } elseif {$cmd eq {ls}} {
             foreach_valkey_id id {
-                puts -nonewline "Redis $id"
+                puts -nonewline "Valkey $id"
                 set errcode [catch {
                     set str {}
                     append str "@[RI $id tcp_port]: "
@@ -391,13 +391,13 @@ proc pause_on_error {} {
                 }
             }
         } elseif {$cmd eq {help}} {
-            puts "ls                     List Sentinel and Redis instances."
+            puts "ls                     List Sentinel and Valkey instances."
             puts "show-sentinel-logs \[N\] Show latest N lines of logs."
-            puts "show-redis-logs \[N\]    Show latest N lines of logs."
+            puts "show-valkey-logs \[N\]    Show latest N lines of logs."
             puts "S <id> cmd ... arg     Call command in Sentinel <id>."
-            puts "R <id> cmd ... arg     Call command in Redis <id>."
+            puts "R <id> cmd ... arg     Call command in Valkey <id>."
             puts "SI <id> <field>        Show Sentinel <id> INFO <field>."
-            puts "RI <id> <field>        Show Redis <id> INFO <field>."
+            puts "RI <id> <field>        Show Valkey <id> INFO <field>."
             puts "continue               Resume test."
         } else {
             set errcode [catch {eval $line} retval]

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -375,7 +375,7 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
             [catch {close [socket "127.0.0.1" $port1]}] == 0 && \
             [catch {close [socket "127.0.0.1" $port2]}] == 0
         } else {
-            fail "Failed to start fake Redis nodes"
+            fail "Failed to start fake Valkey nodes"
         }
         # Run the cli
         assert_equal "OK" [run_cli_host_port_db "127.0.0.1" $port1 0 -c SET foo bar]

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -104,7 +104,7 @@ test "All the other slaves now point to the new master" {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]
             } else {
-                fail "Redis ID $id not configured to replicate with new master"
+                fail "Valkey ID $id not configured to replicate with new master"
             }
         }
     }

--- a/tests/sentinel/tests/02-slaves-reconf.tcl
+++ b/tests/sentinel/tests/02-slaves-reconf.tcl
@@ -18,7 +18,7 @@ proc 02_test_slaves_replication {} {
                     ([RI $id master_port] == $master_port) &&
                     ([RI $id master_link_status] eq {up})
                 } else {
-                    fail "Redis slave $id is replicating from wrong master"
+                    fail "Valkey slave $id is replicating from wrong master"
                 }
             }
         }

--- a/tests/sentinel/tests/05-manual.tcl
+++ b/tests/sentinel/tests/05-manual.tcl
@@ -48,7 +48,7 @@ test "All the other slaves now point to the new master" {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]
             } else {
-                fail "Redis ID $id not configured to replicate with new master"
+                fail "Valkey ID $id not configured to replicate with new master"
             }
         }
     }

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -88,7 +88,7 @@ test "All the other slaves now point to the new master" {
             wait_for_condition 1000 50 {
                 [RI $id master_port] == [lindex $addr 1]
             } else {
-                fail "Redis ID $id not configured to replicate with new master"
+                fail "Valkey ID $id not configured to replicate with new master"
             }
         }
     }

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -201,7 +201,7 @@ proc ::valkey_cluster::__dispatch__ {id method args} {
         # Get the keys from the command.
         set keys [::valkey_cluster::get_keys_from_command $method $args]
         if {$keys eq {}} {
-            error "Redis command '$method' is not supported by valkey_cluster."
+            error "Valkey command '$method' is not supported by valkey_cluster."
         }
 
         # Resolve the keys in the corresponding hash slot they hash to.
@@ -250,7 +250,7 @@ proc ::valkey_cluster::__dispatch__ {id method args} {
                 return $e
             }
         }
-        error "Too many redirections or failures contacting Redis Cluster."
+        error "Too many redirections or failures contacting Valkey Cluster."
     } else {
         uplevel 1 [list ::valkey_cluster::__method__$method $id] $args
     }

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -4,7 +4,7 @@ set ::valgrind_errors {}
 
 proc start_server_error {config_file error} {
     set err {}
-    append err "Can't start the Redis server\n"
+    append err "Can't start the Valkey server\n"
     append err "CONFIGURATION:\n"
     append err [exec cat $config_file]
     append err "\nERROR:\n"

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -258,7 +258,7 @@ proc test {name code {okpattern undefined} {tags {}}} {
     }
 
     if {$::traceleaks} {
-        set output [exec leaks redis-server]
+        set output [exec leaks valkey-server]
         if {![string match {*0 leaks*} $output]} {
             send_data_packet $::test_server_fd err "Detected a memory leak in test '$name': $output"
         }

--- a/tests/support/valkey.tcl
+++ b/tests/support/valkey.tcl
@@ -19,7 +19,7 @@
 #     }
 # }
 #
-# set r [redis]
+# set r [valkey]
 # $r blocking 0
 # $r get fo [list handlePong]
 #

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -455,7 +455,7 @@ start_server {tags {"expire"}} {
         #    to replication lag.
         # 2) We want to unify the way TTLs are replicated in both RDB and replication
         #    stream, which is as absolute timestamps.
-        # See: https://github.com/redis/redis/issues/8433
+        # See Redis OSS issue: https://github.com/redis/redis/issues/8433
 
         r flushall ; # Clean up keyspace to avoid interference by keys from other tests
         set repl [attach_to_replication_stream]

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -656,7 +656,7 @@ start_server {tags {"geo"}} {
             if {$res != $res2} {
                 set diff [compare_lists $res $res2]
                 puts "*** Possible problem in GEO radius query ***"
-                puts "Redis: $res"
+                puts "Valkey: $res"
                 puts "Tcl  : $res2"
                 puts "Diff : $diff"
                 puts [join $debuginfo "\n"]
@@ -664,7 +664,7 @@ start_server {tags {"geo"}} {
                     if {[lsearch -exact $res2 $place] != -1} {
                         set where "(only in Tcl)"
                     } else {
-                        set where "(only in Redis)"
+                        set where "(only in Valkey)"
                     }
                     lassign [lindex [r geopos mypoints $place] 0] lon lat
                     set mydist [geo_distance $lon $lat $search_lon $search_lat]

--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -118,7 +118,7 @@ start_server {tags {"introspection"}} {
         assert_match {*calls=1,*} [cmdstat geoadd]
     } {} {needs:config-resetstat}
 
-    test {COMMAND COUNT get total number of Redis commands} {
+    test {COMMAND COUNT get total number of commands} {
         assert_morethan [r command count] 0
     }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1,8 +1,8 @@
 start_server {tags {"introspection"}} {
     test "PING" {
         assert_equal {PONG} [r ping]
-        assert_equal {redis} [r ping redis]
-        assert_error {*wrong number of arguments for 'ping' command} {r ping hello redis}
+        assert_equal {valkey} [r ping valkey]
+        assert_error {*wrong number of arguments for 'ping' command} {r ping hello valkey}
     }
 
     test {CLIENT LIST} {
@@ -739,7 +739,7 @@ start_server {tags {"introspection"}} {
         catch {exec src/valkey-server --shutdown-on-sigint "now force" --shutdown-on-sigterm} err
         assert_match {*'shutdown-on-sigterm'*argument(s) must be one of the following*} $err
 
-        # Something like `redis-server --some-config --config-value1 --config-value2 --loglevel debug` would break,
+        # Something like `valkey-server --some-config --config-value1 --config-value2 --loglevel debug` would break,
         # because if you want to pass a value to a config starting with `--`, it can only be a single value.
         catch {exec src/valkey-server --replicaof 127.0.0.1 abc} err
         assert_match {*'replicaof "127.0.0.1" "abc"'*Invalid master port*} $err

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -225,7 +225,7 @@ start_server {tags {"maxmemory external:skip"}} {
             }
             # If we add the same number of keys already added again and
             # the policy is allkeys-* we should still be under the limit.
-            # Otherwise we should see an error reported by Redis.
+            # Otherwise we should see an error reported by Server.
             set err 0
             for {set j 0} {$j < $numkeys} {incr j} {
                 if {[catch {r set [randomKey] x} e]} {

--- a/tests/unit/moduleapi/moduleauth.tcl
+++ b/tests/unit/moduleapi/moduleauth.tcl
@@ -286,7 +286,7 @@ start_server {tags {"modules"}} {
         assert_match {*calls=2,*,rejected_calls=0,failed_calls=1} [cmdstat auth]
     }
 
-    test {Disabling Redis User during blocking module auth} {
+    test {Disabling Valkey User during blocking module auth} {
         r config resetstat
         r acl setuser foo >pwd on ~* &* +@all
         set rd [valkey_deferring_client]

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -466,7 +466,7 @@ start_server {tags {"other external:skip"}} {
 
 start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
     r config set dynamic-hz no hz 500
-    test "Redis can trigger resizing" {
+    test "Server can trigger resizing" {
         r flushall
         # hashslot(foo) is 12182
         for {set j 1} {$j <= 128} {incr j} {
@@ -496,7 +496,7 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         }
     } {} {needs:debug}
 
-    test "Redis can rewind and trigger smaller slot resizing" {
+    test "Server can rewind and trigger smaller slot resizing" {
         # hashslot(foo) is 12182
         # hashslot(alice) is 749, smaller than hashslot(foo),
         # attempt to trigger a resize on it, see details in #12802.
@@ -526,7 +526,7 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
 }
 
 start_server {tags {"other external:skip"}} {
-    test "Redis can resize empty dict" {
+    test "Server can resize empty dict" {
         # Write and then delete 128 keys, creating an empty dict
         r flushall
         for {set j 1} {$j <= 128} {incr j} {

--- a/tests/unit/printver.tcl
+++ b/tests/unit/printver.tcl
@@ -2,5 +2,5 @@ start_server {} {
     set i [r info]
     regexp {redis_version:(.*?)\r\n} $i - version
     regexp {redis_git_sha1:(.*?)\r\n} $i - sha1
-    puts "Testing Redis version $version ($sha1)"
+    puts "Testing Valkey version $version ($sha1)"
 }

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -94,7 +94,7 @@ start_server {tags {"protocol network"}} {
                     set elapsed [expr {[clock seconds]-$test_start}]
                     if {$elapsed > $test_time_limit} {
                         close $s
-                        error "assertion:Redis did not closed connection after protocol desync"
+                        error "assertion:Valkey did not closed connection after protocol desync"
                     }
                 }
             }

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -483,7 +483,7 @@ start_server {tags {"pubsub network"}} {
         r hello 3
 
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,
-        # breaks the multi response, see https://github.com/redis/redis/issues/12207
+        # breaks the multi response, see Redis OSS issue: https://github.com/redis/redis/issues/12207
         # this is just a temporary sanity test to detect unintended breakage.
 
         # subscribe for 3 channels actually emits 3 "responses"

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1055,7 +1055,7 @@ start_server {tags {"scripting"}} {
     test "Try trick global protection 3" {
         catch {
             run_script {
-                valkey = function() return 1 end
+                redis = function() return 1 end
             } 0
         } e
         set _ $e


### PR DESCRIPTION
This PR covers below cases.

1. test suite's prints(i.e., puts statement logs).
2. Links refering to redis issues.
3. test names contains redis.
