### PR TITLE
Fix the wrong woff when execute WAIT / WAITAOF in script

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -295,7 +295,7 @@ start_server {tags {"scripting"}} {
 
     # Temporarily disable test for external until it is stabilized, see https://github.com/valkey-io/valkey/issues/770
     test {EVAL - Scripts do not block on waitaof} {
-        run_script {redis.call('incr', 'x') return redis.pcall('waitaof','0','1','0')} 0
+        run_script {return redis.pcall('waitaof','0','1','0')} 0
     } {0 0} {external:skip}
 
     test {EVAL - Scripts do not block on XREAD with BLOCK option} {

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -295,7 +295,7 @@ start_server {tags {"scripting"}} {
 
     test {EVAL - Scripts do not block on waitaof} {
         run_script {return redis.pcall('waitaof','0','1','0')} 0
-    } {* 0} {external:skip}
+    } {* 0}
 
     test {EVAL - Scripts do not block on XREAD with BLOCK option} {
         r del s

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -98,6 +98,35 @@ start_server {} {
         $rd close
         $rd2 close
     }
+
+    start_server {} {
+        test {Setup a new replica} {
+            r replicaof $master_host $master_port
+            wait_for_ofs_sync $master r
+            wait_for_ofs_sync $master $slave
+        }
+
+        test {WAIT in script will work} {
+            # Pause the old replica so it can not catch up the offset.
+            pause_process $slave_pid
+
+            # Primary set a new key and wait the new replica catch up the offset.
+            $master set foo bar
+            wait_for_ofs_sync $master r
+
+            # Wait for the new replica to report the acked offset to the primary.
+            # Because the old replica is paused, so the WAIT can only return 1.
+            # In the old code it will return 2, because the fake client's woff is
+            # always 0 so WAIT will count all the replicas.
+            wait_for_condition 50 100 {
+                [$master eval "return server.call('wait', '2', '0')" 0] eq 1
+            } else {
+                fail "WAIT in script does not work as expected."
+            }
+
+            resume_process $slave_pid
+        }
+    }
 }}
 
 

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -116,8 +116,8 @@ start_server {} {
 
             # Wait for the new replica to report the acked offset to the primary.
             # Because the old replica is paused, so the WAIT can only return 1.
-            # In the old code it will return 2, because the fake client's woff is
-            # always 0 so WAIT will count all the replicas.
+            # In an earlier version it returned 2, because the fake client's woff
+            # is always 0 so WAIT counted all the replicas.
             wait_for_condition 50 100 {
                 [$master eval "return server.call('wait', '2', '0')" 0] eq 1
             } else {


### PR DESCRIPTION
When executing the script, the client passed in is a fake
client, and its woff is always 0.

This results in woff always being 0 when executing wait/waitaof
in the script, and the command returns a wrong number.