### PR TITLE
Remove read handler upon RDB connection close

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1890,6 +1890,7 @@ int freeClientsInAsyncFreeQueue(void) {
              * it serves as a reference to the first required replication data block for
              * this replica */
             if (!c->rdb_client_disconnect_time) {
+                if (c->conn) connSetReadHandler(c->conn, NULL);
                 c->rdb_client_disconnect_time = server.unixtime;
                 serverLog(LL_VERBOSE, "Postpone RDB client id=%llu (%s) free for %d seconds", (unsigned long long)c->id,
                           replicationGetReplicaName(c), server.wait_before_rdb_client_free);


### PR DESCRIPTION
Primary side: Remove read handler upon RDB connection close.

At this stage we do not expect any writed form that connection
so it should be safe to remove the read handler. Otherwise the
read handler will keep printing the `Client closed connection`
logs, see handleReadResult.

re https://github.com/valkey-io/valkey/pull/60#discussion_r1682311891