### PR TITLE
module: fix typo in `REGISTER_API`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -11825,7 +11825,7 @@ int moduleRegisterApi(const char *funcname, void *funcptr) {
  * so that legacy Redis module binaries can continue to function */
 #define REGISTER_API(name) \
     moduleRegisterApi("ValkeyModule_" #name, (void *)(unsigned long)VM_ ## name);\
-    moduleRegisterApi("ValkeyModule_" #name, (void *)(unsigned long)VM_ ## name);\
+    moduleRegisterApi("RedisModule_" #name, (void *)(unsigned long)VM_ ## name);\
 
 /* Global initialization at Redis startup. */
 void moduleRegisterCoreAPI(void);


### PR DESCRIPTION
`REGISTER_API` is supposed to register two functions: one starts with `ValkeyModule_` and the other one with `RedisModule_`. It does so in `unstable` branch. However there was a copy-paste mistake during backporting it to 7.2. This caused modules built with `valkeymodule-rs` to fail since they called `RedisModule_SetModuleAttribs` which caused valkey to segfault.

This commit fixes the typo.