### PR TITLE
Copyright update to reflect IP transfer from Salvatore to Redis

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -17,7 +17,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 BSD 3-Clause License
 
-Copyright (c) 2006-2020, Salvatore Sanfilippo
+Copyright (c) 2006-2020, Redis Ltd.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/deps/fpconv/fpconv_powers.h
+++ b/deps/fpconv/fpconv_powers.h
@@ -6,7 +6,7 @@
  * [1] https://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2021, Redis Labs
+ * Copyright (c) 2021, Redis Ltd.
  * Copyright (c) 2013-2019, night-shift <as.smljk at gmail dot com>
  * Copyright (c) 2009, Florian Loitsch < florian.loitsch at inria dot fr >
  * All rights reserved.

--- a/deps/hiredis/COPYING
+++ b/deps/hiredis/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+Copyright (c) 2009-2011, Redis Ltd.
 Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
 
 All rights reserved.

--- a/deps/hiredis/Makefile
+++ b/deps/hiredis/Makefile
@@ -1,5 +1,5 @@
 # Hiredis Makefile
-# Copyright (C) 2010-2011 Salvatore Sanfilippo <antirez at gmail dot com>
+# Copyright (C) 2010-2011 Redis Ltd.
 # Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 

--- a/deps/hiredis/async.c
+++ b/deps/hiredis/async.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/hiredis/async.h
+++ b/deps/hiredis/async.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/hiredis/async_private.h
+++ b/deps/hiredis/async_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/hiredis/dict.c
+++ b/deps/hiredis/dict.c
@@ -5,7 +5,7 @@
  * tables of power of two in size are used, collisions are handled by
  * chaining. See the source code for more information... :)
  *
- * Copyright (c) 2006-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/deps/hiredis/dict.h
+++ b/deps/hiredis/dict.h
@@ -5,7 +5,7 @@
  * tables of power of two in size are used, collisions are handled by
  * chaining. See the source code for more information... :)
  *
- * Copyright (c) 2006-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/deps/hiredis/fuzzing/format_command_fuzzer.c
+++ b/deps/hiredis/fuzzing/format_command_fuzzer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2020, Redis Ltd.
  * Copyright (c) 2020, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * Copyright (c) 2020, Matt Stancliff <matt at genges dot com>,
  *                     Jan-Erik Rediger <janerik at fnordig dot com>

--- a/deps/hiredis/hiredis.c
+++ b/deps/hiredis/hiredis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2014, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * Copyright (c) 2015, Matt Stancliff <matt at genges dot com>,
  *                     Jan-Erik Rediger <janerik at fnordig dot com>

--- a/deps/hiredis/hiredis.h
+++ b/deps/hiredis/hiredis.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2014, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * Copyright (c) 2015, Matt Stancliff <matt at genges dot com>,
  *                     Jan-Erik Rediger <janerik at fnordig dot com>

--- a/deps/hiredis/hiredis_ssl.h
+++ b/deps/hiredis/hiredis_ssl.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  *
  * All rights reserved.
  *

