### PR TITLE
Replace master-reboot-down-after-period with primary-reboot-down-after-period in sentinel.conf

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -347,12 +347,12 @@ SENTINEL resolve-hostnames no
 #
 SENTINEL announce-hostnames no
 
-# When master_reboot_down_after_period is set to 0, Sentinel does not fail over
-# when receiving a -LOADING response from a master. This was the only supported
-# behavior before version 7.0.
+# When primary_reboot_down_after_period is set to 0, Sentinel does not fail over
+# when receiving a -LOADING response from a primary. This was the only supported
+# behavior before Redis OSS 7.0.
 #
 # Otherwise, Sentinel will use this value as the time (in ms) it is willing to
-# accept a -LOADING response after a master has been rebooted, before failing
+# accept a -LOADING response after a primary has been rebooted, before failing
 # over.
 
-SENTINEL master-reboot-down-after-period mymaster 0
+SENTINEL primary-reboot-down-after-period myprimary 0

--- a/sentinel.conf
+++ b/sentinel.conf
@@ -347,7 +347,7 @@ SENTINEL resolve-hostnames no
 #
 SENTINEL announce-hostnames no
 
-# When primary_reboot_down_after_period is set to 0, Sentinel does not fail over
+# When primary-reboot-down-after-period is set to 0, Sentinel does not fail over
 # when receiving a -LOADING response from a primary. This was the only supported
 # behavior before Redis OSS 7.0.
 #

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1946,7 +1946,9 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         if ((sentinel.announce_hostnames = yesnotoi(argv[1])) == -1) {
             return "Please specify yes or no for the announce-hostnames option.";
         }
-    } else if ((!strcasecmp(argv[0], "primary-reboot-down-after-period") || !strcasecmp(argv[0], "master-reboot-down-after-period")) && argc == 3) {
+    } else if ((!strcasecmp(argv[0], "primary-reboot-down-after-period") || 
+                !strcasecmp(argv[0], "master-reboot-down-after-period")) && 
+		argc == 3) {
         /* primary-reboot-down-after-period <name> <milliseconds> */
         ri = sentinelGetPrimaryByName(argv[1]);
         if (!ri) return "No such master with specified name.";

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1946,9 +1946,9 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         if ((sentinel.announce_hostnames = yesnotoi(argv[1])) == -1) {
             return "Please specify yes or no for the announce-hostnames option.";
         }
-    } else if ((!strcasecmp(argv[0], "primary-reboot-down-after-period") || 
-                !strcasecmp(argv[0], "master-reboot-down-after-period")) && 
-		argc == 3) {
+    } else if ((!strcasecmp(argv[0], "primary-reboot-down-after-period") ||
+                !strcasecmp(argv[0], "master-reboot-down-after-period")) &&
+               argc == 3) {
         /* primary-reboot-down-after-period <name> <milliseconds> */
         ri = sentinelGetPrimaryByName(argv[1]);
         if (!ri) return "No such master with specified name.";
@@ -4251,9 +4251,9 @@ void sentinelSetCommand(client *c) {
                 dictAdd(ri->renamed_commands, oldname, newname);
             }
             changes++;
-        } else if ((!strcasecmp(option, "primary-reboot-down-after-period") || 
-                    !strcasecmp(option, "master-reboot-down-after-period")) && 
-                    moreargs > 0) {
+        } else if ((!strcasecmp(option, "primary-reboot-down-after-period") ||
+                    !strcasecmp(option, "master-reboot-down-after-period")) &&
+                   moreargs > 0) {
             /* primary-reboot-down-after-period <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o, &ll) == C_ERR || ll < 0) {

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4251,7 +4251,9 @@ void sentinelSetCommand(client *c) {
                 dictAdd(ri->renamed_commands, oldname, newname);
             }
             changes++;
-        } else if ((!strcasecmp(option, "primary-reboot-down-after-period") || !strcasecmp(option, "master-reboot-down-after-period")) && moreargs > 0) {
+        } else if ((!strcasecmp(option, "primary-reboot-down-after-period") || 
+                    !strcasecmp(option, "master-reboot-down-after-period")) && 
+                    moreargs > 0) {
             /* primary-reboot-down-after-period <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o, &ll) == C_ERR || ll < 0) {

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -47,47 +47,17 @@ test "Primary reboot in very short time" {
     R $master_id config rewrite
 
     foreach_sentinel_id id {
-        S $id SENTINEL SET mymaster primary-reboot-down-after-period 5000
-        S $id sentinel debug ping-period 500
-        S $id sentinel debug ask-period 500 
+	foreach role {master primary} {
+            S $id SENTINEL SET mymaster $role-reboot-down-after-period 5000
+            S $id sentinel debug ping-period 500
+            S $id sentinel debug ask-period 500 
+	}
     }
 
     kill_instance valkey $master_id
     reboot_instance valkey $master_id
     
     foreach_sentinel_id id {        
-        wait_for_condition 1000 100 {
-            [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
-        } else {
-            fail "At least one Sentinel did not receive failover info"
-        }
-    }
-
-    set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
-    set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
-
-    # Make sure the instance load all the dataset
-    while 1 {
-        catch {[$link ping]} retval
-        if {[string match {*LOADING*} $retval]} {
-            after 100
-            continue
-        } else {
-            break
-        }
-    }
-
-    # Check the master-reboot-down-after-period still works
-    foreach_sentinel_id id {
-        S $id SENTINEL SET mymaster master-reboot-down-after-period 5000
-        S $id sentinel debug ping-period 500
-        S $id sentinel debug ask-period 500
-    }
-
-    kill_instance valkey $master_id
-    reboot_instance valkey $master_id
-
-    foreach_sentinel_id id {
         wait_for_condition 1000 100 {
             [lindex [S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster] 1] != $old_port
         } else {


### PR DESCRIPTION
Update sentinel.conf config parameter,

From:

SENTINEL master-reboot-down-after-period mymaster 0

To:

SENTINEL primary-reboot-down-after-period myprimary 0

But we still keep the backward compatibility, clients could use  SENTINEL master-reboot-down-after-period mymaster 0 OR
SENTINEL primary-reboot-down-after-period myprimary 0
