### PR TITLE
Don't allow duplicate options for sorted set commands such as  ZINTER, ZUNION, and ZDIFF

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2529,8 +2529,8 @@ static void zdiff(zsetopsrc *src, long setnum, zset *dstzset, size_t *maxelelen,
     }
 }
 
-#define DUPLICATE_OPTION_WEIGHTS   1<<1
-#define DUPLICATE_OPTION_AGGREGATE 1<<2
+#define DUPLICATE_OPTION_WEIGHTS 1 << 1
+#define DUPLICATE_OPTION_AGGREGATE 1 << 2
 
 /* The zunionInterDiffGenericCommand() function is called in order to implement the
  * following commands: ZUNION, ZINTER, ZDIFF, ZUNIONSTORE, ZINTERSTORE, ZDIFFSTORE,

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2529,6 +2529,9 @@ static void zdiff(zsetopsrc *src, long setnum, zset *dstzset, size_t *maxelelen,
     }
 }
 
+#define DUPLICATE_OPTION_WEIGHTS   1<<1
+#define DUPLICATE_OPTION_AGGREGATE 1<<2
+
 /* The zunionInterDiffGenericCommand() function is called in order to implement the
  * following commands: ZUNION, ZINTER, ZDIFF, ZUNIONSTORE, ZINTERSTORE, ZDIFFSTORE,
  * ZINTERCARD.
@@ -2555,6 +2558,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
     int withscores = 0;
     unsigned long cardinality = 0;
     long limit = 0; /* Stop searching after reaching the limit. 0 means unlimited. */
+    u_int8_t dupCommandOptionFlag = 0;
 
     /* expect setnum input keys to be given */
     if ((getLongFromObjectOrReply(c, c->argv[numkeysIndex], &setnum, NULL) != C_OK)) return;
@@ -2605,6 +2609,12 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
         while (remaining) {
             if (op != SET_OP_DIFF && !cardinality_only && remaining >= (setnum + 1) &&
                 !strcasecmp(c->argv[j]->ptr, "weights")) {
+                if (dupCommandOptionFlag & DUPLICATE_OPTION_WEIGHTS) {
+                    addReplyError(c, "syntax error, multiple weights option is not allowed");
+                    zfree(src);
+                    return;
+                }
+                dupCommandOptionFlag |= DUPLICATE_OPTION_WEIGHTS;
                 j++;
                 remaining--;
                 for (i = 0; i < setnum; i++, j++, remaining--) {
@@ -2616,6 +2626,12 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                 }
             } else if (op != SET_OP_DIFF && !cardinality_only && remaining >= 2 &&
                        !strcasecmp(c->argv[j]->ptr, "aggregate")) {
+                if (dupCommandOptionFlag & DUPLICATE_OPTION_AGGREGATE) {
+                    addReplyError(c, "syntax error, multiple aggregate option is not allowed");
+                    zfree(src);
+                    return;
+                }
+                dupCommandOptionFlag |= DUPLICATE_OPTION_AGGREGATE;
                 j++;
                 remaining--;
                 if (!strcasecmp(c->argv[j]->ptr, "sum")) {
@@ -2634,6 +2650,11 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
             } else if (remaining >= 1 && !dstkey && !cardinality_only && !strcasecmp(c->argv[j]->ptr, "withscores")) {
                 j++;
                 remaining--;
+                if (withscores) {
+                    addReplyError(c, "syntax error, multiple withscores option is not allowed");
+                    zfree(src);
+                    return;
+                }
                 withscores = 1;
             } else if (cardinality_only && remaining >= 2 && !strcasecmp(c->argv[j]->ptr, "limit")) {
                 j++;


### PR DESCRIPTION
Fixes : https://github.com/valkey-io/valkey/issues/571

I added a flag to check options entered multiple times, if so, server returns an error as mentioned below. This is not the way it was intended, please suggest how it was pleanned so I will change accordingly. This issue may also occur on  the commands which has no maximum limit of arguments such as "arity : -<>". Based on the inputs or approval of this I will look at others, make a list  and fix.

Results after the fix:

```
127.0.0.1:6379> zinter 2 T G AGGREGATE MIN WITHSCORES  WITHSCORES
(error) ERR syntax error, multiple withscores option is not allowed
127.0.0.1:6379> zinter 2 T G AGGREGATE MIN AGGREGATE SUM WITHSCORES
(error) ERR syntax error, multiple aggregate option is not allowed
127.0.0.1:6379>
127.0.0.1:6379>
127.0.0.1:6379> zinter 2 T G WEIGHTS 1 2 WEIGHTS 2 2 WITHSCORES
(error) ERR syntax error, multiple weights option is not allowed
127.0.0.1:6379>
```
