### PR TITLE
Make it to so that unit tests build on mac

### DIFF
--- a/src/unit/test_util.c
+++ b/src/unit/test_util.c
@@ -266,12 +266,14 @@ static int cache_exist(int fd) {
      * page is currently resident in memory */
     return flag&1;
 }
+#endif
 
 int test_reclaimFilePageCache(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
 
+#if defined(__linux__)
     char *tmpfile = "/tmp/redis-reclaim-cache-test";
     int fd = open(tmpfile, O_RDWR|O_CREAT, 0644);
     TEST_ASSERT(fd >= 0);
@@ -291,8 +293,6 @@ int test_reclaimFilePageCache(int argc, char **argv, int flags) {
     TEST_ASSERT(!cache_exist(fd));
 
     unlink(tmpfile);
-    printf("reclaimFilePageCache test is ok\n");
-
+#endif
     return 0;
 }
-#endif


### PR DESCRIPTION
The test logic is not smart enough to realize that a test is fully #ifdef'd out, so it will try to attach it to the test suite anyways. This is a minor work around for the reclaim file page test so that it will still attach the test, it will just always succeed. Also remove an unnecessary print statement that was missed in the same test. 