### PR TITLE
Skip tls for xgroup read regression since it doesn't matter

### DIFF
--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -423,7 +423,7 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 }
 
-start_cluster 2 0 {tags {external:skip cluster regression} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
+start_cluster 2 0 {tags {tls:skip external:skip cluster regression} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
     # Issue #563 regression test
     test "Client blocked on XREADGROUP while stream's slot is migrated" {
         set stream_name aga


### PR DESCRIPTION
"Client blocked on XREADGROUP while stream's slot is migrated" uses the migrate command, which requires special handling for TLS and non-tls. This was not being handled, so was throwing an error.

Example failure: https://github.com/valkey-io/valkey/actions/runs/9310806461/job/25628908045