### PR TITLE
Update gitignore to ignore the cluster-cluster test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.d
 *.log
 dump.rdb
+dump-*.rdb
 *-benchmark
 *-check-aof
 *-check-rdb
@@ -20,6 +21,7 @@ misc/*
 src/release.h
 appendonly.aof*
 appendonlydir
+appendonlydir-*
 SHORT_TERM_TODO
 release.h
 src/transfer.sh
@@ -46,4 +48,5 @@ redis.code-workspace
 .cscope*
 .swp
 nodes.conf
+nodes-*.conf
 tests/cluster/tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@
 *.so
 *.d
 *.log
-dump.rdb
-dump-*.rdb
+dump*.rdb
 *-benchmark
 *-check-aof
 *-check-rdb
@@ -20,8 +19,7 @@ release
 misc/*
 src/release.h
 appendonly.aof*
-appendonlydir
-appendonlydir-*
+appendonlydir*
 SHORT_TERM_TODO
 release.h
 src/transfer.sh
@@ -47,6 +45,5 @@ redis.code-workspace
 .cache
 .cscope*
 .swp
-nodes.conf
-nodes-*.conf
+nodes*.conf
 tests/cluster/tmp/*


### PR DESCRIPTION
Normally we can create a test cluster directly in the directory
using `./utils/create-cluster/create-cluster`, which would keep
the test files under `./` and messed up the git.