### PR TITLE
Ensure only primary sender drives slot ownership updates

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3116,15 +3116,13 @@ int clusterProcessPacket(clusterLink *link) {
         /* Check for role switch: replica -> primary or primary -> replica. */
         if (sender) {
             serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                      sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica",
-                      sender->shard_id);
+                      sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
             if (sender_claims_to_be_primary) {
                 /* Node is a primary. */
                 clusterSetNodeAsPrimary(sender);
             } else {
                 /* Node is a replica. */
-                clusterNode *sender_claimed_primary_node =
-                    clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
+                clusterNode *sender_claimed_primary_node = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
 
                 if (sender_was_primary) {
                     /* Primary turned into a replica! Reconfigure the node. */
@@ -3199,8 +3197,7 @@ int clusterProcessPacket(clusterLink *link) {
          * this ASAP to avoid other computational expensive checks later.*/
 
         if (sender && sender_claims_to_be_primary &&
-            (sender_was_replica ||
-             memcmp(sender->slots, hdr->myslots, sizeof(hdr->myslots)))) {
+            (sender_was_replica || memcmp(sender->slots, hdr->myslots, sizeof(hdr->myslots)))) {
             /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
             serverAssert(nodeIsPrimary(sender));
 
@@ -3277,8 +3274,7 @@ int clusterProcessPacket(clusterLink *link) {
             failing = clusterLookupNode(hdr->data.fail.about.nodename, CLUSTER_NAMELEN);
             if (failing && !(failing->flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_MYSELF))) {
                 serverLog(LL_NOTICE, "FAIL message received from %.40s (%s) about %.40s (%s)", hdr->sender,
-                          sender->human_nodename, hdr->data.fail.about.nodename,
-                          failing->human_nodename);
+                          sender->human_nodename, hdr->data.fail.about.nodename, failing->human_nodename);
                 failing->flags |= CLUSTER_NODE_FAIL;
                 failing->fail_time = now;
                 failing->flags &= ~CLUSTER_NODE_PFAIL;
@@ -3314,8 +3310,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* We consider this vote only if the sender is a primary serving
          * a non zero number of slots, and its currentEpoch is greater or
          * equal to epoch where this node started the election. */
-        if (clusterNodeIsVotingPrimary(sender) &&
-            sender_claimed_current_epoch >= server.cluster->failover_auth_epoch) {
+        if (clusterNodeIsVotingPrimary(sender) && sender_claimed_current_epoch >= server.cluster->failover_auth_epoch) {
             server.cluster->failover_auth_count++;
             /* Maybe we reached a quorum here, set a flag to make sure
              * we check ASAP. */
@@ -3332,8 +3327,7 @@ int clusterProcessPacket(clusterLink *link) {
         server.cluster->mf_replica = sender;
         pauseActions(PAUSE_DURING_FAILOVER, now + (CLUSTER_MF_TIMEOUT * CLUSTER_MF_PAUSE_MULT),
                      PAUSE_ACTIONS_CLIENT_WRITE_SET);
-        serverLog(LL_NOTICE, "Manual failover requested by replica %.40s (%s).", sender->name,
-                  sender->human_nodename);
+        serverLog(LL_NOTICE, "Manual failover requested by replica %.40s (%s).", sender->name, sender->human_nodename);
         /* We need to send a ping message to the replica, as it would carry
          * `server.cluster->mf_primary_offset`, which means the primary paused clients
          * at offset `server.cluster->mf_primary_offset`, so that the replica would

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2932,6 +2932,9 @@ int clusterProcessPacket(clusterLink *link) {
     uint16_t flags = ntohs(hdr->flags);
     uint64_t senderCurrentEpoch = 0, senderConfigEpoch = 0;
     clusterNode *sender = getNodeFromLinkAndMsg(link, hdr);
+    int sender_claims_primary = !memcmp(hdr->replicaof, CLUSTER_NODE_NULL_NAME, CLUSTER_NAMELEN);
+    int sender_was_replica = sender && nodeIsReplica(sender);
+    int sender_was_primary = sender && nodeIsPrimary(sender);
 
     if (sender && (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)) {
         sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
@@ -2949,8 +2952,7 @@ int clusterProcessPacket(clusterLink *link) {
         senderConfigEpoch = ntohu64(hdr->configEpoch);
         if (senderCurrentEpoch > server.cluster->currentEpoch) server.cluster->currentEpoch = senderCurrentEpoch;
         /* Update the sender configEpoch if it is a primary publishing a newer one. */
-        if (!memcmp(hdr->replicaof, CLUSTER_NODE_NULL_NAME, sizeof(hdr->replicaof)) &&
-            senderConfigEpoch > sender->configEpoch) {
+        if (sender_claims_primary && senderConfigEpoch > sender->configEpoch) {
             sender->configEpoch = senderConfigEpoch;
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG);
         }
@@ -3113,19 +3115,17 @@ int clusterProcessPacket(clusterLink *link) {
         /* Check for role switch: replica -> primary or primary -> replica. */
         if (sender) {
             serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                      sender->human_nodename,
-                      !memcmp(hdr->replicaof, CLUSTER_NODE_NULL_NAME, sizeof(hdr->replicaof)) ? "primary" : "replica",
-                      sender->shard_id);
-            if (!memcmp(hdr->replicaof, CLUSTER_NODE_NULL_NAME, sizeof(hdr->replicaof))) {
+                      sender->human_nodename, sender_claims_primary ? "primary" : "replica", sender->shard_id);
+            if (sender_claims_primary) {
                 /* Node is a primary. */
                 clusterSetNodeAsPrimary(sender);
             } else {
                 /* Node is a replica. */
-                clusterNode *primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
+                clusterNode *new_primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
 
-                if (clusterNodeIsPrimary(sender)) {
+                if (sender_was_primary) {
                     /* Primary turned into a replica! Reconfigure the node. */
-                    if (primary && areInSameShard(primary, sender)) {
+                    if (new_primary && areInSameShard(new_primary, sender)) {
                         /* `sender` was a primary and was in the same shard as its new primary */
                         if (sender->configEpoch > senderConfigEpoch) {
                             serverLog(LL_NOTICE,
@@ -3136,13 +3136,13 @@ int clusterProcessPacket(clusterLink *link) {
                         } else {
                             /* `primary` is still a `replica` in this observer node's view;
                              * update its role and configEpoch */
-                            clusterSetNodeAsPrimary(primary);
-                            primary->configEpoch = senderConfigEpoch;
+                            clusterSetNodeAsPrimary(new_primary);
+                            new_primary->configEpoch = senderConfigEpoch;
                             serverLog(LL_NOTICE,
                                       "A failover occurred in shard %.40s; node %.40s (%s)"
                                       " failed over to node %.40s (%s) with a config epoch of %llu",
-                                      sender->shard_id, sender->name, sender->human_nodename, primary->name,
-                                      primary->human_nodename, (unsigned long long)primary->configEpoch);
+                                      sender->shard_id, sender->name, sender->human_nodename, new_primary->name,
+                                      new_primary->human_nodename, (unsigned long long)new_primary->configEpoch);
                         }
                     } else {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
@@ -3151,9 +3151,9 @@ int clusterProcessPacket(clusterLink *link) {
                                   "Node %.40s (%s) is no longer primary of shard %.40s;"
                                   " removed all %d slot(s) it used to own",
                                   sender->name, sender->human_nodename, sender->shard_id, slots);
-                        if (primary != NULL) {
+                        if (new_primary != NULL) {
                             serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
-                                      sender->human_nodename, primary->shard_id);
+                                      sender->human_nodename, new_primary->shard_id);
                         }
                     }
 
@@ -3165,17 +3165,17 @@ int clusterProcessPacket(clusterLink *link) {
                 }
 
                 /* Primary node changed for this replica? */
-                if (primary && sender->replicaof != primary) {
+                if (new_primary && sender->replicaof != new_primary) {
                     if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
                     serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
-                              sender->name, sender->human_nodename, primary->name, primary->human_nodename,
+                              sender->name, sender->human_nodename, new_primary->name, new_primary->human_nodename,
                               sender->shard_id);
-                    clusterNodeAddReplica(primary, sender);
-                    sender->replicaof = primary;
+                    clusterNodeAddReplica(new_primary, sender);
+                    sender->replicaof = new_primary;
 
                     /* Update the shard_id when a replica is connected to its
                      * primary in the very first time. */
-                    updateShardId(sender, primary->shard_id);
+                    updateShardId(sender, new_primary->shard_id);
 
                     /* Update config. */
                     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
@@ -3190,63 +3190,38 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* Many checks are only needed if the set of served slots this
          * instance claims is different compared to the set of slots we have
-         * for it. Check this ASAP to avoid other computational expansive
-         * checks later. */
-        clusterNode *sender_primary = NULL; /* Sender or its primary if replica. */
-        int dirty_slots = 0;                /* Sender claimed slots don't match my view? */
+         * for it or if there was a failover in the sender's shard. Check
+         * this ASAP to avoid other computational expensive checks later.*/
 
-        if (sender) {
-            sender_primary = clusterNodeIsPrimary(sender) ? sender : sender->replicaof;
-            if (sender_primary) {
-                dirty_slots = memcmp(sender_primary->slots, hdr->myslots, sizeof(hdr->myslots)) != 0;
+        if (sender && sender_claims_primary &&
+            (sender_was_replica || memcmp(sender->slots, hdr->myslots, sizeof(hdr->myslots)))) {
+            /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
+            serverAssert(nodeIsPrimary(sender));
 
-                /* Force dirty when the sending shard owns no slots so that
-                 * we have a chance to examine and repair slot migrating/importing
-                 * states that involve empty shards. */
-                dirty_slots |= sender_primary->numslots == 0;
-            }
-        }
+            /* 1) If the sender of the message is a primary, and we detected that
+             *    the set of slots it claims changed, scan the slots to see if we
+             *    need to update our configuration. */
+            clusterUpdateSlotsConfigWith(sender, senderConfigEpoch, hdr->myslots);
 
-        /* 1) If the sender of the message is a primary, and we detected that
-         *    the set of slots it claims changed, scan the slots to see if we
-         *    need to update our configuration. */
-        if (sender_primary && dirty_slots)
-            clusterUpdateSlotsConfigWith(sender_primary, senderConfigEpoch, hdr->myslots);
-
-        /* Explicitly check for a replication loop before attempting the replication
-         * chain folding logic. */
-        if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
-            /* Safeguard against sub-replicas. A replica's primary can turn itself
-             * into a replica if its last slot is removed. If no other node takes
-             * over the slot, there is nothing else to trigger replica migration. */
-            serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
-                      myself->replicaof->replicaof->name, myself->replicaof->name);
-            clusterSetPrimary(myself->replicaof->replicaof, 1);
-            clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
-        }
-
-        /* 2) We also check for the reverse condition, that is, the sender
-         *    claims to serve slots we know are served by a primary with a
-         *    greater configEpoch. If this happens we inform the sender.
-         *
-         * This is useful because sometimes after a partition heals, a
-         * reappearing primary may be the last one to claim a given set of
-         * hash slots, but with a configuration that other instances know to
-         * be deprecated. Example:
-         *
-         * A and B are primary and replica for slots 1,2,3.
-         * A is partitioned away, B gets promoted.
-         * B is partitioned away, and A returns available.
-         *
-         * Usually B would PING A publishing its set of served slots and its
-         * configEpoch, but because of the partition B can't inform A of the
-         * new configuration, so other nodes that have an updated table must
-         * do it. In this way A will stop to act as a primary (or can try to
-         * failover if there are the conditions to win the election). */
-        if (sender && dirty_slots) {
-            int j;
-
-            for (j = 0; j < CLUSTER_SLOTS; j++) {
+            /* 2) We also check for the reverse condition, that is, the sender
+             *    claims to serve slots we know are served by a primary with a
+             *    greater configEpoch. If this happens we inform the sender.
+             *
+             * This is useful because sometimes after a partition heals, a
+             * reappearing primary may be the last one to claim a given set of
+             * hash slots, but with a configuration that other instances know to
+             * be deprecated. Example:
+             *
+             * A and B are primary and replica for slots 1,2,3.
+             * A is partitioned away, B gets promoted.
+             * B is partitioned away, and A returns available.
+             *
+             * Usually B would PING A publishing its set of served slots and its
+             * configEpoch, but because of the partition B can't inform A of the
+             * new configuration, so other nodes that have an updated table must
+             * do it. In this way A will stop to act as a primary (or can try to
+             * failover if there are the conditions to win the election). */
+            for (int j = 0; j < CLUSTER_SLOTS; j++) {
                 if (bitmapTestBit(hdr->myslots, j)) {
                     if (server.cluster->slots[j] == sender || isSlotUnclaimed(j)) continue;
                     if (server.cluster->slots[j]->configEpoch > senderConfigEpoch) {
@@ -3265,10 +3240,21 @@ int clusterProcessPacket(clusterLink *link) {
             }
         }
 
+        /* Explicitly check for a replication loop before attempting the replication
+         * chain folding logic. */
+        if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
+            /* Safeguard against sub-replicas. A replica's primary can turn itself
+             * into a replica if its last slot is removed. If no other node takes
+             * over the slot, there is nothing else to trigger replica migration. */
+            serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
+                      myself->replicaof->replicaof->name, myself->replicaof->name);
+            clusterSetPrimary(myself->replicaof->replicaof, 1);
+            clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
+        }
+
         /* If our config epoch collides with the sender's try to fix
          * the problem. */
-        if (sender && clusterNodeIsPrimary(myself) && clusterNodeIsPrimary(sender) &&
-            senderConfigEpoch == myself->configEpoch) {
+        if (sender && nodeIsPrimary(myself) && nodeIsPrimary(sender) && senderConfigEpoch == myself->configEpoch) {
             clusterHandleConfigEpochCollision(sender);
         }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2998,13 +2998,13 @@ int clusterProcessPacket(clusterLink *link) {
          * flags, replicaof pointer, and so forth, as this details will be
          * resolved when we'll receive PONGs from the node. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
-            clusterNode *n;
+            clusterNode *node;
 
-            n = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
-            serverAssert(nodeIp2String(n->ip, link, hdr->myip) == C_OK);
-            getClientPortFromClusterMsg(hdr, &n->tls_port, &n->tcp_port);
-            n->cport = ntohs(hdr->cport);
-            clusterAddNode(n);
+            node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
+            serverAssert(nodeIp2String(node->ip, link, hdr->myip) == C_OK);
+            getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
+            node->cport = ntohs(hdr->cport);
+            clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
         }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2931,40 +2931,40 @@ int clusterProcessPacket(clusterLink *link) {
 
     uint16_t flags = ntohs(sender_message->flags);
     uint64_t sender_claimed_current_epoch = 0, sender_claimed_config_epoch = 0;
-    clusterNode *sender_node = getNodeFromLinkAndMsg(link, sender_message);
+    clusterNode *sender = getNodeFromLinkAndMsg(link, sender_message);
     int sender_claims_to_be_primary = !memcmp(sender_message->replicaof, CLUSTER_NODE_NULL_NAME, CLUSTER_NAMELEN);
-    int sender_was_replica = sender_node && nodeIsReplica(sender_node);
-    int sender_was_primary = sender_node && nodeIsPrimary(sender_node);
+    int sender_was_replica = sender && nodeIsReplica(sender);
+    int sender_was_primary = sender && nodeIsPrimary(sender);
 
-    if (sender_node && (sender_message->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)) {
-        sender_node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+    if (sender && (sender_message->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)) {
+        sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
     }
 
     /* Update the last time we saw any data from this node. We
      * use this in order to avoid detecting a timeout from a node that
      * is just sending a lot of data in the cluster bus, for instance
      * because of Pub/Sub. */
-    if (sender_node) sender_node->data_received = now;
+    if (sender) sender->data_received = now;
 
-    if (sender_node && !nodeInHandshake(sender_node)) {
+    if (sender && !nodeInHandshake(sender)) {
         /* Update our currentEpoch if we see a newer epoch in the cluster. */
         sender_claimed_current_epoch = ntohu64(sender_message->currentEpoch);
         sender_claimed_config_epoch = ntohu64(sender_message->configEpoch);
         if (sender_claimed_current_epoch > server.cluster->currentEpoch)
             server.cluster->currentEpoch = sender_claimed_current_epoch;
         /* Update the sender configEpoch if it is a primary publishing a newer one. */
-        if (sender_claims_to_be_primary && sender_claimed_config_epoch > sender_node->configEpoch) {
-            sender_node->configEpoch = sender_claimed_config_epoch;
+        if (sender_claims_to_be_primary && sender_claimed_config_epoch > sender->configEpoch) {
+            sender->configEpoch = sender_claimed_config_epoch;
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG);
         }
         /* Update the replication offset info for this node. */
-        sender_node->repl_offset = ntohu64(sender_message->offset);
-        sender_node->repl_offset_time = now;
+        sender->repl_offset = ntohu64(sender_message->offset);
+        sender->repl_offset_time = now;
         /* If we are a replica performing a manual failover and our primary
          * sent its offset while already paused, populate the MF state. */
-        if (server.cluster->mf_end && nodeIsReplica(myself) && myself->replicaof == sender_node &&
+        if (server.cluster->mf_end && nodeIsReplica(myself) && myself->replicaof == sender &&
             sender_message->mflags[0] & CLUSTERMSG_FLAG0_PAUSED && server.cluster->mf_primary_offset == -1) {
-            server.cluster->mf_primary_offset = sender_node->repl_offset;
+            server.cluster->mf_primary_offset = sender->repl_offset;
             clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_MANUALFAILOVER);
             serverLog(LL_NOTICE,
                       "Received replication offset for paused "
@@ -3000,7 +3000,7 @@ int clusterProcessPacket(clusterLink *link) {
          * In this stage we don't try to add the node with the right
          * flags, replicaof pointer, and so forth, as this details will be
          * resolved when we'll receive PONGs from the node. */
-        if (!sender_node && type == CLUSTERMSG_TYPE_MEET) {
+        if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *new_sender_node;
 
             new_sender_node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
@@ -3014,7 +3014,7 @@ int clusterProcessPacket(clusterLink *link) {
         /* If this is a MEET packet from an unknown node, we still process
          * the gossip section here since we have to trust the sender because
          * of the message type. */
-        if (!sender_node && type == CLUSTERMSG_TYPE_MEET) clusterProcessGossipSection(sender_message, link);
+        if (!sender && type == CLUSTERMSG_TYPE_MEET) clusterProcessGossipSection(sender_message, link);
 
         /* Anyway reply with a PONG */
         clusterSendPing(link, CLUSTERMSG_TYPE_PONG);
@@ -3025,22 +3025,22 @@ int clusterProcessPacket(clusterLink *link) {
         serverLog(LL_DEBUG, "%s packet received: %.40s", clusterGetMessageTypeString(type),
                   link->node ? link->node->name : "NULL");
 
-        if (sender_node && (sender_node->flags & CLUSTER_NODE_MEET)) {
+        if (sender && (sender->flags & CLUSTER_NODE_MEET)) {
             /* Once we get a response for MEET from the sender, we can stop sending more MEET. */
-            sender_node->flags &= ~CLUSTER_NODE_MEET;
-            serverLog(LL_NOTICE, "Successfully completed handshake with %.40s (%s)", sender_node->name,
-                      sender_node->human_nodename);
+            sender->flags &= ~CLUSTER_NODE_MEET;
+            serverLog(LL_NOTICE, "Successfully completed handshake with %.40s (%s)", sender->name,
+                      sender->human_nodename);
         }
         if (!link->inbound) {
             if (nodeInHandshake(link->node)) {
                 /* If we already have this node, try to change the
                  * IP/port of the node with the new one. */
-                if (sender_node) {
+                if (sender) {
                     serverLog(LL_VERBOSE,
                               "Handshake: we already know node %.40s (%s), "
                               "updating the address if needed.",
-                              sender_node->name, sender_node->human_nodename);
-                    if (nodeUpdateAddressIfNeeded(sender_node, link, sender_message)) {
+                              sender->name, sender->human_nodename);
+                    if (nodeUpdateAddressIfNeeded(sender, link, sender_message)) {
                         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
                     }
                     /* Free this node as we already have it. This will
@@ -3082,15 +3082,15 @@ int clusterProcessPacket(clusterLink *link) {
          * be propagated because the replica ranking used to understand the
          * delay of each replica in the voting process, needs to know
          * what are the instances really competing. */
-        if (sender_node) {
+        if (sender) {
             int nofailover = flags & CLUSTER_NODE_NOFAILOVER;
-            sender_node->flags &= ~CLUSTER_NODE_NOFAILOVER;
-            sender_node->flags |= nofailover;
+            sender->flags &= ~CLUSTER_NODE_NOFAILOVER;
+            sender->flags |= nofailover;
         }
 
         /* Update the node address if it changed. */
-        if (sender_node && type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender_node) &&
-            nodeUpdateAddressIfNeeded(sender_node, link, sender_message)) {
+        if (sender && type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender) &&
+            nodeUpdateAddressIfNeeded(sender, link, sender_message)) {
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
         }
 
@@ -3114,13 +3114,13 @@ int clusterProcessPacket(clusterLink *link) {
         }
 
         /* Check for role switch: replica -> primary or primary -> replica. */
-        if (sender_node) {
-            serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender_node->name,
-                      sender_node->human_nodename, sender_claims_to_be_primary ? "primary" : "replica",
-                      sender_node->shard_id);
+        if (sender) {
+            serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
+                      sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica",
+                      sender->shard_id);
             if (sender_claims_to_be_primary) {
                 /* Node is a primary. */
-                clusterSetNodeAsPrimary(sender_node);
+                clusterSetNodeAsPrimary(sender);
             } else {
                 /* Node is a replica. */
                 clusterNode *sender_claimed_primary_node =
@@ -3128,15 +3128,15 @@ int clusterProcessPacket(clusterLink *link) {
 
                 if (sender_was_primary) {
                     /* Primary turned into a replica! Reconfigure the node. */
-                    if (sender_claimed_primary_node && areInSameShard(sender_claimed_primary_node, sender_node)) {
+                    if (sender_claimed_primary_node && areInSameShard(sender_claimed_primary_node, sender)) {
                         /* `sender` was a primary and was in the same shard as its new primary */
-                        if (sender_node->configEpoch > sender_claimed_config_epoch) {
+                        if (sender->configEpoch > sender_claimed_config_epoch) {
                             serverLog(LL_NOTICE,
                                       "Ignore stale message from %.40s (%s) in shard %.40s;"
                                       " gossip config epoch: %llu, current config epoch: %llu",
-                                      sender_node->name, sender_node->human_nodename, sender_node->shard_id,
+                                      sender->name, sender->human_nodename, sender->shard_id,
                                       (unsigned long long)sender_claimed_config_epoch,
-                                      (unsigned long long)sender_node->configEpoch);
+                                      (unsigned long long)sender->configEpoch);
                         } else {
                             /* `primary` is still a `replica` in this observer node's view;
                              * update its role and configEpoch */
@@ -3145,42 +3145,42 @@ int clusterProcessPacket(clusterLink *link) {
                             serverLog(LL_NOTICE,
                                       "A failover occurred in shard %.40s; node %.40s (%s)"
                                       " failed over to node %.40s (%s) with a config epoch of %llu",
-                                      sender_node->shard_id, sender_node->name, sender_node->human_nodename,
+                                      sender->shard_id, sender->name, sender->human_nodename,
                                       sender_claimed_primary_node->name, sender_claimed_primary_node->human_nodename,
                                       (unsigned long long)sender_claimed_primary_node->configEpoch);
                         }
                     } else {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-                        int slots = clusterDelNodeSlots(sender_node);
+                        int slots = clusterDelNodeSlots(sender);
                         serverLog(LL_NOTICE,
                                   "Node %.40s (%s) is no longer primary of shard %.40s;"
                                   " removed all %d slot(s) it used to own",
-                                  sender_node->name, sender_node->human_nodename, sender_node->shard_id, slots);
+                                  sender->name, sender->human_nodename, sender->shard_id, slots);
                         if (sender_claimed_primary_node != NULL) {
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender_node->name,
-                                      sender_node->human_nodename, sender_claimed_primary_node->shard_id);
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
+                                      sender->human_nodename, sender_claimed_primary_node->shard_id);
                         }
                     }
 
-                    sender_node->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
-                    sender_node->flags |= CLUSTER_NODE_REPLICA;
+                    sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
+                    sender->flags |= CLUSTER_NODE_REPLICA;
 
                     /* Update config and state. */
                     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
                 }
 
                 /* Primary node changed for this replica? */
-                if (sender_claimed_primary_node && sender_node->replicaof != sender_claimed_primary_node) {
-                    if (sender_node->replicaof) clusterNodeRemoveReplica(sender_node->replicaof, sender_node);
+                if (sender_claimed_primary_node && sender->replicaof != sender_claimed_primary_node) {
+                    if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
                     serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
-                              sender_node->name, sender_node->human_nodename, sender_claimed_primary_node->name,
-                              sender_claimed_primary_node->human_nodename, sender_node->shard_id);
-                    clusterNodeAddReplica(sender_claimed_primary_node, sender_node);
-                    sender_node->replicaof = sender_claimed_primary_node;
+                              sender->name, sender->human_nodename, sender_claimed_primary_node->name,
+                              sender_claimed_primary_node->human_nodename, sender->shard_id);
+                    clusterNodeAddReplica(sender_claimed_primary_node, sender);
+                    sender->replicaof = sender_claimed_primary_node;
 
                     /* Update the shard_id when a replica is connected to its
                      * primary in the very first time. */
-                    updateShardId(sender_node, sender_claimed_primary_node->shard_id);
+                    updateShardId(sender, sender_claimed_primary_node->shard_id);
 
                     /* Update config. */
                     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
@@ -3198,16 +3198,16 @@ int clusterProcessPacket(clusterLink *link) {
          * for it or if there was a failover in the sender's shard. Check
          * this ASAP to avoid other computational expensive checks later.*/
 
-        if (sender_node && sender_claims_to_be_primary &&
+        if (sender && sender_claims_to_be_primary &&
             (sender_was_replica ||
-             memcmp(sender_node->slots, sender_message->myslots, sizeof(sender_message->myslots)))) {
+             memcmp(sender->slots, sender_message->myslots, sizeof(sender_message->myslots)))) {
             /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
-            serverAssert(nodeIsPrimary(sender_node));
+            serverAssert(nodeIsPrimary(sender));
 
             /* 1) If the sender of the message is a primary, and we detected that
              *    the set of slots it claims changed, scan the slots to see if we
              *    need to update our configuration. */
-            clusterUpdateSlotsConfigWith(sender_node, sender_claimed_config_epoch, sender_message->myslots);
+            clusterUpdateSlotsConfigWith(sender, sender_claimed_config_epoch, sender_message->myslots);
 
             /* 2) We also check for the reverse condition, that is, the sender
              *    claims to serve slots we know are served by a primary with a
@@ -3229,13 +3229,13 @@ int clusterProcessPacket(clusterLink *link) {
              * failover if there are the conditions to win the election). */
             for (int j = 0; j < CLUSTER_SLOTS; j++) {
                 if (bitmapTestBit(sender_message->myslots, j)) {
-                    if (server.cluster->slots[j] == sender_node || isSlotUnclaimed(j)) continue;
+                    if (server.cluster->slots[j] == sender || isSlotUnclaimed(j)) continue;
                     if (server.cluster->slots[j]->configEpoch > sender_claimed_config_epoch) {
                         serverLog(LL_VERBOSE,
                                   "Node %.40s has old slots configuration, sending "
                                   "an UPDATE message about %.40s",
-                                  sender_node->name, server.cluster->slots[j]->name);
-                        clusterSendUpdate(sender_node->link, server.cluster->slots[j]);
+                                  sender->name, server.cluster->slots[j]->name);
+                        clusterSendUpdate(sender->link, server.cluster->slots[j]);
 
                         /* TODO: instead of exiting the loop send every other
                          * UPDATE packet for other nodes that are the new owner
@@ -3260,24 +3260,24 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* If our config epoch collides with the sender's try to fix
          * the problem. */
-        if (sender_node && nodeIsPrimary(myself) && nodeIsPrimary(sender_node) &&
+        if (sender && nodeIsPrimary(myself) && nodeIsPrimary(sender) &&
             sender_claimed_config_epoch == myself->configEpoch) {
-            clusterHandleConfigEpochCollision(sender_node);
+            clusterHandleConfigEpochCollision(sender);
         }
 
         /* Get info from the gossip section */
-        if (sender_node) {
+        if (sender) {
             clusterProcessGossipSection(sender_message, link);
             clusterProcessPingExtensions(sender_message, link);
         }
     } else if (type == CLUSTERMSG_TYPE_FAIL) {
         clusterNode *failing;
 
-        if (sender_node) {
+        if (sender) {
             failing = clusterLookupNode(sender_message->data.fail.about.nodename, CLUSTER_NAMELEN);
             if (failing && !(failing->flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_MYSELF))) {
                 serverLog(LL_NOTICE, "FAIL message received from %.40s (%s) about %.40s (%s)", sender_message->sender,
-                          sender_node->human_nodename, sender_message->data.fail.about.nodename,
+                          sender->human_nodename, sender_message->data.fail.about.nodename,
                           failing->human_nodename);
                 failing->flags |= CLUSTER_NODE_FAIL;
                 failing->fail_time = now;
@@ -3289,7 +3289,7 @@ int clusterProcessPacket(clusterLink *link) {
                       sender_message->data.fail.about.nodename);
         }
     } else if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
-        if (!sender_node) return 1; /* We don't know that node. */
+        if (!sender) return 1; /* We don't know that node. */
 
         robj *channel, *message;
         uint32_t channel_len, message_len;
@@ -3307,14 +3307,14 @@ int clusterProcessPacket(clusterLink *link) {
             decrRefCount(message);
         }
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST) {
-        if (!sender_node) return 1; /* We don't know that node. */
-        clusterSendFailoverAuthIfNeeded(sender_node, sender_message);
+        if (!sender) return 1; /* We don't know that node. */
+        clusterSendFailoverAuthIfNeeded(sender, sender_message);
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_ACK) {
-        if (!sender_node) return 1; /* We don't know that node. */
+        if (!sender) return 1; /* We don't know that node. */
         /* We consider this vote only if the sender is a primary serving
          * a non zero number of slots, and its currentEpoch is greater or
          * equal to epoch where this node started the election. */
-        if (clusterNodeIsVotingPrimary(sender_node) &&
+        if (clusterNodeIsVotingPrimary(sender) &&
             sender_claimed_current_epoch >= server.cluster->failover_auth_epoch) {
             server.cluster->failover_auth_count++;
             /* Maybe we reached a quorum here, set a flag to make sure
@@ -3324,16 +3324,16 @@ int clusterProcessPacket(clusterLink *link) {
     } else if (type == CLUSTERMSG_TYPE_MFSTART) {
         /* This message is acceptable only if I'm a primary and the sender
          * is one of my replicas. */
-        if (!sender_node || sender_node->replicaof != myself) return 1;
+        if (!sender || sender->replicaof != myself) return 1;
         /* Manual failover requested from replicas. Initialize the state
          * accordingly. */
         resetManualFailover();
         server.cluster->mf_end = now + CLUSTER_MF_TIMEOUT;
-        server.cluster->mf_replica = sender_node;
+        server.cluster->mf_replica = sender;
         pauseActions(PAUSE_DURING_FAILOVER, now + (CLUSTER_MF_TIMEOUT * CLUSTER_MF_PAUSE_MULT),
                      PAUSE_ACTIONS_CLIENT_WRITE_SET);
-        serverLog(LL_NOTICE, "Manual failover requested by replica %.40s (%s).", sender_node->name,
-                  sender_node->human_nodename);
+        serverLog(LL_NOTICE, "Manual failover requested by replica %.40s (%s).", sender->name,
+                  sender->human_nodename);
         /* We need to send a ping message to the replica, as it would carry
          * `server.cluster->mf_primary_offset`, which means the primary paused clients
          * at offset `server.cluster->mf_primary_offset`, so that the replica would
@@ -3344,7 +3344,7 @@ int clusterProcessPacket(clusterLink *link) {
         clusterNode *n; /* The node the update is about. */
         uint64_t reportedConfigEpoch = ntohu64(sender_message->data.update.nodecfg.configEpoch);
 
-        if (!sender_node) return 1; /* We don't know the sender. */
+        if (!sender) return 1; /* We don't know the sender. */
         n = clusterLookupNode(sender_message->data.update.nodecfg.nodename, CLUSTER_NAMELEN);
         if (!n) return 1;                                    /* We don't know the reported node. */
         if (n->configEpoch >= reportedConfigEpoch) return 1; /* Nothing new. */
@@ -3360,14 +3360,14 @@ int clusterProcessPacket(clusterLink *link) {
          * config accordingly. */
         clusterUpdateSlotsConfigWith(n, reportedConfigEpoch, sender_message->data.update.nodecfg.slots);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
-        if (!sender_node) return 1; /* Protect the module from unknown nodes. */
+        if (!sender) return 1; /* Protect the module from unknown nodes. */
         /* We need to route this message back to the right module subscribed
          * for the right message type. */
         uint64_t module_id = sender_message->data.module.msg.module_id; /* Endian-safe ID */
         uint32_t len = ntohl(sender_message->data.module.msg.len);
         uint8_t type = sender_message->data.module.msg.type;
         unsigned char *payload = sender_message->data.module.msg.bulk_data;
-        moduleCallClusterReceivers(sender_node->name, module_id, type, payload, len);
+        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
     } else {
         serverLog(LL_WARNING, "Received unknown packet type: %d", type);
     }

--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -156,18 +156,18 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
     # to accept our isolated nodes connections. At this point they will
     # start showing up in cluster slots. 
     wait_for_condition 50 100 {
-        [llength [R 6 CLUSTER SLOTS]] eq 3
+        [llength [R 6 CLUSTER SLOTS]] eq 2
     } else {
         fail "Node did not learn about the 2 shards it can talk to"
     }
     wait_for_condition 50 100 {
-        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 1 2 3] 1] eq "shard-1.com"
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 0 2 3] 1] eq "shard-1.com"
     } else {
         fail "hostname for shard-1 didn't reach node 6"
     }
 
     wait_for_condition 50 100 {
-        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 2 2 3] 1] eq "shard-2.com"
+        [lindex [get_slot_field [R 6 CLUSTER SLOTS] 1 2 3] 1] eq "shard-2.com"
     } else {
         fail "hostname for shard-2 didn't reach node 6"
     }


### PR DESCRIPTION
Fixes a regression introduced in PR #445, which allowed a message from a replica
to update the slot ownership of its primary. The regression results in a
`replicaof` cycle, causing server crashes due to the cycle detection assert. The
fix restores the previous behavior where only primary senders can trigger
`clusterUpdateSlotsConfigWith`.

Additional changes:

* Handling of primaries without slots is obsoleted by new handling of when a
  sender that was a replica announces that it is now a primary.
* Replication loop detection code is unchanged but shifted downwards.
* Some variables are renamed for better readability and some are introduced to
  avoid repeated memcmp() calls.

Fixes #753.