### PR TITLE
Fix memory leak when loading slot migrations states fails

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3149,7 +3149,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     if (de != NULL) {
                         handled = 1;
                         rdbAuxFieldCodec *codec = (rdbAuxFieldCodec *)dictGetVal(de);
-                        if (codec->decoder(rdbflags, auxval->ptr) < 0) goto eoferr;
+                        if (codec->decoder(rdbflags, auxval->ptr) == C_ERR) {
+                            decrRefCount(auxkey);
+                            decrRefCount(auxval);
+                            goto eoferr;
+                        }
                     }
                 }
 


### PR DESCRIPTION
When we goto eoferr, we need to release the auxkey and auxval,
this is a cleanup, also explicitly check that decoder return
value is C_ERR.

Introduced in #586.