### PR TITLE
correct the name of Apple's OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ It supports a wide range of native structures and an extensible plugin system fo
 Building Valkey
 --------------
 
-Valkey can be compiled and used on Linux, OSX, OpenBSD, NetBSD, FreeBSD.
+Valkey can be compiled and used on Linux, macOS, OpenBSD, NetBSD, FreeBSD.
 We support big endian and little endian architectures, and both 32 bit
 and 64 bit systems.
 
 It may compile on Solaris derived systems (for instance SmartOS) but our
 support for this platform is *best effort* and Valkey is not guaranteed to
-work as well as in Linux, OSX, and \*BSD.
+work as well as in Linux, macOS, and \*BSD.
 
 It is as simple as:
 
@@ -199,7 +199,7 @@ for Ubuntu and Debian systems:
     % cd utils
     % ./install_server.sh
 
-_Note_: `install_server.sh` will not work on Mac OSX; it is built for Linux only.
+_Note_: `install_server.sh` will not work on macOS; it is built for Linux only.
 
 The script will ask you a few questions and will setup everything you need
 to run Valkey properly as a background daemon that will start again on


### PR DESCRIPTION
Apple stopped using the name "OS X" in 2016.  (And they never used "OSX", without the space.)