### PR TITLE
Change default pidfile from redis.pid to valkey.pid

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -129,7 +129,7 @@ struct hdr_histogram;
 #define RDB_EOF_MARK_SIZE 40
 #define CONFIG_REPL_BACKLOG_MIN_SIZE (1024*16)          /* 16k */
 #define CONFIG_BGSAVE_RETRY_DELAY 5 /* Wait a few secs before trying again. */
-#define CONFIG_DEFAULT_PID_FILE "/var/run/redis.pid"
+#define CONFIG_DEFAULT_PID_FILE "/var/run/valkey.pid"
 #define CONFIG_DEFAULT_BINDADDR_COUNT 2
 #define CONFIG_DEFAULT_BINDADDR { "*", "-::*" }
 #define NET_HOST_STR_LEN 256 /* Longest valid hostname */

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -3,7 +3,7 @@
 always-show-logo yes
 notify-keyspace-events KEA
 daemonize no
-pidfile /var/run/redis.pid
+pidfile /var/run/valkey.pid
 port 6379
 timeout 0
 bind 127.0.0.1

--- a/tests/assets/minimal.conf
+++ b/tests/assets/minimal.conf
@@ -1,5 +1,5 @@
 # Minimal configuration for testing.
 always-show-logo yes
 daemonize no
-pidfile /var/run/redis.pid
+pidfile /var/run/valkey.pid
 loglevel verbose

--- a/valkey.conf
+++ b/valkey.conf
@@ -329,7 +329,7 @@ daemonize no
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/redis.pid".
+# is used even if not specified, defaulting to "/var/run/valkey.pid".
 #
 # Creating a pid file is best effort: if the server is not able to create it
 # nothing bad happens, the server will start and run normally.


### PR DESCRIPTION
Changes the default value for the `pidfile` config.

The template config file `valkey.conf` already contains `pidfile /var/run/valkey_6379.pid`. This is not a default. The default is what you get when you start valkey without config.

Tests suites config pidfile changed to valkey accordingly.

Fixes #321