### PR TITLE
Remove static to avoid compiler warning

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1267,7 +1267,7 @@ void clusterReset(int hard) {
 /* -----------------------------------------------------------------------------
  * CLUSTER communication link
  * -------------------------------------------------------------------------- */
-static clusterMsgSendBlock *createClusterMsgSendBlock(int type, uint32_t msglen) {
+clusterMsgSendBlock *createClusterMsgSendBlock(int type, uint32_t msglen) {
     uint32_t blocklen = msglen + offsetof(clusterMsgSendBlock, msg);
     clusterMsgSendBlock *msgblock = zcalloc(blocklen);
     msgblock->refcount = 1;


### PR DESCRIPTION
We have some compilation error which to me looks like a false positive, https://github.com/valkey-io/valkey/actions/runs/10127360669/job/28005048552. It seems very similar to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104165, which is apparently related to miscalculation of static function sizes. 

Removing the static just to get the build working, given that most of the codebase still doesn't use static consistently, was thinking about just leaving this way.

*NOTE*: This would not have been caught with the extra-test label, since we don't run the extra address sanitizers as part of the extra tests, so maybe we should give that this was missed.

### Testing

See https://github.com/madolson/valkey/actions/runs/10133662275/job/28019055701 for valida