### PR TITLE
Change strlcat function name from redis to valkey

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -65,7 +65,7 @@
 #if (__GNUC__ && __GNUC__ >= 4) && !defined __APPLE__
 int sprintf(char *str, const char *format, ...) __attribute__((deprecated("please avoid use of unsafe C functions. prefer use of snprintf instead")));
 char *strcpy(char *restrict dest, const char *src) __attribute__((deprecated("please avoid use of unsafe C functions. prefer use of valkey_strlcpy instead")));
-char *strcat(char *restrict dest, const char *restrict src) __attribute__((deprecated("please avoid use of unsafe C functions. prefer use of redis_strlcat instead")));
+char *strcat(char *restrict dest, const char *restrict src) __attribute__((deprecated("please avoid use of unsafe C functions. prefer use of valkey_strlcat instead")));
 #endif
 
 #ifdef __linux__

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1615,8 +1615,8 @@ void rdbRemoveTempFile(pid_t childpid, int from_signal) {
     /* Generate temp rdb file name using async-signal safe functions. */
     ll2string(pid, sizeof(pid), childpid);
     valkey_strlcpy(tmpfile, "temp-", sizeof(tmpfile));
-    redis_strlcat(tmpfile, pid, sizeof(tmpfile));
-    redis_strlcat(tmpfile, ".rdb", sizeof(tmpfile));
+    valkey_strlcat(tmpfile, pid, sizeof(tmpfile));
+    valkey_strlcat(tmpfile, ".rdb", sizeof(tmpfile));
 
     if (from_signal) {
         /* bg_unlink is not async-signal-safe, but in this case we don't really

--- a/src/strl.c
+++ b/src/strl.c
@@ -53,7 +53,7 @@ valkey_strlcpy(char *dst, const char *src, size_t dsize)
  * If retval >= dsize, truncation occurred.
  */
 size_t
-redis_strlcat(char *dst, const char *src, size_t dsize)
+valkey_strlcat(char *dst, const char *src, size_t dsize)
 {
     const char *odst = dst;
     const char *osrc = src;

--- a/src/util.h
+++ b/src/util.h
@@ -98,7 +98,7 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...)
 int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...);
 #endif
 size_t valkey_strlcpy(char *dst, const char *src, size_t dsize);
-size_t redis_strlcat(char *dst, const char *src, size_t dsize);
+size_t valkey_strlcat(char *dst, const char *src, size_t dsize);
 
 #ifdef SERVER_TEST
 int utilTest(int argc, char **argv, int flags);


### PR DESCRIPTION
Updated strlcat function and macros name (redis_strlcat -> valkey_strlcat).

I think the standard strcat function is not safe.
(https://codeql.github.com/codeql-query-help/cpp/cpp-unsafe-strcat/)
So, it would be better to keep it as a safe function.