### PR TITLE
Fix query buffer resized test flakiness

### DIFF
--- a/tests/unit/querybuf.tcl
+++ b/tests/unit/querybuf.tcl
@@ -39,7 +39,13 @@ start_server {tags {"querybuf slow"}} {
         # Send partial command to client to make sure it doesn't use the shared qb.
         $rd write "*3\r\n\$3\r\nset\r\n\$2\r\na"
         $rd flush
-        after 100
+        # Wait for the client to start using a private query buffer. 
+        wait_for_condition 1000 10 {
+            [client_query_buffer test_client] > 0
+        } else {
+            fail "client should start using a private query buffer"
+        }
+     
         # send the rest of the command
         $rd write "a\r\n\$1\r\nb\r\n"
         $rd flush


### PR DESCRIPTION
Fix `query buffer resized correctly` test by removing a flaky "after"
Failure example: https://github.com/valkey-io/valkey/actions/runs/9457340771/job/26050970622

```
*** [err]: query buffer resized correctly in tests/unit/querybuf.tcl
Expected 11 >= 16384 && 11 <= 32770 (context: type eval line 24 cmd {assert {$orig_test_client_qbuf >= 16384 && $orig_test_client_qbuf <= $MAX_QUERY_BUFFER_SIZE}} proc ::test)
*** [err]: query buffer resized correctly when not idle in tests/unit/querybuf.tcl
Expected 11 > 32768 (context: type eval line 14 cmd {assert {$orig_test_client_qbuf > 32768}} proc ::test)
*** [err]: query buffer resized correctly with fat argv in tests/unit/querybuf.tcl
query buffer should not be resized when client idle time smaller than 2s
```