### PR TITLE
Make sure standard library is imported when using abort

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -144,6 +144,7 @@
 #if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define valkey_unreachable __builtin_unreachable
 #else
+#include <stdlib.h>
 #define valkey_unreachable abort
 #endif
 


### PR DESCRIPTION
While playing around with https://github.com/valkey-io/valkey/pull/344/files, I found a few cases where serverAssert() resulted in abort being added, but abort requires stdlib. So, when serverAssert() uses abort, also automatically include stdlib.