### PR TITLE
Migrate dict.c unit tests to new test framework

### DIFF
--- a/src/dict.h
+++ b/src/dict.h
@@ -244,8 +244,4 @@ dictStats *dictGetStatsHt(dict *d, int htidx, int full);
 void dictCombineStats(dictStats *from, dictStats *into);
 void dictFreeStats(dictStats *stats);
 
-#ifdef SERVER_TEST
-int dictTest(int argc, char *argv[], int flags);
-#endif
-
 #endif /* __DICT_H */

--- a/src/server.c
+++ b/src/server.c
@@ -6610,7 +6610,6 @@ struct serverTest {
 } serverTests[] = {
     {"quicklist", quicklistTest},
     {"zipmap", zipmapTest},
-    {"dict", dictTest},
     {"listpack", listpackTest},
 };
 serverTestProc *getTestProcByName(const char *name) {

--- a/src/unit/test_dict.c
+++ b/src/unit/test_dict.c
@@ -4,6 +4,7 @@
 #include "../dict.c"
 #include "test_help.h"
 
+
 #define UNUSED(V) ((void)V)
 #define TEST(name) printf("test — %s\n", name);
 
@@ -67,6 +68,8 @@ int test_dict(int argc, char **argv, int flags) {
     } else {
         count = 5000;
     }
+
+    monotonicInit(); // To prevent SIGSEV when calling dictRehashMicroseconds()
 
     TEST("Add 16 keys and verify dict resize is ok") {
         dictSetResizeEnabled(DICT_RESIZE_ENABLE);

--- a/src/unit/test_dict.c
+++ b/src/unit/test_dict.c
@@ -1,0 +1,266 @@
+
+
+/* ------------------------------- Benchmark ---------------------------------*/
+#include "../dict.c"
+#include "test_help.h"
+
+#define UNUSED(V) ((void)V)
+#define TEST(name) printf("test — %s\n", name);
+
+uint64_t hashCallback(const void *key) {
+    return dictGenHashFunction((unsigned char *)key, strlen((char *)key));
+}
+
+int compareCallback(dict *d, const void *key1, const void *key2) {
+    int l1, l2;
+    UNUSED(d);
+
+    l1 = strlen((char *)key1);
+    l2 = strlen((char *)key2);
+    if (l1 != l2) return 0;
+    return memcmp(key1, key2, l1) == 0;
+}
+
+void freeCallback(dict *d, void *val) {
+    UNUSED(d);
+
+    zfree(val);
+}
+
+char *stringFromLongLong(long long value) {
+    char buf[32];
+    int len;
+    char *s;
+
+    len = snprintf(buf, sizeof(buf), "%lld", value);
+    s = zmalloc(len + 1);
+    memcpy(s, buf, len);
+    s[len] = '\0';
+    return s;
+}
+
+dictType BenchmarkDictType = {hashCallback, NULL, compareCallback, freeCallback, NULL, NULL};
+
+#define start_benchmark() start = timeInMilliseconds()
+#define end_benchmark(msg)                                                                                             \
+    do {                                                                                                               \
+        elapsed = timeInMilliseconds() - start;                                                                        \
+        printf(msg ": %ld items in %lld ms\n", count, elapsed);                                                        \
+    } while (0)
+
+/* ./valkey-server test dict [<count> | --accurate] */
+int test_dict(int argc, char **argv, int flags) {
+    long j;
+    long long start, elapsed;
+    int retval;
+    dict *dict = dictCreate(&BenchmarkDictType);
+    long count = 0;
+    unsigned long new_dict_size, current_dict_used, remain_keys;
+    int accurate = (flags & UNIT_TEST_ACCURATE);
+
+    if (argc == 4) {
+        if (accurate) {
+            count = 5000000;
+        } else {
+            count = strtol(argv[3], NULL, 10);
+        }
+    } else {
+        count = 5000;
+    }
+
+    TEST("Add 16 keys and verify dict resize is ok") {
+        dictSetResizeEnabled(DICT_RESIZE_ENABLE);
+        for (j = 0; j < 16; j++) {
+            retval = dictAdd(dict, stringFromLongLong(j), (void *)j);
+            TEST_ASSERT(retval == DICT_OK);
+        }
+        while (dictIsRehashing(dict)) dictRehashMicroseconds(dict, 1000);
+        TEST_ASSERT(dictSize(dict) == 16);
+        TEST_ASSERT(dictBuckets(dict) == 16);
+    }
+
+    TEST("Use DICT_RESIZE_AVOID to disable the dict resize and pad to (dict_force_resize_ratio * 16)") {
+        /* Use DICT_RESIZE_AVOID to disable the dict resize, and pad
+         * the number of keys to (dict_force_resize_ratio * 16), so we can satisfy
+         * dict_force_resize_ratio in next test. */
+        dictSetResizeEnabled(DICT_RESIZE_AVOID);
+        for (j = 16; j < (long)dict_force_resize_ratio * 16; j++) {
+            retval = dictAdd(dict, stringFromLongLong(j), (void *)j);
+            TEST_ASSERT(retval == DICT_OK);
+        }
+        current_dict_used = dict_force_resize_ratio * 16;
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(dictBuckets(dict) == 16);
+    }
+
+    TEST("Add one more key, trigger the dict resize") {
+        retval = dictAdd(dict, stringFromLongLong(current_dict_used), (void *)(current_dict_used));
+        TEST_ASSERT(retval == DICT_OK);
+        current_dict_used++;
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == 16);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
+
+        /* Wait for rehashing. */
+        dictSetResizeEnabled(DICT_RESIZE_ENABLE);
+        while (dictIsRehashing(dict)) dictRehashMicroseconds(dict, 1000);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
+    }
+
+    TEST("Delete keys until we can trigger shrink in next test") {
+        /* Delete keys until we can satisfy (1 / HASHTABLE_MIN_FILL) in the next test. */
+        for (j = new_dict_size / HASHTABLE_MIN_FILL + 1; j < (long)current_dict_used; j++) {
+            char *key = stringFromLongLong(j);
+            retval = dictDelete(dict, key);
+            zfree(key);
+            TEST_ASSERT(retval == DICT_OK);
+        }
+        current_dict_used = new_dict_size / HASHTABLE_MIN_FILL + 1;
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
+    }
+
+    TEST("Delete one more key, trigger the dict resize") {
+        current_dict_used--;
+        char *key = stringFromLongLong(current_dict_used);
+        retval = dictDelete(dict, key);
+        zfree(key);
+        unsigned long oldDictSize = new_dict_size;
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
+        TEST_ASSERT(retval == DICT_OK);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == oldDictSize);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
+
+        /* Wait for rehashing. */
+        while (dictIsRehashing(dict)) dictRehashMicroseconds(dict, 1000);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
+    }
+
+    TEST("Empty the dictionary and add 128 keys") {
+        dictEmpty(dict, NULL);
+        for (j = 0; j < 128; j++) {
+            retval = dictAdd(dict, stringFromLongLong(j), (void *)j);
+            TEST_ASSERT(retval == DICT_OK);
+        }
+        while (dictIsRehashing(dict)) dictRehashMicroseconds(dict, 1000);
+        TEST_ASSERT(dictSize(dict) == 128);
+        TEST_ASSERT(dictBuckets(dict) == 128);
+    }
+
+    TEST("Use DICT_RESIZE_AVOID to disable the dict resize and reduce to 3") {
+        /* Use DICT_RESIZE_AVOID to disable the dict reset, and reduce
+         * the number of keys until we can trigger shrinking in next test. */
+        dictSetResizeEnabled(DICT_RESIZE_AVOID);
+        remain_keys = DICTHT_SIZE(dict->ht_size_exp[0]) / (HASHTABLE_MIN_FILL * dict_force_resize_ratio) + 1;
+        for (j = remain_keys; j < 128; j++) {
+            char *key = stringFromLongLong(j);
+            retval = dictDelete(dict, key);
+            zfree(key);
+            TEST_ASSERT(retval == DICT_OK);
+        }
+        current_dict_used = remain_keys;
+        TEST_ASSERT(dictSize(dict) == remain_keys);
+        TEST_ASSERT(dictBuckets(dict) == 128);
+    }
+
+    TEST("Delete one more key, trigger the dict resize") {
+        current_dict_used--;
+        char *key = stringFromLongLong(current_dict_used);
+        retval = dictDelete(dict, key);
+        zfree(key);
+        new_dict_size = 1UL << _dictNextExp(current_dict_used);
+        TEST_ASSERT(retval == DICT_OK);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == 128);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == new_dict_size);
+
+        /* Wait for rehashing. */
+        dictSetResizeEnabled(DICT_RESIZE_ENABLE);
+        while (dictIsRehashing(dict)) dictRehashMicroseconds(dict, 1000);
+        TEST_ASSERT(dictSize(dict) == current_dict_used);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[0]) == new_dict_size);
+        TEST_ASSERT(DICTHT_SIZE(dict->ht_size_exp[1]) == 0);
+    }
+
+    TEST("Restore to original state") {
+        dictEmpty(dict, NULL);
+        dictSetResizeEnabled(DICT_RESIZE_ENABLE);
+    }
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        retval = dictAdd(dict, stringFromLongLong(j), (void *)j);
+        TEST_ASSERT(retval == DICT_OK);
+    }
+    end_benchmark("Inserting");
+    TEST_ASSERT((long)dictSize(dict) == count);
+
+    /* Wait for rehashing. */
+    while (dictIsRehashing(dict)) {
+        dictRehashMicroseconds(dict, 100 * 1000);
+    }
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        char *key = stringFromLongLong(j);
+        dictEntry *de = dictFind(dict, key);
+        TEST_ASSERT(de != NULL);
+        zfree(key);
+    }
+    end_benchmark("Linear access of existing elements");
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        char *key = stringFromLongLong(j);
+        dictEntry *de = dictFind(dict, key);
+        TEST_ASSERT(de != NULL);
+        zfree(key);
+    }
+    end_benchmark("Linear access of existing elements (2nd round)");
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        char *key = stringFromLongLong(rand() % count);
+        dictEntry *de = dictFind(dict, key);
+        TEST_ASSERT(de != NULL);
+        zfree(key);
+    }
+    end_benchmark("Random access of existing elements");
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        dictEntry *de = dictGetRandomKey(dict);
+        TEST_ASSERT(de != NULL);
+    }
+    end_benchmark("Accessing random keys");
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        char *key = stringFromLongLong(rand() % count);
+        key[0] = 'X';
+        dictEntry *de = dictFind(dict, key);
+        TEST_ASSERT(de == NULL);
+        zfree(key);
+    }
+    end_benchmark("Accessing missing");
+
+    start_benchmark();
+    for (j = 0; j < count; j++) {
+        char *key = stringFromLongLong(j);
+        retval = dictDelete(dict, key);
+        TEST_ASSERT(retval == DICT_OK);
+        key[0] += 17; /* Change first number to letter. */
+        retval = dictAdd(dict, key, (void *)j);
+        TEST_ASSERT(retval == DICT_OK);
+    }
+    end_benchmark("Removing and adding");
+    dictRelease(dict);
+    return 0;
+}

