### PR TITLE
Change default syslog-ident from redis to valkey

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3128,7 +3128,7 @@ standardConfig static_configs[] = {
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", NULL, NULL),
     createStringConfig("cluster-announce-hostname", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_hostname, NULL, isValidAnnouncedHostname, updateClusterHostname),
     createStringConfig("cluster-announce-human-nodename", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_human_nodename, NULL, isValidAnnouncedNodename, updateClusterHumanNodename),
-    createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "redis", NULL, NULL),
+    createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "valkey", NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),
     createStringConfig("appendfilename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_filename, "appendonly.aof", isValidAOFfilename, NULL),
     createStringConfig("appenddirname", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_dirname, "appendonlydir", isValidAOFdirname, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -457,7 +457,6 @@ void loadServerConfigFromString(char *config) {
     sds *lines;
     sds *argv = NULL;
     int argc;
-    int syslog_ident_use_default = 1; /* Flag to decide whether or not use default for the syslog-ident config. */
 
     reading_config_file = 1;
     lines = sdssplitlen(config,strlen(config),"\n",1,&totlines);
@@ -511,11 +510,6 @@ void loadServerConfigFromString(char *config) {
                 if (!config->interface.set(config, &argv[1], argc-1, &err)) {
                     goto loaderr;
                 }
-            }
-
-            /* Check whether user provided custom config for the syslog-ident */
-            if (!strcasecmp(argv[0],"syslog-ident")) {
-                syslog_ident_use_default = 0;
             }
 
             sdsfreesplitres(argv,argc);
@@ -633,12 +627,6 @@ void loadServerConfigFromString(char *config) {
     /* To ensure backward compatibility and work while hz is out of range */
     if (server.config_hz < CONFIG_MIN_HZ) server.config_hz = CONFIG_MIN_HZ;
     if (server.config_hz > CONFIG_MAX_HZ) server.config_hz = CONFIG_MAX_HZ;
-
-    /* For backward compatibility with the Redis OSS */
-    if (syslog_ident_use_default) {
-        zfree(server.syslog_ident);
-        server.syslog_ident = server.extended_redis_compat ? "redis" : SERVER_NAME;
-    }
 
     sdsfreesplitres(lines,totlines);
     reading_config_file = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -457,6 +457,7 @@ void loadServerConfigFromString(char *config) {
     sds *lines;
     sds *argv = NULL;
     int argc;
+    int syslog_ident_use_default = 1; /* Flag to decide whether or not use default for the syslog-ident config. */
 
     reading_config_file = 1;
     lines = sdssplitlen(config,strlen(config),"\n",1,&totlines);
@@ -510,6 +511,11 @@ void loadServerConfigFromString(char *config) {
                 if (!config->interface.set(config, &argv[1], argc-1, &err)) {
                     goto loaderr;
                 }
+            }
+
+            /* Check whether user provided custom config for the syslog-ident */
+            if (!strcasecmp(argv[0],"syslog-ident")) {
+                syslog_ident_use_default = 0;
             }
 
             sdsfreesplitres(argv,argc);
@@ -629,7 +635,10 @@ void loadServerConfigFromString(char *config) {
     if (server.config_hz > CONFIG_MAX_HZ) server.config_hz = CONFIG_MAX_HZ;
 
     /* For backward compatibility with the Redis OSS */
-    server.syslog_ident = server.extended_redis_compat ? "redis" : SERVER_NAME;
+    if (syslog_ident_use_default) {
+        zfree(server.syslog_ident);
+        server.syslog_ident = server.extended_redis_compat ? "redis" : SERVER_NAME;
+    }
 
     sdsfreesplitres(lines,totlines);
     reading_config_file = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -628,6 +628,9 @@ void loadServerConfigFromString(char *config) {
     if (server.config_hz < CONFIG_MIN_HZ) server.config_hz = CONFIG_MIN_HZ;
     if (server.config_hz > CONFIG_MAX_HZ) server.config_hz = CONFIG_MAX_HZ;
 
+    /* For backward compatibility with the Redis OSS */
+    server.syslog_ident = server.extended_redis_compat ? "redis" : SERVER_NAME;
+
     sdsfreesplitres(lines,totlines);
     reading_config_file = 0;
     return;
@@ -3128,7 +3131,7 @@ standardConfig static_configs[] = {
     createStringConfig("cluster-config-file", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.cluster_configfile, "nodes.conf", NULL, NULL),
     createStringConfig("cluster-announce-hostname", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_hostname, NULL, isValidAnnouncedHostname, updateClusterHostname),
     createStringConfig("cluster-announce-human-nodename", NULL, MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.cluster_announce_human_nodename, NULL, isValidAnnouncedNodename, updateClusterHumanNodename),
-    createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, "valkey", NULL, NULL),
+    createStringConfig("syslog-ident", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.syslog_ident, SERVER_NAME, NULL, NULL),
     createStringConfig("dbfilename", NULL, MODIFIABLE_CONFIG | PROTECTED_CONFIG, ALLOW_EMPTY_STRING, server.rdb_filename, "dump.rdb", isValidDBfilename, NULL),
     createStringConfig("appendfilename", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_filename, "appendonly.aof", isValidAOFfilename, NULL),
     createStringConfig("appenddirname", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.aof_dirname, "appendonlydir", isValidAOFdirname, NULL),

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -388,6 +388,31 @@ start_server {tags {"other"}} {
             assert_no_match "*redis_mode:*" $info
             assert_match "*server_mode:*" $info
         }
+
+        # When the extended redis compatibility is enabled, syslog-ident default should be "redis" by default
+        start_server {config "minimal.conf" overrides {extended-redis-compatibility {yes}}} {
+            assert_equal "redis"  [lindex [r config get syslog-ident] 1]
+        }
+
+        # Default for the config syslog-ident should be "valkey", where extended-redis-compatibility is disabled by default
+        assert_equal "valkey" [lindex [r config get syslog-ident] 1]
+    }
+
+    test "Custom syslog-ident config" {
+        # Any user configured syslog-ident is not affected
+        start_server {config "minimal.conf" overrides {syslog-ident {"redis"}}} {
+            assert_equal "redis" [lindex [r config get syslog-ident] 1]
+        }
+
+        # Any user configured syslog-ident is not affected even when the extended-redis-compatibility is enabled
+        start_server {config "minimal.conf" overrides {syslog-ident {"abcd"} extended-redis-compatibility yes}} {
+            assert_equal "abcd" [lindex [r config get syslog-ident] 1]
+        }
+
+        # Any user configured syslog-ident is not affected even when it is an empty string
+        start_server {config "minimal.conf" overrides {syslog-ident {""}}} {
+            assert_equal "" [lindex [r config get syslog-ident] 1]
+        }
     }
 }
 

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -388,31 +388,6 @@ start_server {tags {"other"}} {
             assert_no_match "*redis_mode:*" $info
             assert_match "*server_mode:*" $info
         }
-
-        # When the extended redis compatibility is enabled, syslog-ident default should be "redis" by default
-        start_server {config "minimal.conf" overrides {extended-redis-compatibility {yes}}} {
-            assert_equal "redis"  [lindex [r config get syslog-ident] 1]
-        }
-
-        # Default for the config syslog-ident should be "valkey", where extended-redis-compatibility is disabled by default
-        assert_equal "valkey" [lindex [r config get syslog-ident] 1]
-    }
-
-    test "Custom syslog-ident config" {
-        # Any user configured syslog-ident is not affected
-        start_server {config "minimal.conf" overrides {syslog-ident {"redis"}}} {
-            assert_equal "redis" [lindex [r config get syslog-ident] 1]
-        }
-
-        # Any user configured syslog-ident is not affected even when the extended-redis-compatibility is enabled
-        start_server {config "minimal.conf" overrides {syslog-ident {"abcd"} extended-redis-compatibility yes}} {
-            assert_equal "abcd" [lindex [r config get syslog-ident] 1]
-        }
-
-        # Any user configured syslog-ident is not affected even when it is an empty string
-        start_server {config "minimal.conf" overrides {syslog-ident {""}}} {
-            assert_equal "" [lindex [r config get syslog-ident] 1]
-        }
     }
 }
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -357,7 +357,7 @@ logfile ""
 # syslog-enabled no
 
 # Specify the syslog identity.
-# syslog-ident redis
+# syslog-ident valkey
 
 # Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 # syslog-facility local0


### PR DESCRIPTION
Default value for the "syslog-ident" config changed from "redis" to "valkey".

Fixes #301.