### PR TITLE
CLUSTER SLOT-STATS ORDERBY when stats are the same, compare by slot in ascending order

### DIFF
--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -51,15 +51,23 @@ static uint64_t getSlotStat(int slot, int stat_type) {
     return slot_stat;
 }
 
+/* Compare by stat in ascending order. If stat is the same, compare by slot in ascending order. */
 static int slotStatForSortAscCmp(const void *a, const void *b) {
     slotStatForSort entry_a = *((slotStatForSort *)a);
     slotStatForSort entry_b = *((slotStatForSort *)b);
+    if (entry_a.stat == entry_b.stat) {
+        return entry_a.slot - entry_b.slot;
+    }
     return entry_a.stat - entry_b.stat;
 }
 
+/* Compare by stat in descending order. If stat is the same, compare by slot in ascending order. */
 static int slotStatForSortDescCmp(const void *a, const void *b) {
     slotStatForSort entry_a = *((slotStatForSort *)a);
     slotStatForSort entry_b = *((slotStatForSort *)b);
+    if (entry_b.stat == entry_a.stat) {
+        return entry_a.slot - entry_b.slot;
+    }
     return entry_b.stat - entry_a.stat;
 }
 

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -239,7 +239,8 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         set slot_stats_desc_length [llength $slot_stats_desc]
         set slot_stats_asc_length [llength $slot_stats_asc]
         assert {$limit == $slot_stats_desc_length && $limit == $slot_stats_asc_length}
-        
+
+        # The key count of all slots is 0, so we will order by slot in ascending order.
         set expected_slots [dict create 0 0 1 0 2 0 3 0 4 0]
         assert_slot_visibility $slot_stats_desc $expected_slots
         assert_slot_visibility $slot_stats_asc $expected_slots


### PR DESCRIPTION
Test failed in my local:
```
*** [err]: CLUSTER SLOT-STATS ORDERBY LIMIT correct response pagination, where limit is less than number of assigned slots in tests/unit/cluster/slot-stats.tcl
Expected [dict exists 0 0 1 0 2 0 3 0 4 0 16383] (context: type source line 64 file /xxx/tests/unit/cluster/slot-stats.tcl cmd {assert {[dict exists $expected_slots $slot]}} proc ::assert_slot_visibility level 1)
```

It seems that when the stat is equal, that is, when the key-count is equal,
the qsort performance will be different. When the stat is equal, we compare
by slot (in ascending order).