### PR TITLE
Update rdb and module's child proc name to valkey accordingly (compatible with redis symlink)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -11251,7 +11251,11 @@ int VM_Fork(ValkeyModuleForkDoneHandler cb, void *user_data) {
 
     if ((childpid = serverFork(CHILD_TYPE_MODULE)) == 0) {
         /* Child */
-        serverSetProcTitle("redis-module-fork");
+        if (strstr(server.exec_argv[0],"redis-server") != NULL) {
+            serverSetProcTitle("redis-module-fork");
+        } else {
+            serverSetProcTitle("valkey-module-fork");
+        }
     } else if (childpid == -1) {
         serverLog(LL_WARNING,"Can't fork for module: %s", strerror(errno));
     } else {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3603,7 +3603,7 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
         if (strstr(server.exec_argv[0],"redis-server") != NULL) {
             serverSetProcTitle("redis-rdb-to-slaves");
         } else {
-            serverSetProcTitle("valkey-rdb-to-slaves");
+            serverSetProcTitle("valkey-rdb-to-replicas");
         }
         serverSetCpuAffinity(server.bgsave_cpulist);
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1581,7 +1581,11 @@ int rdbSaveBackground(int req, char *filename, rdbSaveInfo *rsi, int rdbflags) {
         int retval;
 
         /* Child */
-        serverSetProcTitle("redis-rdb-bgsave");
+        if (strstr(server.exec_argv[0],"redis-server") != NULL) {
+            serverSetProcTitle("redis-rdb-bgsave");
+        } else {
+            serverSetProcTitle("valkey-rdb-bgsave");
+        }
         serverSetCpuAffinity(server.bgsave_cpulist);
         retval = rdbSave(req, filename,rsi,rdbflags);
         if (retval == C_OK) {
@@ -3596,8 +3600,11 @@ int rdbSaveToSlavesSockets(int req, rdbSaveInfo *rsi) {
         /* Close the reading part, so that if the parent crashes, the child will
          * get a write error and exit. */
         close(server.rdb_pipe_read);
-
-        serverSetProcTitle("redis-rdb-to-slaves");
+        if (strstr(server.exec_argv[0],"redis-server") != NULL) {
+            serverSetProcTitle("redis-rdb-to-slaves");
+        } else {
+            serverSetProcTitle("valkey-rdb-to-slaves");
+        }
         serverSetCpuAffinity(server.bgsave_cpulist);
 
         retval = rdbSaveRioWithEOFMark(req,&rdb,NULL,rsi);


### PR DESCRIPTION
If `valkey-server` was started with the `redis-server` symlink, the old proc names are used, for backwards compatibility.