### PR TITLE
Increase ping and cluster timeout for cluster-slots test

### DIFF
--- a/tests/unit/cluster/cluster-slots.tcl
+++ b/tests/unit/cluster/cluster-slots.tcl
@@ -10,7 +10,7 @@ proc cluster_allocate_mixedSlots {masters replicas} {
     }
 }
 
-start_cluster 5 10 {tags {external:skip cluster}} {
+start_cluster 5 10 {overrides {cluster-ping-interval 1000 cluster-node-timeout 90000} tags {external:skip cluster}} {
 
 test "Cluster is up" {
     wait_for_cluster_state ok


### PR DESCRIPTION
cluster-slots test is tesing a very fragmented slots range of a relatively large cluster. For this reason, when run under valgrind, some of the nodes are timing out when cluster is attempting to converge and propagate.
This pr sets the test's cluster-node-timeout to 90000 and cluster-ping-interval to 1000.