### PR TITLE
Deprecate MacOS 11 build target

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -896,7 +896,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-11, macos-13]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'valkey-io/valkey')) &&

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -896,7 +896,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-12, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' || (github.event_name != 'workflow_dispatch' && github.repository == 'valkey-io/valkey')) &&


### PR DESCRIPTION
Deprecate MacOS 11 build target. End of life June 2024.  Fixes #523 