### PR TITLE
Improve reliability of querybuf test

### DIFF
--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -33,6 +33,9 @@ start_server {tags {"querybuf slow"}} {
         # Make sure query buff has size of 0 bytes at start as the client uses the shared qb.
         assert {[client_query_buffer test_client] == 0}
 
+        # Pause cron to prevent premature shrinking (timing issue).
+        r debug pause-cron 1
+
         # Send partial command to client to make sure it doesn't use the shared qb.
         $rd write "*3\r\n\$3\r\nset\r\n\$2\r\na"
         $rd flush
@@ -47,6 +50,9 @@ start_server {tags {"querybuf slow"}} {
         # but at least the basic IO reading buffer size (PROTO_IOBUF_LEN) 16k
         set MAX_QUERY_BUFFER_SIZE [expr 32768 + 2] ; # 32k + 2, allowing for potential greedy allocation of (16k + 1) * 2 bytes for the query buffer.
         assert {$orig_test_client_qbuf >= 16384 && $orig_test_client_qbuf <= $MAX_QUERY_BUFFER_SIZE}
+
+        # Allow shrinking to occur
+        r debug pause-cron 0
 
         # Check that the initial query buffer is resized after 2 sec
         wait_for_condition 1000 10 {


### PR DESCRIPTION
We've been seeing some pretty consistent failures from `test-valgrind-test` and `test-sanitizer-address` because of the querybuf test periodically failing. I tracked it down to the test periodically taking too long and the client cron getting triggered. A simple solution is to just disable the cron during the key race condition. I was able to run this locally for 100 iterations without seeing a failure.

Example: https://github.com/valkey-io/valkey/actions/runs/9474458354/job/26104103514 and https://github.com/valkey-io/valkey/actions/runs/9474458354/job/26104106830.