### PR TITLE
Suppress ASAN errors on tests that intentially crash the server via `crash-memcheck-enabled no`

### DIFF
--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -335,7 +335,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 }
 
-start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
+start_cluster 3 3 {tags {external:skip cluster} overrides {crash-memcheck-enabled no cluster-allow-replica-migration no cluster-node-timeout 1000} } {
     set R1_id [R 1 CLUSTER MYID]
 
     test "CLUSTER SETSLOT with an explicit timeout" {


### PR DESCRIPTION
Fix daily CI run errors like https://github.com/valkey-io/valkey/actions/runs/9039450198/job/24842308071#step:6:4176