### PR TITLE
Use 'primary' instead of 'master' in Sentinel tcl testing.

### DIFF
--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -75,7 +75,7 @@ test "SENTINEL SIMULATE-FAILURE HELP list supported flags" {
     assert_equal {crash-after-election crash-after-promotion} $res
 }
 
-test "Basic failover works if the master is down" {
+test "Basic failover works if the primary is down" {
     set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
@@ -94,11 +94,11 @@ test "Basic failover works if the master is down" {
     set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 }
 
-test "New master [join $addr {:}] role matches" {
+test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "All the other slaves now point to the new master" {
+test "All the other slaves now point to the new primary" {
     foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
@@ -110,7 +110,7 @@ test "All the other slaves now point to the new master" {
     }
 }
 
-test "The old master eventually gets reconfigured as a slave" {
+test "The old primary eventually gets reconfigured as a slave" {
     wait_for_condition 1000 50 {
         [RI 0 master_port] == [lindex $addr 1]
     } else {
@@ -190,11 +190,11 @@ test "Failover works if we configure for absolute agreement" {
     }
 }
 
-test "New master [join $addr {:}] role matches" {
+test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "SENTINEL RESET can resets the master" {
+test "SENTINEL RESET can resets the primary" {
     # After SENTINEL RESET, sometimes the sentinel can sense the master again,
     # causing the test to fail. Here we give it a few more chances.
     for {set j 0} {$j < 10} {incr j} {

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -56,7 +56,7 @@ test "SENTINEL PENDING-SCRIPTS returns the information about pending scripts" {
     assert_morethan_equal [llength [S 0 SENTINEL PENDING-SCRIPTS]] 0
 }
 
-test "SENTINEL MASTERS returns a list of monitored masters" {
+test "SENTINEL PRIMARYS returns a list of monitored primarys" {
     assert_match "*mymaster*" [S 0 SENTINEL MASTERS]
     assert_morethan_equal [llength [S 0 SENTINEL MASTERS]] 1
 }

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -56,7 +56,7 @@ test "SENTINEL PENDING-SCRIPTS returns the information about pending scripts" {
     assert_morethan_equal [llength [S 0 SENTINEL PENDING-SCRIPTS]] 0
 }
 
-test "SENTINEL PRIMARYS returns a list of monitored primarys" {
+test "SENTINEL PRIMARIES returns a list of monitored primaries" {
     assert_match "*mymaster*" [S 0 SENTINEL MASTERS]
     assert_morethan_equal [llength [S 0 SENTINEL MASTERS]] 1
 }
@@ -195,7 +195,7 @@ test "New primary [join $addr {:}] role matches" {
 }
 
 test "SENTINEL RESET can resets the primary" {
-    # After SENTINEL RESET, sometimes the sentinel can sense the master again,
+    # After SENTINEL RESET, sometimes the sentinel can sense the primary again,
     # causing the test to fail. Here we give it a few more chances.
     for {set j 0} {$j < 10} {incr j} {
         assert_equal 1 [S 0 SENTINEL RESET mymaster]

--- a/tests/sentinel/tests/01-conf-update.tcl
+++ b/tests/sentinel/tests/01-conf-update.tcl
@@ -34,7 +34,7 @@ test "After Sentinel 1 is restarted, its config gets updated" {
     }
 }
 
-test "New master [join $addr {:}] role matches" {
+test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 

--- a/tests/sentinel/tests/02-slaves-reconf.tcl
+++ b/tests/sentinel/tests/02-slaves-reconf.tcl
@@ -9,7 +9,7 @@ source "../tests/includes/init-tests.tcl"
 
 proc 02_test_slaves_replication {} {
     uplevel 1 {
-        test "Check that slaves replicate from current master" {
+        test "Check that slaves replicate from current primary" {
             set master_port [RPort $master_id]
             foreach_valkey_id id {
                 if {$id == $master_id} continue
@@ -27,7 +27,7 @@ proc 02_test_slaves_replication {} {
 
 proc 02_crash_and_failover {} {
     uplevel 1 {
-        test "Crash the master and force a failover" {
+        test "Crash the primary and force a failover" {
             set old_port [RPort $master_id]
             set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
             assert {[lindex $addr 1] == $old_port}

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -63,7 +63,7 @@ proc wait_for_sentinels_connect_servers { {is_connect 1} } {
     }
 }
 
-test "Sentinels (re)connection following SENTINEL SET mymaster auth-pass" {
+test "Sentinels (re)connection following SENTINEL SET myprimary auth-pass" {
     # 3 types of sentinels to test:
     # (re)started while master changed pwd. Manage to connect only after setting pwd
     set sent2re 0

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -98,7 +98,7 @@ test "Sentinels (re)connection following SENTINEL SET mymaster auth-pass" {
     verify_sentinel_auto_discovery
 }
 
-test "Sentinels (re)connection following master ACL change" {
+test "Sentinels (re)connection following primary ACL change" {
     # Three types of sentinels to test during ACL change:
     # 1. (re)started Sentinel. Manage to connect only after setting new pwd
     # 2. (up)dated Sentinel, get just before ACL change the new password

--- a/tests/sentinel/tests/03-runtime-reconf.tcl
+++ b/tests/sentinel/tests/03-runtime-reconf.tcl
@@ -65,9 +65,9 @@ proc wait_for_sentinels_connect_servers { {is_connect 1} } {
 
 test "Sentinels (re)connection following SENTINEL SET myprimary auth-pass" {
     # 3 types of sentinels to test:
-    # (re)started while master changed pwd. Manage to connect only after setting pwd
+    # (re)started while primary changed pwd. Manage to connect only after setting pwd
     set sent2re 0
-    # (up)dated in advance with master new password
+    # (up)dated in advance with primary new password
     set sent2up 1
     # (un)touched. Yet manage to maintain (old) connection
     set sent2un 2

--- a/tests/sentinel/tests/05-manual.tcl
+++ b/tests/sentinel/tests/05-manual.tcl
@@ -38,11 +38,11 @@ test "Manual failover works" {
     set master_id [get_instance_id_by_port valkey [lindex $addr 1]]
 }
 
-test "New master [join $addr {:}] role matches" {
+test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "All the other slaves now point to the new master" {
+test "All the other slaves now point to the new primary" {
     foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
@@ -54,7 +54,7 @@ test "All the other slaves now point to the new master" {
     }
 }
 
-test "The old master eventually gets reconfigured as a slave" {
+test "The old primary eventually gets reconfigured as a slave" {
     wait_for_condition 1000 50 {
         [RI 0 master_port] == [lindex $addr 1]
     } else {

--- a/tests/sentinel/tests/07-down-conditions.tcl
+++ b/tests/sentinel/tests/07-down-conditions.tcl
@@ -64,7 +64,7 @@ test "SDOWN is triggered by crashed instance" {
     ensure_master_up
 }
 
-test "SDOWN is triggered by masters advertising as slaves" {
+test "SDOWN is triggered by primarys advertising as slaves" {
     ensure_master_up
     R 0 slaveof 127.0.0.1 34567
     ensure_master_down

--- a/tests/sentinel/tests/07-down-conditions.tcl
+++ b/tests/sentinel/tests/07-down-conditions.tcl
@@ -64,7 +64,7 @@ test "SDOWN is triggered by crashed instance" {
     ensure_master_up
 }
 
-test "SDOWN is triggered by primarys advertising as slaves" {
+test "SDOWN is triggered by primaries advertising as slaves" {
     ensure_master_up
     R 0 slaveof 127.0.0.1 34567
     ensure_master_down

--- a/tests/sentinel/tests/12-master-reboot.tcl
+++ b/tests/sentinel/tests/12-master-reboot.tcl
@@ -35,7 +35,7 @@ proc reboot_instance {type id} {
 }
 
 
-test "Master reboot in very short time" {
+test "Primary reboot in very short time" {
     set old_port [RPort $master_id]
     set addr [S 0 SENTINEL GET-MASTER-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
@@ -78,11 +78,11 @@ test "Master reboot in very short time" {
     }
 }
 
-test "New master [join $addr {:}] role matches" {
+test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "All the other slaves now point to the new master" {
+test "All the other slaves now point to the new primary" {
     foreach_valkey_id id {
         if {$id != $master_id && $id != 0} {
             wait_for_condition 1000 50 {
@@ -94,7 +94,7 @@ test "All the other slaves now point to the new master" {
     }
 }
 
-test "The old master eventually gets reconfigured as a slave" {
+test "The old primary eventually gets reconfigured as a slave" {
     wait_for_condition 1000 50 {
         [RI 0 master_port] == [lindex $addr 1]
     } else {

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -5,7 +5,7 @@ test "(init) Restart killed instances" {
     restart_killed_instances
 }
 
-test "(init) Remove old master entry from sentinels" {
+test "(init) Remove old primary entry from sentinels" {
     foreach_sentinel_id id {
         catch {S $id SENTINEL REMOVE mymaster}
     }
@@ -17,7 +17,7 @@ test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances"
 }
 set master_id 0
 
-test "(init) Sentinels can start monitoring a master" {
+test "(init) Sentinels can start monitoring a primary" {
     set sentinels [llength $::sentinel_instances]
     set quorum [expr {$sentinels/2+1}]
     foreach_sentinel_id id {
@@ -38,7 +38,7 @@ test "(init) Sentinels can start monitoring a master" {
     }
 }
 
-test "(init) Sentinels can talk with the master" {
+test "(init) Sentinels can talk with the primary" {
     foreach_sentinel_id id {
         wait_for_condition 1000 50 {
             [catch {S $id SENTINEL GET-MASTER-ADDR-BY-NAME mymaster}] == 0

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -12,7 +12,7 @@ test "(init) Remove old primary entry from sentinels" {
 }
 
 set redis_slaves [expr $::instances_count - 1]
-test "(init) Create a master-slaves cluster of [expr $redis_slaves+1] instances" {
+test "(init) Create a primary-slaves cluster of [expr $redis_slaves+1] instances" {
     create_valkey_master_slave_cluster [expr {$redis_slaves+1}]
 }
 set master_id 0


### PR DESCRIPTION
Use 'primary' instead of 'master' in Sentinel tcl testing.