### PR TITLE
Fix unstable test case EVAL+WAITAOF

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -294,7 +294,7 @@ start_server {tags {"scripting"}} {
     } {0}
 
     test {EVAL - Scripts do not block on waitaof} {
-        run_script {return redis.pcall('waitaof','0','1','0')} 0
+        run_script {redis.call('incr', 'x') return redis.pcall('waitaof','0','1','0')} 0
     } {0 0}
 
     test {EVAL - Scripts do not block on XREAD with BLOCK option} {


### PR DESCRIPTION
Test case "EVAL - Scripts do not block on waitaof" observed to fail in e.g. https://github.com/valkey-io/valkey/actions/runs/9860131487/job/27233756421?pr=688

It can happen that the local AOF has been written and 1 is returned here where 0 is expected. Writing a key inside the EVAL script makes sure there's no time to write the AOF.