### PR TITLE
Don't include config.h from serverassert.h

### DIFF
--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -40,8 +40,8 @@
 
 /* This is a drop-in replacement of assert. We use it even in code copied from
  * other sources. To make these files usable outside of Valkey, it should be
- * enough to replace this include with <assert.h>. Therefore, this file shoudn't
- * have any dependencies to any other valkey code. */
+ * enough to replace this include with <assert.h>. Therefore, this file
+ * shouldn't have any dependencies to any other valkey code. */
 
 #if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define valkey_unreachable __builtin_unreachable

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -38,7 +38,23 @@
 #ifndef VALKEY_ASSERT_H
 #define VALKEY_ASSERT_H
 
-#include "config.h"
+/* This is a drop-in replacement of assert. We use it even in code copied from
+ * other sources. To make these files usable outside of Valkey, it should be
+ * enough to replace this include with <assert.h>. Therefore, this file shoudn't
+ * have any dependencies to any other valkey code. */
+
+#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#define valkey_unreachable __builtin_unreachable
+#else
+#include <stdlib.h>
+#define valkey_unreachable abort
+#endif
+
+#if __GNUC__ >= 3
+#define likely(x) __builtin_expect(!!(x), 1)
+#else
+#define likely(x) (x)
+#endif
 
 #define assert(_e) (likely((_e))?(void)0 : (_serverAssert(#_e,__FILE__,__LINE__),valkey_unreachable()))
 #define panic(...) _serverPanic(__FILE__,__LINE__,__VA_ARGS__),valkey_unreachable()

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -38,10 +38,7 @@
 #ifndef VALKEY_ASSERT_H
 #define VALKEY_ASSERT_H
 
-/* This is a drop-in replacement of assert. We use it even in code copied from
- * other sources. To make these files usable outside of Valkey, it should be
- * enough to replace this include with <assert.h>. Therefore, this file
- * shouldn't have any dependencies to any other valkey code. */
+/* This file shouldn't have any dependencies to any other Valkey code. */
 
 #if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
 #define valkey_unreachable __builtin_unreachable


### PR DESCRIPTION
Serverassert is a drop-in replacement of assert. We use it even in code copied from other sources. To make these files usable outside of Valkey, it should be enough to replace the `serverassert.h` include with `<assert.h>`. Therefore, this file shouldn't have any dependencies to the rest of the valkey code.

This was mentioned in comments in #350.