### PR TITLE
Add lfu support for DEBUG OBJECT command, added lfu_freq and lfu_access_time_minutes fields

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -658,7 +658,9 @@ void debugCommand(client *c) {
         sds s = sdsempty();
         s = sdscatprintf(s, "Value at:%p refcount:%d encoding:%s", (void *)val, val->refcount, strenc);
         if (!fast) s = sdscatprintf(s, " serializedlength:%zu", rdbSavedObjectLen(val, c->argv[2], c->db->id));
+        /* Either lru or lfu field could work correctly which depends on server.maxmemory_policy. */
         s = sdscatprintf(s, " lru:%d lru_seconds_idle:%llu", val->lru, estimateObjectIdleTime(val) / 1000);
+        s = sdscatprintf(s, " lfu_freq:%lu lfu_access_time_minutes:%u", LFUDecrAndReturn(val), val->lru >> 8);
         s = sdscatprintf(s, "%s", extra);
         addReplyStatusLength(c, s, sdslen(s));
         sdsfree(s);


### PR DESCRIPTION
For `debug object` command, we use `val->lru` but ignore the `lfu` mode.  
So in `lfu` mode, `debug object` would return meaningless `lru` descriptions. 

Added two new fields lfu_freq and lfu_access_time_minutes.
