### PR TITLE
Remove intsettest declaration from intset.h

### DIFF
--- a/src/intset.h
+++ b/src/intset.h
@@ -50,8 +50,4 @@ uint32_t intsetLen(const intset *is);
 size_t intsetBlobLen(intset *is);
 int intsetValidateIntegrity(const unsigned char *is, size_t size, int deep);
 
-#ifdef SERVER_TEST
-int intsetTest(int argc, char *argv[], int flags);
-#endif
-
 #endif // __INTSET_H


### PR DESCRIPTION
All the intset unit tests are migrated to new test framework as part of https://github.com/valkey-io/valkey/pull/344, but the old framework declaration is missed to remove from intset.h. So removed the code.