### PR TITLE
Replicas with the same offset queue up for election

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4095,8 +4095,9 @@ void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
  * replication offset, and so forth. Note that because how the rank is computed
  * multiple replicas may have the same rank, in case they have the same offset.
  *
- * If the replication offsets are the same, the one with the smaller node id
- * will have a better ranking to avoid simultaneous elections of replicas.
+ * If the replication offsets are the same, the one with the lexicographically
+ * smaller Node id  * will have a better ranking to avoid simultaneous elections
+ * of replicas.
  *
  * The replica rank is used to add a delay to start an election in order to
  * get voted and replace a failing primary. Replicas with better replication

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4096,7 +4096,7 @@ void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
  * multiple replicas may have the same rank, in case they have the same offset.
  *
  * If the replication offsets are the same, the one with the lexicographically
- * smaller Node id  * will have a better ranking to avoid simultaneous elections
+ * smaller node id will have a lower rank to avoid simultaneous elections
  * of replicas.
  *
  * The replica rank is used to add a delay to start an election in order to

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -171,7 +171,7 @@ proc count_log_message {srv_idx pattern} {
     return [count_message_lines $stdout $pattern]
 }
 
-# verify pattern exists in server's sdtout after a certain line number
+# verify pattern exists in server's stdout after a certain line number
 proc verify_log_message {srv_idx pattern from_line} {
     incr from_line
     set result [exec tail -n +$from_line < [srv $srv_idx stdout]]

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -70,3 +70,64 @@ test "Instance #0 gets converted into a slave" {
 }
 
 } ;# start_cluster
+
+# Add all replicas to the first primary node.
+proc cluster_allocate_replicas_to_one_primary {primaries replicas} {
+    set primary_id 0
+    for {set j 0} {$j < $replicas} {incr j} {
+        set replica_id [cluster_find_available_replica $primaries]
+        set primary_myself [cluster_get_myself $primary_id]
+        R $replica_id cluster replicate [dict get $primary_myself id]
+    }
+}
+
+start_cluster 5 10 {tags {external:skip cluster} overrides {cluster-node-timeout 5000}} {
+
+test "Cluster is up" {
+    wait_for_cluster_state ok
+}
+
+test "Cluster is writable" {
+    cluster_write_test [srv 0 port]
+}
+
+set current_epoch [CI 1 cluster_current_epoch]
+
+set paused_pid [srv 0 pid]
+test "Killing the first primary node" {
+    pause_process $paused_pid
+}
+
+test "Wait for failover" {
+    wait_for_condition 1000 50 {
+        [CI 1 cluster_current_epoch] > $current_epoch
+    } else {
+        fail "No failover detected"
+    }
+}
+
+test "Cluster should eventually be up again" {
+    for {set j 0} {$j < [llength $::servers]} {incr j} {
+        if {[process_is_paused $paused_pid]} continue
+        wait_for_condition 1000 50 {
+            [CI $j cluster_state] eq "ok"
+        } else {
+            fail "Cluster node $j cluster_state:[CI $j cluster_state]"
+        }
+    }
+}
+
+test "Restarting the previously killed primary node" {
+    resume_process $paused_pid
+}
+
+test "Instance #0 gets converted into a replica" {
+    wait_for_condition 1000 50 {
+        [s 0 role] eq {slave}
+    } else {
+        fail "Old primary was not converted into replica"
+    }
+    wait_for_cluster_propagation
+}
+
+} continuous_slot_allocation cluster_allocate_replicas_to_one_primary ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -73,61 +73,61 @@ test "Instance #0 gets converted into a slave" {
 
 start_cluster 3 6 {tags {external:skip cluster}} {
 
-test "Cluster is up" {
-    wait_for_cluster_state ok
-}
-
-test "Cluster is writable" {
-    cluster_write_test [srv 0 port]
-}
-
-set current_epoch [CI 1 cluster_current_epoch]
-
-set paused_pid [srv 0 pid]
-test "Killing the first primary node" {
-    pause_process $paused_pid
-}
-
-test "Wait for failover" {
-    wait_for_condition 1000 50 {
-        [CI 1 cluster_current_epoch] > $current_epoch
-    } else {
-        fail "No failover detected"
+    test "Cluster is up" {
+        wait_for_cluster_state ok
     }
-}
 
-test "Cluster should eventually be up again" {
-    for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused [srv -$j pid]]} continue
+    test "Cluster is writable" {
+        cluster_write_test [srv 0 port]
+    }
+
+    set current_epoch [CI 1 cluster_current_epoch]
+
+    set paused_pid [srv 0 pid]
+    test "Killing the first primary node" {
+        pause_process $paused_pid
+    }
+
+    test "Wait for failover" {
         wait_for_condition 1000 50 {
-            [CI $j cluster_state] eq "ok"
+            [CI 1 cluster_current_epoch] > $current_epoch
         } else {
-            fail "Cluster node $j cluster_state:[CI $j cluster_state]"
+            fail "No failover detected"
         }
     }
-}
 
-test "Restarting the previously killed primary node" {
-    resume_process $paused_pid
-}
-
-test "Instance #0 gets converted into a replica" {
-    wait_for_condition 1000 50 {
-        [s 0 role] eq {slave}
-    } else {
-        fail "Old primary was not converted into replica"
+    test "Cluster should eventually be up again" {
+        for {set j 0} {$j < [llength $::servers]} {incr j} {
+            if {[process_is_paused [srv -$j pid]]} continue
+            wait_for_condition 1000 50 {
+                [CI $j cluster_state] eq "ok"
+            } else {
+                fail "Cluster node $j cluster_state:[CI $j cluster_state]"
+            }
+        }
     }
-    wait_for_cluster_propagation
-}
 
-test "Make sure the replicas always get the different ranks" {
-    if {[s -3 role] == "master"} {
-        verify_log_message -3 "*Start of election*rank #0*" 0
-        verify_log_message -6 "*Start of election*rank #1*" 0
-    } else {
-        verify_log_message -3 "*Start of election*rank #1*" 0
-        verify_log_message -6 "*Start of election*rank #0*" 0
+    test "Restarting the previously killed primary node" {
+        resume_process $paused_pid
     }
-}
+
+    test "Instance #0 gets converted into a replica" {
+        wait_for_condition 1000 50 {
+            [s 0 role] eq {slave}
+        } else {
+            fail "Old primary was not converted into replica"
+        }
+        wait_for_cluster_propagation
+    }
+
+    test "Make sure the replicas always get the different ranks" {
+        if {[s -3 role] == "master"} {
+            verify_log_message -3 "*Start of election*rank #0*" 0
+            verify_log_message -6 "*Start of election*rank #1*" 0
+        } else {
+            verify_log_message -3 "*Start of election*rank #1*" 0
+            verify_log_message -6 "*Start of election*rank #0*" 0
+        }
+    }
 
 } ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -98,7 +98,7 @@ test "Wait for failover" {
 
 test "Cluster should eventually be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {


### PR DESCRIPTION
In some cases, like read more than write scenario, the replication
offset of the replicas are the same. When the primary fails, the
replicas have the same rankings (rank == 0). They issue the election
at the same time (although we have a random 500), the simultaneous
elections may lead to the failure of the election due to quorum.

In clusterGetReplicaRank, when we calculates the rank, if the offsets
are the same, the one with the smaller node name will have a better
rank to avoid this situation.