### PR TITLE
Quick fix of failure when use libc allocator in daily CI.

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -378,6 +378,7 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
     }
     s[len] = '\0';
     sdssetlen(s, len);
+    if (newsize > sdsTypeMaxSize(s[-1])) newsize = sdsTypeMaxSize(s[-1]);
     sdssetalloc(s, newsize);
     return s;
 }


### PR DESCRIPTION
Make `sdsResize` logic align with `_sdsnewlen`, fix of https://github.com/valkey-io/valkey/pull/476.
Fix: 
https://github.com/valkey-io/valkey/actions/runs/9143545732/job/25140329542#step:6:1505
https://github.com/valkey-io/valkey/actions/runs/9135654696/job/25123330670#step:6:1501
