### PR TITLE
Use kqueue as the backend of AE on DragonFlyBSD

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -115,7 +115,12 @@
 #define HAVE_PIPE2 1
 #endif
 
-#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
+/* Detect for kqueue */
+#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || \
+    defined(__DragonFly__) || \
+    defined(__FreeBSD__) || \
+    defined(__OpenBSD__) || \
+    defined (__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif
 


### PR DESCRIPTION
Currently, we use select(2) on DragonFlyBSD while
`kqueue` is available on DragonFlyBSD since FreeBSD 4.1
and DragonFlyBSD was originally forked from FreeBSD 4.8

`select(2)` is a pretty old technique that has many defects
compared to `kqueue`, we should switch to `kqueue` on DragonFlyBSD.