### PR TITLE
Fix build error for unit test

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -466,7 +466,7 @@ $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
 
 # valkey-unit-tests
 $(ENGINE_UNIT_TESTS): $(ENGINE_TEST_OBJ) $(ENGINE_LIB_NAME)
-	$(SERVER_LD) $(ALLOW_DUPLICATE_FLAG) -o $@ $^ ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
+	$(SERVER_LD) $(ALLOW_DUPLICATE_FLAG) -o $@ $^ ../deps/hiredis/libhiredis.a ../deps/lua/src/liblua.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
 
 # valkey-sentinel
 $(ENGINE_SENTINEL_NAME): $(SERVER_NAME)


### PR DESCRIPTION
Fix the compile error with the following command:
`make all-with-unit-tests SERVER_CFLAGS='-Werror -DSERVER_TEST'
`

```
/usr/bin/ld: /home/ubuntu/valkey-shiv-repo/valkey/src/eval.c:1172: undefined reference to `lua_next'
/usr/bin/ld: /home/ubuntu/valkey-shiv-repo/valkey/src/eval.c:1154: undefined reference to `lua_toboolean'
/usr/bin/ld: /home/ubuntu/valkey-shiv-repo/valkey/src/eval.c:1175: undefined reference to `lua_type'
/usr/bin/ld: /home/ubuntu/valkey-shiv-repo/valkey/src/eval.c:1176: undefined reference to `lua_tonumber'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:469: valkey-unit-tests] Error 1
make[1]: Leaving directory '/home/ubuntu/valkey-shiv-repo/valkey/src'
make: *** [Makefile:6: all-with-unit-tests] Error 2
```

Issue is happened as all deps libraries not linked for  valkey-unit-tests, so linked all libraries to the binary.