### PR TITLE
Make sure clear the CLUSTER SLOTS cache on time when updating hostname

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -752,7 +752,6 @@ void clusterSaveConfigOrDie(int do_fsync) {
         serverLog(LL_WARNING, "Fatal: can't update cluster config file.");
         exit(1);
     }
-    clearCachedClusterSlotsResponse();
 }
 
 /* Lock the cluster config using flock(), and retain the file descriptor used to
@@ -4847,6 +4846,9 @@ void clusterBeforeSleep(void) {
 }
 
 void clusterDoBeforeSleep(int flags) {
+    /* Clear the cache if there are config changes here. */
+    if (flags & CLUSTER_TODO_SAVE_CONFIG) clearCachedClusterSlotsResponse();
+
     server.cluster->todo_before_sleep |= flags;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2612,7 +2612,6 @@ static int updateClusterIp(const char **err) {
 int updateClusterHostname(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfHostname();
-    clearCachedClusterSlotsResponse();
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2612,6 +2612,7 @@ static int updateClusterIp(const char **err) {
 int updateClusterHostname(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfHostname();
+    clearCachedClusterSlotsResponse();
     return 1;
 }
 

--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -73,6 +73,20 @@ test "Verify cluster-preferred-endpoint-type behavior for redirects and info" {
     # Verify prefer hostname behavior
     R 0 config set cluster-preferred-endpoint-type hostname
 
+    # Make sure the cache is cleared when updating hostname.
+    R 0 multi
+    R 0 cluster slots
+    R 0 config set cluster-announce-hostname "new-me.com"
+    R 0 cluster slots
+    set multi_result [R 0 exec]
+    set slot_result1 [lindex $multi_result 0]
+    set slot_result2 [lindex $multi_result 2]
+    assert_equal "me.com" [get_slot_field $slot_result1 0 2 0]
+    assert_equal "new-me.com" [get_slot_field $slot_result2 0 2 0]
+
+    # Set it back to its original value.
+    R 0 config set cluster-announce-hostname "me.com"
+
     set slot_result [R 0 cluster slots]
     assert_equal "me.com" [get_slot_field $slot_result 0 2 0]
     assert_equal "them.com" [get_slot_field $slot_result 2 2 0]


### PR DESCRIPTION
In #53, we will cache the CLUSTER SLOTS response to improve the
throughput and reduct the latency.

In the code snippet below, the second cluster slots will use the
old hostname:
```
config set cluster-preferred-endpoint-type hostname
config set cluster-announce-hostname old-hostname.com
multi
cluster slots
config set cluster-announce-hostname new-hostname.com
cluster slots
exec
```

When updating the hostname, in updateAnnouncedHostname, we will set
CLUSTER_TODO_SAVE_CONFIG and we will do a clearCachedClusterSlotsResponse
in clusterSaveConfigOrDie, so harmless in most cases.

Move the clearCachedClusterSlotsResponse call to clusterDoBeforeSleep
instead of scheduling it to be called in clusterSaveConfigOrDie.