### PR TITLE
Support pipe2() on *BSD

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -745,7 +745,7 @@ error:
  * and one of the use cases is O_CLOEXEC|O_NONBLOCK. */
 int anetPipe(int fds[2], int read_flags, int write_flags) {
     int pipe_flags = 0;
-#if defined(__linux__) || defined(__FreeBSD__)
+#ifdef HAVE_PIPE2
     /* When possible, try to leverage pipe2() to apply flags that are common to both ends.
      * There is no harm to set O_CLOEXEC to prevent fd leaks. */
     pipe_flags = O_CLOEXEC | (read_flags & write_flags);

--- a/src/config.h
+++ b/src/config.h
@@ -106,6 +106,15 @@
 #define HAVE_ACCEPT4 1
 #endif
 
+/* Detect for pipe2() */
+#if defined(__linux__) || \
+    defined(__FreeBSD__) || \
+    defined(OpenBSD5_7) || \
+    (defined(__DragonFly__) && __DragonFly_version >= 400106) || \
+    (defined(__NetBSD__) && (defined(NetBSD6_0) || __NetBSD_Version__ >= 600000000))
+#define HAVE_PIPE2 1
+#endif
+
 #if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif


### PR DESCRIPTION
Before this PR, `pipe2()` is only enabled on Linux and FreeBSD while `pipe2()` is available on *BSD.

This PR enables `pipe2()` for the rest of *BSD: DragonFlyBSD, NetBSD and OpenBSD.

## References

- [pipe2 on DraonFlyBSD](https://man.dragonflybsd.org/?command=pipe&section=2)
- [__DragonFly_version for pipe2](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/7485684fa5c3fadb6c7a1da0d8bb6ea5da4e0f2f/sys/sys/param.h#L121)
- [pipe2 on  NetBSD](https://man.netbsd.org/pipe.2)
- [pipe2 on OpenBSD](https://man.openbsd.org/pipe.2)