### PR TITLE
Fix for Test Failures in Coverage Target (Issue #503)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -254,8 +254,8 @@ mstime_t commandTimeSnapshot(void) {
 
 /* After an RDB dump or AOF rewrite we exit from children using _exit() instead of
  * exit(), because the latter may interact with the same file objects used by
- * the parent process. However if we are testing the coverage normal exit() is
- * used in order to obtain the right coverage information. */
+ * the parent process. However if we are testing for coverage, in order to obtain
+ * the child process coverage data we first need to flush gcov files. */
 void exitFromChild(int retcode) {
 #ifdef COVERAGE_TEST
     extern void __gcov_flush(void);

--- a/src/server.c
+++ b/src/server.c
@@ -258,10 +258,10 @@ mstime_t commandTimeSnapshot(void) {
  * used in order to obtain the right coverage information. */
 void exitFromChild(int retcode) {
 #ifdef COVERAGE_TEST
-    exit(retcode);
-#else
-    _exit(retcode);
+    extern void __gcov_flush(void);
+    __gcov_flush();
 #endif
+    _exit(retcode);
 }
 
 /*====================== Hash table type implementation  ==================== */


### PR DESCRIPTION
As discussed in [Issue #503](https://github.com/valkey-io/valkey/issues/503), some tests fail when building the coverage target. The root cause is the difference in how we handle the exit from child function during the build process. When building for coverage, we use exit(), which allows gcov to properly close all .gcda files. However, in the regular build, we use _exit(), which exits abruptly, preventing the child process coverage data from being recorded.

While using exit() resolves the issue with .gcda files, it introduces other problems that likely cause the tests to fail for coverage even though they usually pass.

My proposed solution is to continue using _exit() but to manually flush all .gcda files before the _exit() command is executed. This ensures that the coverage data is properly recorded without the additional issues caused by using exit().

