### PR TITLE
Correctly recode client infomation to the slowlog when runing script

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3270,6 +3270,13 @@ void slowlogPushCurrentCommand(client *c, struct serverCommand *cmd, ustime_t du
      * arguments. */
     robj **argv = c->original_argv ? c->original_argv : c->argv;
     int argc = c->original_argv ? c->original_argc : c->argc;
+
+    /* If a script is currently running, the client passed in is a
+     * fake client. Or the client passed in is the original client
+     * if this is a EVAL or alike, doesn't matter. In this case,
+     * use the original client to get the client information. */
+    c = scriptIsRunning() ? scriptGetCaller() : c;
+
     slowlogPushEntryIfNeeded(c, argv, argc, duration);
 }
 

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -248,4 +248,37 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
         
         $rd close
     }
+
+    foreach is_eval {0 1} {
+        test "SLOWLOG - the commands in script are recorded normally - is_eval: $is_eval" {
+            if {$is_eval == 0} {
+                r function load replace "#!lua name=mylib \n redis.register_function('myfunc', function(KEYS, ARGS) server.call('ping') end)"
+            }
+
+            r client setname test-client
+            r config set slowlog-log-slower-than 0
+            r slowlog reset
+
+            if {$is_eval} {
+                r eval "server.call('ping')" 0
+            } else {
+                r fcall myfunc 0
+            }
+            set slowlog_resp [r slowlog get 2]
+
+            # Make sure the command are logged.
+            assert_equal 2 [llength $slowlog_resp]
+            if {$is_eval} {
+                assert_equal {eval server.call('ping') 0} [lindex [lindex $slowlog_resp 0] 3]
+            } else {
+                assert_equal {fcall myfunc 0} [lindex [lindex $slowlog_resp 0] 3]
+            }
+            assert_equal {ping} [lindex [lindex $slowlog_resp 1] 3]
+
+            # Make sure the client info are the logged.
+            assert_equal [lindex [lindex $slowlog_resp 0] 4] [lindex [lindex $slowlog_resp 1] 4]
+            assert_equal {test-client} [lindex [lindex $slowlog_resp 0] 5]
+            assert_equal {test-client} [lindex [lindex $slowlog_resp 1] 5]
+        }
+    }
 }


### PR DESCRIPTION
Currently when we are runing a script, we will passing a fake client.
So if the command executed in the script is recoded in the slowlog,
the client's ip:port and name information will be empty.