### PR TITLE
Fix bad memory accounting for sds when no malloc_size available

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -415,7 +415,7 @@ size_t sdsAllocSize(sds s) {
     char type = s[-1] & SDS_TYPE_MASK;
     /* SDS_TYPE_5 header doesn't contain the size of the allocation */
     if (type == SDS_TYPE_5) {
-        return s_malloc_size(sdsAllocPtr(s));
+        return s_malloc_usable_size(sdsAllocPtr(s));
     } else {
         return sdsHdrSize(type) + sdsalloc(s) + 1;
     }

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -51,5 +51,6 @@
 #define s_trymalloc_usable ztrymalloc_usable
 #define s_tryrealloc_usable ztryrealloc_usable
 #define s_malloc_size zmalloc_size
+#define s_malloc_usable_size zmalloc_usable_size
 
 #endif


### PR DESCRIPTION
Issue Introduced  by #453. 
When we check the SDS _TYPE_5 allocation size we mistakenly used zmalloc_size which DOES take the PREFIX size into account when no malloc_size support.
Later when we free we add the PREFIX_SIZE again which leads to negative memory accounting on some tests.
Example test failure: https://github.com/valkey-io/valkey/actions/runs/9654170962/job/26627901497