### PR TITLE
Delete dead code "zfree_usable" 

### DIFF
--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -49,6 +49,5 @@
 #define s_realloc_usable zrealloc_usable
 #define s_trymalloc_usable ztrymalloc_usable
 #define s_tryrealloc_usable ztryrealloc_usable
-#define s_free_usable zfree_usable
 
 #endif

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -381,25 +381,6 @@ void zfree(void *ptr) {
 #endif
 }
 
-/* Similar to zfree, '*usable' is set to the usable size being freed. */
-void zfree_usable(void *ptr, size_t *usable) {
-#ifndef HAVE_MALLOC_SIZE
-    void *realptr;
-    size_t oldsize;
-#endif
-
-    if (ptr == NULL) return;
-#ifdef HAVE_MALLOC_SIZE
-    update_zmalloc_stat_free(*usable = zmalloc_size(ptr));
-    free(ptr);
-#else
-    realptr = (char*)ptr-PREFIX_SIZE;
-    *usable = oldsize = *((size_t*)realptr);
-    update_zmalloc_stat_free(oldsize+PREFIX_SIZE);
-    free(realptr);
-#endif
-}
-
 char *zstrdup(const char *s) {
     size_t l = strlen(s)+1;
     char *p = zmalloc(l);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -123,7 +123,6 @@ void *zrealloc_usable(void *ptr, size_t size, size_t *usable);
 void *ztrymalloc_usable(size_t size, size_t *usable);
 void *ztrycalloc_usable(size_t size, size_t *usable);
 void *ztryrealloc_usable(void *ptr, size_t size, size_t *usable);
-void zfree_usable(void *ptr, size_t *usable);
 __attribute__((malloc)) char *zstrdup(const char *s);
 size_t zmalloc_used_memory(void);
 void zmalloc_set_oom_handler(void (*oom_handler)(size_t));


### PR DESCRIPTION
Implemented in https://github.com/valkey-io/valkey/commit/3945a321779a0be52e556aa11babb3fe15883a78#diff-a154d1fa454a9868e2c455acdae971e3605151516f9a8efac7f2c9b2845d914d, this function is never called and never used. I was trying to understand whether we could use this for another PR, but couldn't really find a point for it because it didn't do exactly what I expected.