### PR TITLE
Reduce redundant call of prepareClientToWrite when call addReply* continuously.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -962,7 +962,7 @@ void addReplyHumanLongDouble(client *c, long double d) {
 
 /* Add a long long as integer reply or bulk len / multi bulk count.
  * Basically this is used to output <prefix><long long><crlf>. */
-void addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
+void _addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
     char buf[128];
     int len;
 
@@ -972,16 +972,16 @@ void addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
     const int opt_hdr = ll < OBJ_SHARED_BULKHDR_LEN && ll >= 0;
     const size_t hdr_len = OBJ_SHARED_HDR_STRLEN(ll);
     if (prefix == '*' && opt_hdr) {
-        addReplyProto(c, shared.mbulkhdr[ll]->ptr, hdr_len);
+        _addReplyToBufferOrList(c, shared.mbulkhdr[ll]->ptr, hdr_len);
         return;
     } else if (prefix == '$' && opt_hdr) {
-        addReplyProto(c, shared.bulkhdr[ll]->ptr, hdr_len);
+        _addReplyToBufferOrList(c, shared.bulkhdr[ll]->ptr, hdr_len);
         return;
     } else if (prefix == '%' && opt_hdr) {
-        addReplyProto(c, shared.maphdr[ll]->ptr, hdr_len);
+        _addReplyToBufferOrList(c, shared.maphdr[ll]->ptr, hdr_len);
         return;
     } else if (prefix == '~' && opt_hdr) {
-        addReplyProto(c, shared.sethdr[ll]->ptr, hdr_len);
+        _addReplyToBufferOrList(c, shared.sethdr[ll]->ptr, hdr_len);
         return;
     }
 
@@ -989,7 +989,7 @@ void addReplyLongLongWithPrefix(client *c, long long ll, char prefix) {
     len = ll2string(buf + 1, sizeof(buf) - 1, ll);
     buf[len + 1] = '\r';
     buf[len + 2] = '\n';
-    addReplyProto(c, buf, len + 3);
+    _addReplyToBufferOrList(c, buf, len + 3);
 }
 
 void addReplyLongLong(client *c, long long ll) {
@@ -997,13 +997,16 @@ void addReplyLongLong(client *c, long long ll) {
         addReply(c, shared.czero);
     else if (ll == 1)
         addReply(c, shared.cone);
-    else
-        addReplyLongLongWithPrefix(c, ll, ':');
+    else {
+        if (prepareClientToWrite(c) != C_OK) return;
+        _addReplyLongLongWithPrefix(c, ll, ':');
+    }
 }
 
 void addReplyAggregateLen(client *c, long length, int prefix) {
     serverAssert(length >= 0);
-    addReplyLongLongWithPrefix(c, length, prefix);
+    if (prepareClientToWrite(c) != C_OK) return;
+    _addReplyLongLongWithPrefix(c, length, prefix);
 }
 
 void addReplyArrayLen(client *c, long length) {
@@ -1063,8 +1066,8 @@ void addReplyNullArray(client *c) {
 /* Create the length prefix of a bulk reply, example: $2234 */
 void addReplyBulkLen(client *c, robj *obj) {
     size_t len = stringObjectLen(obj);
-
-    addReplyLongLongWithPrefix(c, len, '$');
+    if (prepareClientToWrite(c) != C_OK) return;
+    _addReplyLongLongWithPrefix(c, len, '$');
 }
 
 /* Add an Object as a bulk reply */
@@ -1076,14 +1079,16 @@ void addReplyBulk(client *c, robj *obj) {
 
 /* Add a C buffer as bulk reply */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
-    addReplyLongLongWithPrefix(c, len, '$');
-    addReplyProto(c, p, len);
-    addReplyProto(c, "\r\n", 2);
+    if (prepareClientToWrite(c) != C_OK) return;
+    _addReplyLongLongWithPrefix(c, len, '$');
+    _addReplyToBufferOrList(c, p, len);
+    _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
 /* Add sds to reply (takes ownership of sds and frees it) */
 void addReplyBulkSds(client *c, sds s) {
-    addReplyLongLongWithPrefix(c, sdslen(s), '$');
+    if (prepareClientToWrite(c) != C_OK) return;
+    _addReplyLongLongWithPrefix(c, sdslen(s), '$');
     addReplySds(c, s);
     addReplyProto(c, "\r\n", 2);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -2667,7 +2667,6 @@ void addReplyErrorArity(client *c);
 void addReplyErrorExpireTime(client *c);
 void addReplyStatus(client *c, const char *status);
 void addReplyDouble(client *c, double d);
-void addReplyLongLongWithPrefix(client *c, long long ll, char prefix);
 void addReplyBigNum(client *c, const char *num, size_t len);
 void addReplyHumanLongDouble(client *c, long double d);
 void addReplyLongLong(client *c, long long ll);


### PR DESCRIPTION
## Description

While exploring hotspots with profiling some benchmark workloads, we noticed the high cycles ratio of `prepareClientToWrite`, taking about 9% of the CPU of `smembers`, `lrange` commands. After deep dive the code logic, we thought we can gain the performance by reducing the redundant call of `prepareClientToWrite` when call addReply* continuously. 

For example:  In https://github.com/valkey-io/valkey/blob/unstable/src/networking.c#L1080-L1082,  `prepareClientToWrite`  is called three times in a row.

### Profiling of Hotspots
![image](https://github.com/valkey-io/valkey/assets/698621/08ae941c-169d-4b1a-99d8-9575bf719d08)

### Test Environment

- OPERATING SYSTEM: CentOS Stream 9
- Kernel: 6.2.0
- PROCESSOR: Intel Xeon Platinum 8380
- Server and Client in same socket.

###  Performance Result
#### Perf Boost

| Test Name| Perf Boost|
|-|-|
|[memtier_benchmark-1key-list-100-elements-lrange-all-elements.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-100-elements-lrange-all-elements.yml)|3.5%|
|[memtier_benchmark-1key-list-1K-elements-lrange-all-elements.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-1K-elements-lrange-all-elements.yml)|13.1%|
|[memtier_benchmark-1key-set-100-elements-smembers.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-set-100-elements-smembers.yml)|4.9%|
|[memtier_benchmark-1key-list-1K-elements-lrange-all-elements.yml](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-1K-elements-lrange-all-elements.yml)|10.0%|

#### Test Scenario

#### 1. Start server
```
taskset -c 0-3 ~/valkey/src/valkey-server /tmp/valkey.conf

port 9001
bind * -::*
daemonize no
protected-mode no
save ""
```

#### 2. Prepare test data
```
valkey-cli -h 127.0.0.1 -p 9001 "SADD" "set:1000" "tocawprsxz" "csqcfxyzsy" "ipubipttcb" "jqurtadjro" "zdulfflfqx" "bbfvuialin" "ifpfyncdfe" "kjeevccyof" "stttkrbfqs" "qatkvfuttq" "ltvfnuuwil" "znartcywze" "bzursuzuei" "jlghqxtvok" "osncqcuest" "uxvibjduto" "giubyhvaav" "joijmgposs" "lqxpnplleo" "bnatichltp" "nnfxoqebys" "lyhqvxolfw" "caaqjozcqh" "nlqtadqinl" "hfjxrrsszf" "fussukqrph" "cbjovvgqqy" "wcpbfslakk" "slskrnekbc" "nvonwipkta" "jhdcicttmm" "rpyroriegs" "lnuuootxmp" "ufdxqlonpg" "qgasrnjrld" "jhocasnttw" "smwbxeqbed" "kapxglqccs" "hhwvslfxmf" "rbdabbmnrf" "ltgidziwzm" "qpffifpdiz" "sadqcfniau" "bqoabrqwwj" "wghyakzbit" "bnxtlmiwup" "akzsgaeqon" "zwlhpcahwu" "kfselnpkim" "dxtzxeguoi" "roczxpuisd" "myzjxvtvjh" "alfftdxaxc" "vyiqkfoics" "dygkzcpakt" "ukprrucywq" "afzlyodwiz" "vdaebbupfe" "wemmvswznk" "xzbqjpzqlm" "lqqivzlppd" "rrzcqyzdzf" "ncckxlmsvg" "cpjveufsvk" "babfjxxabw" "btcvhacldb" "mqqrgbacfa" "eqaxrccwjq" "erahoeivfw" "omeatkwwtc" "mjwrbndexu" "gktcjcfxbb" "tfonhwnuxj" "pheajlhymx" "vefgwelnfo" "gayysuldha" "tqpqihwjtl" "eirhwkdgfq" "rnfodijavx" "erqgyscser" "nnnxouavyp" "yhejmjwwni" "mwmcwqzbld" "ofcurtthcs" "idmjjbjvni" "ovqohpxjft" "ocoflktdhp" "kgopxvsdah" "pyjpxqnavq" "nubsytpfao" "ddpgrvwowd" "glynpmsjcf" "whsxmqffqg" "sstqpivwip" "cqfnhujrbj" "gsvkmnluiz" "zdmgjjyukl" "gcfcbjybkx" "qmhyoyctod" "kdodndexvr" "tkgihmsrha" "kmifjielrw" "gefoharnza" "tcpwkimype" "nxllkzroin" "bpvbnmpekh" "ljinllovsw" "mugdxqnjxj" "tqqmmvwact" "uidvmrqyjd" "dthtfrqkce" "efhynoxlul" "iosqxoobrk" "sujbwndgwl" "btxehrokkw" "pmaagvqldo" "evuxmkrrfl" "dclualrzqb" "jfqxkxgqhj" "fvemodlpgz" "lawrpikwsk" "socoxaegfa" "snomfrutha" "yxsnreuepl" "vjihaakiof" "nnhrgirrtw" "jccorylnjg" "gehuriygwq" "icqjxcermo" "ocgjeuljxf" "qslrwqmixc" "rhzpguhsws" "zxlbhyeckf" "iziwqojsoq" "qlorevyltp" "gbjzsedhag" "mkxysrkpug" "bhrvnadcdk" "qxxinxaqxn" "ctnaggdbru" "fsthobmdxk" "cvnnitrrow" "vlhtdpqavh" "vhjaphfdpj" "yhdgqenmwv" "ysntbzffxq" "emfjcnujqn" "qnqzibcmip" "ngcxqjjpdm" "gkneclxnnt" "rhkpfsuhoq" "dgodkfjzos" "isqymcuffe" "ripecixnpr" "dxpepbctea" "gbeizdzdyb" "aqlapmghln" "yhlalzusch" "xglrugpjkt" "ngwifjdpha" "jvekvvldai" "hmdzsuuyrn" "ncabqesziv" "whdftyqojv" "rhzqdtxucc" "ftyxhyfokj" "vqtixjkcbb" "krfosgrmjb" "ahcaaodvgi" "ooeswhfdnj" "jhctncrzlw" "haxesjafmh" "vxrtzngznb" "fidsuuizcf" "mamtueyrqn" "quemrlmwod" "pkgpjwyfbh" "ckibsdtfff" "tjnjhejnju" "puvgjfjyaf" "cvmicoarvv" "mxpzuzrzuo" "rrrfhnclbv" "xeurpmfdmo" "yqvkykgjbe" "behdxlfdho" "dyzedskzkq" "rfhlttsuqy" "pkehotsmka" "alokvrpbih" "mobwpcyxuk" "umwunfzsvo" "naggqdxcjm" "rakustfykw" "dtkfydidli" "kohpozxkhl" "usjmfkopln" "axhoxkubdv" "asretszbav" "tmkoxwdgpx" "wjhaavxfge" "pcuaesomdc" "vjhpmffzxc" "qwxzqlqter" "jjumoixniz" "ruxsmttpak" "pjdundsxrd" "kdklhpxntt" "muhewfzihs" "dplonqlliz" "wjibkklezg" "dfemamyevk" "nryvfijxhj" "bqqohkuylc" "wiqhmhkiel" "lftmqoxhfc" "sjbaedopjb" "dlomhvkoxg" "jhkdwtqvwl" "vqashxkrik" "mupcilqfjg" "suahxaebee" "rqkcyxiwhz" "jqgtbgbybq" "ygbfgfefac" "kjblkrvknt" "yajpmxmuwz" "wwowdvybjj" "bdtbaxnuko" "adfhfatarh" "vfcpevtekf" "fiugzrozky" "spogjykkfs" "tdggmsxysk" "aoqlctikzg" "nwywtydqew" "qjrhtqgwjc" "dhzgpwewsx" "outdlyeqvq" "trwzipsers" "qtpcwuafar" "scgjdkyetq" "aqyfvxyjqr" "xkvgnzjgrm" "hhbceuegvh" "paitaeqrpb" "yfdsmhtria" "bxwvqvndcc" "dpyjoihqrs" "tnratexlre" "hplvvuoscb" "muocqqypmt" "pxzkuasjek" "flrsaczxzc" "pubqtzzzko" "vpqlxtfkjz" "fiafoggekm" "qtewhixedb" "iijjcabgak" "tqjpijliii" "uttazeawix" "hxbmykkugi" "bekchebgys" "ffrviosqzo" "rjrptuhkav" "sldzewoxas" "uesalivsis" "maxylirjgh" "vpzsmbjkvy" "eiziligjfr" "tqblforkpa" "nszbrpweoz" "rzanpefsfy" "cejkfhuykf" "abinkgshoi" "gqybtjuhvq" "oqdlpaubsc" "nrbfkysxaf" "mhxojehvxx" "vuqlqdpfdn" "orqqevpmca" "xigznrdgqy" "jzceexkqam" "szupcnvvij" "btgeubdzbb" "nojnedgabk" "sdnkjddyut" "lbjarnpxhh" "wevfinjbqk" "dvgqwzignk" "ejzwnidqwr" "nlxwjmzwln" "brrlblrxwa" "hyikggurti" "wybmlpqblt" "hertbwuzyw" "rwhzzytdsq" "symbgeyple" "zbfeyptemz" "pghbwbtfmk" "mxydilgynv" "bhwytqsafu" "ecsburyjhh" "cvohdragtx" "lscjhgztom" "giswndixdf" "etsngvbrff" "lgqazzajpx" "pypepewjvq" "nswjopvtqv" "tuajnnqtcq" "bvvoibkfrt" "kjqeujfkoh" "diwmfuckel" "bwizktcwmb" "ughnpilqqm" "ihealvwnxb" "thqttakyzy" "auwfujaoya" "rofnkytnhm" "ilkuddrdvh" "hmwfncgzxg" "pzrchtwaaw" "ffksbrtbfq" "ethxaycsil" "uwiqrvcqvu" "fgcehqgsso" "yoblelzlkd" "gjiwldcfqh" "sbrjnwxdip" "nenhiiibwx" "ebhhhgabjd" "xpkwqbfban" "pupmdjgyed" "aejnvyfdst" "krxneqolle" "nouncgkoik" "kamgfgbxel" "fffylsswky" "agswwrfabr" "pkvcbelpos" "mxapzqqqsw" "ywmqoaztmy" "sfuvzzxbxq" "kdcvbkrbsj" "twpiiaedpc" "egmgddriry" "nmfihtnkel" "kqzjnkdlxd" "eovsizpcjp" "bsavjyaksg" "xlmvatfsly" "dlhjfafskj" "wmvhvwnowp" "vjjozwrovk" "gbazuqnmit" "ubwlcefgqb" "jttqzbazgz" "dozecfsvue" "pgdhjrxhga" "gzekysdunp" "ygoiannoht" "hklchdenoe" "sotbjzlsvz" "qjwrnhooax" "cdghgcsoth" "mjlpvuoghe" "qclkaeciey" "oownjpxrov" "nvqfyljbef" "tsnawydcru" "wrrgxxkxkc" "ylulwsnjay" "lxsinouutc" "ozpyyaznsh" "cmhkstsjok" "ybckvbeoib" "fsoardckcw" "ltkauvxggz" "sqwhsgboef" "wgtjxahmef" "spoqshzjoi" "pfvfxrrfhl" "nahweurftw" "fojjpqmbck" "zexblqeora" "qsoiwsugdv" "ksppwhhqzj" "otadcihtmd" "imnjbkmsls" "zzenkvuesw" "kbfqdppnfa" "igehetokzq" "koujdppfua" "wqsqzzbqhm" "tglieutcis" "owovlhorvw" "nraylduhut" "nwnyjkugcf" "kpfqxroqbs" "xwxwosqkhm" "ollacusjzj" "wcouaiatsu" "nvkfnfzoki" "fgjnsosfrp" "pltsnzqvpi" "rhnkzlsjtk" "ysnndkycix" "bpnfopinub" "blujwnyluy" "wgtmckqknh" "zorzyqtjtr" "hvtlkrungk" "rgtondctpo" "mjgvtydjtm" "kcbotffyca" "gybxnvwchp" "gazojexans" "hmcpcrjumm" "zejhycldyy" "iiissmznfe" "qvpuudyuks" "gviypfayfm" "plqbwsiuzw" "nunchscyqc" "qocjpufxio" "iqbyikqjmx" "omwbgglqsp" "nywteueaig" "ntmgbzaivy" "ijdgnlzprg" "rnlaakgsrf" "fpdflprzvn" "azkdbpnshy" "mvfnirshbd" "sotsxznskx" "uzktwqcdeb" "myrrmvflyw" "jgaieawkcu" "utymwhxigo" "vtaiyncmyg" "gpodilvrnm" "xgfzndhodu" "saqilljaid" "jxiewthqls" "nbwksmwxpx" "rwfykeeqgx" "tlnkrncpwi" "ogyvxbgcwi" "ffcqkkzllx" "rtnhivnxtb" "vzcclamtun" "jjlefkekuw" "xjksnqifds" "ctusqixohm" "osaekeukqx" "irlduoinie" "nifzrybfuh" "ctqxoyxbwc" "vsvhjrymqc" "bzwxqcpftf" "ltghdkluqq" "vklwhyzqhk" "ghwcrdlbjj" "lzzptujbjp" "qlvgfplbod" "ghepftfjgk" "aiqqyusnuv" "rspghuhpbp" "lfkqrtxocm" "iibgagtkpg" "ywiurvfbpg" "tdceweesxh" "pvwvdaorrl" "ejlunxlwxn" "ymqxhmnidz" "lydebbpmfb" "ztjuqomjck" "eyrbqexkff" "oqmuhlruqy" "gnrmnwaxls" "mumhqarhgg" "skbzfbeziu" "hnnfmyurhx" "yrsizkbbwz" "azpwrzovza" "txhllnvudv" "aslibwggrp" "ubghghklvj" "jqqogagqni" "emfqsjraia" "ctgwmawlgl" "mivctgaajt" "knycrcrsbm" "ubtiscdgrn" "ulepgommyy" "qbhdjhoohc" "cctlfgicpv" "phfuspevwk" "oeawjlqnyg" "jpphbjtbrh" "ofykgotycd" "csjfbpjyzq" "thmmmlqluk" "buzhjxsbkm" "pisgqibyae" "skkawcmqqt" "mmqblvrscy" "dpkiubfzbx" "yivxcecwlp" "kbnjiilaqd" "rwrxxrnwtq" "veegnotgmj" "pbfijwccjp" "expefhkisx" "ynnhyctikq" "bhfmhanvxe" "otclvmbilg" "hskkmrluuf" "ftnbjymlll" "nbkaxrojqq" "qydrgilxxt" "dxufcyurjx" "fgygwdazbm" "tivnqailcl" "jwvqixjhho" "oglqutqfcx" "wvrlxfoxff" "ropuqidkxv" "qcsxjrjcfc" "twuvkpjzzw" "fqtktfghcv" "suhwnartid" "wvsnfinuil" "rngtndwjyg" "tsmzfswaxo" "uvlswctlhx" "llamjvxyqo" "wovoupawzt" "caxgjftjyj" "gwzqcetcji" "yzrdbalexf" "fnpdsuozxt" "dbtbtvkqss" "pwgjoppmgc" "wxjdgbugeu" "qchpfcigwa" "lxzdcbveuy" "bwjyghaztz" "uedehyieof" "pfaytznuaa" "lspvrnxnjo" "zkbqvttlzy" "fkdmuxraqf" "nbizrabfuo" "fgzwwaedjy" "gkmwutvars" "bwsdzrxzse" "txgjxzovte" "cbtpbbfrdd" "vqgztpmzhz" "rdipvyeqoi" "bovkdabcdo" "fhobhpwwkp" "mkbkflixkr" "mjifqzmtsd" "pkcqdokojd" "dtgjnddwch" "uboipezuni" "dfdodbelzn" "fzsoiryhfn" "krtsiucvvu" "aieekmivcb" "aeafusfzdn" "ehnrizfmfo" "dcjlwhfstw" "wksgvbkbyw" "hvfprkjlbc" "jlgepeyhpc" "ljklggibcy" "mhrvuemywb" "wdqygrxkya" "ystnkbogee" "flvftlpbjq" "vgfgbsbnwy" "rsivptwulz" "bzjzucrypq" "bweysooxiv" "mmcunsiwad" "mszjkgsrio" "bvurseeqmh" "wtcpliaxmk" "ndwiompimr" "mdcwoblmkl" "dflxukffgl" "mcojdazpfq" "tctgzmjads" "dewdgfrhos" "iwqanwtvcd" "nfucelqjfe" "wgtrwefdsw" "skstqdgbos" "rwllkdzxrj" "qwozutlufu" "fmpdixcckx" "jybzltmwrs" "ossjrvqmaa" "adlxahxsbq" "mbewprqunw" "xbvbujurqw" "rnvhfxbuoi" "pyrpwxalpc" "adlryhdbpr" "gritvkzfgw" "aufhfrhccf" "umoicweaab" "kgirldeylz" "nknlysgviv" "plbxaamppj" "ikpikupjoi" "eioxaswdee" "imexfccbxk" "ouroipthpq" "jbzyfznpdn" "asidljmwgb" "jeazfmhrcb" "dablvesuho" "zuoqjiciij" "qmxxfyuodo" "vkqalcokst" "jhibapuhga" "cmqraybrlw" "beqsnrixhl" "rmqxtqcxua" "ndltyojjxj" "hyanpicfan" "yzutuazhmh" "tumnalubch" "eksvvoxziw" "weqhfkosif" "wwfbpjatrp" "lrhrkuyzry" "uvbtcgtopw" "fmyleefltp" "kkrxiaiife" "gbkqhfumyu" "tdmjyuitvv" "jvtalmlkng" "rdsfcdvkqz" "xqvjnlpssl" "fuftndsnim" "keklddczkd" "wrqnytptzm" "rwzijctxzs" "btakuczlec" "fuipidfbjt" "kjiqagynco" "ahjawbsqcw" "iehxaaneev" "ezbiwqnabg" "pnnzqcutoq" "wlogkzxkpo" "xzswnnldvs" "qqfnugftmr" "zuccleayil" "ckqebhazel" "brwlqbfoat" "anmcogawkg" "roqzbzpbbt" "dxnprfawun" "fffreqppjj" "gfdzgxfdcg" "sshbuxfljd" "shckmujxzo" "rqurawzebz" "vpehhmoxva" "vldwfdnicm" "tzhjrlfvfp" "ymwwctfodg" "qsxfnsicrx" "gfhrrjczsp" "gtqrsktbaa" "dniplpxfof" "htawohddyn" "dbcxnsiacw" "dhfundvlpn" "uewpgskfpu" "cuuytorpnp" "vlcnbfqvox" "jbqibabrmv" "xhspgwheck" "fsuovvpgng" "gcjruttnno" "wxswusqpeo" "qhhhipzncq" "mcbuftndrr" "owjfgjqqjc" "vvmkjgajwa" "wvlvshnhmx" "ekponflaeq" "kuiumwomxi" "aoydkdfrpe" "cglxptkcsz" "uqbpcvkipa" "ubzgvzputq" "wmyphdckda" "ukdnaklmcp" "ramoirrdyd" "vwayaqmtid" "ltomuspfzc" "wzxdkpehwf" "yzcspfvcot" "cgpvvnbvlk" "farwqgfyjf" "lbxvlwzony" "ocesqguvym" "yzviqaobku" "cnngbbpowp" "ucxeoqcssr" "zcffhzusrl" "yzmodbpsnb" "aryiyaltqw" "xkaailrpns" "lpahctqgna" "cnbqnvxmjp" "nugjvhftma" "xsgcuvxzor" "xwtwtwmbgu" "emdwpvauyc" "ahfktrqmgh" "jznackjcrd" "etcsjxoqab" "kpzmuwqbnt" "dspznsgszk" "rcwbzvwbva" "mlznoaajqq" "iwuuxdactm" "zujobawsct" "snepgcispg" "cgmivhyskk" "snunzlgfkd" "ppdxnadmje" "wtzqqecgfy" "ncremxgfdb" "cblsafugqk" "hjekcxfyds" "faxedqgskm" "jjczogqdwz" "jfbgmhtjke" "nehqnkqnld" "lcdchjadll" "llimzyabsp" "iwapedwyle" "iobkwbwceu" "twmbtaxdro" "nmtmjmhmdl" "ewoqykjbkc" "tmyuncyoyd" "dcepfcdddn" "dnvwyhyhsn" "nrencopzqn" "yjyffpgoop" "uvqtefqdhk" "yjhypaonqq" "uqvzpcvugl" "cakvxrdpmj" "tvzacklhdz" "higdkhodzy" "ormdblyhhn" "wbouqpojzl" "eyhgspybnr" "lywsezpzgf" "usykkwszvh" "bcwncpnibg" "jgcqryhsvk" "yfvwesgulw" "geizujxrkg" "zknlteeaxq" "nqwjivcosg" "qmnxipsiga" "pthacnunjj" "afamsavgsi" "bzfzxzecrs" "sxcihybfci" "padscbypdo" "gaotvjctjh" "beicnwdryg" "xsueeljljp" "mkrrypcfzy" "ekjgqnjxyl" "iyeiercbxr" "rkwlgzhvvy" "hmnaoeeasz" "aquymkrswt" "ulnnuwyptq" "xftfzsoiwc" "urkkyscfti" "wabroeeoop" "qpzkuxsipr" "dxdngrmypg" "icatrrbcjs" "fhuptkhkzm" "apyzwvajot" "vealtjlqyc" "khkkfmzkow" "trzqdcaqdw" "itmekixthv" "pudgkcbwdx" "zuibhuihtz" "kzuywkxlku" "ogtqmpnzie" "jetamrlglx" "fjdjumschq" "kprzbyngsw" "xeyxlxiqch" "dtuhvpszzt" "fpmbbgiaao" "hjlhurakwh" "mshexjmkmn" "cynhehkcxs" "cvbbbdzmie" "cvnlzjdfgf" "ifhkjgmxrd" "audguegpmo" "jzstgleeby" "eafrzhdhhq" "fmmammvdyj" "uncqdpbhwb" "fzatoyblsr" "xtwlklqdna" "ydqppngxvh" "mkngszsxeu" "vyewicgjio" "tstbluhyhj" "qzxxwlfeki" "ocmtsfpsgh" "xmknbbmdbf" "pdjmftsmob" "ygrpkpstxq" "hrhiqcarju" "aadzbodres" "curhymvwsx" "tbqidtevrl" "avchkjnlwm" "tyephutkmb" "lxoaezrdxs" "ctkwlhmgfz" "xkiuuciwrn" "irrovfyshb" "hwuofuftlr" "mhbfsuaovv" "wzuhzzdezi" "jlpobgvouj" "qbpmtomqpu" "shlwywnxpk" "srkvjhetmj" "hvxefqtmqu" "fazsvkljef" "bstezdkmig" "asbtvfzien" "vewfxcxkpf" "tqkprkoixe" "rcaatkjyur" "euleuicawb" "ifiizdeong" "cjcrpmggtu" "kxggjpatkd" "klwqsggtob" "mnsaklzgob" "xfxlervrgn" "eraxdyjftw" "xrvonyieqa" "fswhywqxhy" "iqzxblqkeo" "rxvhmzvbcv" "wvdmobfisx" "ujybghjfnf" "yufagalzhk" "qxbqbfcgjp" "vorgqhmaoq" "zewylkylsy" "vvmaucizkv" "bgcoyoduda" "vnsufnurol" "rtskokvklv" "svvdufedug" "qgdgujdvtg" "rjrtvpntke" "shgetgsird" "ywgeotcect" "zsikdzycyt" "gcsswbksnc" "qgobfhgspy" "pbxrbaxnor" "viwarrumob" "eaetplspga" "jqmscuprwq" "nkyuframnm" "gygftrsdbm" "qzlfnntjar" "fzzcioobeb" "ydigxptqbl" "bgtxhxkhvv" "hggqmlgwha" "ywlqbjqeug" "qwowxqzrkz" "zybosgbtxt" "cflarkquuv" "klaeknlbrm" "ccnbldglgl" "dpauqcpgyi" "ylxiwiesps" "xyxmlrdbui" "arqfxfqkzh" "byrkeibrfb" "laepwenqmc" "kluswgtjsf" "mgldvzleyy" "yqmzmmzwpd" "tvlckdoyfe" "dmxcbvzrxg" "qquwyuyvvw" "pmytvtksfi" "umttshfkpk" "rmdayyptch" "glwrmjpotx" "bgcnzgcmza" "ivinvxopgz" "dmbarohbfj" "rncdgqxqfq" "zmmwzkjrjl" "gdlztbhpeq" "zrwgpknaop" "powzkcrtvv" "cszvzbrmoy" "dtjljhzqcm" "anznywecwk" "amuwlfaxwv" "ajdkqflpen" "evjrybtwww" "oxsdmrdbit" "yafipxfsip" "xekxarmwcq" "dgcesswkvc" "gdqgmwxkmt" "spdyueanru" "yrvmdhnnfc" "aexxjlgwuo" "xpcpytommm" "gjutzwoxlf" "stnfirydgi" "snpuvnebpy" "rfxibyjmpg" "ortxlvmdoc" "gdozstnglr" "eqiukbyscu" "qzcrpbvatq" "dwzqowbrsd" "iesbitdnjd" "inboyxgoqa" "lfojnetxdc" "njmufqrykx" "ybcdthmgws" "igwekdegcw" "ajkgxmtamu" "qkyfpamste" "nwybjbhgep" "arqqmfmmbz" "rqiyxwpuyv" "nsdvirehqh" "qckueiqiwh" "tjnbsybxws" "jphvxuqipp" "ghtoyhrfxh" "erglflfnql" "kngwkkzwts" "nmguhcygct" "jigyicdeft" "gamcdtywne" "nunpqugdit" "ghqwxaqlef" "nqxdrqigvf" "xepfvvcovk" "ezgxjiwwig" "izizuzzjuv" "mallnshtok" "tctrsxgnrc" "exhjfssojj" "yilvzcevlj" "nepxmyiuhr" "dqqfcdugde" "iamjlqlznh" "mvmsikqfxu" "kmqlwfbsex" "pribqncfuf" "zavrjnezrf" "kmcwshsbye" "uzaejrbwue" "olezxlliej" "hjjxyybxiv"
```

#### 3. Run benchmark 
```
numactl --cpunodebind 1 memtier_benchmark -s 127.0.0.1 -p 9001 --command="SMEMBERS set:1000"  --hide-histogram --test-time 180
```