--- a/deps/hiredis/net.c
+++ b/deps/hiredis/net.c
@@ -1,6 +1,6 @@
 /* Extracted from anet.c to work properly with Hiredis error reporting.
  *
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2014, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * Copyright (c) 2015, Matt Stancliff <matt at genges dot com>,
  *                     Jan-Erik Rediger <janerik at fnordig dot com>

--- a/deps/hiredis/net.h
+++ b/deps/hiredis/net.h
@@ -1,6 +1,6 @@
 /* Extracted from anet.c to work properly with Hiredis error reporting.
  *
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2014, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * Copyright (c) 2015, Matt Stancliff <matt at genges dot com>,
  *                     Jan-Erik Rediger <janerik at fnordig dot com>

--- a/deps/hiredis/read.c
+++ b/deps/hiredis/read.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/hiredis/read.h
+++ b/deps/hiredis/read.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/hiredis/sds.c
+++ b/deps/hiredis/sds.c
@@ -1,8 +1,7 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2015, Redis Ltd.
  * Copyright (c) 2015, Oran Agra
- * Copyright (c) 2015, Redis Labs, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/deps/hiredis/sds.h
+++ b/deps/hiredis/sds.h
@@ -1,8 +1,7 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2015, Redis Ltd.
  * Copyright (c) 2015, Oran Agra
- * Copyright (c) 2015, Redis Labs, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/deps/hiredis/sdsalloc.h
+++ b/deps/hiredis/sdsalloc.h
@@ -1,8 +1,7 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2015, Redis Ltd.
  * Copyright (c) 2015, Oran Agra
- * Copyright (c) 2015, Redis Labs, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/deps/hiredis/ssl.c
+++ b/deps/hiredis/ssl.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2011, Redis Ltd.
  * Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  *
  * All rights reserved.
  *

--- a/deps/linenoise/linenoise.c
+++ b/deps/linenoise/linenoise.c
@@ -10,7 +10,7 @@
  *
  * ------------------------------------------------------------------------
  *
- * Copyright (c) 2010-2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2016, Redis Ltd.
  * Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/linenoise/linenoise.h
+++ b/deps/linenoise/linenoise.h
@@ -7,7 +7,7 @@
  *
  * ------------------------------------------------------------------------
  *
- * Copyright (c) 2010-2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2014, Redis Ltd.
  * Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.

--- a/deps/lua/src/lua_cmsgpack.c
+++ b/deps/lua/src/lua_cmsgpack.c
@@ -10,7 +10,7 @@
 #define LUACMSGPACK_NAME        "cmsgpack"
 #define LUACMSGPACK_SAFE_NAME   "cmsgpack_safe"
 #define LUACMSGPACK_VERSION     "lua-cmsgpack 0.4.0"
-#define LUACMSGPACK_COPYRIGHT   "Copyright (C) 2012, Salvatore Sanfilippo"
+#define LUACMSGPACK_COPYRIGHT   "Copyright (C) 2012, Redis Ltd."
 #define LUACMSGPACK_DESCRIPTION "MessagePack C implementation for Lua"
 
 /* Allows a preprocessor directive to override MAX_NESTING */
