### PR TITLE
Remove endian coverage from server.c

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6932,7 +6932,6 @@ struct serverTest {
     {"ziplist", ziplistTest},
     {"quicklist", quicklistTest},
     {"zipmap", zipmapTest},
-    {"endianconv", endianconvTest},
     {"zmalloc", zmalloc_test},
     {"dict", dictTest},
     {"listpack", listpackTest},


### PR DESCRIPTION
In https://github.com/valkey-io/valkey/commit/c7ad9feb52973da8ba7d49b5530837466a910477, we missed removed endian coverage from the legacy unit tests, so it failed to find it when building. Will fix the tests from https://github.com/valkey-io/valkey/actions/runs/9055193879/job/24875946145.