### PR TITLE
Rename __redis__:invalidate to __valkey__:invalidate from client-side-caching

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -195,7 +195,7 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
     if (TrackingTable == NULL) {
         TrackingTable = raxNew();
         PrefixTable = raxNew();
-        TrackingChannelName = createStringObject("__redis__:invalidate",20);
+        TrackingChannelName = createStringObject("__valkey__:invalidate",20);
     }
 
     /* For broadcasting, set the list of prefixes in the client. */
@@ -303,7 +303,7 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
     /* Only send such info for clients in RESP version 3 or more. However
      * if redirection is active, and the connection we redirect to is
      * in Pub/Sub mode, we can support the feature with RESP 2 as well,
-     * by sending Pub/Sub messages in the __redis__:invalidate channel. */
+     * by sending Pub/Sub messages in the __valkey__:invalidate channel. */
     if (c->resp > 2) {
         addReplyPushLen(c,2);
         addReplyBulkCBuffer(c,"invalidate",10);

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -195,7 +195,7 @@ void enableTracking(client *c, uint64_t redirect_to, uint64_t options, robj **pr
     if (TrackingTable == NULL) {
         TrackingTable = raxNew();
         PrefixTable = raxNew();
-        TrackingChannelName = createStringObject("__valkey__:invalidate",20);
+        TrackingChannelName = createStringObject("__valkey__:invalidate",21);
     }
 
     /* For broadcasting, set the list of prefixes in the client. */

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -203,7 +203,7 @@ start_server {} {
         set redirected_c [valkey_client]
         $redirected_c client setname redirected_client
         set redir_id [$redirected_c client id]
-        $redirected_c SUBSCRIBE __redis__:invalidate
+        $redirected_c SUBSCRIBE __valkey__:invalidate
         $rr client tracking on redirect $redir_id bcast
         # Use a big key name to fill the redirected tracking client's buffer quickly
         set key_length [expr 1024*200]

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -5,7 +5,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
     set rd_redirection [valkey_deferring_client]
     $rd_redirection client id
     set redir_id [$rd_redirection read]
-    $rd_redirection subscribe __redis__:invalidate
+    $rd_redirection subscribe __valkey__:invalidate
     $rd_redirection read ; # Consume the SUBSCRIBE reply.
 
     # Create another client that's not used as a redirection client
@@ -28,7 +28,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
             set rd_redirection [valkey_deferring_client]
             $rd_redirection client id
             set redir_id [$rd_redirection read]
-            $rd_redirection subscribe __redis__:invalidate
+            $rd_redirection subscribe __valkey__:invalidate
             $rd_redirection read ; # Consume the SUBSCRIBE reply.
             r FLUSHALL
             r HELLO 2
@@ -272,7 +272,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         set rd_redirection [valkey_deferring_client]
         $rd_redirection CLIENT ID
         set redir_id [$rd_redirection read]
-        $rd_redirection SUBSCRIBE __redis__:invalidate
+        $rd_redirection SUBSCRIBE __valkey__:invalidate
         $rd_redirection read ; # Consume the SUBSCRIBE reply
     }
 
@@ -360,15 +360,15 @@ start_server {tags {"tracking network logreqres:skip"}} {
     }
 
     test {Able to redirect to a RESP3 client} {
-        $rd_redirection UNSUBSCRIBE __redis__:invalidate ; # Need to unsub first before we can do HELLO 3
+        $rd_redirection UNSUBSCRIBE __valkey__:invalidate ; # Need to unsub first before we can do HELLO 3
         set res [$rd_redirection read] ; # Consume the UNSUBSCRIBE reply
-        assert_equal {__redis__:invalidate} [lindex $res 1]
+        assert_equal {__valkey__:invalidate} [lindex $res 1]
         $rd_redirection HELLO 3
         set res [$rd_redirection read] ; # Consume the HELLO reply
         assert_equal [dict get $reply proto] 3
-        $rd_redirection SUBSCRIBE __redis__:invalidate
+        $rd_redirection SUBSCRIBE __valkey__:invalidate
         set res [$rd_redirection read] ; # Consume the SUBSCRIBE reply
-        assert_equal {__redis__:invalidate} [lindex $res 1]
+        assert_equal {__valkey__:invalidate} [lindex $res 1]
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1


### PR DESCRIPTION
Change the name of the internal tracking channel handled by client side caching from redis to valkey.

And then, Update in the corresponding <code>tracking.c</code>, <code>tracking.tcl</code>, and <code>client-eviction.tcl files</code>.

I tested Client tracking through the valkey server.

![valkey_server](https://github.com/valkey-io/valkey/assets/70243256/6ca66c2e-0ae8-4946-bfe5-6121830a8033)
![client7_8_9](https://github.com/valkey-io/valkey/assets/70243256/74945d20-0cdf-470f-8501-2659270d493e)



The test environment has three clients and one server.
- The ID of the first client is 7
- The ID of the second client is 8
- The ID of the third client is 9

Test scenario:
I checked the ID value of each client.

Firstly, in Client 7(ID), command "Client tracking on redirect 8".
Enter the subscribe __valkey__:invalidate command on Client 8 (ID), and it is in the subscribe state.
Check the current value with get Tracking_key command on Client 7 (ID).
Result: (nill)

Next, enter the “set Tracking_key value1” command on Client 9 (ID).
At the same time, confirm that a message has been received from Client 8 (ID).
1) "message"
2) "__valkey__:invalidate"
3) 1 "Tracking_key"
You can check the changed Tracking_key value in Client 7 (ID) as picture of client 7.

Lastly, When Client 9(ID) changes back to value5 of Tracking_key, You can see that the __valkey__:invalidate invalidation message was received from client 8 (ID). 
It can check the changed Tracking_key value again in Client 7 (ID).

In conclusion, it was confirmed through testing that it was processed without problems.