### PR TITLE
Fix rdb pipe uninitialized false positive warning

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3509,7 +3509,7 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
     listNode *ln;
     listIter li;
     pid_t childpid;
-    int pipefds[2], rdb_pipe_write, safe_to_exit_pipe;
+    int pipefds[2], rdb_pipe_write = 0, safe_to_exit_pipe = 0;
     int dual_channel = (req & REPLICA_REQ_RDB_CHANNEL);
 
     if (hasActiveChildProcess()) return C_ERR;


### PR DESCRIPTION
After #60, the CI report this warning:
```
rdb.c: In function 'rdbSaveToReplicasSockets':
rdb.c:3661:28: error: 'safe_to_exit_pipe' may be used uninitialized [-Werror=maybe-uninitialized]
 3661 |         if (!dual_channel) close(safe_to_exit_pipe);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
rdb.c:3512:37: note: 'safe_to_exit_pipe' was declared here
 3512 |     int pipefds[2], rdb_pipe_write, safe_to_exit_pipe;
      |                                     ^~~~~~~~~~~~~~~~~
rdb.c:3654:17: error: 'rdb_pipe_write' may be used uninitialized [-Werror=maybe-uninitialized]
 3654 |                 close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
      |                 ^~~~~~~~~~~~~~~~~~~~~
rdb.c:3512:21: note: 'rdb_pipe_write' was declared here
 3512 |     int pipefds[2], rdb_pipe_write, safe_to_exit_pipe;
      |                     ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```