### PR TITLE
Remove unnecessary clang-format off annotations

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1587,12 +1587,10 @@ static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keyle
     listRewind(selector->patterns, &li);
 
     int key_flags = 0;
-    /* clang-format off */
     if (keyspec_flags & CMD_KEY_ACCESS) key_flags |= ACL_READ_PERMISSION;
     if (keyspec_flags & CMD_KEY_INSERT) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_DELETE) key_flags |= ACL_WRITE_PERMISSION;
     if (keyspec_flags & CMD_KEY_UPDATE) key_flags |= ACL_WRITE_PERMISSION;
-    /* clang-format on */
 
     /* Test this key against every pattern. */
     while ((ln = listNext(&li))) {
@@ -1618,12 +1616,10 @@ static int ACLSelectorHasUnrestrictedKeyAccess(aclSelector *selector, int flags)
     listRewind(selector->patterns, &li);
 
     int access_flags = 0;
-    /* clang-format off */
     if (flags & CMD_KEY_ACCESS) access_flags |= ACL_READ_PERMISSION;
     if (flags & CMD_KEY_INSERT) access_flags |= ACL_WRITE_PERMISSION;
     if (flags & CMD_KEY_DELETE) access_flags |= ACL_WRITE_PERMISSION;
     if (flags & CMD_KEY_UPDATE) access_flags |= ACL_WRITE_PERMISSION;
-    /* clang-format on */
 
     /* Test this key against every pattern. */
     while ((ln = listNext(&li))) {
@@ -2669,15 +2665,13 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     if (object) {
         le->object = object;
     } else {
-        /* clang-format off */
-        switch(reason) {
+        switch (reason) {
         case ACL_DENIED_CMD: le->object = sdsdup(c->cmd->fullname); break;
         case ACL_DENIED_KEY: le->object = sdsdup(c->argv[argpos]->ptr); break;
         case ACL_DENIED_CHANNEL: le->object = sdsdup(c->argv[argpos]->ptr); break;
         case ACL_DENIED_AUTH: le->object = sdsdup(c->argv[0]->ptr); break;
         default: le->object = sdsempty();
         }
-        /* clang-format on */
     }
 
     /* if we have a real client from the network, use it (could be missing on module timers) */
@@ -3058,28 +3052,24 @@ void aclCommand(client *c) {
 
             addReplyBulkCString(c, "reason");
             char *reasonstr;
-            /* clang-format off */
-            switch(le->reason) {
-            case ACL_DENIED_CMD: reasonstr="command"; break;
-            case ACL_DENIED_KEY: reasonstr="key"; break;
-            case ACL_DENIED_CHANNEL: reasonstr="channel"; break;
-            case ACL_DENIED_AUTH: reasonstr="auth"; break;
-            default: reasonstr="unknown";
+            switch (le->reason) {
+            case ACL_DENIED_CMD: reasonstr = "command"; break;
+            case ACL_DENIED_KEY: reasonstr = "key"; break;
+            case ACL_DENIED_CHANNEL: reasonstr = "channel"; break;
+            case ACL_DENIED_AUTH: reasonstr = "auth"; break;
+            default: reasonstr = "unknown";
             }
-            /* clang-format on */
             addReplyBulkCString(c, reasonstr);
 
             addReplyBulkCString(c, "context");
             char *ctxstr;
-            /* clang-format off */
-            switch(le->context) {
-            case ACL_LOG_CTX_TOPLEVEL: ctxstr="toplevel"; break;
-            case ACL_LOG_CTX_MULTI: ctxstr="multi"; break;
-            case ACL_LOG_CTX_LUA: ctxstr="lua"; break;
-            case ACL_LOG_CTX_MODULE: ctxstr="module"; break;
-            default: ctxstr="unknown";
+            switch (le->context) {
+            case ACL_LOG_CTX_TOPLEVEL: ctxstr = "toplevel"; break;
+            case ACL_LOG_CTX_MULTI: ctxstr = "multi"; break;
+            case ACL_LOG_CTX_LUA: ctxstr = "lua"; break;
+            case ACL_LOG_CTX_MODULE: ctxstr = "module"; break;
+            default: ctxstr = "unknown";
             }
-            /* clang-format on */
             addReplyBulkCString(c, ctxstr);
 
             addReplyBulkCString(c, "object");

--- a/src/aof.c
+++ b/src/aof.c
@@ -1994,21 +1994,19 @@ int rioWriteStreamPendingEntry(rio *r,
               RETRYCOUNT <count> JUSTID FORCE. */
     streamID id;
     streamDecodeID(rawid, &id);
-    /* clang-format off */
-    if (rioWriteBulkCount(r,'*',12) == 0) return 0;
-    if (rioWriteBulkString(r,"XCLAIM",6) == 0) return 0;
-    if (rioWriteBulkObject(r,key) == 0) return 0;
-    if (rioWriteBulkString(r,groupname,groupname_len) == 0) return 0;
-    if (rioWriteBulkString(r,consumer->name,sdslen(consumer->name)) == 0) return 0;
-    if (rioWriteBulkString(r,"0",1) == 0) return 0;
-    if (rioWriteBulkStreamID(r,&id) == 0) return 0;
-    if (rioWriteBulkString(r,"TIME",4) == 0) return 0;
-    if (rioWriteBulkLongLong(r,nack->delivery_time) == 0) return 0;
-    if (rioWriteBulkString(r,"RETRYCOUNT",10) == 0) return 0;
-    if (rioWriteBulkLongLong(r,nack->delivery_count) == 0) return 0;
-    if (rioWriteBulkString(r,"JUSTID",6) == 0) return 0;
-    if (rioWriteBulkString(r,"FORCE",5) == 0) return 0;
-    /* clang-format on */
+    if (rioWriteBulkCount(r, '*', 12) == 0) return 0;
+    if (rioWriteBulkString(r, "XCLAIM", 6) == 0) return 0;
+    if (rioWriteBulkObject(r, key) == 0) return 0;
+    if (rioWriteBulkString(r, groupname, groupname_len) == 0) return 0;
+    if (rioWriteBulkString(r, consumer->name, sdslen(consumer->name)) == 0) return 0;
+    if (rioWriteBulkString(r, "0", 1) == 0) return 0;
+    if (rioWriteBulkStreamID(r, &id) == 0) return 0;
+    if (rioWriteBulkString(r, "TIME", 4) == 0) return 0;
+    if (rioWriteBulkLongLong(r, nack->delivery_time) == 0) return 0;
+    if (rioWriteBulkString(r, "RETRYCOUNT", 10) == 0) return 0;
+    if (rioWriteBulkLongLong(r, nack->delivery_count) == 0) return 0;
+    if (rioWriteBulkString(r, "JUSTID", 6) == 0) return 0;
+    if (rioWriteBulkString(r, "FORCE", 5) == 0) return 0;
     return 1;
 }
 
@@ -2021,14 +2019,12 @@ int rioWriteStreamEmptyConsumer(rio *r,
                                 size_t groupname_len,
                                 streamConsumer *consumer) {
     /* XGROUP CREATECONSUMER <key> <group> <consumer> */
-    /* clang-format off */
-    if (rioWriteBulkCount(r,'*',5) == 0) return 0;
-    if (rioWriteBulkString(r,"XGROUP",6) == 0) return 0;
-    if (rioWriteBulkString(r,"CREATECONSUMER",14) == 0) return 0;
-    if (rioWriteBulkObject(r,key) == 0) return 0;
-    if (rioWriteBulkString(r,groupname,groupname_len) == 0) return 0;
-    if (rioWriteBulkString(r,consumer->name,sdslen(consumer->name)) == 0) return 0;
-    /* clang-format on */
+    if (rioWriteBulkCount(r, '*', 5) == 0) return 0;
+    if (rioWriteBulkString(r, "XGROUP", 6) == 0) return 0;
+    if (rioWriteBulkString(r, "CREATECONSUMER", 14) == 0) return 0;
+    if (rioWriteBulkObject(r, key) == 0) return 0;
+    if (rioWriteBulkString(r, groupname, groupname_len) == 0) return 0;
+    if (rioWriteBulkString(r, consumer->name, sdslen(consumer->name)) == 0) return 0;
     return 1;
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -1221,20 +1221,18 @@ char *ldbRespToHuman_Double(sds *o, char *reply);
  * char*) so that we can return a modified pointer, as for SDS semantics. */
 char *ldbRespToHuman(sds *o, char *reply) {
     char *p = reply;
-    /* clang-format off */
-    switch(*p) {
-    case ':': p = ldbRespToHuman_Int(o,reply); break;
-    case '$': p = ldbRespToHuman_Bulk(o,reply); break;
-    case '+': p = ldbRespToHuman_Status(o,reply); break;
-    case '-': p = ldbRespToHuman_Status(o,reply); break;
-    case '*': p = ldbRespToHuman_MultiBulk(o,reply); break;
-    case '~': p = ldbRespToHuman_Set(o,reply); break;
-    case '%': p = ldbRespToHuman_Map(o,reply); break;
-    case '_': p = ldbRespToHuman_Null(o,reply); break;
-    case '#': p = ldbRespToHuman_Bool(o,reply); break;
-    case ',': p = ldbRespToHuman_Double(o,reply); break;
+    switch (*p) {
+    case ':': p = ldbRespToHuman_Int(o, reply); break;
+    case '$': p = ldbRespToHuman_Bulk(o, reply); break;
+    case '+': p = ldbRespToHuman_Status(o, reply); break;
+    case '-': p = ldbRespToHuman_Status(o, reply); break;
+    case '*': p = ldbRespToHuman_MultiBulk(o, reply); break;
+    case '~': p = ldbRespToHuman_Set(o, reply); break;
+    case '%': p = ldbRespToHuman_Map(o, reply); break;
+    case '_': p = ldbRespToHuman_Null(o, reply); break;
+    case '#': p = ldbRespToHuman_Bool(o, reply); break;
+    case ',': p = ldbRespToHuman_Double(o, reply); break;
     }
-    /* clang-format on */
     return p;
 }
 

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -427,19 +427,17 @@ static inline void lpEncodeString(unsigned char *buf, unsigned char *s, uint32_t
  * lpCurrentEncodedSizeBytes or ASSERT_INTEGRITY_LEN (possibly since 'p' is
  * a return value of another function that validated its return. */
 static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
-    /* clang-format off */
     if (LP_ENCODING_IS_7BIT_UINT(p[0])) return 1;
-    if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1+LP_ENCODING_6BIT_STR_LEN(p);
+    if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1 + LP_ENCODING_6BIT_STR_LEN(p);
     if (LP_ENCODING_IS_13BIT_INT(p[0])) return 2;
     if (LP_ENCODING_IS_16BIT_INT(p[0])) return 3;
     if (LP_ENCODING_IS_24BIT_INT(p[0])) return 4;
     if (LP_ENCODING_IS_32BIT_INT(p[0])) return 5;
     if (LP_ENCODING_IS_64BIT_INT(p[0])) return 9;
-    if (LP_ENCODING_IS_12BIT_STR(p[0])) return 2+LP_ENCODING_12BIT_STR_LEN(p);
-    if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5+LP_ENCODING_32BIT_STR_LEN(p);
+    if (LP_ENCODING_IS_12BIT_STR(p[0])) return 2 + LP_ENCODING_12BIT_STR_LEN(p);
+    if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5 + LP_ENCODING_32BIT_STR_LEN(p);
     if (p[0] == LP_EOF) return 1;
     return 0;
-    /* clang-format on */
 }
 
 /* Return bytes needed to encode the length of the listpack element pointed by 'p'.
@@ -447,7 +445,6 @@ static inline uint32_t lpCurrentEncodedSizeUnsafe(unsigned char *p) {
  * of the element (excluding the element data itself)
  * If the element encoding is wrong then 0 is returned. */
 static inline uint32_t lpCurrentEncodedSizeBytes(unsigned char *p) {
-    /* clang-format off */
     if (LP_ENCODING_IS_7BIT_UINT(p[0])) return 1;
     if (LP_ENCODING_IS_6BIT_STR(p[0])) return 1;
     if (LP_ENCODING_IS_13BIT_INT(p[0])) return 1;
@@ -459,7 +456,6 @@ static inline uint32_t lpCurrentEncodedSizeBytes(unsigned char *p) {
     if (LP_ENCODING_IS_32BIT_STR(p[0])) return 5;
     if (p[0] == LP_EOF) return 1;
     return 0;
-    /* clang-format on */
 }
 
 /* Skip the current entry returning the next. It is invalid to call this

--- a/src/networking.c
+++ b/src/networking.c
@@ -2843,7 +2843,6 @@ sds catClientInfoString(sds s, client *client) {
         else
             *p++ = 'S';
     }
-    /* clang-format off */
     if (client->flags & CLIENT_PRIMARY) *p++ = 'M';
     if (client->flags & CLIENT_PUBSUB) *p++ = 'P';
     if (client->flags & CLIENT_MULTI) *p++ = 'x';
@@ -2860,7 +2859,6 @@ sds catClientInfoString(sds s, client *client) {
     if (client->flags & CLIENT_NO_EVICT) *p++ = 'e';
     if (client->flags & CLIENT_NO_TOUCH) *p++ = 'T';
     if (p == flags) *p++ = 'N';
-    /* clang-format on */
     *p++ = '\0';
 
     p = events;
@@ -3269,15 +3267,13 @@ NULL
         listRewind(server.clients, &li);
         while ((ln = listNext(&li)) != NULL) {
             client *client = listNodeValue(ln);
-            /* clang-format off */
-            if (addr && strcmp(getClientPeerId(client),addr) != 0) continue;
-            if (laddr && strcmp(getClientSockname(client),laddr) != 0) continue;
+            if (addr && strcmp(getClientPeerId(client), addr) != 0) continue;
+            if (laddr && strcmp(getClientSockname(client), laddr) != 0) continue;
             if (type != -1 && getClientType(client) != type) continue;
             if (id != 0 && client->id != id) continue;
             if (user && client->user != user) continue;
             if (c == client && skipme) continue;
             if (max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) < max_age) continue;
-            /* clang-format on */
 
             /* Kill it. */
             if (c == client) {

--- a/src/notify.c
+++ b/src/notify.c
@@ -42,8 +42,7 @@ int keyspaceEventsStringToFlags(char *classes) {
     int c, flags = 0;
 
     while ((c = *p++) != '\0') {
-        /* clang-format off */
-        switch(c) {
+        switch (c) {
         case 'A': flags |= NOTIFY_ALL; break;
         case 'g': flags |= NOTIFY_GENERIC; break;
         case '$': flags |= NOTIFY_STRING; break;
@@ -61,7 +60,6 @@ int keyspaceEventsStringToFlags(char *classes) {
         case 'n': flags |= NOTIFY_NEW; break;
         default: return -1;
         }
-        /* clang-format on */
     }
     return flags;
 }
@@ -73,28 +71,26 @@ int keyspaceEventsStringToFlags(char *classes) {
 sds keyspaceEventsFlagsToString(int flags) {
     sds res;
 
-    /* clang-format off */
     res = sdsempty();
     if ((flags & NOTIFY_ALL) == NOTIFY_ALL) {
-        res = sdscatlen(res,"A",1);
+        res = sdscatlen(res, "A", 1);
     } else {
-        if (flags & NOTIFY_GENERIC) res = sdscatlen(res,"g",1);
-        if (flags & NOTIFY_STRING) res = sdscatlen(res,"$",1);
-        if (flags & NOTIFY_LIST) res = sdscatlen(res,"l",1);
-        if (flags & NOTIFY_SET) res = sdscatlen(res,"s",1);
-        if (flags & NOTIFY_HASH) res = sdscatlen(res,"h",1);
-        if (flags & NOTIFY_ZSET) res = sdscatlen(res,"z",1);
-        if (flags & NOTIFY_EXPIRED) res = sdscatlen(res,"x",1);
-        if (flags & NOTIFY_EVICTED) res = sdscatlen(res,"e",1);
-        if (flags & NOTIFY_STREAM) res = sdscatlen(res,"t",1);
-        if (flags & NOTIFY_MODULE) res = sdscatlen(res,"d",1);
-        if (flags & NOTIFY_NEW) res = sdscatlen(res,"n",1);
+        if (flags & NOTIFY_GENERIC) res = sdscatlen(res, "g", 1);
+        if (flags & NOTIFY_STRING) res = sdscatlen(res, "$", 1);
+        if (flags & NOTIFY_LIST) res = sdscatlen(res, "l", 1);
+        if (flags & NOTIFY_SET) res = sdscatlen(res, "s", 1);
+        if (flags & NOTIFY_HASH) res = sdscatlen(res, "h", 1);
+        if (flags & NOTIFY_ZSET) res = sdscatlen(res, "z", 1);
+        if (flags & NOTIFY_EXPIRED) res = sdscatlen(res, "x", 1);
+        if (flags & NOTIFY_EVICTED) res = sdscatlen(res, "e", 1);
+        if (flags & NOTIFY_STREAM) res = sdscatlen(res, "t", 1);
+        if (flags & NOTIFY_MODULE) res = sdscatlen(res, "d", 1);
+        if (flags & NOTIFY_NEW) res = sdscatlen(res, "n", 1);
     }
-    if (flags & NOTIFY_KEYSPACE) res = sdscatlen(res,"K",1);
-    if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res,"E",1);
-    if (flags & NOTIFY_KEY_MISS) res = sdscatlen(res,"m",1);
+    if (flags & NOTIFY_KEYSPACE) res = sdscatlen(res, "K", 1);
+    if (flags & NOTIFY_KEYEVENT) res = sdscatlen(res, "E", 1);
+    if (flags & NOTIFY_KEY_MISS) res = sdscatlen(res, "m", 1);
     return res;
-    /* clang-format on */
 }
 
 /* The API provided to the rest of the serer core is a simple function:

--- a/src/object.c
+++ b/src/object.c
@@ -372,8 +372,7 @@ void incrRefCount(robj *o) {
 
 void decrRefCount(robj *o) {
     if (o->refcount == 1) {
-        /* clang-format off */
-        switch(o->type) {
+        switch (o->type) {
         case OBJ_STRING: freeStringObject(o); break;
         case OBJ_LIST: freeListObject(o); break;
         case OBJ_SET: freeSetObject(o); break;
@@ -383,7 +382,6 @@ void decrRefCount(robj *o) {
         case OBJ_STREAM: freeStreamObject(o); break;
         default: serverPanic("Unknown object type"); break;
         }
-        /* clang-format on */
         zfree(o);
     } else {
         if (o->refcount <= 0) serverPanic("decrRefCount against refcount <= 0");
@@ -552,8 +550,7 @@ void dismissObject(robj *o, size_t size_hint) {
          * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     if (o->refcount != 1) return;
-    /* clang-format off */
-    switch(o->type) {
+    switch (o->type) {
     case OBJ_STRING: dismissStringObject(o); break;
     case OBJ_LIST: dismissListObject(o, size_hint); break;
     case OBJ_SET: dismissSetObject(o, size_hint); break;
@@ -562,7 +559,6 @@ void dismissObject(robj *o, size_t size_hint) {
     case OBJ_STREAM: dismissStreamObject(o, size_hint); break;
     default: break;
     }
-    /* clang-format on */
 #else
     UNUSED(o);
     UNUSED(size_hint);
@@ -930,8 +926,7 @@ int getIntFromObjectOrReply(client *c, robj *o, int *target, const char *msg) {
 }
 
 char *strEncoding(int encoding) {
-    /* clang-format off */
-    switch(encoding) {
+    switch (encoding) {
     case OBJ_ENCODING_RAW: return "raw";
     case OBJ_ENCODING_INT: return "int";
     case OBJ_ENCODING_HT: return "hashtable";
@@ -943,7 +938,6 @@ char *strEncoding(int encoding) {
     case OBJ_ENCODING_STREAM: return "stream";
     default: return "unknown";
     }
-    /* clang-format on */
 }
 
 /* =========================== Memory introspection ========================= */

--- a/src/replication.c
+++ b/src/replication.c
@@ -3149,8 +3149,7 @@ void roleCommand(client *c) {
         if (replicaIsInHandshakeState()) {
             replica_state = "handshake";
         } else {
-            /* clang-format off */
-            switch(server.repl_state) {
+            switch (server.repl_state) {
             case REPL_STATE_NONE: replica_state = "none"; break;
             case REPL_STATE_CONNECT: replica_state = "connect"; break;
             case REPL_STATE_CONNECTING: replica_state = "connecting"; break;
@@ -3158,7 +3157,6 @@ void roleCommand(client *c) {
             case REPL_STATE_CONNECTED: replica_state = "connected"; break;
             default: replica_state = "unknown"; break;
             }
-            /* clang-format on */
         }
         addReplyBulkCString(c, replica_state);
         addReplyLongLong(c, server.primary ? server.primary->reploff : -1);

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -223,7 +223,8 @@ int parseReply(ReplyParser *parser, void *p_ctx) {
     case '(': return parseBigNumber(parser, p_ctx);
     case '=': return parseVerbatimString(parser, p_ctx);
     case '|': return parseAttributes(parser, p_ctx);
-    default: if (parser->callbacks.error) parser->callbacks.error(p_ctx);
+    default:
+        if (parser->callbacks.error) parser->callbacks.error(p_ctx);
     }
     return C_ERR;
 }

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -209,7 +209,6 @@ static int parseMap(ReplyParser *parser, void *p_ctx) {
 
 /* Parse a reply pointed to by parser->curr_location. */
 int parseReply(ReplyParser *parser, void *p_ctx) {
-    /* clang-format off */
     switch (parser->curr_location[0]) {
     case '$': return parseBulk(parser, p_ctx);
     case '+': return parseSimpleString(parser, p_ctx);
@@ -226,6 +225,5 @@ int parseReply(ReplyParser *parser, void *p_ctx) {
     case '|': return parseAttributes(parser, p_ctx);
     default: if (parser->callbacks.error) parser->callbacks.error(p_ctx);
     }
-    /* clang-format on */
     return C_ERR;
 }

--- a/src/sds.c
+++ b/src/sds.c
@@ -986,8 +986,7 @@ int is_hex_digit(char c) {
 /* Helper function for sdssplitargs() that converts a hex digit into an
  * integer from 0 to 15 */
 int hex_digit_to_int(char c) {
-    /* clang-format off */
-    switch(c) {
+    switch (c) {
     case '0': return 0;
     case '1': return 1;
     case '2': return 2;
@@ -1006,7 +1005,6 @@ int hex_digit_to_int(char c) {
     case 'f': case 'F': return 15;
     default: return 0;
     }
-    /* clang-format on */
 }
 
 /* Split a line into arguments, where every argument can be in the

--- a/src/sds.c
+++ b/src/sds.c
@@ -910,7 +910,7 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
     *count = elements;
     return tokens;
 
-cleanup : {
+cleanup: {
     int i;
     for (i = 0; i < elements; i++) sdsfree(tokens[i]);
     s_free(tokens);

--- a/src/sds.c
+++ b/src/sds.c
@@ -910,7 +910,7 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
     *count = elements;
     return tokens;
 
-cleanup: {
+cleanup : {
     int i;
     for (i = 0; i < elements; i++) sdsfree(tokens[i]);
     s_free(tokens);
@@ -997,12 +997,18 @@ int hex_digit_to_int(char c) {
     case '7': return 7;
     case '8': return 8;
     case '9': return 9;
-    case 'a': case 'A': return 10;
-    case 'b': case 'B': return 11;
-    case 'c': case 'C': return 12;
-    case 'd': case 'D': return 13;
-    case 'e': case 'E': return 14;
-    case 'f': case 'F': return 15;
+    case 'a':
+    case 'A': return 10;
+    case 'b':
+    case 'B': return 11;
+    case 'c':
+    case 'C': return 12;
+    case 'd':
+    case 'D': return 13;
+    case 'e':
+    case 'E': return 14;
+    case 'f':
+    case 'F': return 15;
     default: return 0;
     }
 }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3238,21 +3238,21 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     fields++;
 
     addReplyBulkCString(c, "flags");
-    if (ri->flags & SRI_S_DOWN) flags = sdscat(flags,"s_down,");
-    if (ri->flags & SRI_O_DOWN) flags = sdscat(flags,"o_down,");
-    if (ri->flags & SRI_PRIMARY) flags = sdscat(flags,"master,");
-    if (ri->flags & SRI_REPLICA) flags = sdscat(flags,"slave,");
-    if (ri->flags & SRI_SENTINEL) flags = sdscat(flags,"sentinel,");
-    if (ri->link->disconnected) flags = sdscat(flags,"disconnected,");
-    if (ri->flags & SRI_PRIMARY_DOWN) flags = sdscat(flags,"master_down,");
-    if (ri->flags & SRI_FAILOVER_IN_PROGRESS) flags = sdscat(flags,"failover_in_progress,");
-    if (ri->flags & SRI_PROMOTED) flags = sdscat(flags,"promoted,");
-    if (ri->flags & SRI_RECONF_SENT) flags = sdscat(flags,"reconf_sent,");
-    if (ri->flags & SRI_RECONF_INPROG) flags = sdscat(flags,"reconf_inprog,");
-    if (ri->flags & SRI_RECONF_DONE) flags = sdscat(flags,"reconf_done,");
-    if (ri->flags & SRI_FORCE_FAILOVER) flags = sdscat(flags,"force_failover,");
-    if (ri->flags & SRI_SCRIPT_KILL_SENT) flags = sdscat(flags,"script_kill_sent,");
-    if (ri->flags & SRI_PRIMARY_REBOOT) flags = sdscat(flags,"master_reboot,");
+    if (ri->flags & SRI_S_DOWN) flags = sdscat(flags, "s_down,");
+    if (ri->flags & SRI_O_DOWN) flags = sdscat(flags, "o_down,");
+    if (ri->flags & SRI_PRIMARY) flags = sdscat(flags, "master,");
+    if (ri->flags & SRI_REPLICA) flags = sdscat(flags, "slave,");
+    if (ri->flags & SRI_SENTINEL) flags = sdscat(flags, "sentinel,");
+    if (ri->link->disconnected) flags = sdscat(flags, "disconnected,");
+    if (ri->flags & SRI_PRIMARY_DOWN) flags = sdscat(flags, "master_down,");
+    if (ri->flags & SRI_FAILOVER_IN_PROGRESS) flags = sdscat(flags, "failover_in_progress,");
+    if (ri->flags & SRI_PROMOTED) flags = sdscat(flags, "promoted,");
+    if (ri->flags & SRI_RECONF_SENT) flags = sdscat(flags, "reconf_sent,");
+    if (ri->flags & SRI_RECONF_INPROG) flags = sdscat(flags, "reconf_inprog,");
+    if (ri->flags & SRI_RECONF_DONE) flags = sdscat(flags, "reconf_done,");
+    if (ri->flags & SRI_FORCE_FAILOVER) flags = sdscat(flags, "force_failover,");
+    if (ri->flags & SRI_SCRIPT_KILL_SENT) flags = sdscat(flags, "script_kill_sent,");
+    if (ri->flags & SRI_PRIMARY_REBOOT) flags = sdscat(flags, "master_reboot,");
 
     if (sdslen(flags) != 0) sdsrange(flags, 0, -2); /* remove last "," */
     addReplyBulkCString(c, flags);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -3015,15 +3015,13 @@ static void populateDict(dict *options_dict, char **options) {
 }
 
 const char *getLogLevel(void) {
-    /* clang-format off */
-   switch (server.verbosity) {
+    switch (server.verbosity) {
     case LL_DEBUG: return "debug";
     case LL_VERBOSE: return "verbose";
     case LL_NOTICE: return "notice";
     case LL_WARNING: return "warning";
     case LL_NOTHING: return "nothing";
     }
-    /* clang-format on */
     return "unknown";
 }
 
@@ -3203,8 +3201,7 @@ void sentinelConfigGetCommand(client *c) {
 }
 
 const char *sentinelFailoverStateStr(int state) {
-    /* clang-format off */
-    switch(state) {
+    switch (state) {
     case SENTINEL_FAILOVER_STATE_NONE: return "none";
     case SENTINEL_FAILOVER_STATE_WAIT_START: return "wait_start";
     case SENTINEL_FAILOVER_STATE_SELECT_REPLICA: return "select_slave";
@@ -3214,7 +3211,6 @@ const char *sentinelFailoverStateStr(int state) {
     case SENTINEL_FAILOVER_STATE_UPDATE_CONFIG: return "update_config";
     default: return "unknown";
     }
-    /* clang-format on */
 }
 
 /* Server instance to RESP representation. */
@@ -3242,7 +3238,6 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     fields++;
 
     addReplyBulkCString(c, "flags");
-    /* clang-format off */
     if (ri->flags & SRI_S_DOWN) flags = sdscat(flags,"s_down,");
     if (ri->flags & SRI_O_DOWN) flags = sdscat(flags,"o_down,");
     if (ri->flags & SRI_PRIMARY) flags = sdscat(flags,"master,");
@@ -3258,7 +3253,6 @@ void addReplySentinelRedisInstance(client *c, sentinelRedisInstance *ri) {
     if (ri->flags & SRI_FORCE_FAILOVER) flags = sdscat(flags,"force_failover,");
     if (ri->flags & SRI_SCRIPT_KILL_SENT) flags = sdscat(flags,"script_kill_sent,");
     if (ri->flags & SRI_PRIMARY_REBOOT) flags = sdscat(flags,"master_reboot,");
-    /* clang-format on */
 
     if (sdslen(flags) != 0) sdsrange(flags, 0, -2); /* remove last "," */
     addReplyBulkCString(c, flags);

--- a/src/server.c
+++ b/src/server.c
@@ -5078,27 +5078,29 @@ void commandGetKeysCommand(client *c) {
 
 /* COMMAND HELP */
 void commandHelpCommand(client *c) {
+    /* clang-format off */
     const char *help[] = {
-        "(no subcommand)",
-        "    Return details about all commands.",
-        "COUNT",
-        "    Return the total number of commands in this server.",
-        "LIST",
-        "    Return a list of all commands in this server.",
-        "INFO [<command-name> ...]",
-        "    Return details about multiple commands.",
-        "    If no command names are given, documentation details for all",
-        "    commands are returned.",
-        "DOCS [<command-name> ...]",
-        "    Return documentation details about multiple commands.",
-        "    If no command names are given, documentation details for all",
-        "    commands are returned.",
-        "GETKEYS <full-command>",
-        "    Return the keys from a full command.",
-        "GETKEYSANDFLAGS <full-command>",
-        "    Return the keys and the access flags from a full command.",
-        NULL
+"(no subcommand)",
+"    Return details about all commands.",
+"COUNT",
+"    Return the total number of commands in this server.",
+"LIST",
+"    Return a list of all commands in this server.",
+"INFO [<command-name> ...]",
+"    Return details about multiple commands.",
+"    If no command names are given, documentation details for all",
+"    commands are returned.",
+"DOCS [<command-name> ...]",
+"    Return documentation details about multiple commands.",
+"    If no command names are given, documentation details for all",
+"    commands are returned.",
+"GETKEYS <full-command>",
+"    Return the keys from a full command.",
+"GETKEYSANDFLAGS <full-command>",
+"    Return the keys and the access flags from a full command.",
+NULL
     };
+    /* clang-format on */
     addReplyHelp(c, help);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -614,15 +614,13 @@ void updateDictResizePolicy(void) {
 }
 
 const char *strChildType(int type) {
-    /* clang-format off */
-    switch(type) {
+    switch (type) {
     case CHILD_TYPE_RDB: return "RDB";
     case CHILD_TYPE_AOF: return "AOF";
     case CHILD_TYPE_LDB: return "LDB";
     case CHILD_TYPE_MODULE: return "MODULE";
     default: return "Unknown";
     }
-    /* clang-format on */
 }
 
 /* Return true if there are active children processes doing RDB saving,
@@ -5080,29 +5078,27 @@ void commandGetKeysCommand(client *c) {
 
 /* COMMAND HELP */
 void commandHelpCommand(client *c) {
-    /* clang-format off */
     const char *help[] = {
-"(no subcommand)",
-"    Return details about all commands.",
-"COUNT",
-"    Return the total number of commands in this server.",
-"LIST",
-"    Return a list of all commands in this server.",
-"INFO [<command-name> ...]",
-"    Return details about multiple commands.",
-"    If no command names are given, documentation details for all",
-"    commands are returned.",
-"DOCS [<command-name> ...]",
-"    Return documentation details about multiple commands.",
-"    If no command names are given, documentation details for all",
-"    commands are returned.",
-"GETKEYS <full-command>",
-"    Return the keys from a full command.",
-"GETKEYSANDFLAGS <full-command>",
-"    Return the keys and the access flags from a full command.",
-NULL
+        "(no subcommand)",
+        "    Return details about all commands.",
+        "COUNT",
+        "    Return the total number of commands in this server.",
+        "LIST",
+        "    Return a list of all commands in this server.",
+        "INFO [<command-name> ...]",
+        "    Return details about multiple commands.",
+        "    If no command names are given, documentation details for all",
+        "    commands are returned.",
+        "DOCS [<command-name> ...]",
+        "    Return documentation details about multiple commands.",
+        "    If no command names are given, documentation details for all",
+        "    commands are returned.",
+        "GETKEYS <full-command>",
+        "    Return the keys from a full command.",
+        "GETKEYSANDFLAGS <full-command>",
+        "    Return the keys and the access flags from a full command.",
+        NULL
     };
-    /* clang-format on */
     addReplyHelp(c, help);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1251,7 +1251,6 @@ static char *i2string_async_signal_safe(int base, int64_t val, char *buf) {
         int ix;
         buf = orig_buf - 1;
         for (ix = 0; ix < 16; ++ix, --buf) {
-            /* clang-format off */
             switch (*buf) {
             case '0': *buf = 'f'; break;
             case '1': *buf = 'e'; break;
@@ -1270,7 +1269,6 @@ static char *i2string_async_signal_safe(int base, int64_t val, char *buf) {
             case 'e': *buf = '1'; break;
             case 'f': *buf = '0'; break;
             }
-            /* clang-format on */
         }
     }
     return buf + 1;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -146,7 +146,7 @@ typedef struct _client {
     int thread_id;
     struct clusterNode *cluster_node;
     int slots_last_update;
-} * client;
+} *client;
 
 /* Threads. */
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -146,7 +146,7 @@ typedef struct _client {
     int thread_id;
     struct clusterNode *cluster_node;
     int slots_last_update;
-} *client;
+} * client;
 
 /* Threads. */
 
@@ -1098,7 +1098,7 @@ static int fetchClusterConfiguration(void) {
             *p = '\0';
             char *token = line;
             line = p + 1;
-            switch (i++){
+            switch (i++) {
             case 0: name = token; break;
             case 1: addr = token; break;
             case 2: flags = token; break;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1098,14 +1098,12 @@ static int fetchClusterConfiguration(void) {
             *p = '\0';
             char *token = line;
             line = p + 1;
-            /* clang-format off */
-            switch(i++){
+            switch (i++){
             case 0: name = token; break;
             case 1: addr = token; break;
             case 2: flags = token; break;
             case 3: primary_id = token; break;
             }
-            /* clang-format on */
             if (i == 8) break; // Slots
         }
         if (!flags) {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -5141,8 +5141,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
             *p = '\0';
             char *token = line;
             line = p + 1;
-            /* clang-format off */
-            switch(i++){
+            switch (i++){
             case 0: name = token; break;
             case 1: addr = token; break;
             case 2: flags = token; break;
@@ -5152,7 +5151,6 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
             case 6: config_epoch = token; break;
             case 7: link_status = token; break;
             }
-            /* clang-format on */
             if (i == 8) break; // Slots
         }
         if (!flags) {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -5141,7 +5141,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
             *p = '\0';
             char *token = line;
             line = p + 1;
-            switch (i++){
+            switch (i++) {
             case 0: name = token; break;
             case 1: addr = token; break;
             case 2: flags = token; break;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -341,7 +341,7 @@ static inline unsigned int zipEncodingLenSize(unsigned char encoding) {
 /* Return bytes needed to store integer encoded by 'encoding' */
 static inline unsigned int zipIntSize(unsigned char encoding) {
     switch (encoding) {
-    case ZIP_INT_8B:  return 1;
+    case ZIP_INT_8B: return 1;
     case ZIP_INT_16B: return 2;
     case ZIP_INT_24B: return 3;
     case ZIP_INT_32B: return 4;

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -340,15 +340,13 @@ static inline unsigned int zipEncodingLenSize(unsigned char encoding) {
 
 /* Return bytes needed to store integer encoded by 'encoding' */
 static inline unsigned int zipIntSize(unsigned char encoding) {
-    /* clang-format off */
-    switch(encoding) {
+    switch (encoding) {
     case ZIP_INT_8B:  return 1;
     case ZIP_INT_16B: return 2;
     case ZIP_INT_24B: return 3;
     case ZIP_INT_32B: return 4;
     case ZIP_INT_64B: return 8;
     }
-    /* clang-format on */
     if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX) return 0; /* 4 bit immediate */
     /* bad encoding, covered by a previous call to ZIP_ASSERT_ENCODING */
     valkey_unreachable();


### PR DESCRIPTION
We added some clang-format off comments before we had decided on the format configuration. Now, it turns out that turning formatting off is often not necessary.