### PR TITLE
Update dir in valkey.conf to mention cluster-config-file

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -513,6 +513,9 @@ rdb-del-sync-files no
 #
 # The Append Only File will also be created inside this directory.
 #
+# The Cluster config file be written inside this directory, with the filename
+# specified using the 'cluster-config-file' configuration directive.
+#
 # Note that you must specify a directory here, not a file name.
 dir ./
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -513,8 +513,8 @@ rdb-del-sync-files no
 #
 # The Append Only File will also be created inside this directory.
 #
-# The Cluster config file be written inside this directory, with the filename
-# specified using the 'cluster-config-file' configuration directive.
+# The Cluster config file be written inside this directory, if 'cluster-config-file'
+# configuration directive is not an absolute path.
 #
 # Note that you must specify a directory here, not a file name.
 dir ./

--- a/valkey.conf
+++ b/valkey.conf
@@ -513,8 +513,8 @@ rdb-del-sync-files no
 #
 # The Append Only File will also be created inside this directory.
 #
-# The Cluster config file be written inside this directory, if 'cluster-config-file'
-# configuration directive is not an absolute path.
+# The Cluster config file is written relative this directory, if the
+# 'cluster-config-file' configuration directive is a relative path.
 #
 # Note that you must specify a directory here, not a file name.
 dir ./


### PR DESCRIPTION
I think it is a good idea to mention this.

The Cluster config file is written relative this directory, if the
'cluster-config-file' configuration directive is a relative path.