@@ -39,7 +39,7 @@
 
 /* =============================================================================
  * MessagePack implementation and bindings for Lua 5.1/5.2.
- * Copyright(C) 2012 Salvatore Sanfilippo <antirez@gmail.com>
+ * Copyright(C) 2012 Redis Ltd.
  *
  * http://github.com/antirez/lua-cmsgpack
  *
@@ -958,7 +958,7 @@ LUALIB_API int luaopen_cmsgpack_safe(lua_State *L) {
 }
 
 /******************************************************************************
-* Copyright (C) 2012 Salvatore Sanfilippo.  All rights reserved.
+* Copyright (C) 2012 Redis Ltd.  All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining
 * a copy of this software and associated documentation files (the

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 # Valkey Makefile
-# Copyright (C) 2009 Salvatore Sanfilippo <antirez at gmail dot com>
+# Copyright (C) 2009 Redis Ltd.
 # This file is released under the BSD license, see the COPYING file
 #
 # The Makefile composes the final FINAL_CFLAGS and FINAL_LDFLAGS using

--- a/src/acl.c
+++ b/src/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -1,6 +1,6 @@
 /* adlist.c - A generic doubly linked list implementation
  *
- * Copyright (c) 2006-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -1,6 +1,6 @@
 /* adlist.h - A generic doubly linked list implementation
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ae.c
+++ b/src/ae.c
@@ -2,7 +2,7 @@
  * for the Jim's event-loop (Jim is a Tcl interpreter) but later translated
  * it in form of a library for easy reuse.
  *
- * Copyright (c) 2006-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ae.h
+++ b/src/ae.h
@@ -2,7 +2,7 @@
  * for the Jim's event-loop (Jim is a Tcl interpreter) but later translated
  * it in form of a library for easy reuse.
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -1,6 +1,6 @@
 /* Linux epoll(2) based ae.c module
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ae_select.c
+++ b/src/ae_select.c
@@ -1,6 +1,6 @@
 /* Select()-based ae.c module.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/anet.c
+++ b/src/anet.c
@@ -1,6 +1,6 @@
 /* anet.c -- Basic TCP socket stuff made a bit less boring
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/anet.h
+++ b/src/anet.h
@@ -1,6 +1,6 @@
 /* anet.c -- Basic TCP socket stuff made a bit less boring
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/aof.c
+++ b/src/aof.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/asciilogo.h
+++ b/src/asciilogo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * Copyright (c) 2024, Valkey contributors
  * All rights reserved.
  *

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -45,7 +45,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/bio.c
+++ b/src/bio.c
@@ -31,7 +31,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/bio.h
+++ b/src/bio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1,6 +1,6 @@
 /* Bit operations.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -1,6 +1,6 @@
 /* blocked.c - generic support for blocking operations like BLPOP & WAIT.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021, Redis Labs Ltd.
+ * Copyright (c) 2009-2021, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/call_reply.h
+++ b/src/call_reply.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021, Redis Labs Ltd.
+ * Copyright (c) 2009-2021, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -1,6 +1,6 @@
 /* CLI (command line interface) common methods
  *
- * Copyright (c) 2020, Redis Labs
+ * Copyright (c) 2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/config.c
+++ b/src/config.c
@@ -1,6 +1,6 @@
 /* Configuration file parsing and CONFIG GET/SET commands implementation.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/connection.h
+++ b/src/connection.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/connhelpers.h
+++ b/src/connhelpers.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/crc16.c
+++ b/src/crc16.c
@@ -2,7 +2,7 @@
 
 /*
  * Copyright 2001-2010 Georges Menie (www.menie.org)
- * Copyright 2010-2012 Salvatore Sanfilippo (adapted to Redis coding style)
+ * Copyright 2010-2012 Redis Ltd. (adapted to Redis coding style)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/db.c
+++ b/src/db.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Salvatore Sanfilippo <antirez at gmail dot com>
- * Copyright (c) 2020, Redis Labs, Inc
+ * Copyright (c) 2009-2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/debugmacro.h
+++ b/src/debugmacro.h
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -5,7 +5,7 @@
  * We do that by scanning the keyspace and for each pointer we have, we can try to
  * ask the allocator if moving it to a new address will help reduce fragmentation.
  *
- * Copyright (c) 2020, Redis Labs, Inc
+ * Copyright (c) 2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dict.c
+++ b/src/dict.c
@@ -5,7 +5,7 @@
  * tables of power of two in size are used, collisions are handled by
  * chaining. See the source code for more information... :)
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dict.h
+++ b/src/dict.h
@@ -5,7 +5,7 @@
  * tables of power of two in size are used, collisions are handled by
  * chaining. See the source code for more information... :)
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/endianconv.c
+++ b/src/endianconv.c
@@ -13,7 +13,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2011-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2011-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -2,7 +2,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2011-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2011-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/eval.c
+++ b/src/eval.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/evict.c
+++ b/src/evict.c
@@ -2,7 +2,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/expire.c
+++ b/src/expire.c
@@ -2,7 +2,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/geo.c
+++ b/src/geo.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
- * Copyright (c) 2015-2016, Salvatore Sanfilippo <antirez@gmail.com>.
+ * Copyright (c) 2015-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/geohash.c
+++ b/src/geohash.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
  * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
- * Copyright (c) 2015-2016, Salvatore Sanfilippo <antirez@gmail.com>.
+ * Copyright (c) 2015-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/geohash.h
+++ b/src/geohash.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
  * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
- * Copyright (c) 2015, Salvatore Sanfilippo <antirez@gmail.com>.
+ * Copyright (c) 2015, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
  * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
- * Copyright (c) 2015-2016, Salvatore Sanfilippo <antirez@gmail.com>.
+ * Copyright (c) 2015-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/geohash_helper.h
+++ b/src/geohash_helper.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
  * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
- * Copyright (c) 2015, Salvatore Sanfilippo <antirez@gmail.com>.
+ * Copyright (c) 2015, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -1,7 +1,7 @@
 /* hyperloglog.c - HyperLogLog probabilistic cardinality approximation.
  * This file implements the algorithm and the exported commands.
  *
- * Copyright (c) 2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2014, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/intset.c
+++ b/src/intset.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/intset.h
+++ b/src/intset.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/latency.c
+++ b/src/latency.c
@@ -5,7 +5,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2014, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/latency.h
+++ b/src/latency.h
@@ -3,7 +3,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2014, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -4,8 +4,7 @@
  *
  *  https://github.com/antirez/listpack
  *
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
- * Copyright (c) 2020, Redis Labs, Inc
+ * Copyright (c) 2017,2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -166,7 +166,7 @@ int lpSafeToAdd(unsigned char *lp, size_t add) {
  * "utils.c", function string2ll(), and is copyright:
  *
  * Copyright(C) 2011, Pieter Noordhuis
- * Copyright(C) 2011, Salvatore Sanfilippo
+ * Copyright(C) 2011, Redis Ltd.
  *
  * The function is released under the BSD 3-clause license.
  */

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -4,7 +4,7 @@
  *
  *  https://github.com/antirez/listpack
  *
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/listpack_malloc.h
+++ b/src/listpack_malloc.h
@@ -1,7 +1,7 @@
 /* Listpack -- A lists of strings serialization format
  * https://github.com/antirez/listpack
  *
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/localtime.c
+++ b/src/localtime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/lolwut.c
+++ b/src/lolwut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/lolwut.h
+++ b/src/lolwut.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018-2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/lolwut5.c
+++ b/src/lolwut5.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/lolwut6.c
+++ b/src/lolwut6.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/memtest.c
+++ b/src/memtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/module.c
+++ b/src/module.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/helloblock.c
+++ b/src/modules/helloblock.c
@@ -3,7 +3,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/hellocluster.c
+++ b/src/modules/hellocluster.c
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/hellodict.c
+++ b/src/modules/hellodict.c
@@ -5,7 +5,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/hellohook.c
+++ b/src/modules/hellohook.c
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/hellotimer.c
+++ b/src/modules/hellotimer.c
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/hellotype.c
+++ b/src/modules/hellotype.c
@@ -7,7 +7,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/modules/helloworld.c
+++ b/src/modules/helloworld.c
@@ -6,7 +6,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/networking.c
+++ b/src/networking.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/notify.c
+++ b/src/notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2013, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/object.c
+++ b/src/object.c
@@ -1,6 +1,6 @@
 /* Object implementation.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/pqsort.c
+++ b/src/pqsort.c
@@ -1,7 +1,7 @@
 /* The following is the NetBSD libc qsort implementation modified in order to
  * support partial sorting of ranges.
  *
- * Copyright(C) 2009-2012 Salvatore Sanfilippo. All rights reserved.
+ * Copyright(C) 2009-2012 Redis Ltd.
  *
  * The original copyright notice follows. */
 

