### PR TITLE
Remove duplicate definition of UNUSED(V)

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1806,7 +1806,6 @@ void dictGetStats(char *buf, size_t bufsize, dict *d, int full) {
 #ifdef SERVER_TEST
 #include "testhelp.h"
 
-#define UNUSED(V) ((void)V)
 #define TEST(name) printf("test — %s\n", name);
 
 uint64_t hashCallback(const void *key) {


### PR DESCRIPTION
Already defined in https://github.com/nitaicaro/valkey/blob/2977a790d77c861df24dbe917e858c90824d3c10/src/dict.c#L56