### PR TITLE
Make valkey compatible with redis-sentinel to start sentinel

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6380,6 +6380,9 @@ void memtest(size_t megabytes, int passes);
 int checkForSentinelMode(int argc, char **argv, char *exec_name) {
     if (strstr(exec_name, "valkey-sentinel") != NULL) return 1;
 
+    /* valkey may install symlinks like redis-sentinel -> valkey-sentinel. */
+    if (strstr(exec_name, "redis-sentinel") != NULL) return 1;
+
     for (int j = 1; j < argc; j++)
         if (!strcmp(argv[j], "--sentinel")) return 1;
     return 0;


### PR DESCRIPTION
We already have similar changes to check-rdb / check-aof, apply
this change to sentinel.

Fixes #719.