### PR TITLE
Revert mmap_rnd bits back to default value in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,7 @@ jobs:
         # build with TLS module just for compilation coverage
         run: make SANITIZER=address SERVER_CFLAGS='-Werror -DDEBUG_ASSERTIONS' BUILD_TLS=module
       - name: testprep
-        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
-        run: |
-          sudo apt-get install tcl8.6 tclx -y
-          sudo sysctl vm.mmap_rnd_bits=28
+        run: sudo apt-get install tcl8.6 tclx -y
       - name: test
         run: ./runtest --verbose --tags -slow --dump-logs
       - name: module api test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -600,11 +600,9 @@ jobs:
       - name: make
         run: make all-with-unit-tests OPT=-O3 SANITIZER=address SERVER_CFLAGS='-DSERVER_TEST -Werror -DDEBUG_ASSERTIONS'
       - name: testprep
-        # Work around ASAN issue, see https://github.com/google/sanitizers/issues/1716
         run: |
           sudo apt-get update
           sudo apt-get install tcl8.6 tclx -y
-          sudo sysctl vm.mmap_rnd_bits=28
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
         run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}


### PR DESCRIPTION
In 3f725b8, we introduced a change back in march to reduce the
entropy of ASLR, because ASAN didn't support it. Now the vm.mmap_rnd_bits
was reverted in actions/runner-images#9491 so can remove this changes.

Closes #519.