### PR TITLE
Make LSC command does not accept WITHMATCHLEN or MINMATCHLEN options when used without IDX, as it does not make sense.

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -738,7 +738,7 @@ void lcsCommand(client *c) {
     uint32_t i, j;
     long long minmatchlen = 0;
     sds a = NULL, b = NULL;
-    int getlen = 0, getidx = 0, withmatchlen = 0;
+    int getlen = 0, getidx = 0, withmatchlen = 0, minmatchlenflag = 0;
     robj *obja = NULL, *objb = NULL;
 
     obja = lookupKeyRead(c->db,c->argv[1]);
@@ -773,6 +773,7 @@ void lcsCommand(client *c) {
             if (getLongLongFromObjectOrReply(c,c->argv[j+1],&minmatchlen,NULL)
                 != C_OK) goto cleanup;
             if (minmatchlen < 0) minmatchlen = 0;
+            minmatchlenflag = 1;
             j++;
         } else {
             addReplyErrorObject(c,shared.syntaxerr);
@@ -784,6 +785,12 @@ void lcsCommand(client *c) {
     if (getlen && getidx) {
         addReplyError(c,
             "If you want both the length and indexes, please just use IDX.");
+        goto cleanup;
+    }
+
+    /* Complain if user passed WITHMATCHLEN or MINMATCHLEN without IDX */
+    if ((withmatchlen || minmatchlenflag) && !getidx) {
+        addReplyError(c, "WITHMATCHLEN and MINMATCHLEN can only be used with IDX.");
         goto cleanup;
     }
 

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -647,6 +647,16 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         dict get [r LCS virus1{t} virus2{t} IDX WITHMATCHLEN MINMATCHLEN 5] matches
     } {{{1 222} {13 234} 222}}
 
+    test {LCS with LEN and IDX option} {
+        assert_error "ERR If you want both the length and indexes, please just use IDX." {r LCS virus1{t} virus2{t} LEN IDX}
+    }
+
+    test {LCS with WITHMATCHLEN and MINMATCHLEN option without IDX option} {
+        assert_error "*ERR*WITHMATCHLEN*MINMATCHLEN*can only be used with IDX*" {r LCS virus1{t} virus2{t} WITHMATCHLEN}
+        assert_error "*ERR*WITHMATCHLEN*MINMATCHLEN*can only be used with IDX*" {r LCS virus1{t} virus2{t} MINMATCHLEN 5}
+        assert_error "*ERR*WITHMATCHLEN*MINMATCHLEN*can only be used with IDX*" {r LCS virus1{t} virus2{t} LEN WITHMATCHLEN MINMATCHLEN 5}
+    }
+
     test {SETRANGE with huge offset} {
         foreach value {9223372036854775807 2147483647} {
             catch {[r setrange K $value A]} res


### PR DESCRIPTION
ref: https://github.com/redis/redis/pull/12387

WITHMATCHLEN and MINMATCHLEN options only makes sense when used with IDX, But still we are allowing it without IDX. Without IDX its doesn't matter and creates the confusion

**Current Behaviour**

```
127.0.0.1:6379> mget k1 k2
1) "mynameisrandomhello"
2) "mygateisnamehellorandom"

127.0.0.1:6379> lcs k1 k2 MINMATCHLEN 3 idx
1) "matches"
2) 1) 1) 1) (integer) 14
         2) (integer) 17
      2) 1) (integer) 12
         2) (integer) 15
   2) 1) 1) (integer) 5
         2) (integer) 7
      2) 1) (integer) 5
         2) (integer) 7
3) "len"
4) (integer) 13
127.0.0.1:6379> lcs k1 k2
"myaeisnmhello"
127.0.0.1:6379> lcs k1 k2 MINMATCHLEN 4
"myaeisnmhello"
127.0.0.1:6379> lcs k1 k2 MINMATCHLEN 2
"myaeisnmhello"
127.0.0.1:6379> lcs k1 k2 LEN MINMATCHLEN 4
(integer) 13

127.0.0.1:6379> lcs k1 k2 IDX WITHMATCHLEN MINMATCHLEN 3
1) "matches"
2) 1) 1) 1) (integer) 14
         2) (integer) 17
      2) 1) (integer) 12
         2) (integer) 15
      3) (integer) 4
   2) 1) 1) (integer) 5
         2) (integer) 7
      2) 1) (integer) 5
         2) (integer) 7
      3) (integer) 3
3) "len"
4) (integer) 13
127.0.0.1:6379> lcs k1 k2 WITHMATCHLEN
"myaeisnmhello"
127.0.0.1:6379> lcs k1 k2 WITHMATCHLEN LEN
(integer) 13
127.0.0.1:6379> lcs k1 k2 WITHMATCHLEN MINMATCHLEN 3
"myaeisnmhello"
```
**What I was expecting**
some error mentioning that it can only used with IDX ,

This PR Covers

Makes WITHMATCHLEN and MINMATCHLEN mutually inclusive with IDX
Covers 1 missing testcase when len and idx is given together.
```
127.0.0.1:6379> lcs k1 k2 withmatchlen minmatchlen 1
(error) ERR WITHMATCHLEN and MINMATCHLEN can only be used with IDX.
```