### PR TITLE
Fix bitops.c clang-format properly

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -808,10 +808,9 @@ void bitcountCommand(client *c) {
             }
         }
         if (c->argc >= 4) {
-            if (getLongLongFromObjectOrReply(c,c->argv[3],&end,NULL) != C_OK)
-                return;
+            if (getLongLongFromObjectOrReply(c, c->argv[3], &end, NULL) != C_OK) return;
         }
-        
+
         /* Lookup, check for type. */
         o = lookupKeyRead(c->db, c->argv[1]);
         if (checkType(c, o, OBJ_STRING)) return;
@@ -821,7 +820,7 @@ void bitcountCommand(client *c) {
         /* Make sure we will not overflow */
         serverAssert(totlen <= LLONG_MAX >> 3);
 
-        if (c->argc < 4) end = totlen-1;
+        if (c->argc < 4) end = totlen - 1;
 
         /* Convert negative indexes */
         if (start < 0 && end < 0 && start > end) {


### PR DESCRIPTION
ref:
- https://github.com/valkey-io/valkey/pull/118 (my pervious change)
- https://github.com/valkey-io/valkey/pull/461 (issuing that clang format checker fails due to my change)

There was an issue that clang-format cheker failed.
I don't know why I missed it and why it didn't catch.

just running `clang-format -i bitops.c` was all.