--- a/src/unit/test_files.h
+++ b/src/unit/test_files.h
@@ -9,6 +9,7 @@ typedef struct unitTest {
 
 int test_crc64(int argc, char **argv, int flags);
 int test_crc64combine(int argc, char **argv, int flags);
+int test_dict(int argc, char **argv, int flags);
 int test_endianconv(int argc, char *argv[], int flags);
 int test_intsetValueEncodings(int argc, char **argv, int flags);
 int test_intsetBasicAdding(int argc, char **argv, int flags);
@@ -76,6 +77,7 @@ int test_zmallocAllocZeroByteAndFree(int argc, char **argv, int flags);
 
 unitTest __test_crc64_c[] = {{"test_crc64", test_crc64}, {NULL, NULL}};
 unitTest __test_crc64combine_c[] = {{"test_crc64combine", test_crc64combine}, {NULL, NULL}};
+unitTest __test_dict_c[] = {{"test_dict", test_dict}, {NULL, NULL}};
 unitTest __test_endianconv_c[] = {{"test_endianconv", test_endianconv}, {NULL, NULL}};
 unitTest __test_intset_c[] = {{"test_intsetValueEncodings", test_intsetValueEncodings}, {"test_intsetBasicAdding", test_intsetBasicAdding}, {"test_intsetLargeNumberRandomAdd", test_intsetLargeNumberRandomAdd}, {"test_intsetUpgradeFromint16Toint32", test_intsetUpgradeFromint16Toint32}, {"test_intsetUpgradeFromint16Toint64", test_intsetUpgradeFromint16Toint64}, {"test_intsetUpgradeFromint32Toint64", test_intsetUpgradeFromint32Toint64}, {"test_intsetStressLookups", test_intsetStressLookups}, {"test_intsetStressAddDelete", test_intsetStressAddDelete}, {NULL, NULL}};
 unitTest __test_kvstore_c[] = {{"test_kvstoreAdd16Keys", test_kvstoreAdd16Keys}, {"test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyDict", test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyDict}, {"test_kvstoreIteratorRemoveAllKeysDeleteEmptyDict", test_kvstoreIteratorRemoveAllKeysDeleteEmptyDict}, {"test_kvstoreDictIteratorRemoveAllKeysNoDeleteEmptyDict", test_kvstoreDictIteratorRemoveAllKeysNoDeleteEmptyDict}, {"test_kvstoreDictIteratorRemoveAllKeysDeleteEmptyDict", test_kvstoreDictIteratorRemoveAllKeysDeleteEmptyDict}, {NULL, NULL}};
@@ -91,6 +93,7 @@ struct unitTestSuite {
 } unitTestSuite[] = {
     {"test_crc64.c", __test_crc64_c},
     {"test_crc64combine.c", __test_crc64combine_c},
+    {"test_dict.c", __test_dict_c},
     {"test_endianconv.c", __test_endianconv_c},
     {"test_intset.c", __test_intset_c},
     {"test_kvstore.c", __test_kvstore_c},


### PR DESCRIPTION
Fixes #428 for `dict.c`


Currently, all tests are in a single function. Before splititng it into induvidual unit tests, I wanted to ensure that everything was working as expected.

Currently, the [3rd test](https://github.com/jay-tau/valkey/blob/82f56e8ab79c52a7a39d907e4091510aa9a65312/src/unit/test_dict.c#L107) is raising a `SIGSEV`.
By performing print debugging, I have concluded that the issue lies in [this line](https://github.com/valkey-io/valkey/blob/ae2d4217e147996bd6c546f559aa564f873f9203/src/dict.c#L409).
This type is declared in `monotonic.h`, so I am unsure why it is leading to a segfault.
Note, I believe it might be the same issue described by @jazelly **[here](https://github.com/valkey-io/valkey/issues/428#issuecomment-2122268980)**

Because of the issue with the monotime timer, all calls to [`dictRehashMicroseconds`](https://github.com/jay-tau/valkey/blob/82f56e8ab79c52a7a39d907e4091510aa9a65312/src/dict.c#L406) are leading to a segfault.

@madolson I would appreciate your thoughts. I am currently unsure how to proceed.
Please do let me know if I can provide any more information in this regard.

<!--
I would appreciate some guidance on how to proceed, into breaking this into individual unit tests, keeping in mind the benchmarks.
Unfortunately, I was not able to find an answer to this in the [unit test README](https://github.com/valkey-io/valkey/blob/unstable/src/unit/README.md)
-->