### PR TITLE
Decline unsubscribe related command in non-subscribed mode

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4037,10 +4037,10 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Not allow several UBSUBSCRIBE commands executed under non-pubsub mode */
+    /* Not allow several UNSUBSCRIBE commands executed under non-pubsub mode */
     if (!c->flag.pubsub && (c->cmd->proc == unsubscribeCommand || c->cmd->proc == sunsubscribeCommand ||
                             c->cmd->proc == punsubscribeCommand)) {
-        rejectCommandFormat(c, "Can't execute '%s' command in non-subscribe mode", c->cmd->fullname);
+        rejectCommandFormat(c, "-NOSUB '%s' command executed not in subscribed mode", c->cmd->fullname);
         return C_OK;
     }
     /* Only allow commands with flag "t", such as INFO, REPLICAOF and so on,

--- a/src/server.c
+++ b/src/server.c
@@ -4037,6 +4037,12 @@ int processCommand(client *c) {
         return C_OK;
     }
 
+    /* Not allow several UBSUBSCRIBE commands executed under non-pubsub mode */
+    if (!c->flag.pubsub && (c->cmd->proc == unsubscribeCommand || c->cmd->proc == sunsubscribeCommand ||
+                            c->cmd->proc == punsubscribeCommand)) {
+        rejectCommandFormat(c, "Can't execute '%s' command in non-subscribe mode", c->cmd->fullname);
+        return C_OK;
+    }
     /* Only allow commands with flag "t", such as INFO, REPLICAOF and so on,
      * when replica-serve-stale-data is no and we are a replica with a broken
      * link with primary. */

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -427,7 +427,7 @@ start_server {tags {"info" "external:skip"}} {
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # non-pubsub clients should not be involved
             catch {unsubscribe $rd2 {non-exist-chan}} e
-            assert_match {*Can't execute 'unsubscribe' command in non-subscribe mode*} $e
+            assert_match {*NOSUB*} $e
             set info [r info clients]
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # close all clients

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -426,7 +426,8 @@ start_server {tags {"info" "external:skip"}} {
             set info [r info clients]
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # non-pubsub clients should not be involved
-            assert_equal {0} [unsubscribe $rd2 {non-exist-chan}]
+            catch {unsubscribe $rd2 {non-exist-chan}} e
+            assert_match {*Can't execute 'unsubscribe' command in non-subscribe mode*} $e
             set info [r info clients]
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # close all clients

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -247,15 +247,17 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    #test "PUNSUBSCRIBE and UNSUBSCRIBE should always reply" {
+    test "PUNSUBSCRIBE and UNSUBSCRIBE should always reply when they are executed in subscribe mode" {
         # Make sure we are not subscribed to any channel at all.
-    #    r punsubscribe
-    #    r unsubscribe
-        # Now check if the commands still reply correctly.
-    #    set reply1 [r punsubscribe]
-    #    set reply2 [r unsubscribe]
-    #    concat $reply1 $reply2
-    #} {punsubscribe {} 0 unsubscribe {} 0}
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [subscribe $rd1 {foo}]
+        assert_equal {2} [psubscribe $rd1 {foo.*}]
+        set reply1 [punsubscribe $rd1]
+        set reply2 [unsubscribe $rd1]
+        concat $reply1 $reply2
+        # clean up clients
+        $rd1 close
+    } {0}
 
     ### Keyspace events notification tests
 

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -111,8 +111,8 @@ start_server {tags {"pubsub network"}} {
 
     test "UNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
-        assert_equal {0 0 0} [unsubscribe $rd1 {foo bar quux}]
-
+        catch {unsubscribe $rd1 {foo bar quux}} e
+        assert_match {*Can't execute 'unsubscribe' command in non-subscribe mode*} $e
         # clean up clients
         $rd1 close
     }
@@ -204,8 +204,8 @@ start_server {tags {"pubsub network"}} {
 
     test "PUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
-        assert_equal {0 0 0} [punsubscribe $rd1 {foo.* bar.* quux.*}]
-
+        catch {punsubscribe $rd1 {foo.* bar.* quux.*}} e
+        assert_match {*Can't execute 'punsubscribe' command in non-subscribe mode*} $e
         # clean up clients
         $rd1 close
     }
@@ -247,15 +247,15 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    test "PUNSUBSCRIBE and UNSUBSCRIBE should always reply" {
+    #test "PUNSUBSCRIBE and UNSUBSCRIBE should always reply" {
         # Make sure we are not subscribed to any channel at all.
-        r punsubscribe
-        r unsubscribe
+    #    r punsubscribe
+    #    r unsubscribe
         # Now check if the commands still reply correctly.
-        set reply1 [r punsubscribe]
-        set reply2 [r unsubscribe]
-        concat $reply1 $reply2
-    } {punsubscribe {} 0 unsubscribe {} 0}
+    #    set reply1 [r punsubscribe]
+    #    set reply2 [r unsubscribe]
+    #    concat $reply1 $reply2
+    #} {punsubscribe {} 0 unsubscribe {} 0}
 
     ### Keyspace events notification tests
 

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -109,10 +109,12 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    test "UNSUBSCRIBE from non-subscribed channels" {
+    test "UNSUBSCRIBE and PUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
-        catch {unsubscribe $rd1 {foo bar quux}} e
-        assert_match {*Can't execute 'unsubscribe' command in non-subscribe mode*} $e
+        foreach command {unsubscribe punsubscribe} {
+            catch {$command $rd1 {foo bar quux}} e
+            assert_match {*NOSUB*} $e
+        }
         # clean up clients
         $rd1 close
     }
@@ -202,14 +204,6 @@ start_server {tags {"pubsub network"}} {
         $rd close
     } {0} {resp3}
 
-    test "PUNSUBSCRIBE from non-subscribed channels" {
-        set rd1 [valkey_deferring_client]
-        catch {punsubscribe $rd1 {foo.* bar.* quux.*}} e
-        assert_match {*Can't execute 'punsubscribe' command in non-subscribe mode*} $e
-        # clean up clients
-        $rd1 close
-    }
-
     test "NUMSUB returns numbers, not strings (#1561)" {
         r pubsub numsub abc def
     } {abc 0 def 0}
@@ -246,18 +240,6 @@ start_server {tags {"pubsub network"}} {
         # clean up clients
         $rd1 close
     }
-
-    test "PUNSUBSCRIBE and UNSUBSCRIBE should always reply when they are executed in subscribe mode" {
-        # Make sure we are not subscribed to any channel at all.
-        set rd1 [valkey_deferring_client]
-        assert_equal {1} [subscribe $rd1 {foo}]
-        assert_equal {2} [psubscribe $rd1 {foo.*}]
-        set reply1 [punsubscribe $rd1]
-        set reply2 [unsubscribe $rd1]
-        concat $reply1 $reply2
-        # clean up clients
-        $rd1 close
-    } {0}
 
     ### Keyspace events notification tests
 

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -75,7 +75,7 @@ start_server {tags {"pubsubshard external:skip"}} {
     test "SUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
         catch {sunsubscribe $rd1 {foo}} e
-        assert_match {*Can't execute 'sunsubscribe' command in non-subscribe mode*} $e
+        assert_match {*NOSUB*} $e
 
         # clean up clients
         $rd1 close

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -74,9 +74,8 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
-        assert_equal {0} [sunsubscribe $rd1 {foo}]
-        assert_equal {0} [sunsubscribe $rd1 {bar}]
-        assert_equal {0} [sunsubscribe $rd1 {quux}]
+        catch {sunsubscribe $rd1 {foo}} e
+        assert_match {*Can't execute 'sunsubscribe' command in non-subscribe mode*} $e
 
         # clean up clients
         $rd1 close


### PR DESCRIPTION
Now, when clients run the unsubscribe, sunsubscribe and punsubscribe commands in the non-subscribed mode, it returns 0.
Indeed this is a bug, we should not allow client run these kind of commands here.

Thus, this PR fixes this bug, but it is a break change for existing clients

## Update
This was introduced in Valkey8, and it is a breaking change, this will be revert in #1265