### PR TITLE
Include stddef in zmalloc.h

### DIFF
--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -31,6 +31,8 @@
 #ifndef __ZMALLOC_H
 #define __ZMALLOC_H
 
+#include <stddef.h>
+
 /* Double expansion needed for stringification of macro values. */
 #define __xstr(s) __str(s)
 #define __str(s) #s


### PR DESCRIPTION
zmalloc.h uses size_t, which requires stddef. It seems like all the previous code paths were properly including it except for ASAN, which uses libc malloc and skips the special mac only malloc inclusions.

Example failure: https://github.com/valkey-io/valkey/actions/runs/9143545732/job/25140329029

See https://github.com/valkey-io/valkey/actions/runs/9149533754/job/25153263875. 