### PR TITLE
Minor fix in module API doc script

### DIFF
--- a/utils/generate-module-api-doc.rb
+++ b/utils/generate-module-api-doc.rb
@@ -25,7 +25,7 @@ def markdown(s)
             # Add backquotes around macro and var names containing underscores.
             l = l.gsub(/(?<![`A-z\*])[A-Za-z]+_[A-Za-z0-9_]+/){|x| "`#{x}`"}
             # Link URLs preceded by space or newline (not already linked)
-            l = l.gsub(/(^| )(https?:\/\/[A-Za-z0-9_\/\.\-]+[A-Za-z0-9\/])/,
+            l = l.gsub(/(^| )(https?:\/\/[A-Za-z0-9_\/\.\?=&+\#\-]+[A-Za-z0-9\/])/,
                        '\1[\2](\2)')
             # Replace double-dash with unicode ndash
             l = l.gsub(/ -- /, ' – ')
@@ -140,7 +140,6 @@ end
 puts "---\n"
 puts "title: \"Modules API reference\"\n"
 puts "linkTitle: \"API reference\"\n"
-puts "weight: 1\n"
 puts "description: >\n"
 puts "    Reference for the Valkey Modules API\n"
 puts "---\n"


### PR DESCRIPTION
The script extracts the comments and prototypes from module.c and does some pre-processing, e.g. converts URLs to markdown links. The URL regexp didn't account for '#', '?' (and a few more chars) so an URL like `https://example.com/#section` was converted to markdown as

    [https://example.com/](https://example.com/)#section

With this change, it's instead correctly converted to

    [https://example.com/#section](https://example.com/#section)

Additional change: Removes an unused metadata field.