### PR TITLE
Fix issues for older versions of Darwin and improve PowerPC support

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -217,12 +217,13 @@ void setproctitle(const char *fmt, ...);
 
 #if defined(sel) || defined(pyr) || defined(mc68000) || defined(sparc) || \
     defined(is68k) || defined(tahoe) || defined(ibm032) || defined(ibm370) || \
-    defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) ||\
+    defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) || \
     defined(apollo) || defined(__convex__) || defined(_CRAY) || \
     defined(__hppa) || defined(__hp9000) || \
     defined(__hp9000s300) || defined(__hp9000s700) || \
-    defined (BIT_ZERO_ON_LEFT) || defined(m68k) || defined(__sparc)
-#define BYTE_ORDER	BIG_ENDIAN
+    defined (BIT_ZERO_ON_LEFT) || defined(m68k) || defined(__sparc) || \
+    (defined(__APPLE__) && defined(__POWERPC__))
+#define BYTE_ORDER    BIG_ENDIAN
 #endif
 #endif /* linux */
 #endif /* BSD */

--- a/src/config.h
+++ b/src/config.h
@@ -42,7 +42,7 @@
 #include <fcntl.h>
 #endif
 
-#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
 #define MAC_OS_10_6_DETECTED
 #endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -304,7 +304,7 @@ void setproctitle(const char *fmt, ...);
 #include <kernel/OS.h>
 #define valkey_set_thread_title(name) rename_thread(find_thread(0), name)
 #else
-#if (defined __APPLE__ && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
+#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
 int pthread_setname_np(const char *name);
 #include <pthread.h>
 #define valkey_set_thread_title(name) pthread_setname_np(name)

--- a/src/debug.c
+++ b/src/debug.c
@@ -1192,6 +1192,7 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     #elif defined(__i386__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
     #else
+    /* OSX PowerPC */
     GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
     #endif
 #elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
@@ -1200,6 +1201,8 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
     GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
     #elif defined(__i386__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
+    #elif defined(__ppc__)
+    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
     #else
     /* OSX ARM64 */
     void *old_val = (void*)arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
@@ -1344,7 +1347,7 @@ void logRegisters(ucontext_t *uc) {
         (unsigned long) uc->uc_mcontext->__ss.__gs
     );
     logStackContent((void**)uc->uc_mcontext->__ss.__esp);
-    #else
+    #elif defined(__arm64__)
     /* OSX ARM64 */
     serverLog(LL_WARNING,
     "\n"
@@ -1393,6 +1396,9 @@ void logRegisters(ucontext_t *uc) {
         (unsigned long) uc->uc_mcontext->__ss.__cpsr
     );
     logStackContent((void**) arm_thread_state64_get_sp(uc->uc_mcontext->__ss));
+    #else
+    /* At the moment we do not implement this for PowerPC */
+    NOT_SUPPORTED();
     #endif
 /* Linux */
 #elif defined(__linux__)


### PR DESCRIPTION
Existing code does not build on macOS < 10.7. There are two issues:
1. The check for `MAC_OS_10_6_DETECTED` does the opposite of what it should, since `AvailabilityMacros.h` does not define underscore-prefixed versions of macros. `__MAC_OS_X_VERSION_MAX_ALLOWED` evaluates to 0, and on 10.6 everything breaks down:
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_databases_valkey/valkey/work/compwrap/cc/opt/local/bin/clang-mp-11 -pedantic -DREDIS_STATIC='' -Wno-c11-extensions -std=gnu11 -Wall -W -Wno-missing-field-initializers -Werror=deprecated-declarations -Wstrict-prototypes -O3 -g -ggdb -arch x86_64 -isystem/opt/local/include/LegacySupport -isystem/opt/local/include -I../deps/hiredis -I../deps/linenoise -I../deps/lua/src -I../deps/hdr_histogram -I../deps/fpconv -DUSE_JEMALLOC -I../deps/jemalloc/include -DUSE_OPENSSL=1 -I/usr/local/opt/openssl/include -DBUILD_TLS_MODULE=0 -MMD -o rdb.o -c rdb.c
replication.c:1666:21: error: 'fstat64' is deprecated [-Werror,-Wdeprecated-declarations]
                    redis_fstat(slave->repldbfd,&buf) == -1) {
                    ^
./config.h:50:21: note: expanded from macro 'redis_fstat'
#define redis_fstat fstat64
                    ^
/usr/include/sys/stat.h:463:35: note: 'fstat64' has been explicitly marked deprecated here
int     fstat64(int, struct stat64 *) __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_5,__MAC_10_6,__IPHONE_NA,__IPHONE_NA);
                                      ^
/usr/include/Availability.h:137:53: note: expanded from macro '__OSX_AVAILABLE_BUT_DEPRECATED'
                                                    __AVAILABILITY_INTERNAL##_macIntro##_DEP##_macDep
                                                    ^
<scratch space>:179:1: note: expanded from here
__AVAILABILITY_INTERNAL__MAC_10_5_DEP__MAC_10_6
^
/usr/include/AvailabilityInternal.h:253:72: note: expanded from macro '__AVAILABILITY_INTERNAL__MAC_10_5_DEP__MAC_10_6'
        #define __AVAILABILITY_INTERNAL__MAC_10_5_DEP__MAC_10_6        __AVAILABILITY_INTERNAL_DEPRECATED
                                                                       ^
/usr/include/AvailabilityInternal.h:36:67: note: expanded from macro '__AVAILABILITY_INTERNAL_DEPRECATED'
#define __AVAILABILITY_INTERNAL_DEPRECATED         __attribute__((deprecated,visibility("default")))
                                                                  ^
1 error generated.
make[1]: *** [replication.o] Error 1
```
Credits to @mohd-akram who pointed out at possible origin of the this problem.

2. Once that is fixed, on 10.6 when building for `ppc` there are new errors, because the code uses inaccurate assumptions for archs. Fix that too.