### PR TITLE
Don't try to set SO_REUSEADDR on sockets of AF_UNIX

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -616,7 +616,7 @@ int anetUnixServer(char *err, char *path, mode_t perm, int backlog)
     }
 
     int type = SOCK_STREAM;
-    int flags = ANET_SOCKET_CLOEXEC | ANET_SOCKET_NONBLOCK | ANET_SOCKET_REUSEADDR;
+    int flags = ANET_SOCKET_CLOEXEC | ANET_SOCKET_NONBLOCK;
     if ((s = anetCreateSocket(err,AF_LOCAL,type,0,flags)) == ANET_ERR)
         return ANET_ERR;
 


### PR DESCRIPTION
Despite the fact that SO_REUSEADDR can be set on a Unix domain socket via setsockopt() without reporting an error, SO_REUSEADDR was actually created for ipv4/ipv6 and it's not supported for sockets of AF_UNIX.

Therefore, setting this option on a Unix domain socket does nothing but costs one extra system call.