### PR TITLE
Don't initialize the key buffer in getKeysResult

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1717,7 +1717,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
      * mentioned in the command arguments. */
     if (!(selector->flags & SELECTOR_FLAG_ALLKEYS) && doesCommandHaveKeys(cmd)) {
         if (!(cache->keys_init)) {
-            cache->keys = (getKeysResult)GETKEYS_RESULT_INIT;
+            initGetKeysResult(&(cache->keys));
             getKeysFromCommandWithSpecs(cmd, argv, argc, GET_KEYSPEC_DEFAULT, &(cache->keys));
             cache->keys_init = 1;
         }
@@ -1737,7 +1737,8 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
      * mentioned in the command arguments */
     const int channel_flags = CMD_CHANNEL_PUBLISH | CMD_CHANNEL_SUBSCRIBE;
     if (!(selector->flags & SELECTOR_FLAG_ALLCHANNELS) && doesCommandHaveChannelsWithFlags(cmd, channel_flags)) {
-        getKeysResult channels = (getKeysResult)GETKEYS_RESULT_INIT;
+        getKeysResult channels;
+        initGetKeysResult(&channels);
         getChannelsFromCommand(cmd, argv, argc, &channels);
         keyReference *channelref = channels.keys;
         for (int j = 0; j < channels.numkeys; j++) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1017,7 +1017,8 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
         margc = ms->commands[i].argc;
         margv = ms->commands[i].argv;
 
-        getKeysResult result = GETKEYS_RESULT_INIT;
+        getKeysResult result;
+        initGetKeysResult(&result);
         numkeys = getKeysFromCommand(mcmd, margv, margc, &result);
         keyindex = result.keys;
 

--- a/src/db.c
+++ b/src/db.c
@@ -1894,7 +1894,7 @@ unsigned long long dbScan(serverDb *db, unsigned long long cursor, dictScanFunct
  * the result, and can be called repeatedly to enlarge the result array.
  */
 keyReference *getKeysPrepareResult(getKeysResult *result, int numkeys) {
-    /* GETKEYS_RESULT_INIT initializes keys to NULL, point it to the pre-allocated stack
+    /* initGetKeysResult initializes keys to NULL, point it to the pre-allocated stack
      * buffer here. */
     if (!result->keys) {
         serverAssert(!result->numkeys);

--- a/src/module.c
+++ b/src/module.c
@@ -13247,7 +13247,8 @@ int *VM_GetCommandKeysWithFlags(ValkeyModuleCtx *ctx,
         return NULL;
     }
 
-    getKeysResult result = GETKEYS_RESULT_INIT;
+    getKeysResult result;
+    initGetKeysResult(&result);
     getKeysFromCommand(cmd, argv, argc, &result);
 
     *num_keys = result.numkeys;

--- a/src/server.c
+++ b/src/server.c
@@ -4840,7 +4840,8 @@ void addReplyCommandDocs(client *c, struct serverCommand *cmd) {
 /* Helper for COMMAND GETKEYS and GETKEYSANDFLAGS */
 void getKeysSubcommandImpl(client *c, int with_flags) {
     struct serverCommand *cmd = lookupCommand(c->argv + 2, c->argc - 2);
-    getKeysResult result = GETKEYS_RESULT_INIT;
+    getKeysResult result;
+    initGetKeysResult(&result);
     int j;
 
     if (!cmd) {

--- a/src/server.h
+++ b/src/server.h
@@ -2136,12 +2136,17 @@ typedef struct {
  * for returning channel information.
  */
 typedef struct {
-    keyReference keysbuf[MAX_KEYS_BUFFER]; /* Pre-allocated buffer, to save heap allocations */
-    keyReference *keys;                    /* Key indices array, points to keysbuf or heap */
     int numkeys;                           /* Number of key indices return */
     int size;                              /* Available array size */
+    keyReference *keys;                    /* Key indices array, points to keysbuf or heap */
+    keyReference keysbuf[MAX_KEYS_BUFFER]; /* Pre-allocated buffer, to save heap allocations */
 } getKeysResult;
-#define GETKEYS_RESULT_INIT {{{0}}, NULL, 0, MAX_KEYS_BUFFER}
+
+static inline void initGetKeysResult(getKeysResult *result) {
+    result->numkeys = 0;
+    result->size = 0;
+    result->keys = NULL;
+}
 
 /* Key specs definitions.
  *

--- a/src/server.h
+++ b/src/server.h
@@ -2144,7 +2144,7 @@ typedef struct {
 
 static inline void initGetKeysResult(getKeysResult *result) {
     result->numkeys = 0;
-    result->size = 0;
+    result->size = MAX_KEYS_BUFFER;
     result->keys = NULL;
 }
 

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -216,7 +216,8 @@ void trackingRememberKeys(client *tracking, client *executing) {
     uint64_t caching_given = tracking->flags & CLIENT_TRACKING_CACHING;
     if ((optin && !caching_given) || (optout && caching_given)) return;
 
-    getKeysResult result = GETKEYS_RESULT_INIT;
+    getKeysResult result;
+    initGetKeysResult(&result);
     int numkeys = getKeysFromCommand(executing->cmd, executing->argv, executing->argc, &result);
     if (!numkeys) {
         getKeysFreeResult(&result);


### PR DESCRIPTION
getKeysResults is typically initialized with 2kb of zeros (16 * 256), which isn't strictly necessary since the only thing we have to initialize is some of the metadata fields. The rest of the data can remain junk as long as we don't access it. This was a bit of a regression in 7.0 with the keyspecs, since we doubled the size of the zeros, but hopefully this recovers a lot of the performance drop.

<img width="531" alt="image" src="https://github.com/valkey-io/valkey/assets/34459052/ec823994-5e06-4c3a-9620-846ce727a6b4">

I saw a modest performance bump for a single shard cluster:

Before:
```
./src/valkey-benchmark --threads 2 -n 20000000 -r 100000 -d 128 -P 25 -t set
Summary:
  throughput summary: 518672.19 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        2.328     0.312     2.495     3.231     3.519    11.831
```

After:
```
./src/valkey-benchmark --threads 2 -n 20000000 -r 100000 -d 128 -P 25 -t set
Summary:
  throughput summary: 551040.12 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        2.191     0.840     2.367     2.999     3.207     6.503
```

I think we would see some comparable improvements in the other places where we are using it such as tracking and ACLs.