### PR TITLE
Introduce `enable-debug-assert` to enable/disable debug asserts at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: make
         # build with TLS module just for compilation coverage
-        run: make SANITIZER=address SERVER_CFLAGS='-Werror -DDEBUG_ASSERTIONS' BUILD_TLS=module
+        run: make SANITIZER=address SERVER_CFLAGS='-Werror' BUILD_TLS=module
       - name: testprep
         run: sudo apt-get install tcl8.6 tclx -y
       - name: test

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -598,7 +598,7 @@ jobs:
           repository: ${{ env.GITHUB_REPOSITORY }}
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
-        run: make all-with-unit-tests OPT=-O3 SANITIZER=address SERVER_CFLAGS='-DSERVER_TEST -Werror -DDEBUG_ASSERTIONS'
+        run: make all-with-unit-tests OPT=-O3 SANITIZER=address SERVER_CFLAGS='-DSERVER_TEST -Werror'
       - name: testprep
         run: |
           sudo apt-get update

--- a/src/config.c
+++ b/src/config.c
@@ -3191,7 +3191,9 @@ standardConfig static_configs[] = {
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
+    createBoolConfig("enable-debug-assert", NULL, MODIFIABLE_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
 
+    /* Tls configs */
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20 * 1024, INTEGER_CONFIG, NULL, applyTlsCfg),
     createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, INTEGER_CONFIG, NULL, applyTlsCfg),

--- a/src/config.c
+++ b/src/config.c
@@ -3191,7 +3191,7 @@ standardConfig static_configs[] = {
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
-    createBoolConfig("enable-debug-assert", NULL, MODIFIABLE_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
+    createBoolConfig("enable-debug-assert", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
 
     /* Tls configs */
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */

--- a/src/server.h
+++ b/src/server.h
@@ -701,13 +701,11 @@ typedef enum {
 #define serverAssert(_e) (likely(_e) ? (void)0 : (_serverAssert(#_e, __FILE__, __LINE__), valkey_unreachable()))
 #define serverPanic(...) _serverPanic(__FILE__, __LINE__, __VA_ARGS__), valkey_unreachable()
 
-/* The following macros provide assertions that are only executed during test builds and should be used to add
- * assertions that are too computationally expensive or dangerous to run during normal operations.  */
-#ifdef DEBUG_ASSERTIONS
-#define debugServerAssertWithInfo(...) serverAssertWithInfo(__VA_ARGS__)
-#else
-#define debugServerAssertWithInfo(...)
-#endif
+/* The following macro provides a conditional assertion that is only executed
+ * when the server config 'enable-debug-assert' is true. This is useful for adding
+ * assertions that are too computationally expensive or risky to run in normal
+ * operation, but are valuable for debugging or testing. */
+#define debugServerAssertWithInfo(...) (server.enable_debug_assert ? serverAssertWithInfo(__VA_ARGS__) : (void)0)
 
 /* latency histogram per command init settings */
 #define LATENCY_HISTOGRAM_MIN_VALUE 1L          /* >= 1 nanosec */
@@ -1680,6 +1678,7 @@ struct valkeyServer {
     int enable_protected_configs; /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
     int enable_debug_cmd;         /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
     int enable_module_cmd;        /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+    int enable_debug_assert;      /* Enable debug asserts */
 
     /* RDB / AOF loading information */
     volatile sig_atomic_t loading;       /* We are loading data from disk if true */

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -35,3 +35,5 @@ propagation-error-behavior panic
 
 # Make sure shutdown doesn't fail if there's an initial AOFRW
 shutdown-on-sigterm force
+
+enable-debug-assert yes

--- a/valkey.conf
+++ b/valkey.conf
@@ -133,7 +133,6 @@ protected-mode yes
 # enable-protected-configs no
 # enable-debug-command no
 # enable-module-command no
-# enable-debug-assert no
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified the server will not listen on a TCP socket.

--- a/valkey.conf
+++ b/valkey.conf
@@ -133,6 +133,7 @@ protected-mode yes
 # enable-protected-configs no
 # enable-debug-command no
 # enable-module-command no
+# enable-debug-assert no
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified the server will not listen on a TCP socket.


### PR DESCRIPTION
Introduce a new server configuration, `enable-debug-assert`, which allows selectively enabling or disabling, at runtime, expensive or risky assertions used primarily for debugging and testing.

Fix #569 