### PR TITLE
[Feat] Support fast fail option for tcl test cases

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -299,7 +299,7 @@ proc parse_options {} {
             set val2 [lindex $::argv [expr $j+2]]
             dict set ::global_config $val $val2
             incr j 2
-        } elseif {$opt eq {--fastfail}} {
+        } elseif {$opt eq {--fast-fail}} {
             set ::exit_on_failure 1
         } elseif {$opt eq {--stop}} {
             set ::stop_on_failure 1
@@ -319,7 +319,7 @@ proc parse_options {} {
             puts "--tls-module            Run tests in TLS mode with Valkey module."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
-            puts "--fastfail              Exit immediately once the first test fails."
+            puts "--fast-fail             Exit immediately once the first test fails."
             puts "--stop                  Blocks once the first test fails."
             puts "--loop                  Execute the specified set of tests forever."
             puts "--help                  Shows this help."
@@ -488,7 +488,7 @@ while 1 {
             # letting the tests resume, so we'll eventually reach the cleanup and report crashes
 
             if {$::exit_on_failure} {
-                puts -nonewline "(Fastfail: test will exit now)"
+                puts -nonewline "(Fast fail: test will exit now)"
                 flush stdout
                 exit 1
             }

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -35,6 +35,7 @@ set ::leaked_fds_file [file normalize "tmp/leaked_fds.txt"]
 set ::pids {} ; # We kill everything at exit
 set ::dirs {} ; # We remove all the temp dirs at exit
 set ::run_matching {} ; # If non empty, only tests matching pattern are run.
+set ::exit_on_failure 0
 set ::stop_on_failure 0
 set ::loop 0
 
@@ -298,6 +299,8 @@ proc parse_options {} {
             set val2 [lindex $::argv [expr $j+2]]
             dict set ::global_config $val $val2
             incr j 2
+        } elseif {$opt eq {--fastfail}} {
+            set ::exit_on_failure 1
         } elseif {$opt eq {--stop}} {
             set ::stop_on_failure 1
         } elseif {$opt eq {--loop}} {
@@ -316,6 +319,7 @@ proc parse_options {} {
             puts "--tls-module            Run tests in TLS mode with Valkey module."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
+            puts "--fastfail              Exit immediately once the first test fails."
             puts "--stop                  Blocks once the first test fails."
             puts "--loop                  Execute the specified set of tests forever."
             puts "--help                  Shows this help."
@@ -483,6 +487,11 @@ while 1 {
             incr ::failed
             # letting the tests resume, so we'll eventually reach the cleanup and report crashes
 
+            if {$::exit_on_failure} {
+                puts -nonewline "(Fastfail: test will exit now)"
+                flush stdout
+                exit 1
+            }
             if {$::stop_on_failure} {
                 puts -nonewline "(Test stopped, press enter to resume the tests)"
                 flush stdout

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -233,6 +233,11 @@ proc test {name code {okpattern undefined} {tags {}}} {
             incr ::num_failed
             send_data_packet $::test_server_fd err [join $details "\n"]
 
+            if {$::exit_on_failure} {
+                puts "Test error (last server port:[srv port], log:[srv stdout]), test will exit now"
+                flush stdout
+                exit 1
+            }
             if {$::stop_on_failure} {
                 puts "Test error (last server port:[srv port], log:[srv stdout]), press enter to teardown the test."
                 flush stdout

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -385,7 +385,7 @@ proc read_from_test_client fd {
         lappend ::failed_tests $err
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
-            puts -nonewline "(Fastfail: test will exit now)"
+            puts -nonewline "(Fast fail: test will exit now)"
             flush stdout
             exit 1
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -65,6 +65,7 @@ set ::active_servers {} ; # Pids of active server instances.
 set ::dont_clean 0
 set ::dont_pre_clean 0
 set ::wait_server 0
+set ::exit_on_failure 0
 set ::stop_on_failure 0
 set ::dump_logs 0
 set ::loop 0
@@ -383,6 +384,11 @@ proc read_from_test_client fd {
         puts $err
         lappend ::failed_tests $err
         set ::active_clients_task($fd) "(ERR) $data"
+        if {$::exit_on_failure} {
+            puts -nonewline "(Fastfail: test will exit now)"
+            flush stdout
+            exit 1
+        }
         if {$::stop_on_failure} {
             puts -nonewline "(Test stopped, press enter to resume the tests)"
             flush stdout
@@ -564,6 +570,7 @@ proc print_help_screen {} {
         "--dont-clean       Don't delete valkey log files after the run."
         "--dont-pre-clean   Don't delete existing valkey log files before the run."
         "--no-latency       Skip latency measurements and validation by some tests."
+        "--fastfail         Exit immediately once the first test fails."
         "--stop             Blocks once the first test fails."
         "--loop             Execute the specified set of tests forever."
         "--loops <count>    Execute the specified set of tests several times."
@@ -688,6 +695,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::wait_server 1
     } elseif {$opt eq {--dump-logs}} {
         set ::dump_logs 1
+    } elseif {$opt eq {--fastfail}} {
+        set ::exit_on_failure 1
     } elseif {$opt eq {--stop}} {
         set ::stop_on_failure 1
     } elseif {$opt eq {--loop}} {


### PR DESCRIPTION
 #452 was closed by misoperation, recreate it here

```
Hi, new here in valkey community.

This PR added a new option for tcl test case which will fail fast once any test cases fail.
This can be useful while running redis CI pipeline, and you want to accelerate the CI pipeline.

Appreciate all the things you guys have done, hope can contribute to this project.
```

usage for example

> ./runtest --single unit/type/hash --fast-fail

```
[ok]: HSET/HLEN - Small hash creation (2 ms)
[ok]: Is the small hash encoded with a listpack? (0 ms)
[ok]: HRANDFIELD - listpack (8 ms)
[ok]: HRANDFIELD - hashtable (7 ms)
Test error (last server port:21113, log:./tests/tmp/server.3935664.1/stdout), test will exit now
[err]: HRANDFIELD with RESP3 in tests/unit/type/hash.tcl
Expected '3' to be equal to '2333' (context: type eval line 8 cmd {assert_equal [llength $res] 2333} proc ::test)
(Fastfail: test will exit now)
```