### PR TITLE
Reinitialize pointer 'p' after ziplistDeleteRange to fix head deletion bug

### DIFF
--- a/src/unit/test_ziplist.c
+++ b/src/unit/test_ziplist.c
@@ -360,7 +360,7 @@ int test_ziplistDeleteInclusiveRange0To0(int argc, char **argv, int flags) {
     int orig_len = ziplistLen(zl);
 
     zl = ziplistDeleteRange(zl, 0, 1);
-
+    p = ziplistIndex(zl, 0);
     TEST_ASSERT(ziplistCompare(p, (unsigned char *)"foo", 3));
     int new_len = ziplistLen(zl);
     TEST_ASSERT(orig_len - 1 == new_len);


### PR DESCRIPTION
Fix https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916

```
=================================================================
==60641==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040000005da at pc 0x562fc88[7](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:8)d0b1 bp 0x7ffccf8a7bf0 sp 0x7ffccf8a7be8
READ of size 1 at 0x6040000005da thread T0
    #0 0x562fc887d0b0 in ziplistCompare /home/runner/work/valkey/valkey/src/unit/../ziplist.c:1329:9
    #1 0x562fc[8](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:9)884c3b in test_ziplistDeleteInclusiveRange0To0 /home/runner/work/valkey/valkey/src/unit/test_ziplist.c:364:5
    #2 0x562fc886e0[9](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:10)b in runTestSuite /home/runner/work/valkey/valkey/src/unit/test_main.c:26:28
    #3 0x562fc886e4b2 in main /home/runner/work/valkey/valkey/src/unit/test_main.c:58:14
    #4 0x7fd720229d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #5 0x7fd720229e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #6 0x562fc87a34b4 in _start (/home/runner/work/valkey/valkey/src/valkey-unit-tests+0x394b4) (BuildId: d79616e0ee9bbd4edc7e6a8b6363e5b02ff633dc)

0x6040000005da is located [10](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:11) bytes inside of 33-byte region [0x6040000005d0,0x6040000005f1)
freed by thread T0 here:
    #0 0x562fc8826726 in __interceptor_realloc (/home/runner/work/valkey/valkey/src/valkey-unit-tests+0xbc726) (BuildId: d79616e0ee9bbd4edc7e6a8b6363e5b02ff633dc)
    #1 0x562fc88b4824 in ztryrealloc_usable_internal /home/runner/work/valkey/valkey/src/zmalloc.c:288:14
    #2 0x562fc88b4870 in zrealloc /home/runner/work/valkey/valkey/src/zmalloc.c:328:[11](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:12)
    #3 0x562fc88798e2 in ziplistResize /home/runner/work/valkey/valkey/src/unit/../ziplist.c:727:10
    #4 0x562fc88798e2 in __ziplistDelete /home/runner/work/valkey/valkey/src/unit/../ziplist.c:909:14
    #5 0x562fc8884c19 in ziplistDeleteRange /home/runner/work/valkey/valkey/src/unit/../ziplist.c:[12](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:13)84:31
    #6 0x562fc8884c19 in test_ziplistDeleteInclusiveRange0To0 /home/runner/work/valkey/valkey/src/unit/test_ziplist.c:362:10
    #7 0x562fc886e09b in runTestSuite /home/runner/work/valkey/valkey/src/unit/test_main.c:26:28
    #8 0x562fc886e4b2 in main /home/runner/work/valkey/valkey/src/unit/test_main.c:58:14
    #9 0x7fd720229d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 962015aa9d[13](https://github.com/valkey-io/valkey/actions/runs/9200055659/job/25305949916#step:11:14)3c6cbcfb31ec300596d7f44d3348)
    ```