### PR TITLE
For MEETs, save the extensions support flag immediately during MEET processing

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3010,6 +3010,8 @@ int clusterProcessPacket(clusterLink *link) {
             if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
             }
+            node->inbound_link = link;
+            link->node = node;
             clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2996,8 +2996,8 @@ int clusterProcessPacket(clusterLink *link) {
         /* Add this node if it is new for us and the msg type is MEET.
          * In this stage we don't try to add the node with the right
          * flags, replicaof pointer, and so forth, as this details will be
-         * resolved when we'll receive PONGs from the node. The exception 
-         * to this is the flag that indicates extensions are supported, as 
+         * resolved when we'll receive PONGs from the node. The exception
+         * to this is the flag that indicates extensions are supported, as
          * we want to send extensions right away in the return PONG in order
          * to reduce the amount of time needed to stabilize the shard ID. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
@@ -3009,7 +3009,7 @@ int clusterProcessPacket(clusterLink *link) {
             node->cport = ntohs(hdr->cport);
             if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
-            } 
+            }
             clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2997,9 +2997,9 @@ int clusterProcessPacket(clusterLink *link) {
          * In this stage we don't try to add the node with the right
          * flags, replicaof pointer, and so forth, as this details will be
          * resolved when we'll receive PONGs from the node. The exception 
-	     * to this is the flag that indicates extensions are supported, as 
+         * to this is the flag that indicates extensions are supported, as 
          * we want to send extensions right away in the return PONG in order
-	     * to reduce the amount of time needed to stabilize the shard ID */
+         * to reduce the amount of time needed to stabilize the shard ID */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *node;
 
@@ -3007,7 +3007,7 @@ int clusterProcessPacket(clusterLink *link) {
             serverAssert(nodeIp2String(node->ip, link, hdr->myip) == C_OK);
             getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
             node->cport = ntohs(hdr->cport);
-	        if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+            if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
             } 
             clusterAddNode(node);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2996,7 +2996,10 @@ int clusterProcessPacket(clusterLink *link) {
         /* Add this node if it is new for us and the msg type is MEET.
          * In this stage we don't try to add the node with the right
          * flags, replicaof pointer, and so forth, as this details will be
-         * resolved when we'll receive PONGs from the node. */
+         * resolved when we'll receive PONGs from the node. The exception 
+	 * to this is the flag that indicates extensions are supported, as 
+	 * we want to send extensions right away in the return PONG in order
+	 * to reduce the amount of time needed to stabilize the shard ID */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *node;
 
@@ -3004,6 +3007,9 @@ int clusterProcessPacket(clusterLink *link) {
             serverAssert(nodeIp2String(node->ip, link, hdr->myip) == C_OK);
             getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
             node->cport = ntohs(hdr->cport);
+	    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+            } 
             clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2999,7 +2999,7 @@ int clusterProcessPacket(clusterLink *link) {
          * resolved when we'll receive PONGs from the node. The exception 
          * to this is the flag that indicates extensions are supported, as 
          * we want to send extensions right away in the return PONG in order
-         * to reduce the amount of time needed to stabilize the shard ID */
+         * to reduce the amount of time needed to stabilize the shard ID. */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *node;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2997,9 +2997,9 @@ int clusterProcessPacket(clusterLink *link) {
          * In this stage we don't try to add the node with the right
          * flags, replicaof pointer, and so forth, as this details will be
          * resolved when we'll receive PONGs from the node. The exception 
-	 * to this is the flag that indicates extensions are supported, as 
-	 * we want to send extensions right away in the return PONG in order
-	 * to reduce the amount of time needed to stabilize the shard ID */
+	     * to this is the flag that indicates extensions are supported, as 
+         * we want to send extensions right away in the return PONG in order
+	     * to reduce the amount of time needed to stabilize the shard ID */
         if (!sender && type == CLUSTERMSG_TYPE_MEET) {
             clusterNode *node;
 
@@ -3007,8 +3007,8 @@ int clusterProcessPacket(clusterLink *link) {
             serverAssert(nodeIp2String(node->ip, link, hdr->myip) == C_OK);
             getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
             node->cport = ntohs(hdr->cport);
-	    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
-                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+	        if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+                node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
             } 
             clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3010,8 +3010,7 @@ int clusterProcessPacket(clusterLink *link) {
             if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
                 node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
             }
-            node->inbound_link = link;
-            link->node = node;
+            setClusterNodeToInboundClusterLink(node, link);
             clusterAddNode(node);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
         }


### PR DESCRIPTION
For backwards compatibility reasons, a node will wait until it receives a cluster message with the extensions flag before sending its own extensions. This leads to a delay in shard ID propagation that can corrupt nodes.conf with inaccurate shard IDs if a node is restarted before this can stabilize.

This fixes much of that delay by immediately triggering the extensions-supported flag during the MEET processing and attaching the node to the link, allowing the PONG reply to contain OSS extensions.

Partially fixes #774