### PR TITLE
Mention one of rediss:// and valkeys:// in error message, not both

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -50,6 +50,14 @@
 
 #define UNUSED(V) ((void) V)
 
+/* Scheme specific constants. */
+#define SCHEME_PREFIX_DELIM "://"
+#define SCHEME_VALKEY "valkey://"
+#define TLS_SCHEME_VALKEY "valkeys://"
+/* We need to support redis:// and rediss:// too for backward compatibility. */
+#define SCHEME_PRE_VALKEY "redis://"
+#define TLS_SCHEME_PRE_VALKEY "rediss://"
+
 char *serverGitSHA1(void);
 char *serverGitDirty(void);
 
@@ -318,36 +326,26 @@ void parseRedisUri(const char *uri, const char* tool_name, cliConnInfo *connInfo
     UNUSED(tls_flag);
 #endif
 
-    const char *scheme = "valkey://";
-    const char *tlsscheme = "valkeys://";
-    /* We need to support redis:// and rediss:// too for compatibility. */
-    const char *redisScheme = "redis://";
-    const char *redisTlsscheme = "rediss://";
     const char *curr = uri;
     const char *end = uri + strlen(uri);
     const char *userinfo, *username, *port, *host, *path;
 
     /* URI must start with a valid scheme. */
-    if (!strncasecmp(tlsscheme, curr, strlen(tlsscheme))) {
+    if (!strncasecmp(TLS_SCHEME_VALKEY, curr, strlen(TLS_SCHEME_VALKEY)) ||
+        !strncasecmp(TLS_SCHEME_PRE_VALKEY, curr, strlen(TLS_SCHEME_PRE_VALKEY))) {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
-        curr += strlen(tlsscheme);
+        char *del = strstr(curr, SCHEME_PREFIX_DELIM);
+        curr += (del - curr) + strlen(SCHEME_PREFIX_DELIM);
 #else
-        fprintf(stderr,"valkeys:// and rediss:// are only supported when %s is compiled with OpenSSL\n", tool_name);
+        char *curr_scheme = strtok(curr, SCHEME_PREFIX_DELIM);
+        fprintf(stderr,"%s:// is only supported when %s is compiled with OpenSSL\n", curr_scheme, tool_name);
         exit(1);
 #endif
-    } else if (!strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
-#ifdef USE_OPENSSL
-        *tls_flag = 1;
-        curr += strlen(redisTlsscheme);
-#else
-        fprintf(stderr,"valkeys:// and rediss:// are only supported when %s is compiled with OpenSSL\n", tool_name);
-        exit(1);
-#endif
-    } else if (!strncasecmp(scheme, curr, strlen(scheme))) {
-        curr += strlen(scheme);
-    } else if (!strncasecmp(redisScheme, curr, strlen(redisScheme))) {
-        curr += strlen(redisScheme);
+    } else if (!strncasecmp(SCHEME_VALKEY, curr, strlen(SCHEME_VALKEY)) ||
+               !strncasecmp(SCHEME_PRE_VALKEY, curr, strlen(SCHEME_PRE_VALKEY))) {
+        char *del = strstr(curr, SCHEME_PREFIX_DELIM);
+        curr += (del - curr) + strlen(SCHEME_PREFIX_DELIM);
     } else {
         fprintf(stderr,"Invalid URI scheme\n");
         exit(1);


### PR DESCRIPTION
When using a TLS scheme for valkey-cli and benchmark-cli compiled without TLS, make the error message only mention the scheme used.

Before:

    "valkeys:// and rediss:// are only supported when valkey-cli is compiled with OpenSSL"

After, depending on which scheme the user tried to use:

    "valkeys:// is only supported when valkey-cli is compiled with OpenSSL"
    "rediss:// is only supported when valkey-cli is compiled with OpenSSL"

Follow up of #199.