### PR TITLE
Add zfree_with_size to optimize sdsfree since we can get zmalloc_size from the header

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,13 +21,13 @@ CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 # some automatic defaults are added to it. To specify optimization flags
 # explicitly without any defaults added, pass the OPT variable instead.
 OPTIMIZATION?=-O3
-# ifeq ($(OPTIMIZATION),-O3)
-# 	ifeq (clang,$(CLANG))
-# 		OPTIMIZATION+=-flto
-# 	else
-# 		OPTIMIZATION+=-flto=auto
-# 	endif
-# endif
+ifeq ($(OPTIMIZATION),-O3)
+	ifeq (clang,$(CLANG))
+		OPTIMIZATION+=-flto
+	else
+		OPTIMIZATION+=-flto=auto
+	endif
+endif
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,13 +21,13 @@ CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 # some automatic defaults are added to it. To specify optimization flags
 # explicitly without any defaults added, pass the OPT variable instead.
 OPTIMIZATION?=-O3
-ifeq ($(OPTIMIZATION),-O3)
-	ifeq (clang,$(CLANG))
-		OPTIMIZATION+=-flto
-	else
-		OPTIMIZATION+=-flto=auto
-	endif
-endif
+# ifeq ($(OPTIMIZATION),-O3)
+# 	ifeq (clang,$(CLANG))
+# 		OPTIMIZATION+=-flto
+# 	else
+# 		OPTIMIZATION+=-flto=auto
+# 	endif
+# endif
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer
 endif

--- a/src/sds.c
+++ b/src/sds.c
@@ -39,6 +39,7 @@
 #include "sds.h"
 #include "sdsalloc.h"
 #include "util.h"
+#include "zmalloc.h"
 
 const char *SDS_NOINIT = "SDS_NOINIT";
 