--- a/src/pqsort.h
+++ b/src/pqsort.h
@@ -1,7 +1,7 @@
 /* The following is the NetBSD libc qsort implementation modified in order to
  * support partial sorting of ranges.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rand.c
+++ b/src/rand.c
@@ -13,7 +13,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2010-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rand.h
+++ b/src/rand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rax.c
+++ b/src/rax.c
@@ -2,7 +2,7 @@
  *
  * Version 1.2 -- 7 February 2019
  *
- * Copyright (c) 2017-2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017-2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rax.h
+++ b/src/rax.h
@@ -1,6 +1,6 @@
 /* Rax -- A radix tree implementation.
  *
- * Copyright (c) 2017-2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017-2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -1,6 +1,6 @@
 /* Rax -- A radix tree implementation.
  *
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/release.c
+++ b/src/release.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/replication.c
+++ b/src/replication.c
@@ -1,6 +1,6 @@
 /* Asynchronous replication implementation.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021, Redis Labs Ltd.
+ * Copyright (c) 2009-2021, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/resp_parser.h
+++ b/src/resp_parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Redis Labs Ltd.
+ * Copyright (c) 2021, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rio.c
+++ b/src/rio.c
@@ -16,7 +16,7 @@
  * ----------------------------------------------------------------------------
  *
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/rio.h
+++ b/src/rio.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sds.c
+++ b/src/sds.c
@@ -1,8 +1,7 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2015, Redis Ltd.
  * Copyright (c) 2015, Oran Agra
- * Copyright (c) 2015, Redis Labs, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sds.h
+++ b/src/sds.h
@@ -1,8 +1,7 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2015, Redis Ltd.
  * Copyright (c) 2015, Oran Agra
- * Copyright (c) 2015, Redis Labs, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -1,7 +1,6 @@
 /* SDSLib 2.0 -- A C dynamic strings library
  *
- * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
- * Copyright (c) 2015, Redis Labs, Inc
+ * Copyright (c) 2006-2015, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -1,6 +1,6 @@
 /* Sentinel implementation
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/server.c
+++ b/src/server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/server.h
+++ b/src/server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/serverassert.c
+++ b/src/serverassert.c
@@ -6,7 +6,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2021, Andy Pan <panjf2000@gmail.com> and Redis Labs
+ * Copyright (c) 2021, Andy Pan <panjf2000@gmail.com> and Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -7,7 +7,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2006-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2006-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/setproctitle.c
+++ b/src/setproctitle.c
@@ -2,7 +2,7 @@
  * setproctitle.c - Linux/Darwin setproctitle.
  * --------------------------------------------------------------------------
  * Copyright (C) 2010  William Ahern
- * Copyright (C) 2013  Salvatore Sanfilippo
+ * Copyright (C) 2013  Redis Ltd.
  * Copyright (C) 2013  Stam He
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/siphash.c
+++ b/src/siphash.c
@@ -4,7 +4,7 @@
    Copyright (c) 2012-2016 Jean-Philippe Aumasson
    <jeanphilippe.aumasson@gmail.com>
    Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
-   Copyright (c) 2017 Salvatore Sanfilippo <antirez@gmail.com>
+   Copyright (c) 2017 Redis Ltd.
 
    To the extent possible under law, the author(s) have dedicated all copyright
    and related and neighboring rights to this software to the public domain
@@ -16,7 +16,7 @@
 
    ----------------------------------------------------------------------------
 
-   This version was modified by Salvatore Sanfilippo <antirez@gmail.com>
+   This version was modified by Redis Ltd.
    in the following ways:
 
    1. We use SipHash 1-2. This is not believed to be as strong as the

--- a/src/slowlog.c
+++ b/src/slowlog.c
@@ -10,7 +10,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/slowlog.h
+++ b/src/slowlog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/solarisfixes.h
+++ b/src/solarisfixes.h
@@ -1,6 +1,6 @@
 /* Solaris specific fixes.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sort.c
+++ b/src/sort.c
@@ -1,6 +1,6 @@
 /* SORT command and helper functions.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sparkline.c
+++ b/src/sparkline.c
@@ -5,7 +5,7 @@
  *
  * ---------------------------------------------------------------------------
  *
- * Copyright(C) 2011-2014 Salvatore Sanfilippo <antirez@gmail.com>
+ * Copyright(C) 2011-2014 Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/sparkline.h
+++ b/src/sparkline.h
@@ -2,7 +2,7 @@
  *
  * ---------------------------------------------------------------------------
  *
- * Copyright(C) 2011-2014 Salvatore Sanfilippo <antirez@gmail.com>
+ * Copyright(C) 2011-2014 Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/syncio.c
+++ b/src/syncio.c
@@ -1,6 +1,6 @@
 /* Synchronous socket and file I/O operations useful across the core.
  *
- * Copyright (c) 2009-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/syscheck.c
+++ b/src/syscheck.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2022, Redis Ltd.
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, 2022, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  * All rights reserved.
  *

--- a/src/testhelp.h
+++ b/src/testhelp.h
@@ -8,7 +8,7 @@
  *
  * ----------------------------------------------------------------------------
  *
- * Copyright (c) 2010-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2009-2020, Salvatore Sanfilippo <antirez at gmail dot com>
+/* Copyright (c) 2009-2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/tls.c
+++ b/src/tls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Redis Labs
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -1,6 +1,6 @@
 /* tracking.c - Client side caching: keys tracking and invalidation
  *
- * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/util.c
+++ b/src/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * Copyright (c) 2012, Twitter, Inc.
  * All rights reserved.
  *

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1,6 +1,6 @@
 /* Server benchmark utility.
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1,6 +1,6 @@
 /* Server CLI (command line interface)
  *
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -151,8 +151,7 @@
  * ----------------------------------------------------------------------------
  *
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2017, Salvatore Sanfilippo <antirez at gmail dot com>
- * Copyright (c) 2020, Redis Labs, Inc
+ * Copyright (c) 2009-2017, 2020, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/ziplist.h
+++ b/src/ziplist.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009-2012, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2012, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -12,7 +12,7 @@
  *
  * --------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/zipmap.h
+++ b/src/zipmap.h
@@ -4,7 +4,7 @@
  *
  * --------------------------------------------------------------------------
  *
- * Copyright (c) 2009-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -1,6 +1,6 @@
 /* zmalloc - total amount of allocated memory aware version of malloc()
  *
- * Copyright (c) 2009-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -1,6 +1,6 @@
 /* zmalloc - total amount of allocated memory aware version of malloc()
  *
- * Copyright (c) 2009-2010, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2009-2010, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -1,6 +1,6 @@
 # Cluster-specific test functions.
 #
-# Copyright (C) 2014 Salvatore Sanfilippo antirez@gmail.com
+# Copyright (C) 2014 Redis Ltd.
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -1,4 +1,4 @@
-# Cluster test suite. Copyright (C) 2014 Salvatore Sanfilippo antirez@gmail.com
+# Cluster test suite. Copyright (C) 2014 Redis Ltd.
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -3,7 +3,7 @@
 # basic capabilities for spawning and handling N parallel Server / Sentinel
 # instances.
 #
-# Copyright (C) 2014 Salvatore Sanfilippo antirez@gmail.com
+# Copyright (C) 2014 Redis Ltd.
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 

--- a/tests/modules/basics.c
+++ b/tests/modules/basics.c
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2016, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2016, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -2,7 +2,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -9,7 +9,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -1,4 +1,4 @@
-# Sentinel test suite. Copyright (C) 2014 Salvatore Sanfilippo antirez@gmail.com
+# Sentinel test suite. Copyright (C) 2014 Redis Ltd.
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -1,5 +1,5 @@
 # Tcl cluster client as a wrapper of redis.rb.
-# Copyright (C) 2014 Salvatore Sanfilippo
+# Copyright (c) 2014 Redis Ltd.
 # Released under the BSD license like Redis itself
 #
 # Example usage:

--- a/tests/support/valkey.tcl
+++ b/tests/support/valkey.tcl
@@ -1,5 +1,5 @@
 # Tcl client library - used by the server test
-# Copyright (C) 2009-2014 Salvatore Sanfilippo
+# Copyright (c) 2009-2014 Redis Ltd.
 # Released under the BSD license like Redis itself
 #
 # Example usage:

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1,4 +1,4 @@
-# Server test suite. Copyright (C) 2009 Salvatore Sanfilippo antirez@gmail.com
+# Server test suite. Copyright (C) 2009 Redis Ltd.
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 

--- a/utils/build-static-symbols.tcl
+++ b/utils/build-static-symbols.tcl
@@ -2,7 +2,7 @@
 # Useful to get stack traces on segfault without a debugger. See redis.c
 # for more information.
 #
-# Copyright(C) 2009 Salvatore Sanfilippo, under the BSD license.
+# Copyright(C) 2009 Redis Ltd.
 
 set fd [open redis.c]
 set symlist {}

--- a/utils/corrupt_rdb.c
+++ b/utils/corrupt_rdb.c
@@ -1,7 +1,7 @@
 /* Trivia program to corrupt an RDB file in order to check the RDB check
  * program behavior and effectiveness.
  *
- * Copyright (C) 2016 Salvatore Sanfilippo.
+ * Copyright (C) 2016 Redis ltd.
  * This software is released in the 3-clause BSD license. */
 
 #include <stdio.h>

