### PR TITLE
[Fix] move deps from slowlog.c into slowlog.h

### DIFF
--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -38,8 +38,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-#include "server.h"
 #include "slowlog.h"
 
 /* Create a new slowlog entry.

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -30,6 +30,8 @@
 #ifndef __SLOWLOG_H__
 #define __SLOWLOG_H__
 
+#include "server.h"
+
 #define SLOWLOG_ENTRY_MAX_ARGC 32
 #define SLOWLOG_ENTRY_MAX_STRING 128
 


### PR DESCRIPTION
move dependency from `slowlog.c` into `slowlog.h`, make sure the language server can work properly under `slowlog.h`