### PR TITLE
Fix incorrect usage of process_is_paused in tests

### DIFF
--- a/tests/unit/cluster/faildet.tcl
+++ b/tests/unit/cluster/faildet.tcl
@@ -15,8 +15,7 @@ test "Killing two slave nodes" {
 
 test "Cluster should be still up" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid5]} continue
-        if {[process_is_paused $paused_pid6]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {
@@ -34,9 +33,7 @@ test "Killing one master node" {
 # failover is possible, that would change the state back to ok.
 test "Cluster should be down now" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
-        if {[process_is_paused $paused_pid5]} continue
-        if {[process_is_paused $paused_pid6]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {
@@ -51,8 +48,7 @@ test "Restarting master node" {
 
 test "Cluster should be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid5]} continue
-        if {[process_is_paused $paused_pid6]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -39,7 +39,7 @@ test "Wait for failover" {
 
 test "Cluster should eventually be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {

--- a/tests/unit/cluster/manual-takeover.tcl
+++ b/tests/unit/cluster/manual-takeover.tcl
@@ -33,9 +33,7 @@ foreach id $replica_ids {
 
 test "Cluster should eventually be down" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
-        if {[process_is_paused $paused_pid1]} continue
-        if {[process_is_paused $paused_pid2]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "fail"
         } else {
@@ -52,9 +50,7 @@ test "Use takeover to bring slaves back" {
 
 test "Cluster should eventually be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
-        if {[process_is_paused $paused_pid1]} continue
-        if {[process_is_paused $paused_pid2]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {

--- a/tests/unit/cluster/slave-selection.tcl
+++ b/tests/unit/cluster/slave-selection.tcl
@@ -94,7 +94,7 @@ test "Wait for the node #10 to return alive before ending the test" {
 
 test "Cluster should eventually be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {
@@ -190,7 +190,7 @@ test "New Master down consecutively" {
         }
 
         for {set j 0} {$j < [llength $::servers]} {incr j} {
-            if {[process_is_paused $paused_pid]} continue
+            if {[process_is_paused [srv -$j pid]]} continue
             wait_for_condition 1000 50 {
                 [CI $j cluster_state] eq "ok"
             } else {

--- a/tests/unit/cluster/slave-stop-cond.tcl
+++ b/tests/unit/cluster/slave-stop-cond.tcl
@@ -71,7 +71,7 @@ test "Slave #5 should not be able to failover" {
 
 test "Cluster should be down" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 100 50 {
             [CI $j cluster_state] eq "fail"
         } else {

--- a/tests/unit/cluster/update-msg.tcl
+++ b/tests/unit/cluster/update-msg.tcl
@@ -48,7 +48,7 @@ test "Wait for failover" {
 
 test "Cluster should eventually be up again" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "ok"
         } else {
@@ -72,8 +72,7 @@ test "Killing the new master #5" {
 
 test "Cluster should be down now" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        if {[process_is_paused $paused_pid]} continue
-        if {[process_is_paused $paused_pid5]} continue
+        if {[process_is_paused [srv -$j pid]]} continue
         wait_for_condition 1000 50 {
             [CI $j cluster_state] eq "fail"
         } else {


### PR DESCRIPTION
It was introduced wrong in #442.