### PR TITLE
Update redis keyword to valkey in some sentinel functions (Redis Legacy)

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -244,7 +244,7 @@ typedef struct sentinelValkeyInstance {
     mstime_t failover_start_time;                    /* Last failover attempt start time. */
     mstime_t failover_timeout;                       /* Max time to refresh failover state. */
     mstime_t failover_delay_logged;                  /* For what failover_start_time value we
-logged the failover delay. */
+                                                      * logged the failover delay. */
     struct sentinelValkeyInstance *promoted_replica; /* Promoted replica instance. */
     /* Scripts executed to notify admin or reconfigure clients: when they
      * are set to NULL no script is executed. */


### PR DESCRIPTION
This PR updates all Redis/redis keywords to Valkey/valkey, including variable names, comments, function names. 

All sentinel test cases passed.