### PR TITLE
cli: Add prompt when Ctrl-C pressed

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2273,6 +2273,8 @@ static void cliWaitForMessagesOrStdin(void) {
             /* Ctrl-C pressed */
             config.blocking_state_aborted = 0;
             config.pubsub_mode = 0;
+            printf("Exiting current connection, ready to reconnect to Valkey server... \n");
+            fflush(stdout);
             if (cliConnect(CC_FORCE) != REDIS_OK) {
                 cliPrintContextError();
                 exit(1);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2273,7 +2273,7 @@ static void cliWaitForMessagesOrStdin(void) {
             /* Ctrl-C pressed */
             config.blocking_state_aborted = 0;
             config.pubsub_mode = 0;
-            printf("Exiting current connection, ready to reconnect to Valkey server... \n");
+            printf("Closing current connection. Ready to reconnect to Valkey server... \n");
             fflush(stdout);
             if (cliConnect(CC_FORCE) != REDIS_OK) {
                 cliPrintContextError();


### PR DESCRIPTION
When I play the pubsub command in console, I am confused by the following scenario:

![image](https://github.com/valkey-io/valkey/assets/51993843/c56e3976-1e8f-4053-9abb-16fa05ef6ec4)

The reason is that when I press Ctrl-C, client exits current connection and reconnects to the server.
Thus I add one prompt message to make everyone clear what it happens.

![image](https://github.com/valkey-io/valkey/assets/51993843/cc620f27-4522-4f34-a7b3-86bcdeedfaba)
