### PR TITLE
Skip tls for xgroup read regression since it doesn't matter

### DIFF
--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -24,7 +24,7 @@ start_cluster 2 2 {tags {external:skip cluster}} {
     }
 }
 
-start_cluster 2 0 {tags {external:skip cluster regression} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
+start_cluster 2 0 {tags {tls:skip external:skip cluster regression} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
     # Issue #563 regression test
     test "Client blocked on XREADGROUP while stream's slot is migrated" {
         set stream_name aga


### PR DESCRIPTION
We backported https://github.com/valkey-io/valkey/pull/526, but missed an additional followup PR that stabilized a test. So backporting that now.