### PR TITLE
Prevent clang-format in certain places

### DIFF
--- a/src/.clang-format-ignore
+++ b/src/.clang-format-ignore
@@ -1,0 +1,12 @@
+# Don't format files copied from other sources.
+lzf*
+crccombine.*
+crcspeed.*
+mt19937-64.*
+pqsort.*
+setcpuaffinity.c
+setproctitle.c
+sha1.*
+sha256.*
+siphash.c
+strl.c

--- a/src/acl.c
+++ b/src/acl.c
@@ -1601,10 +1601,12 @@ static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keyle
     listRewind(selector->patterns,&li);
 
     int key_flags = 0;
+    /* clang-format off */
     if (keyspec_flags & CMD_KEY_ACCESS) key_flags |= ACL_READ_PERMISSION;
     if (keyspec_flags & CMD_KEY_INSERT) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_DELETE) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_UPDATE) key_flags |= ACL_WRITE_PERMISSION;
+    /* clang-format on */
 
     /* Test this key against every pattern. */
     while((ln = listNext(&li))) {
@@ -1632,10 +1634,12 @@ static int ACLSelectorHasUnrestrictedKeyAccess(aclSelector *selector, int flags)
     listRewind(selector->patterns,&li);
 
     int access_flags = 0;
+    /* clang-format off */
     if (flags & CMD_KEY_ACCESS) access_flags |= ACL_READ_PERMISSION;
     if (flags & CMD_KEY_INSERT) access_flags |= ACL_WRITE_PERMISSION;
     if (flags & CMD_KEY_DELETE) access_flags |= ACL_WRITE_PERMISSION;
     if (flags & CMD_KEY_UPDATE) access_flags |= ACL_WRITE_PERMISSION;
+    /* clang-format on */
 
     /* Test this key against every pattern. */
     while((ln = listNext(&li))) {
@@ -2700,13 +2704,15 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     if (object) {
         le->object = object;
     } else {
+        /* clang-format off */
         switch(reason) {
-            case ACL_DENIED_CMD: le->object = sdsdup(c->cmd->fullname); break;
-            case ACL_DENIED_KEY: le->object = sdsdup(c->argv[argpos]->ptr); break;
-            case ACL_DENIED_CHANNEL: le->object = sdsdup(c->argv[argpos]->ptr); break;
-            case ACL_DENIED_AUTH: le->object = sdsdup(c->argv[0]->ptr); break;
-            default: le->object = sdsempty();
+        case ACL_DENIED_CMD: le->object = sdsdup(c->cmd->fullname); break;
+        case ACL_DENIED_KEY: le->object = sdsdup(c->argv[argpos]->ptr); break;
+        case ACL_DENIED_CHANNEL: le->object = sdsdup(c->argv[argpos]->ptr); break;
+        case ACL_DENIED_AUTH: le->object = sdsdup(c->argv[0]->ptr); break;
+        default: le->object = sdsempty();
         }
+        /* clang-format on */
     }
 
     /* if we have a real client from the network, use it (could be missing on module timers) */
@@ -3090,6 +3096,7 @@ void aclCommand(client *c) {
 
             addReplyBulkCString(c,"reason");
             char *reasonstr;
+            /* clang-format off */
             switch(le->reason) {
             case ACL_DENIED_CMD: reasonstr="command"; break;
             case ACL_DENIED_KEY: reasonstr="key"; break;
@@ -3097,10 +3104,12 @@ void aclCommand(client *c) {
             case ACL_DENIED_AUTH: reasonstr="auth"; break;
             default: reasonstr="unknown";
             }
+            /* clang-format on */
             addReplyBulkCString(c,reasonstr);
 
             addReplyBulkCString(c,"context");
             char *ctxstr;
+            /* clang-format off */
             switch(le->context) {
             case ACL_LOG_CTX_TOPLEVEL: ctxstr="toplevel"; break;
             case ACL_LOG_CTX_MULTI: ctxstr="multi"; break;
@@ -3108,6 +3117,7 @@ void aclCommand(client *c) {
             case ACL_LOG_CTX_MODULE: ctxstr="module"; break;
             default: ctxstr="unknown";
             }
+            /* clang-format on */
             addReplyBulkCString(c,ctxstr);
 
             addReplyBulkCString(c,"object");
@@ -3156,6 +3166,7 @@ void aclCommand(client *c) {
 
         addReply(c,shared.ok);
     } else if (c->argc == 2 && !strcasecmp(sub,"help")) {
+        /* clang-format off */
         const char *help[] = {
 "CAT [<category>]",
 "    List all commands that belong to <category>, or all command categories",
@@ -3185,6 +3196,7 @@ void aclCommand(client *c) {
 "    Return the current connection username.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c,help);
     } else {
         addReplySubcommandSyntaxError(c);

--- a/src/aof.c
+++ b/src/aof.c
@@ -2035,6 +2035,7 @@ int rioWriteStreamPendingEntry(rio *r, robj *key, const char *groupname, size_t 
                RETRYCOUNT <count> JUSTID FORCE. */
     streamID id;
     streamDecodeID(rawid,&id);
+    /* clang-format off */
     if (rioWriteBulkCount(r,'*',12) == 0) return 0;
     if (rioWriteBulkString(r,"XCLAIM",6) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
@@ -2048,6 +2049,7 @@ int rioWriteStreamPendingEntry(rio *r, robj *key, const char *groupname, size_t 
     if (rioWriteBulkLongLong(r,nack->delivery_count) == 0) return 0;
     if (rioWriteBulkString(r,"JUSTID",6) == 0) return 0;
     if (rioWriteBulkString(r,"FORCE",5) == 0) return 0;
+    /* clang-format on */
     return 1;
 }
 
@@ -2056,12 +2058,14 @@ int rioWriteStreamPendingEntry(rio *r, robj *key, const char *groupname, size_t 
  * All this in the context of the specified key and group. */
 int rioWriteStreamEmptyConsumer(rio *r, robj *key, const char *groupname, size_t groupname_len, streamConsumer *consumer) {
     /* XGROUP CREATECONSUMER <key> <group> <consumer> */
+    /* clang-format off */
     if (rioWriteBulkCount(r,'*',5) == 0) return 0;
     if (rioWriteBulkString(r,"XGROUP",6) == 0) return 0;
     if (rioWriteBulkString(r,"CREATECONSUMER",14) == 0) return 0;
     if (rioWriteBulkObject(r,key) == 0) return 0;
     if (rioWriteBulkString(r,groupname,groupname_len) == 0) return 0;
     if (rioWriteBulkString(r,consumer->name,sdslen(consumer->name)) == 0) return 0;
+    /* clang-format on */
     return 1;
 }
 

--- a/src/asciilogo.h
+++ b/src/asciilogo.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2024, Valkey contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* clang-format off */
 const char *ascii_logo =
 "                .+^+.                                                \n"
 "            .+#########+.                                            \n"
@@ -47,3 +49,4 @@ const char *ascii_logo =
 "        '|   |####+########+'                                        \n"
 "             +#########+'                                            \n"
 "                '+v+'                                                \n\n";
+/* clang-format off */

--- a/src/eval.c
+++ b/src/eval.c
@@ -675,6 +675,7 @@ void evalShaRoCommand(client *c) {
 
 void scriptCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        /* clang-format off */
         const char *help[] = {
 "DEBUG (YES|SYNC|NO)",
 "    Set the debug mode for subsequent scripts executed.",
@@ -682,8 +683,8 @@ void scriptCommand(client *c) {
 "    Return information about the existence of the scripts in the script cache.",
 "FLUSH [ASYNC|SYNC]",
 "    Flush the Lua scripts cache. Very dangerous on replicas.",
-"    When called without the optional mode argument, the behavior is determined by the",
-"    lazyfree-lazy-user-flush configuration directive. Valid modes are:",
+"    When called without the optional mode argument, the behavior is determined",
+"     by the lazyfree-lazy-user-flush configuration directive. Valid modes are:",
 "    * ASYNC: Asynchronously flush the scripts cache.",
 "    * SYNC: Synchronously flush the scripts cache.",
 "KILL",
@@ -692,6 +693,7 @@ void scriptCommand(client *c) {
 "    Load a script into the scripts cache without executing it.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (c->argc >= 2 && !strcasecmp(c->argv[1]->ptr,"flush")) {
         int async = 0;
@@ -1251,6 +1253,7 @@ char *ldbRedisProtocolToHuman_Double(sds *o, char *reply);
  * char*) so that we can return a modified pointer, as for SDS semantics. */
 char *ldbRedisProtocolToHuman(sds *o, char *reply) {
     char *p = reply;
+    /* clang-format off */
     switch(*p) {
     case ':': p = ldbRedisProtocolToHuman_Int(o,reply); break;
     case '$': p = ldbRedisProtocolToHuman_Bulk(o,reply); break;
@@ -1263,6 +1266,7 @@ char *ldbRedisProtocolToHuman(sds *o, char *reply) {
     case '#': p = ldbRedisProtocolToHuman_Bool(o,reply); break;
     case ',': p = ldbRedisProtocolToHuman_Double(o,reply); break;
     }
+    /* clang-format on */
     return p;
 }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -826,6 +826,7 @@ void functionFlushCommand(client *c) {
 
 /* FUNCTION HELP */
 void functionHelpCommand(client *c) {
+    /* clang-format off */
     const char *help[] = {
 "LOAD [REPLACE] <FUNCTION CODE>",
 "    Create a new library with the given library name and code.",
@@ -864,6 +865,7 @@ void functionHelpCommand(client *c) {
 "      libraries with the new libraries (notice that even on this option there is a chance of failure",
 "      in case of functions name collision with another library).",
 NULL };
+    /* clang-format on */
     addReplyHelp(c, help);
 }
 

--- a/src/latency.c
+++ b/src/latency.c
@@ -696,6 +696,7 @@ void latencyCommand(client *c) {
             latencySpecificCommandsFillCDF(c);
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"help") && c->argc == 2) {
+        /* clang-format off */
         const char *help[] = {
 "DOCTOR",
 "    Return a human readable latency analysis report.",
@@ -713,6 +714,7 @@ void latencyCommand(client *c) {
 "    If no commands are specified then all histograms are replied.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else {
         addReplySubcommandSyntaxError(c);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -426,6 +426,7 @@ static inline void lpEncodeString(unsigned char *buf, unsigned char *s, uint32_t
  * lpCurrentEncodedSizeBytes or ASSERT_INTEGRITY_LEN (possibly since 'p' is
  * a return value of another function that validated its return. */
 static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
+    /* clang-format off */
     if (LP_ENCODING_IS_7BIT_UINT(p[0])) return 1;
     if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1+LP_ENCODING_6BIT_STR_LEN(p);
     if (LP_ENCODING_IS_13BIT_INT(p[0])) return 2;
@@ -437,6 +438,7 @@ static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
     if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5+LP_ENCODING_32BIT_STR_LEN(p);
     if (p[0] == LP_EOF) return 1;
     return 0;
+    /* clang-format on */
 }
 
 /* Return bytes needed to encode the length of the listpack element pointed by 'p'.
@@ -444,6 +446,7 @@ static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
  * of the element (excluding the element data itself)
  * If the element encoding is wrong then 0 is returned. */
 static inline uint32_t lpCurrentEncodedSizeBytes(unsigned char *p) {
+    /* clang-format off */
     if (LP_ENCODING_IS_7BIT_UINT(p[0])) return 1;
     if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1;
     if (LP_ENCODING_IS_13BIT_INT(p[0])) return 1;
@@ -455,6 +458,7 @@ static inline uint32_t lpCurrentEncodedSizeBytes(unsigned char *p) {
     if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5;
     if (p[0] == LP_EOF) return 1;
     return 0;
+    /* clang-format on */
 }
 
 /* Skip the current entry returning the next. It is invalid to call this

--- a/src/module.c
+++ b/src/module.c
@@ -1143,6 +1143,7 @@ int64_t commandFlagsFromString(char *s) {
     sds *tokens = sdssplitlen(s,strlen(s)," ",1,&count);
     for (j = 0; j < count; j++) {
         char *t = tokens[j];
+        /* clang-format off */
         if (!strcasecmp(t,"write")) flags |= CMD_WRITE;
         else if (!strcasecmp(t,"readonly")) flags |= CMD_READONLY;
         else if (!strcasecmp(t,"admin")) flags |= CMD_ADMIN;
@@ -1164,6 +1165,7 @@ int64_t commandFlagsFromString(char *s) {
         else if (!strcasecmp(t,"no-mandatory-keys")) flags |= CMD_NO_MANDATORY_KEYS;
         else if (!strcasecmp(t,"allow-busy")) flags |= CMD_ALLOW_BUSY;
         else break;
+        /* clang-format on */
     }
     sdsfreesplitres(tokens,count);
     if (j != count) return -1; /* Some token not processed correctly. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -2813,6 +2813,7 @@ sds catClientInfoString(sds s, client *client) {
         else
             *p++ = 'S';
     }
+    /* clang-format off */
     if (client->flags & CLIENT_MASTER) *p++ = 'M';
     if (client->flags & CLIENT_PUBSUB) *p++ = 'P';
     if (client->flags & CLIENT_MULTI) *p++ = 'x';
@@ -2829,6 +2830,7 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_NO_EVICT) *p++ = 'e';
     if (client->flags & CLIENT_NO_TOUCH) *p++ = 'T';
     if (p == flags) *p++ = 'N';
+    /* clang-format on */
     *p++ = '\0';
 
     p = events;
@@ -2848,6 +2850,7 @@ sds catClientInfoString(sds s, client *client) {
         used_blocks_of_repl_buf = last->id - cur->id + 1;
     }
 
+    /* clang-format off */
     sds ret = sdscatfmt(s, FMTARGS(
         "id=%U", (unsigned long long) client->id,
         " addr=%s", getClientPeerId(client),
@@ -2883,6 +2886,7 @@ sds catClientInfoString(sds s, client *client) {
         " tot-net-in=%U", client->net_input_bytes,
         " tot-net-out=%U", client->net_output_bytes,
         " tot-cmds=%U", client->commands_processed));
+    /* clang-format on */
     return ret;
 }
 
@@ -3025,6 +3029,7 @@ void clientCommand(client *c) {
     listIter li;
 
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        /* clang-format off */
         const char *help[] = {
 "CACHING (YES|NO)",
 "    Enable/disable tracking of the keys for next command in OPTIN/OPTOUT modes.",
@@ -3083,6 +3088,7 @@ void clientCommand(client *c) {
 "    Will not touch LRU/LFU stats when this mode is on.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"id") && c->argc == 2) {
         /* CLIENT ID */
@@ -3242,6 +3248,7 @@ NULL
         listRewind(server.clients,&li);
         while ((ln = listNext(&li)) != NULL) {
             client *client = listNodeValue(ln);
+            /* clang-format off */
             if (addr && strcmp(getClientPeerId(client),addr) != 0) continue;
             if (laddr && strcmp(getClientSockname(client),laddr) != 0) continue;
             if (type != -1 && getClientType(client) != type) continue;
@@ -3249,6 +3256,7 @@ NULL
             if (user && client->user != user) continue;
             if (c == client && skipme) continue;
             if (max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) < max_age) continue;
+            /* clang-format on */
 
             /* Kill it. */
             if (c == client) {

--- a/src/notify.c
+++ b/src/notify.c
@@ -42,6 +42,7 @@ int keyspaceEventsStringToFlags(char *classes) {
     int c, flags = 0;
 
     while((c = *p++) != '\0') {
+        /* clang-format off */
         switch(c) {
         case 'A': flags |= NOTIFY_ALL; break;
         case 'g': flags |= NOTIFY_GENERIC; break;
@@ -60,6 +61,7 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 'n': flags |= NOTIFY_NEW; break;
         default: return -1;
         }
+        /* clang-format on */
     }
     return flags;
 }
@@ -71,6 +73,7 @@ int keyspaceEventsStringToFlags(char *classes) {
 sds keyspaceEventsFlagsToString(int flags) {
     sds res;
 
+    /* clang-format off */
     res = sdsempty();
     if ((flags & NOTIFY_ALL) == NOTIFY_ALL) {
         res = sdscatlen(res,"A",1);
@@ -91,6 +94,7 @@ sds keyspaceEventsFlagsToString(int flags) {
     if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);
     if (flags & NOTIFY_KEY_MISS) res = sdscatlen(res,"m",1);
     return res;
+    /* clang-format on */
 }
 
 /* The API provided to the rest of the serer core is a simple function:

--- a/src/object.c
+++ b/src/object.c
@@ -391,6 +391,7 @@ void incrRefCount(robj *o) {
 
 void decrRefCount(robj *o) {
     if (o->refcount == 1) {
+        /* clang-format off */
         switch(o->type) {
         case OBJ_STRING: freeStringObject(o); break;
         case OBJ_LIST: freeListObject(o); break;
@@ -401,6 +402,7 @@ void decrRefCount(robj *o) {
         case OBJ_STREAM: freeStreamObject(o); break;
         default: serverPanic("Unknown object type"); break;
         }
+        /* clang-format on */
         zfree(o);
     } else {
         if (o->refcount <= 0) serverPanic("decrRefCount against refcount <= 0");
@@ -569,15 +571,17 @@ void dismissObject(robj *o, size_t size_hint) {
      * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (o->refcount != 1) return;
+    /* clang-format off */
     switch(o->type) {
-        case OBJ_STRING: dismissStringObject(o); break;
-        case OBJ_LIST: dismissListObject(o, size_hint); break;
-        case OBJ_SET: dismissSetObject(o, size_hint); break;
-        case OBJ_ZSET: dismissZsetObject(o, size_hint); break;
-        case OBJ_HASH: dismissHashObject(o, size_hint); break;
-        case OBJ_STREAM: dismissStreamObject(o, size_hint); break;
-        default: break;
+    case OBJ_STRING: dismissStringObject(o); break;
+    case OBJ_LIST: dismissListObject(o, size_hint); break;
+    case OBJ_SET: dismissSetObject(o, size_hint); break;
+    case OBJ_ZSET: dismissZsetObject(o, size_hint); break;
+    case OBJ_HASH: dismissHashObject(o, size_hint); break;
+    case OBJ_STREAM: dismissStreamObject(o, size_hint); break;
+    default: break;
     }
+    /* clang-format on */
 #else
     UNUSED(o); UNUSED(size_hint);
 #endif
@@ -954,6 +958,7 @@ int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg) {
 }
 
 char *strEncoding(int encoding) {
+    /* clang-format off */
     switch(encoding) {
     case OBJ_ENCODING_RAW: return "raw";
     case OBJ_ENCODING_INT: return "int";
@@ -966,6 +971,7 @@ char *strEncoding(int encoding) {
     case OBJ_ENCODING_STREAM: return "stream";
     default: return "unknown";
     }
+    /* clang-format on */
 }
 
 /* =========================== Memory introspection ========================= */
@@ -1518,6 +1524,7 @@ NULL
  * Usage: MEMORY usage <key> */
 void memoryCommand(client *c) {
     if (!strcasecmp(c->argv[1]->ptr,"help") && c->argc == 2) {
+        /* clang-format off */
         const char *help[] = {
 "DOCTOR",
 "    Return memory problems reports.",
@@ -1532,6 +1539,7 @@ void memoryCommand(client *c) {
 "    sampled up to <count> times (default: 5, 0 means sample all).",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"usage") && c->argc >= 3) {
         dictEntry *de;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3253,6 +3253,7 @@ void roleCommand(client *c) {
         if (slaveIsInHandshakeState()) {
             slavestate = "handshake";
         } else {
+            /* clang-format off */
             switch(server.repl_state) {
             case REPL_STATE_NONE: slavestate = "none"; break;
             case REPL_STATE_CONNECT: slavestate = "connect"; break;
@@ -3261,6 +3262,7 @@ void roleCommand(client *c) {
             case REPL_STATE_CONNECTED: slavestate = "connected"; break;
             default: slavestate = "unknown"; break;
             }
+            /* clang-format on */
         }
         addReplyBulkCString(c,slavestate);
         addReplyLongLong(c,server.master ? server.master->reploff : -1);

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -208,21 +208,23 @@ static int parseMap(ReplyParser *parser, void *p_ctx) {
 
 /* Parse a reply pointed to by parser->curr_location. */
 int parseReply(ReplyParser *parser, void *p_ctx) {
+    /* clang-format off */
     switch (parser->curr_location[0]) {
-        case '$': return parseBulk(parser, p_ctx);
-        case '+': return parseSimpleString(parser, p_ctx);
-        case '-': return parseError(parser, p_ctx);
-        case ':': return parseLong(parser, p_ctx);
-        case '*': return parseArray(parser, p_ctx);
-        case '~': return parseSet(parser, p_ctx);
-        case '%': return parseMap(parser, p_ctx);
-        case '#': return parseBool(parser, p_ctx);
-        case ',': return parseDouble(parser, p_ctx);
-        case '_': return parseNull(parser, p_ctx);
-        case '(': return parseBigNumber(parser, p_ctx);
-        case '=': return parseVerbatimString(parser, p_ctx);
-        case '|': return parseAttributes(parser, p_ctx);
-        default: if (parser->callbacks.error) parser->callbacks.error(p_ctx);
+    case '$': return parseBulk(parser, p_ctx);
+    case '+': return parseSimpleString(parser, p_ctx);
+    case '-': return parseError(parser, p_ctx);
+    case ':': return parseLong(parser, p_ctx);
+    case '*': return parseArray(parser, p_ctx);
+    case '~': return parseSet(parser, p_ctx);
+    case '%': return parseMap(parser, p_ctx);
+    case '#': return parseBool(parser, p_ctx);
+    case ',': return parseDouble(parser, p_ctx);
+    case '_': return parseNull(parser, p_ctx);
+    case '(': return parseBigNumber(parser, p_ctx);
+    case '=': return parseVerbatimString(parser, p_ctx);
+    case '|': return parseAttributes(parser, p_ctx);
+    default: if (parser->callbacks.error) parser->callbacks.error(p_ctx);
     }
+    /* clang-format on */
     return C_ERR;
 }

--- a/src/sds.c
+++ b/src/sds.c
@@ -965,6 +965,7 @@ int is_hex_digit(char c) {
 /* Helper function for sdssplitargs() that converts a hex digit into an
  * integer from 0 to 15 */
 int hex_digit_to_int(char c) {
+    /* clang-format off */
     switch(c) {
     case '0': return 0;
     case '1': return 1;
@@ -984,6 +985,7 @@ int hex_digit_to_int(char c) {
     case 'f': case 'F': return 15;
     default: return 0;
     }
+    /* clang-format on */
 }
 
 /* Split a line into arguments, where every argument can be in the

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3186,6 +3186,7 @@ static void populateDict(dict *options_dict, char **options) {
 }
 
 const char* getLogLevel(void) {
+    /* clang-format off */
    switch (server.verbosity) {
     case LL_DEBUG: return "debug";
     case LL_VERBOSE: return "verbose";
@@ -3193,6 +3194,7 @@ const char* getLogLevel(void) {
     case LL_WARNING: return "warning";
     case LL_NOTHING: return "nothing";
     }
+    /* clang-format on */
     return "unknown";
 }
 
@@ -3383,6 +3385,7 @@ void sentinelConfigGetCommand(client *c) {
 }
 
 const char *sentinelFailoverStateStr(int state) {
+    /* clang-format off */
     switch(state) {
     case SENTINEL_FAILOVER_STATE_NONE: return "none";
     case SENTINEL_FAILOVER_STATE_WAIT_START: return "wait_start";
@@ -3393,6 +3396,7 @@ const char *sentinelFailoverStateStr(int state) {
     case SENTINEL_FAILOVER_STATE_UPDATE_CONFIG: return "update_config";
     default: return "unknown";
     }
+    /* clang-format on */
 }
 
 /* Server instance to RESP representation. */
@@ -3420,6 +3424,7 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     fields++;
 
     addReplyBulkCString(c,"flags");
+    /* clang-format off */
     if (ri->flags & SRI_S_DOWN) flags = sdscat(flags,"s_down,");
     if (ri->flags & SRI_O_DOWN) flags = sdscat(flags,"o_down,");
     if (ri->flags & SRI_MASTER) flags = sdscat(flags,"master,");
@@ -3427,8 +3432,7 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     if (ri->flags & SRI_SENTINEL) flags = sdscat(flags,"sentinel,");
     if (ri->link->disconnected) flags = sdscat(flags,"disconnected,");
     if (ri->flags & SRI_MASTER_DOWN) flags = sdscat(flags,"master_down,");
-    if (ri->flags & SRI_FAILOVER_IN_PROGRESS)
-        flags = sdscat(flags,"failover_in_progress,");
+    if (ri->flags & SRI_FAILOVER_IN_PROGRESS) flags = sdscat(flags,"failover_in_progress,");
     if (ri->flags & SRI_PROMOTED) flags = sdscat(flags,"promoted,");
     if (ri->flags & SRI_RECONF_SENT) flags = sdscat(flags,"reconf_sent,");
     if (ri->flags & SRI_RECONF_INPROG) flags = sdscat(flags,"reconf_inprog,");
@@ -3436,6 +3440,7 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     if (ri->flags & SRI_FORCE_FAILOVER) flags = sdscat(flags,"force_failover,");
     if (ri->flags & SRI_SCRIPT_KILL_SENT) flags = sdscat(flags,"script_kill_sent,");
     if (ri->flags & SRI_MASTER_REBOOT) flags = sdscat(flags,"master_reboot,");
+    /* clang-format on */
 
     if (sdslen(flags) != 0) sdsrange(flags,0,-2); /* remove last "," */
     addReplyBulkCString(c,flags);
@@ -3863,6 +3868,7 @@ int sentinelIsQuorumReachable(sentinelRedisInstance *master, int *usableptr) {
 
 void sentinelCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        /* clang-format off */
         const char *help[] = {
 "CKQUORUM <master-name>",
 "    Check if the current Sentinel configuration is able to reach the quorum",
@@ -3912,6 +3918,7 @@ void sentinelCommand(client *c) {
 "    Simulate a Sentinel crash.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (!strcasecmp(c->argv[1]->ptr,"masters")) {
         /* SENTINEL MASTERS */

--- a/src/server.c
+++ b/src/server.c
@@ -651,13 +651,15 @@ void updateDictResizePolicy(void) {
 }
 
 const char *strChildType(int type) {
+    /* clang-format off */
     switch(type) {
-        case CHILD_TYPE_RDB: return "RDB";
-        case CHILD_TYPE_AOF: return "AOF";
-        case CHILD_TYPE_LDB: return "LDB";
-        case CHILD_TYPE_MODULE: return "MODULE";
-        default: return "Unknown";
+    case CHILD_TYPE_RDB: return "RDB";
+    case CHILD_TYPE_AOF: return "AOF";
+    case CHILD_TYPE_LDB: return "LDB";
+    case CHILD_TYPE_MODULE: return "MODULE";
+    default: return "Unknown";
     }
+    /* clang-format on */
 }
 
 /* Return true if there are active children processes doing RDB saving,
@@ -5329,6 +5331,7 @@ void commandGetKeysCommand(client *c) {
 
 /* COMMAND HELP */
 void commandHelpCommand(client *c) {
+    /* clang-format off */
     const char *help[] = {
 "(no subcommand)",
 "    Return details about all commands.",
@@ -5350,7 +5353,7 @@ void commandHelpCommand(client *c) {
 "    Return the keys and the access flags from a full command.",
 NULL
     };
-
+    /* clang-format on */
     addReplyHelp(c, help);
 }
 
@@ -5611,6 +5614,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             call_uname = 0;
         }
 
+        /* clang-format off */
         info = sdscatfmt(info, "# Server\r\n" FMTARGS(
             "redis_version:%s\r\n", REDIS_VERSION,
             "server_name:%s\r\n", SERVER_NAME,
@@ -5641,6 +5645,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "executable:%s\r\n", server.executable ? server.executable : "",
             "config_file:%s\r\n", server.configfile ? server.configfile : "",
             "io_threads_active:%i\r\n", server.io_threads_active));
+        /* clang-format on */
 
         /* Conditional properties */
         if (isShutdownInitiated()) {
@@ -5660,6 +5665,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         getExpansiveClientsInfo(&maxin,&maxout);
         totalNumberOfStatefulKeys(&blocking_keys, &blocking_keys_on_nokey, &watched_keys);
         if (sections++) info = sdscat(info,"\r\n");
+        /* clang-format off */
         info = sdscatprintf(info, "# Clients\r\n" FMTARGS(
             "connected_clients:%lu\r\n", listLength(server.clients) - listLength(server.slaves),
             "cluster_connections:%lu\r\n", getClusterConnectionsCount(),
@@ -5674,6 +5680,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "total_watched_keys:%lu\r\n", watched_keys,
             "total_blocking_keys:%lu\r\n", blocking_keys,
             "total_blocking_keys_on_nokey:%lu\r\n", blocking_keys_on_nokey));
+        /* clang-format on */
     }
 
     /* Memory */
@@ -5710,6 +5717,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         bytesToHuman(maxmemory_hmem,sizeof(maxmemory_hmem),server.maxmemory);
 
         if (sections++) info = sdscat(info,"\r\n");
+        /* clang-format off */
         info = sdscatprintf(info, "# Memory\r\n" FMTARGS(
             "used_memory:%zu\r\n", zmalloc_used,
             "used_memory_human:%s\r\n", hmem,
@@ -5768,6 +5776,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "active_defrag_running:%d\r\n", server.active_defrag_running,
             "lazyfree_pending_objects:%zu\r\n", lazyfreeGetPendingObjectsCount(),
             "lazyfreed_objects:%zu\r\n", lazyfreeGetFreedObjectsCount()));
+        /* clang-format on */
         freeMemoryOverheadData(mh);
     }
 
@@ -5783,6 +5792,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         int aof_bio_fsync_status;
         atomicGet(server.aof_bio_fsync_status,aof_bio_fsync_status);
 
+        /* clang-format off */
         info = sdscatprintf(info, "# Persistence\r\n" FMTARGS(
             "loading:%d\r\n", (int)(server.loading && !server.async_loading),
             "async_loading:%d\r\n", (int)server.async_loading,
@@ -5819,8 +5829,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "aof_last_cow_size:%zu\r\n", server.stat_aof_cow_bytes,
             "module_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_MODULE,
             "module_fork_last_cow_size:%zu\r\n", server.stat_module_cow_bytes));
+        /* clang-format on */
 
         if (server.aof_enabled) {
+            /* clang-format off */
             info = sdscatprintf(info, FMTARGS(
                 "aof_current_size:%lld\r\n", (long long) server.aof_current_size,
                 "aof_base_size:%lld\r\n", (long long) server.aof_rewrite_base_size,
@@ -5828,6 +5840,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "aof_buffer_length:%zu\r\n", sdslen(server.aof_buf),
                 "aof_pending_bio_fsync:%lu\r\n", bioPendingJobsOfType(BIO_AOF_FSYNC),
                 "aof_delayed_fsync:%lu\r\n", server.aof_delayed_fsync));
+            /* clang-format on */
         }
 
         if (server.loading) {
@@ -5854,6 +5867,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 eta = (elapsed*remaining_bytes)/(server.loading_loaded_bytes+1);
             }
 
+            /* clang-format off */
             info = sdscatprintf(info, FMTARGS(
                 "loading_start_time:%jd\r\n", (intmax_t) server.loading_start_time,
                 "loading_total_bytes:%llu\r\n", (unsigned long long) server.loading_total_bytes,
@@ -5861,6 +5875,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "loading_loaded_bytes:%llu\r\n", (unsigned long long) server.loading_loaded_bytes,
                 "loading_loaded_perc:%.2f\r\n", perc,
                 "loading_eta_seconds:%jd\r\n", (intmax_t)eta));
+            /* clang-format on */
         }
     }
 
@@ -5883,6 +5898,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
         atomicGet(server.stat_client_qbuf_limit_disconnections, stat_client_qbuf_limit_disconnections);
 
         if (sections++) info = sdscat(info,"\r\n");
+        /* clang-format off */
         info = sdscatprintf(info, "# Stats\r\n" FMTARGS(
             "total_connections_received:%lld\r\n", server.stat_numconnections,
             "total_commands_processed:%lld\r\n", server.stat_numcommands,
@@ -5943,6 +5959,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
             "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
         info = genValkeyInfoStringACLStats(info);
+        /* clang-format on */
     }
 
     /* Replication */
@@ -5964,6 +5981,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 slave_read_repl_offset = server.cached_master->read_reploff;
             }
 
+            /* clang-format off */
             info = sdscatprintf(info, FMTARGS(
                 "master_host:%s\r\n", server.masterhost,
                 "master_port:%d\r\n", server.masterport,
@@ -5972,18 +5990,21 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "master_sync_in_progress:%d\r\n", server.repl_state == REPL_STATE_TRANSFER,
                 "slave_read_repl_offset:%lld\r\n", slave_read_repl_offset,
                 "slave_repl_offset:%lld\r\n", slave_repl_offset));
+            /* clang-format on */
 
             if (server.repl_state == REPL_STATE_TRANSFER) {
                 double perc = 0;
                 if (server.repl_transfer_size) {
                     perc = ((double)server.repl_transfer_read / server.repl_transfer_size) * 100;
                 }
+                /* clang-format off */
                 info = sdscatprintf(info, FMTARGS(
                     "master_sync_total_bytes:%lld\r\n", (long long) server.repl_transfer_size,
                     "master_sync_read_bytes:%lld\r\n", (long long) server.repl_transfer_read,
                     "master_sync_left_bytes:%lld\r\n", (long long) (server.repl_transfer_size - server.repl_transfer_read),
                     "master_sync_perc:%.2f\r\n", perc,
                     "master_sync_last_io_seconds_ago:%d\r\n", (int)(server.unixtime-server.repl_transfer_lastio)));
+                /* clang-format on */
             }
 
             if (server.repl_state != REPL_STATE_CONNECTED) {
@@ -5992,10 +6013,12 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                     server.repl_down_since ?
                     (intmax_t)(server.unixtime-server.repl_down_since) : -1);
             }
+            /* clang-format off */
             info = sdscatprintf(info, FMTARGS(
                 "slave_priority:%d\r\n", server.slave_priority,
                 "slave_read_only:%d\r\n", server.repl_slave_ro,
                 "replica_announced:%d\r\n", server.replica_announced));
+            /* clang-format on */
         }
 
         info = sdscatprintf(info,
@@ -6041,6 +6064,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 slaveid++;
             }
         }
+        /* clang-format off */
         info = sdscatprintf(info, FMTARGS(
             "master_failover_state:%s\r\n", getFailoverStateString(),
             "master_replid:%s\r\n", server.replid,
@@ -6051,6 +6075,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "repl_backlog_size:%lld\r\n", server.repl_backlog_size,
             "repl_backlog_first_byte_offset:%lld\r\n", server.repl_backlog ? server.repl_backlog->offset : 0,
             "repl_backlog_histlen:%lld\r\n", server.repl_backlog ? server.repl_backlog->histlen : 0));
+        /* clang-format on */
     }
 
     /* CPU */
@@ -6166,11 +6191,13 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
 
     if (dictFind(section_dict, "debug") != NULL) {
         if (sections++) info = sdscat(info,"\r\n");
+        /* clang-format off */
         info = sdscatprintf(info, "# Debug\r\n" FMTARGS(
             "eventloop_duration_aof_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_AOF].sum,
             "eventloop_duration_cron_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CRON].sum,
             "eventloop_duration_max:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].max,
             "eventloop_cmd_per_cycle_max:%lld\r\n", server.el_cmd_cnt_max));
+        /* clang-format on */
     }
 
     return info;

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -141,6 +141,7 @@ void slowlogReset(void) {
  * slow log. */
 void slowlogCommand(client *c) {
     if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"help")) {
+        /* clang-format off */
         const char *help[] = {
 "GET [<count>]",
 "    Return top <count> entries from the slowlog (default: 10, -1 mean all).",
@@ -153,6 +154,7 @@ void slowlogCommand(client *c) {
 "    Reset the slowlog.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr,"reset")) {
         slowlogReset();

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2657,6 +2657,7 @@ void xgroupCommand(client *c) {
 
     /* Dispatch the different subcommands. */
     if (c->argc == 2 && !strcasecmp(opt,"HELP")) {
+        /* clang-format off */
         const char *help[] = {
 "CREATE <key> <groupname> <id|$> [option]",
 "    Create a new consumer group. Options are:",
@@ -2674,6 +2675,7 @@ void xgroupCommand(client *c) {
 "    Set the current group ID and entries_read counter.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
     } else if (!strcasecmp(opt,"CREATE") && (c->argc >= 5 && c->argc <= 8)) {
         streamID id;
@@ -3871,6 +3873,7 @@ void xinfoCommand(client *c) {
 
     /* HELP is special. Handle it ASAP. */
     if (!strcasecmp(c->argv[1]->ptr,"HELP")) {
+        /* clang-format off */
         const char *help[] = {
 "CONSUMERS <key> <groupname>",
 "    Show consumers of <groupname>.",
@@ -3880,6 +3883,7 @@ void xinfoCommand(client *c) {
 "    Show information about the stream.",
 NULL
         };
+        /* clang-format on */
         addReplyHelp(c, help);
         return;
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -213,6 +213,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
         char *opt = c->argv[j]->ptr;
         robj *next = (j == c->argc-1) ? NULL : c->argv[j+1];
 
+        /* clang-format off */
         if ((opt[0] == 'n' || opt[0] == 'N') &&
             (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
             !(*flags & OBJ_SET_XX) && (command_type == COMMAND_SET))
@@ -286,6 +287,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
             addReplyErrorObject(c,shared.syntaxerr);
             return C_ERR;
         }
+        /* clang-format off */
     }
     return C_OK;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1270,7 +1270,7 @@ static char *i2string_async_signal_safe(int base, int64_t val, char *buf) {
             case 'e': *buf = '1'; break;
             case 'f': *buf = '0'; break;
             }
-            /* clang-format off */
+            /* clang-format on */
         }
     }
     return buf + 1;

--- a/src/util.c
+++ b/src/util.c
@@ -1251,7 +1251,7 @@ static char *i2string_async_signal_safe(int base, int64_t val, char *buf) {
         int ix;
         buf = orig_buf - 1;
         for (ix = 0; ix < 16; ++ix, --buf) {
-            /* *INDENT-OFF* */
+            /* clang-format off */
             switch (*buf) {
             case '0': *buf = 'f'; break;
             case '1': *buf = 'e'; break;
@@ -1270,7 +1270,7 @@ static char *i2string_async_signal_safe(int base, int64_t val, char *buf) {
             case 'e': *buf = '1'; break;
             case 'f': *buf = '0'; break;
             }
-            /* *INDENT-ON* */
+            /* clang-format off */
         }
     }
     return buf + 1;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1134,12 +1134,14 @@ static int fetchClusterConfiguration(void) {
             *p = '\0';
             char *token = line;
             line = p + 1;
+            /* clang-format off */
             switch(i++){
             case 0: name = token; break;
             case 1: addr = token; break;
             case 2: flags = token; break;
             case 3: master_id = token; break;
             }
+            /* clang-format on */
             if (i == 8) break; // Slots
         }
         if (!flags) {
@@ -1560,6 +1562,7 @@ invalid:
     printf("Invalid option \"%s\" or option argument missing\n\n",argv[i]);
 
 usage:
+    /* clang-format off */
     tls_usage =
 #ifdef USE_OPENSSL
 " --tls              Establish a secure TLS connection.\n"
@@ -1651,6 +1654,7 @@ tls_usage,
 " On user specified command lines __rand_int__ is replaced with a random integer\n"
 " with a range of values selected by the -r option.\n"
     );
+    /* clang-format off */
     exit(exit_status);
 }
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1654,7 +1654,7 @@ tls_usage,
 " On user specified command lines __rand_int__ is replaced with a random integer\n"
 " with a range of values selected by the -r option.\n"
     );
-    /* clang-format off */
+    /* clang-format on */
     exit(exit_status);
 }
 

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -3147,7 +3147,7 @@ version,tls_usage);
 "Type \"help\" in interactive mode for information on available commands\n"
 "and settings.\n"
 "\n");
-    /* clang-format off */
+    /* clang-format on */
     sdsfree(version);
     exit(err);
 }

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2999,6 +2999,7 @@ static void parseEnv(void) {
 static void usage(int err) {
     sds version = cliVersion();
     FILE *target = err ? stderr: stdout;
+    /* clang-format off */
     const char *tls_usage =
 #ifdef USE_OPENSSL
 "  --tls              Establish a secure TLS connection.\n"
@@ -3146,6 +3147,7 @@ version,tls_usage);
 "Type \"help\" in interactive mode for information on available commands\n"
 "and settings.\n"
 "\n");
+    /* clang-format off */
     sdsfree(version);
     exit(err);
 }
@@ -5388,6 +5390,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts,
             *p = '\0';
             char *token = line;
             line = p + 1;
+            /* clang-format off */
             switch(i++){
             case 0: name = token; break;
             case 1: addr = token; break;
@@ -5398,6 +5401,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts,
             case 6: config_epoch = token; break;
             case 7: link_status = token; break;
             }
+            /* clang-format on */
             if (i == 8) break; // Slots
         }
         if (!flags) {

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -340,6 +340,7 @@ static inline unsigned int zipEncodingLenSize(unsigned char encoding) {
 
 /* Return bytes needed to store integer encoded by 'encoding' */
 static inline unsigned int zipIntSize(unsigned char encoding) {
+    /* clang-format off */
     switch(encoding) {
     case ZIP_INT_8B:  return 1;
     case ZIP_INT_16B: return 2;
@@ -347,6 +348,7 @@ static inline unsigned int zipIntSize(unsigned char encoding) {
     case ZIP_INT_32B: return 4;
     case ZIP_INT_64B: return 8;
     }
+    /* clang-format on */
     if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX)
         return 0; /* 4 bit immediate */
     /* bad encoding, covered by a previous call to ZIP_ASSERT_ENCODING */


### PR DESCRIPTION
This is a preparation for adding clang-format.

These comments prevent automatic formatting in some places. With these exceptions, we will be able to run clang-format on the rest of the code.

This is a preparation for #323.