### PR TITLE
Modify mem_freed variable in evict.c and Update debug.c

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2625,7 +2625,7 @@ static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_
         if(tids_count == TIDS_MAX_SIZE) break;
     }
 
-    /* Swap the last tid with the the current thread id */
+    /* Swap the last tid with the current thread id */
     if(current_thread_index != -1) {
         pid_t last_tid = tids[tids_count - 1];
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -545,7 +545,7 @@ int performEvictions(void) {
 
     int keys_freed = 0;
     size_t mem_reported, mem_tofree;
-    long long mem_freed; /* May be negative */
+    long long mem_freed = 0; /* Maybe become negative */
     mstime_t latency, eviction_latency;
     long long delta;
     int slaves = listLength(server.slaves);
@@ -562,8 +562,6 @@ int performEvictions(void) {
     }
 
     unsigned long eviction_time_limit_us = evictionTimeLimitUs();
-
-    mem_freed = 0;
 
     latencyStartMonitor(latency);
 


### PR DESCRIPTION
Fix the mem_freed variable to be initialized with init.
with this PR prevents the variable from acting unknownly.

evict.c 548 line
long long mem_freed = 0;

debug.c 2628 line
Also, the word "the" appears twice in the comment.
fixed it.