### PR TITLE
Remove valdup from BenchmarkDictType, Fix "Remove unused valDup #443" 

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1748,7 +1748,7 @@ char *stringFromLongLong(long long value) {
     return s;
 }
 
-dictType BenchmarkDictType = {hashCallback, NULL, NULL, compareCallback, freeCallback, NULL, NULL};
+dictType BenchmarkDictType = {hashCallback, NULL, compareCallback, freeCallback, NULL, NULL};
 
 #define start_benchmark() start = timeInMilliseconds()
 #define end_benchmark(msg)                                                                                             \


### PR DESCRIPTION
makes SERVER_CFLAGS='-DSERVER_TEST' compile as well