@@ -195,13 +196,7 @@ sds sdsdup(const sds s) {
 /* Free an sds string. No operation is performed if 's' is NULL. */
 void sdsfree(sds s) {
     if (s == NULL) return;
-
-    /* SDS_TYPE_5 header doesn't contain the size of the allocation */
-    if ((s[-1] & SDS_TYPE_MASK) == SDS_TYPE_5) {
-        s_free(sdsAllocPtr(s));
-    } else {
-        s_free_with_size(sdsAllocPtr(s), sdsAllocSize(s));
-    }
+    s_free_with_size(sdsAllocPtr(s), sdsAllocSize(s));
 }
 
 /* Set the sds string length to the length as obtained with strlen(), so
@@ -375,7 +370,7 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
          * We aim to avoid calling realloc() when using Jemalloc if there is no
          * change in the allocation size, as it incurs a cost even if the
          * allocation size stays the same. */
-        bufsize = zmalloc_size(sh);
+        bufsize = sdsAllocSize(s);
         alloc_already_optimal = (je_nallocx(newlen, 0) == bufsize);
 #endif
         if (!alloc_already_optimal) {
@@ -418,8 +413,13 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
  * 4) The implicit null term.
  */
 size_t sdsAllocSize(sds s) {
-    size_t alloc = sdsalloc(s);
-    return sdsHdrSize(s[-1]) + alloc + 1;
+    char type = s[-1] & SDS_TYPE_MASK;
+    /* SDS_TYPE_5 header doesn't contain the size of the allocation */
+    if (type == SDS_TYPE_5) {
+        return zmalloc_size(sdsAllocPtr(s));
+    } else {
+        return sdsHdrSize(type) + sdsalloc(s) + 1;
+    }
 }
 
 /* Return the pointer of the actual SDS allocation (normally SDS strings

--- a/src/sds.c
+++ b/src/sds.c
@@ -39,7 +39,6 @@
 #include "sds.h"
 #include "sdsalloc.h"
 #include "util.h"
-#include "zmalloc.h"
 
 const char *SDS_NOINIT = "SDS_NOINIT";
 
@@ -416,7 +415,7 @@ size_t sdsAllocSize(sds s) {
     char type = s[-1] & SDS_TYPE_MASK;
     /* SDS_TYPE_5 header doesn't contain the size of the allocation */
     if (type == SDS_TYPE_5) {
-        return zmalloc_size(sdsAllocPtr(s));
+        return s_malloc_size(sdsAllocPtr(s));
     } else {
         return sdsHdrSize(type) + sdsalloc(s) + 1;
     }

--- a/src/sds.c
+++ b/src/sds.c
@@ -195,7 +195,13 @@ sds sdsdup(const sds s) {
 /* Free an sds string. No operation is performed if 's' is NULL. */
 void sdsfree(sds s) {
     if (s == NULL) return;
-    s_free((char *)s - sdsHdrSize(s[-1]));
+
+    /* SDS_TYPE_5 header doesn't contain the size of the allocation */
+    if ((s[-1] & SDS_TYPE_MASK) == SDS_TYPE_5) {
+        s_free(sdsAllocPtr(s));
+    } else {
+        s_free_with_size(sdsAllocPtr(s), sdsAllocSize(s));
+    }
 }
 
 /* Set the sds string length to the length as obtained with strlen(), so

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -45,6 +45,7 @@
 #define s_trymalloc ztrymalloc
 #define s_tryrealloc ztryrealloc
 #define s_free zfree
+#define s_free_with_size zfree_with_size
 #define s_malloc_usable zmalloc_usable
 #define s_realloc_usable zrealloc_usable
 #define s_trymalloc_usable ztrymalloc_usable

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -362,9 +362,9 @@ size_t zmalloc_usable_size(void *ptr) {
 #endif
 
 /* Frees the memory buffer pointed by ptr and updates statistics.
- * ptr must already point to the start of the buffer. On systems where we store
+ * ptr must point to the start of the buffer. On systems where we store
  * an additional header, the caller must do the necessary adjustments.
- * ptr must not be NULL. With jemalloc this function uses the fast track by
+ * ptr must not be NULL. When using jemalloc this function uses the fast track by
  * specifying the buffer size */
 void zfree_with_size(void *ptr, size_t size) {
     update_zmalloc_stat_free(size);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -361,11 +361,16 @@ size_t zmalloc_usable_size(void *ptr) {
 }
 #endif
 
-/* Frees the memory buffer pointed by ptr and updates statistics.
- * ptr must point to the start of the buffer. On systems where we store
- * an additional header, the caller must do the necessary adjustments.
- * ptr must not be NULL. When using jemalloc this function uses the fast track by
- * specifying the buffer size */
+/* Frees the memory buffer pointed by ptr and updates statistics. When using
+ * jemalloc this function uses the fast track by specifying the buffer size.
+ *
+ * ptr must point to the start of the buffer. On systems where we have
+ * the additional header with size, the caller must do the necessary adjustments
+ * to ptr. ptr must not be NULL.
+ * The caller is responsible to provide the real allocaction size.
+ *
+ * If the caller can't satisfy any of the conditions above, it should call
+ * zfree() instead. */
 void zfree_with_size(void *ptr, size_t size) {
     update_zmalloc_stat_free(size);
 

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -364,11 +364,11 @@ size_t zmalloc_usable_size(void *ptr) {
 /* Frees the memory buffer pointed by ptr and updates statistics. When using
  * jemalloc it uses the fast track by specifying the buffer size.
  *
- * ptr must point to the start of the buffer. On systems where we have the
- * additional header with size, the caller must do the necessary adjustments to
- * ptr. ptr must not be NULL. The caller is responsible to provide the real
- * allocaction size. */
+ * ptr must point to the start of the buffer. It must have been returned by a
+ * previous call to the system allocator. ptr must not be NULL. The caller is
+ * responsible to provide the real allocaction size. */
 static inline void zfree_internal(void *ptr, size_t size) {
+    assert(ptr != NULL);
     update_zmalloc_stat_free(size);
 
 #ifdef USE_JEMALLOC

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -368,7 +368,7 @@ size_t zmalloc_usable_size(void *ptr) {
  * ptr must have been returned by a previous call to the system allocator which
  * returned the usable size, such as zmalloc_usable. ptr must not be NULL. The
  * caller is responsible to provide the actual allocation size, which may be
- * different from the requested size */
+ * different from the requested size. */
 static inline void zfree_internal(void *ptr, size_t size) {
     assert(ptr != NULL);
     update_zmalloc_stat_free(size);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -31,6 +31,7 @@
 #include "fmacros.h"
 #include "config.h"
 #include "solarisfixes.h"
+#include "serverassert.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -628,8 +629,6 @@ size_t zmalloc_get_rss(void) {
 #endif
 
 #if defined(USE_JEMALLOC)
-
-#include "serverassert.h"
 
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -362,12 +362,13 @@ size_t zmalloc_usable_size(void *ptr) {
 }
 #endif
 
-/* Frees the memory buffer pointed by ptr and updates statistics. When using
+/* Frees the memory buffer pointed to by ptr and updates statistics. When using
  * jemalloc it uses the fast track by specifying the buffer size.
  *
- * ptr must point to the start of the buffer. It must have been returned by a
- * previous call to the system allocator. ptr must not be NULL. The caller is
- * responsible to provide the real allocaction size. */
+ * ptr must have been returned by a previous call to the system allocator which
+ * returned the usable size, such as zmalloc_usable. ptr must not be NULL. The
+ * caller is responsible to provide the actual allocation size, which may be
+ * different from the requested size */
 static inline void zfree_internal(void *ptr, size_t size) {
     assert(ptr != NULL);
     update_zmalloc_stat_free(size);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -118,6 +118,7 @@ __attribute__((malloc, alloc_size(1), noinline)) void *ztrymalloc(size_t size);
 __attribute__((malloc, alloc_size(1), noinline)) void *ztrycalloc(size_t size);
 __attribute__((alloc_size(2), noinline)) void *ztryrealloc(void *ptr, size_t size);
 void zfree(void *ptr);
+void zfree_with_size(void *ptr, size_t size);
 void *zmalloc_usable(size_t size, size_t *usable);
 void *zcalloc_usable(size_t size, size_t *usable);
 void *zrealloc_usable(void *ptr, size_t size, size_t *usable);


### PR DESCRIPTION
### Description ###
zfree updates memory statistics. It gets the size of the buffer from jemalloc by calling zmalloc_size. This operation is costly. We can avoid it if we know the buffer size. For example, we can calculate size of sds from the data we have in its header.

This commit introduces zfree_with_size function that accepts both pointer to a buffer, and its size. zfree is refactored to call zfree_with_size.

sdsfree uses the new interface for all but SDS_TYPE_5.


### Benchmark ###

Dataset is 3 million strings. Each benchmark run uses its own value size (8192, 512, and 120). The benchmark is 100% write load for 5 minutes.

```
value size       new tps      old tps      %       new us/call    old us/call    %
8k               272088.53    269971.75    0.78    1.83           1.92           -4.69
512              356881.91    352856.72    1.14    1.27           1.35           -5.93
120              377523.81    368774.78    2.37    1.14           1.19           -4.20
```