### PR TITLE
Fix WAITAOF test in external test due to appendonly is enabled

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -293,10 +293,9 @@ start_server {tags {"scripting"}} {
         run_script {return redis.pcall('wait','1','0')} 0
     } {0}
 
-    # Temporarily disable test for external until it is stabilized, see https://github.com/valkey-io/valkey/issues/770
     test {EVAL - Scripts do not block on waitaof} {
         run_script {redis.call('incr', 'x') return redis.pcall('waitaof','0','1','0')} 0
-    } {0 0} {external:skip}
+    } {* 0}
 
     test {EVAL - Scripts do not block on XREAD with BLOCK option} {
         r del s


### PR DESCRIPTION
The test fails because, in external, another test may have
enabled appendonly, causing acklocal to return 1.

We can add a CONFIG SET to disable the appendonly, but this
is not safe too unless we use multi. The test does not actually
rely on appendonly, so we can just * it.

Fixes #770.