### PR TITLE
Upstream the availability zone info string from KeyDB

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3100,6 +3100,7 @@ standardConfig static_configs[] = {
     /* SDS Configs */
     createSDSConfig("primaryauth", "masterauth", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_auth, NULL, NULL, NULL),
     createSDSConfig("requirepass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.requirepass, NULL, NULL, updateRequirePass),
+    createSDSConfig("availability-zone", NULL, MODIFIABLE_CONFIG, 0, server.availability_zone, "", NULL, NULL),
 
     /* Enum Configs */
     createEnumConfig("supervised", NULL, IMMUTABLE_CONFIG, supervised_mode_enum, server.supervised_mode, SUPERVISED_NONE, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -5381,7 +5381,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             "lru_clock:%u\r\n", server.lruclock,
             "executable:%s\r\n", server.executable ? server.executable : "",
             "config_file:%s\r\n", server.configfile ? server.configfile : "",
-            "io_threads_active:%i\r\n", server.io_threads_active));
+            "io_threads_active:%i\r\n", server.io_threads_active,
+            "availability_zone:%s\r\n", server.availability_zone));
         /* clang-format on */
 
         /* Conditional properties */

--- a/src/server.h
+++ b/src/server.h
@@ -2121,6 +2121,7 @@ struct valkeyServer {
                                                 is down, doesn't affect pubsub global. */
     long reply_buffer_peak_reset_time; /* The amount of time (in milliseconds) to wait between reply buffer peak resets */
     int reply_buffer_resizing_enabled; /* Is reply buffer resizing enabled (1 by default) */
+    sds availability_zone; /* When run in a cloud environment we can configure the availability zone it is running in */
     /* Local environment */
     char *locale_collate;
 };

--- a/valkey.conf
+++ b/valkey.conf
@@ -2319,3 +2319,9 @@ jemalloc-bg-thread yes
 # to suppress
 #
 # ignore-warnings ARM64-COW-BUG
+
+# Inform Valkey of the availability zone if running in a cloud environment.  Currently
+# this is only exposed via the info command for clients to use, but in the future we
+# we may also use this when making decisions for replication.
+#
+# availability-zone "zone-name"


### PR DESCRIPTION
When Redis/Valkey/KeyDB is run in a cloud environment across multiple AZ's it is preferable to keep traffic local to an AZ both for cost reasons and for latency.  This is typically done when you are enabling reads on replicas with the READONLY command.

For this change we are creating a setting that is echo'd back in the info command.  We do not want to add the cloud SDKs as dependencies and this is the easiest way around that.  It is fairly trivial to grab the AZ from the cloud and push that into your setting file.

Currently at Snapchat we have a custom client that after connecting reads this from the server and will preferentially use that server if the AZ string matches its internally configured AZ.

In the future it would be ideal if we used this information when performing failover or even exposed it in cluster nodes.

New configuration item: availability-zone
New info field: availability_zone
availability_zone was also added in HELLO response in 8.1, see #1487 for more details.