### PR TITLE
Update rewriteConfigSaveOption function code to rewrite multiple save in one line.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1369,11 +1369,12 @@ void rewriteConfigSaveOption(standardConfig *config, const char *name, struct re
     if (!server.saveparamslen) {
         rewriteConfigRewriteLine(state, name, sdsnew("save \"\""), 1);
     } else {
+        line = sdsnew(name);
         for (j = 0; j < server.saveparamslen; j++) {
-            line = sdscatprintf(sdsempty(), "save %ld %d", (long)server.saveparams[j].seconds,
+            line = sdscatprintf(line, " %ld %d", (long)server.saveparams[j].seconds,
                                 server.saveparams[j].changes);
-            rewriteConfigRewriteLine(state, name, line, 1);
         }
+        rewriteConfigRewriteLine(state, name, line, 1);
     }
 
     /* Mark "save" as processed in case server.saveparamslen is zero. */

--- a/src/config.c
+++ b/src/config.c
@@ -1371,8 +1371,7 @@ void rewriteConfigSaveOption(standardConfig *config, const char *name, struct re
     } else {
         line = sdsnew(name);
         for (j = 0; j < server.saveparamslen; j++) {
-            line = sdscatprintf(line, " %ld %d", (long)server.saveparams[j].seconds,
-                                server.saveparams[j].changes);
+            line = sdscatprintf(line, " %ld %d", (long)server.saveparams[j].seconds, server.saveparams[j].changes);
         }
         rewriteConfigRewriteLine(state, name, line, 1);
     }


### PR DESCRIPTION
Currently, "config rewrite" writes some default value in the config file incase of empty config file specified.

But it adds multiple "save" config entries as follows:
```
save 3600 1
save 300 100
save 60 10000
```

After the fix the save will look like:
```
save 3600 1 300 100 60 10000
```