### PR TITLE
Optimize linear search of WAIT and WAITAOF when unblocking the client

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -593,6 +593,11 @@ void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, lon
     c->bstate.numreplicas = numreplicas;
     c->bstate.numlocal = numlocal;
     listAddNodeHead(server.clients_waiting_acks, c);
+    /* Note that we remember the linked list node where the client is stored,
+     * this way removing the client in unblockClientWaitingReplicas() will not
+     * require a linear scan, but just a constant time operation. */
+    serverAssert(c->client_waiting_acks_list_node == NULL);
+    c->client_waiting_acks_list_node = listFirst(server.clients_waiting_acks);
     blockClient(c, BLOCKED_WAIT);
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -204,6 +204,7 @@ client *createClient(connection *conn) {
     c->peerid = NULL;
     c->sockname = NULL;
     c->client_list_node = NULL;
+    c->client_waiting_acks_list_node = NULL;
     c->postponed_list_node = NULL;
     c->io_read_state = CLIENT_IDLE;
     c->io_write_state = CLIENT_IDLE;

--- a/src/networking.c
+++ b/src/networking.c
@@ -204,7 +204,6 @@ client *createClient(connection *conn) {
     c->peerid = NULL;
     c->sockname = NULL;
     c->client_list_node = NULL;
-    c->client_waiting_acks_list_node = NULL;
     c->postponed_list_node = NULL;
     c->io_read_state = CLIENT_IDLE;
     c->io_write_state = CLIENT_IDLE;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3513,9 +3513,9 @@ void waitaofCommand(client *c) {
  * waiting for replica acks. Never call it directly, call unblockClient()
  * instead. */
 void unblockClientWaitingReplicas(client *c) {
-    serverAssert(c->client_waiting_acks_list_node);
-    listDelNode(server.clients_waiting_acks, c->client_waiting_acks_list_node);
-    c->client_waiting_acks_list_node = NULL;
+    serverAssert(c->bstate.client_waiting_acks_list_node);
+    listDelNode(server.clients_waiting_acks, c->bstate.client_waiting_acks_list_node);
+    c->bstate.client_waiting_acks_list_node = NULL;
     updateStatsOnUnblock(c, 0, 0, 0);
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3513,9 +3513,9 @@ void waitaofCommand(client *c) {
  * waiting for replica acks. Never call it directly, call unblockClient()
  * instead. */
 void unblockClientWaitingReplicas(client *c) {
-    listNode *ln = listSearchKey(server.clients_waiting_acks, c);
-    serverAssert(ln != NULL);
-    listDelNode(server.clients_waiting_acks, ln);
+    serverAssert(c->client_waiting_acks_list_node);
+    listDelNode(server.clients_waiting_acks, c->client_waiting_acks_list_node);
+    c->client_waiting_acks_list_node = NULL;
     updateStatsOnUnblock(c, 0, 0, 0);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1267,6 +1267,7 @@ typedef struct client {
     sds peerid;                          /* Cached peer ID. */
     sds sockname;                        /* Cached connection target address. */
     listNode *client_list_node;          /* list node in client list */
+    listNode *client_waiting_acks_list_node;  /* list node in client waiting acks list. */
     listNode *postponed_list_node;       /* list node within the postponed list */
     void *module_blocked_client;         /* Pointer to the ValkeyModuleBlockedClient associated with this
                                           * client. This is set in case of module authentication before the

--- a/src/server.h
+++ b/src/server.h
@@ -988,9 +988,9 @@ typedef struct blockingState {
     dict *keys; /* The keys we are blocked on */
 
     /* BLOCKED_WAIT and BLOCKED_WAITAOF */
-    int numreplicas;      /* Number of replicas we are waiting for ACK. */
-    int numlocal;         /* Indication if WAITAOF is waiting for local fsync. */
-    long long reploffset; /* Replication offset to reach. */
+    int numreplicas;                         /* Number of replicas we are waiting for ACK. */
+    int numlocal;                            /* Indication if WAITAOF is waiting for local fsync. */
+    long long reploffset;                    /* Replication offset to reach. */
     listNode *client_waiting_acks_list_node; /* list node in server.clients_waiting_acks list. */
 
     /* BLOCKED_MODULE */

--- a/src/server.h
+++ b/src/server.h
@@ -1267,14 +1267,14 @@ typedef struct client {
     sds peerid;                          /* Cached peer ID. */
     sds sockname;                        /* Cached connection target address. */
     listNode *client_list_node;          /* list node in client list */
-    listNode *client_waiting_acks_list_node;  /* list node in client waiting acks list. */
-    listNode *postponed_list_node;       /* list node within the postponed list */
-    void *module_blocked_client;         /* Pointer to the ValkeyModuleBlockedClient associated with this
-                                          * client. This is set in case of module authentication before the
-                                          * unblocked client is reprocessed to handle reply callbacks. */
-    void *module_auth_ctx;               /* Ongoing / attempted module based auth callback's ctx.
-                                          * This is only tracked within the context of the command attempting
-                                          * authentication. If not NULL, it means module auth is in progress. */
+    listNode *client_waiting_acks_list_node;   /* list node in client waiting acks list. */
+    listNode *postponed_list_node;             /* list node within the postponed list */
+    void *module_blocked_client;               /* Pointer to the ValkeyModuleBlockedClient associated with this
+                                                * client. This is set in case of module authentication before the
+                                                * unblocked client is reprocessed to handle reply callbacks. */
+    void *module_auth_ctx;                     /* Ongoing / attempted module based auth callback's ctx.
+                                                * This is only tracked within the context of the command attempting
+                                                * authentication. If not NULL, it means module auth is in progress. */
     ValkeyModuleUserChangedFunc auth_callback; /* Module callback to execute
                                                 * when the authenticated user
                                                 * changes. */


### PR DESCRIPTION
Currently, if the client enters a blocked state, it will be
added to the server.clients_waiting_acks list. When the client
is unblocked, that is, when unblockClient is called, we will
need to linearly traverse server.clients_waiting_acks to delete
the client, and this search is O(N).

When WAIT (or WAITAOF) is used extensively in some cases, this
O(N) search may be time-consuming. We can remember the list node
and store it in the blockingState struct and it can avoid the
linear search in unblockClientWaitingReplicas.