--- a/utils/hyperloglog/hll-err.rb
+++ b/utils/hyperloglog/hll-err.rb
@@ -1,4 +1,4 @@
-# hll-err.rb - Copyright (C) 2014 Salvatore Sanfilippo
+# hll-err.rb - Copyright (C) 2014 Redis Ltd.
 # BSD license, See the COPYING file for more information.
 #
 # Check error of HyperLogLog implementation for different set sizes.

--- a/utils/hyperloglog/hll-gnuplot-graph.rb
+++ b/utils/hyperloglog/hll-gnuplot-graph.rb
@@ -1,4 +1,4 @@
-# hll-err.rb - Copyright (C) 2014 Salvatore Sanfilippo
+# hll-err.rb - Copyright (C) 2014 Redis Ltd.
 # BSD license, See the COPYING file for more information.
 #
 # This program is suited to output average and maximum errors of

--- a/utils/redis-copy.rb
+++ b/utils/redis-copy.rb
@@ -1,4 +1,4 @@
-# redis-copy.rb - Copyright (C) 2009-2010 Salvatore Sanfilippo
+# redis-copy.rb - Copyright (C) 2009-2010 Redis Ltd.
 # BSD license, See the COPYING file for more information.
 #
 # Copy the whole dataset from one server instance to another one

