### PR TITLE
Fix bug in writeToClient during refactoring I/O threading

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2092,7 +2092,7 @@ int _writeToClient(client *c) {
     ssize_t tot_written = 0;
 
     while (tot_written < bytes_to_write) {
-        int nwritten = connWrite(c->conn, c->buf + c->sentlen, bytes_to_write - tot_written);
+        int nwritten = connWrite(c->conn, c->buf + c->sentlen + tot_written, bytes_to_write - tot_written);
         if (nwritten <= 0) {
             c->write_flags |= WRITE_FLAGS_WRITE_ERROR;
             tot_written = tot_written > 0 ? tot_written : nwritten;


### PR DESCRIPTION
Fix bug in writeToClient
In https://github.com/valkey-io/valkey/pull/758, a major refactor was done to `networking.c`. 

As part of this refactor, a new bug was introduced: we don't advance the `c->buf` pointer in repeated writes.

This bug should be very unlikely to manifest, as it requires the client's TCP buffer to be filled in the first try and then released immediately after in the second try.

Despite all my efforts to reproduce this scenario, I was unable to do so.