--- a/utils/redis-sha1.rb
+++ b/utils/redis-sha1.rb
@@ -1,4 +1,4 @@
-# redis-sha1.rb - Copyright (C) 2009 Salvatore Sanfilippo
+# redis-sha1.rb - Copyright (C) 2009 Redis Ltd.
 # BSD license, See the COPYING file for more information.
 #
 # Performs the SHA1 sum of the whole dataset.

--- a/utils/speed-regression.tcl
+++ b/utils/speed-regression.tcl
@@ -1,5 +1,5 @@
 #!/usr/bin/env tclsh8.5
-# Copyright (C) 2011 Salvatore Sanfilippo
+# Copyright (C) 2011 Redis Ltd.
 # Released under the BSD license like Redis itself
 
 source ../tests/support/valkey.tcl

--- a/utils/tracking_collisions.c
+++ b/utils/tracking_collisions.c
@@ -17,7 +17,7 @@
  *
  * --------------------------------------------------------------------------
  *
- * Copyright (C) 2019 Salvatore Sanfilippo
+ * Copyright (C) 2019 Redis Ltd.
  * This code is released under the BSD 2 clause license.
  */
 


### PR DESCRIPTION
Update references of copyright being assigned to Salvatore when it was
transferred to Redis Ltd. as per https://github.com/valkey-io/valkey/issues/544.