### PR TITLE
Fix bugs related to synchronous TLS connections blocking

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1518,7 +1518,11 @@ void unlinkClient(client *c) {
             }
         }
         /* Only use shutdown when the fork is active and we are the parent. */
-        if (server.child_type) connShutdown(c->conn);
+        if (server.child_type && !c->flag.repl_rdb_channel) {
+            connShutdown(c->conn);
+        } else if (c->flag.repl_rdb_channel) {
+            shutdown(c->conn->fd, SHUT_RDWR);
+        }
         connClose(c->conn);
         c->conn = NULL;
     }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3557,15 +3557,15 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
             if (replica->replica_req != req) continue;
 
             conns[connsnum++] = replica->conn;
-            if (dual_channel) {
-                /* Put the socket in blocking mode to simplify RDB transfer. */
-                connBlock(replica->conn);
+            if (dual_channel) {                
                 connSendTimeout(replica->conn, server.repl_timeout * 1000);
                 /* This replica uses diskless dual channel sync, hence we need
                  * to inform it with the save end offset.*/
                 sendCurrentOffsetToReplica(replica);
                 /* Make sure repl traffic is appended to the replication backlog */
                 addRdbReplicaToPsyncWait(replica);
+                /* Put the socket in blocking mode to simplify RDB transfer. */
+                connBlock(replica->conn);
             } else {
                 server.rdb_pipe_numconns++;
             }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3450,10 +3450,9 @@ static void backgroundSaveDoneHandlerSocket(int exitcode, int bysignal) {
     if (!bysignal && exitcode == 0) {
         serverLog(LL_NOTICE, "Background RDB transfer terminated with success");
     } else if (!bysignal && exitcode != 0) {
-        serverLog(LL_WARNING, "Background transfer error");
-        server.lastbgsave_status = C_ERR;
+        serverLog(LL_WARNING, "Background RDB transfer error");
     } else {
-        serverLog(LL_WARNING, "Background transfer terminated by signal %d", bysignal);
+        serverLog(LL_WARNING, "Background RDB transfer terminated by signal %d", bysignal);
     }
     if (server.rdb_child_exit_pipe != -1) close(server.rdb_child_exit_pipe);
     if (server.rdb_pipe_read > 0) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3557,7 +3557,7 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
             if (replica->replica_req != req) continue;
 
             conns[connsnum++] = replica->conn;
-            if (dual_channel) {                
+            if (dual_channel) {
                 connSendTimeout(replica->conn, server.repl_timeout * 1000);
                 /* This replica uses diskless dual channel sync, hence we need
                  * to inform it with the save end offset.*/

--- a/src/replication.c
+++ b/src/replication.c
@@ -4159,6 +4159,7 @@ void replicationResurrectProvisionalPrimary(void) {
     memcpy(server.primary->replid, server.repl_provisional_primary.replid, CONFIG_RUN_ID_SIZE);
     server.primary->reploff = server.repl_provisional_primary.reploff;
     server.primary->read_reploff = server.repl_provisional_primary.read_reploff;
+    server.primary_repl_offset = server.primary->reploff;
     establishPrimaryConnection();
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -4160,6 +4160,7 @@ void replicationResurrectProvisionalPrimary(void) {
     server.primary->reploff = server.repl_provisional_primary.reploff;
     server.primary->read_reploff = server.repl_provisional_primary.read_reploff;
     server.primary_repl_offset = server.primary->reploff;
+    memcpy(server.replid, server.primary->replid, sizeof(server.primary->replid));
     establishPrimaryConnection();
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -956,7 +956,9 @@ int startBgsaveForReplication(int mincapa, int req) {
     /* `SYNC` should have failed with error if we don't support socket and require a filter, assert this here */
     serverAssert(socket_target || !(req & REPLICA_REQ_RDB_MASK));
 
-    serverLog(LL_NOTICE, "Starting BGSAVE for SYNC with target: %s", socket_target ? "replicas sockets" : "disk");
+    serverLog(LL_NOTICE, "Starting BGSAVE for SYNC with target: %s using: %s",
+              socket_target ? "replicas sockets" : "disk",
+              (req & REPLICA_REQ_RDB_CHANNEL) ? "dual-channel" : "normal sync");
 
     rdbSaveInfo rsi, *rsiptr;
     rsiptr = rdbPopulateSaveInfo(&rsi);

--- a/src/replication.c
+++ b/src/replication.c
@@ -391,7 +391,7 @@ void freeReplicaReferencedReplBuffer(client *replica) {
         uint64_t rdb_cid = htonu64(replica->id);
         if (raxRemove(server.replicas_waiting_psync, (unsigned char *)&rdb_cid, sizeof(rdb_cid), NULL)) {
             serverLog(LL_DEBUG, "Remove psync waiting replica %s with cid %llu from replicas rax.",
-                      replicationGetReplicaName(replica), (long long unsigned int)rdb_cid);
+                      replicationGetReplicaName(replica), (long long unsigned int)replica->id);
         }
     }
     if (replica->ref_repl_buf_node != NULL) {

--- a/src/replication.c
+++ b/src/replication.c
@@ -391,7 +391,7 @@ void freeReplicaReferencedReplBuffer(client *replica) {
         uint64_t rdb_cid = htonu64(replica->id);
         if (raxRemove(server.replicas_waiting_psync, (unsigned char *)&rdb_cid, sizeof(rdb_cid), NULL)) {
             serverLog(LL_DEBUG, "Remove psync waiting replica %s with cid %llu from replicas rax.",
-                      replicationGetReplicaName(replica), (long long unsigned int)replica->associated_rdb_client_id);
+                      replicationGetReplicaName(replica), (long long unsigned int)rdb_cid);
         }
     }
     if (replica->ref_repl_buf_node != NULL) {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -23,6 +23,7 @@ proc get_client_id_by_last_cmd {r cmd} {
     return $client_id
 }
 
+# Wait until the process enters a paused state, then resume the process.
 proc wait_and_resume_process idx {
     set pid [srv $idx pid]
     wait_for_condition 50 1000 {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -25,7 +25,12 @@ proc get_client_id_by_last_cmd {r cmd} {
 
 proc wait_and_resume_process idx {
     set pid [srv $idx pid]
-    wait_for_log_messages $idx {"*Process is about to stop.*"} 0 2000 1
+    wait_for_condition 50 1000 {
+        [exec ps -o state= -p $pid] eq "T" ||
+        [exec ps -o state= -p $pid] eq "Z"
+    } else {
+        fail "Process $pid didn't stop"
+    }
     resume_process $pid
 }
 

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -271,7 +271,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set primary_port [srv 0 port]
             set loglines [count_log_lines -1]
 
-            populate 100000 primary 10
+            populate 10000 primary 10
             $primary set key1 val1
 
             $primary config set repl-diskless-sync yes
@@ -323,9 +323,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test replica's buffer limit reached" {
                 $primary config set repl-diskless-sync-delay 0
-                $primary config set rdb-key-save-delay 1000
-                # At this point we have about 100k keys in the db, 
-                # We expect that the next full sync will take 100 seconds (100k*1000)ms
+                $primary config set rdb-key-save-delay 10000
+                # At this point we have about 10k keys in the db, 
+                # We expect that the next full sync will take 100 seconds (10k*10000)ms
                 # It will give us enough time to fill the replica buffer.
                 $replica1 config set dual-channel-replication-enabled yes
                 $replica1 config set client-output-buffer-limit "replica 16383 16383 0"
@@ -356,11 +356,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             $replica1 replicaof no one
-            wait_for_condition 500 1000 {
-                [s -1 rdb_bgsave_in_progress] eq 0
-            } else {
-                fail "Primary should abort sync"
-            }
             $replica1 config set client-output-buffer-limit "replica 256mb 256mb 0"; # remove repl buffer limitation
             $primary config set rdb-key-save-delay 0
 
@@ -1050,8 +1045,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
 
     # Generating RDB will cost 100 sec to generate
-    $primary debug populate 100000 primary 1
-    $primary config set rdb-key-save-delay 1000
+    $primary debug populate 10000 primary 1
+    $primary config set rdb-key-save-delay 10000
     
     start_server {} {
         set replica [srv 0 client]

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -27,9 +27,9 @@ proc get_client_id_by_last_cmd {r cmd} {
 proc wait_and_resume_process idx {
     set pid [srv $idx pid]
     wait_for_condition 50 1000 {
-        [exec ps -o state= -p $pid] eq "T"
+        [string match "T*" [exec ps -o state= -p $pid]]
     } else {
-        fail "Process $pid didn't stop"
+        fail "Process $pid didn't stop, current state is [exec ps -o state= -p $pid]"
     }
     resume_process $pid
 }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -993,9 +993,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set loglevel debug
     $primary config set repl-diskless-sync-delay 0; # don't wait for other replicas
 
-    # Generating RDB will cost 5s(10000 * 0.0001s)
+    # Generating RDB will cost 100s
     $primary debug populate 10000 primary 1
-    $primary config set rdb-key-save-delay 100
+    $primary config set rdb-key-save-delay 10000
     
     start_server {} {
         set replica_1 [srv 0 client]
@@ -1027,11 +1027,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 }
                 $replica_2 replicaof $primary_host $primary_port
                 wait_for_log_messages -2 {"*Current BGSAVE has socket target. Waiting for next BGSAVE for SYNC*"} $loglines 100 1000
-                $primary config set rdb-key-save-delay 0
-                # Verify second replica needed new session
-                wait_for_sync $replica_2
-                assert {[s -2 sync_partial_ok] eq 2}
-                assert {[s -2 sync_full] eq 2}
             }
             stop_write_load $load_handle
         }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -29,7 +29,7 @@ proc wait_and_resume_process idx {
     wait_for_condition 50 1000 {
         [exec ps -o state= -p $pid] eq "T"
     } else {
-        fail "Process $pid didn't stop"
+        puts "Process $pid didn't stop"
     }
     resume_process $pid
 }
@@ -348,7 +348,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 }
                 assert {[s -2 replicas_replication_buffer_size] <= 16385*2}
 
-                # Wait for sync to succeed 
+                # Wait for sync to succeed
+                $primary config set rdb-key-save-delay 0
                 wait_for_condition 50 1000 {
                     [status $replica1 master_link_status] == "up"
                 } else {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -271,7 +271,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set primary_port [srv 0 port]
             set loglines [count_log_lines -1]
 
-            populate 10000 primary 10
+            populate 100000 primary 10
             $primary set key1 val1
 
             $primary config set repl-diskless-sync yes
@@ -323,9 +323,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test replica's buffer limit reached" {
                 $primary config set repl-diskless-sync-delay 0
-                $primary config set rdb-key-save-delay 10000
-                # At this point we have about 10k keys in the db, 
-                # We expect that the next full sync will take 100 seconds (10k*10000)ms
+                $primary config set rdb-key-save-delay 1000
+                # At this point we have about 100k keys in the db, 
+                # We expect that the next full sync will take 100 seconds (100k*1000)ms
                 # It will give us enough time to fill the replica buffer.
                 $replica1 config set dual-channel-replication-enabled yes
                 $replica1 config set client-output-buffer-limit "replica 16383 16383 0"
@@ -356,6 +356,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             $replica1 replicaof no one
+            wait_for_condition 500 1000 {
+                [s -1 rdb_bgsave_in_progress] eq 0
+            } else {
+                fail "Primary should abort sync"
+            }
             $replica1 config set client-output-buffer-limit "replica 256mb 256mb 0"; # remove repl buffer limitation
             $primary config set rdb-key-save-delay 0
 
@@ -1045,8 +1050,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
 
     # Generating RDB will cost 100 sec to generate
-    $primary debug populate 10000 primary 1
-    $primary config set rdb-key-save-delay 10000
+    $primary debug populate 100000 primary 1
+    $primary config set rdb-key-save-delay 1000
     
     start_server {} {
         set replica [srv 0 client]

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -894,6 +894,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary debug log "killing replica main connection"
             set replica_main_conn_id [get_client_id_by_last_cmd $primary "psync"]
             assert {$replica_main_conn_id != ""}
+            set loglines [count_log_lines -1]
             $primary client kill id $replica_main_conn_id
             # Wait for primary to abort the sync
             wait_for_condition 50 1000 {
@@ -901,11 +902,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_condition 1000 10 {
-                [s -1 rdb_last_bgsave_status] eq "err"
-            } else {
-                fail "bgsave did not stop in time"
-            }
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
         }
 
         test "Test dual channel replication slave of no one after main conn kill" {
@@ -931,14 +928,10 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set replica_rdb_channel_id [get_client_id_by_last_cmd $primary "sync"]
             $primary debug log "killing replica rdb connection $replica_rdb_channel_id"
             assert {$replica_rdb_channel_id != ""}
+            set loglines [count_log_lines -1]
             $primary client kill id $replica_rdb_channel_id
             # Wait for primary to abort the sync
-            wait_for_condition 1000 10 {
-                [s -1 rdb_bgsave_in_progress] eq 0 &&
-                [s -1 rdb_last_bgsave_status] eq "err" 
-            } else {
-                fail "Primary should abort sync"
-            }
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
         }
 
         test "Test dual channel replication slave of no one after rdb conn kill" {
@@ -1072,6 +1065,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary debug log "killing replica rdb connection"
             set replica_rdb_channel_id [get_client_id_by_last_cmd $primary "sync"]
             assert {$replica_rdb_channel_id != ""}
+            set loglines [count_log_lines -1]
             $primary client kill id $replica_rdb_channel_id
             # Wait for primary to abort the sync
             wait_for_condition 50 1000 {
@@ -1079,11 +1073,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_condition 1000 10 {
-                [s -1 rdb_last_bgsave_status] eq "err"
-            } else {
-                fail "bgsave did not stop in time"
-            }
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
@@ -1113,6 +1103,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary debug log "killing replica main connection"
             set replica_main_conn_id [get_client_id_by_last_cmd $primary "sync"]
             assert {$replica_main_conn_id != ""}
+            set loglines [count_log_lines -1]
             $primary client kill id $replica_main_conn_id
             # Wait for primary to abort the sync
             wait_for_condition 50 1000 {
@@ -1120,11 +1111,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_condition 1000 10 {
-                [s -1 rdb_last_bgsave_status] eq "err"
-            } else {
-                fail "bgsave did not stop in time"
-            }
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -26,8 +26,7 @@ proc get_client_id_by_last_cmd {r cmd} {
 proc wait_and_resume_process idx {
     set pid [srv $idx pid]
     wait_for_condition 50 1000 {
-        [exec ps -o state= -p $pid] eq "T" ||
-        [exec ps -o state= -p $pid] eq "Z"
+        [exec ps -o state= -p $pid] eq "T"
     } else {
         fail "Process $pid didn't stop"
     }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -29,7 +29,7 @@ proc wait_and_resume_process idx {
     wait_for_condition 50 1000 {
         [exec ps -o state= -p $pid] eq "T"
     } else {
-        puts "Process $pid didn't stop"
+        fail "Process $pid didn't stop"
     }
     resume_process $pid
 }
@@ -348,8 +348,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 }
                 assert {[s -2 replicas_replication_buffer_size] <= 16385*2}
 
-                # Wait for sync to succeed
-                $primary config set rdb-key-save-delay 0
+                # Wait for sync to succeed 
                 wait_for_condition 50 1000 {
                     [status $replica1 master_link_status] == "up"
                 } else {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -359,6 +359,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica1 config set client-output-buffer-limit "replica 256mb 256mb 0"; # remove repl buffer limitation
             $primary config set rdb-key-save-delay 0
 
+            wait_for_condition 500 1000 {
+                [s 0 rdb_bgsave_in_progress] eq 0
+            } else {
+                fail "can't kill rdb child"
+            }
+
             $primary set key3 val3
             
             test "dual-channel-replication fails when primary diskless disabled" {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -102,6 +102,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set primary_host [srv 0 host]
         set primary_port [srv 0 port]
 
+        $primary config set rdb-key-save-delay 200
         $primary config set dual-channel-replication-enabled yes
         $replica config set dual-channel-replication-enabled yes
         $replica config set repl-diskless-sync no
@@ -319,12 +320,13 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             $replica1 replicaof no one
+            $primary set key3 val3
             
             test "Test replica's buffer limit reached" {
                 $primary config set repl-diskless-sync-delay 0
-                $primary config set rdb-key-save-delay 10000
+                $primary config set rdb-key-save-delay 500
                 # At this point we have about 10k keys in the db, 
-                # We expect that the next full sync will take 100 seconds (10k*10000)ms
+                # We expect that the next full sync will take 5 seconds (10k*500)ms
                 # It will give us enough time to fill the replica buffer.
                 $replica1 config set dual-channel-replication-enabled yes
                 $replica1 config set client-output-buffer-limit "replica 16383 16383 0"
@@ -345,14 +347,21 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                     fail "Replica buffer should fill"
                 }
                 assert {[s -2 replicas_replication_buffer_size] <= 16385*2}
+
+                # Wait for sync to succeed
+                $primary config set rdb-key-save-delay 0
+                wait_for_condition 50 1000 {
+                    [status $replica1 master_link_status] == "up"
+                } else {
+                    fail "Replica is not synced"
+                }
+                wait_for_value_to_propegate_to_replica $primary $replica1 "key3"
             }
 
             $replica1 replicaof no one
-            catch {exec kill -9 [get_child_pid 0]}
-
             $replica1 config set client-output-buffer-limit "replica 256mb 256mb 0"; # remove repl buffer limitation
-            $primary config set rdb-key-save-delay 0
-            $primary set key3 val3
+
+            $primary set key4 val4
             
             test "dual-channel-replication fails when primary diskless disabled" {
                 set cur_psync [status $primary sync_partial_ok]
@@ -367,7 +376,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 } else {
                     fail "Replica is not synced"
                 }
-                wait_for_value_to_propegate_to_replica $primary $replica1 "key3"
+                wait_for_value_to_propegate_to_replica $primary $replica1 "key4"
 
                 # Verify that we did not use dual-channel-replication sync
                 assert {[status $primary sync_partial_ok] == $cur_psync}
@@ -430,6 +439,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $primary config set repl-backlog-size $backlog_size
         $primary config set loglevel debug
         $primary config set repl-timeout 10
+        $primary config set rdb-key-save-delay 200
         populate 10000 primary 10000
         
         set load_handle1 [start_one_key_write_load $primary_host $primary_port 100 "mykey1"]
@@ -489,6 +499,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set repl-backlog-size $backlog_size
             $primary config set loglevel debug
             $primary config set repl-timeout 10
+            $primary config set rdb-key-save-delay 10
             populate 1024 primary 16
             
             set load_handle0 [start_write_load $primary_host $primary_port 20]
@@ -554,6 +565,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     populate 10 primary 10
     # Pause primary main process after fork
     $primary debug pause-after-fork 1
+    # Give replica two second grace period before disconnection
+    $primary debug delay-rdb-client-free-seconds 2
 
     start_server {} {
         set replica [srv 0 client]
@@ -614,7 +627,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     populate 10 primary 10
     # Pause primary main process after fork
     $primary debug pause-after-fork 1
-    $primary debug delay-rdb-client-free-seconds 100
+    # Give replica two second grace period before disconnection
+    $primary debug delay-rdb-client-free-seconds 2
 
     start_server {} {
         set replica [srv 0 client]
@@ -646,7 +660,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary should wait before freeing repl block"
             }
-            $primary debug delay-rdb-client-free-seconds 1
+
             # Sync should fail once the replica ask for PSYNC using main channel
             set res [wait_for_log_messages -1 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 4000 1]
             wait_for_condition 50 100 {
@@ -679,9 +693,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set replica_log [srv 0 stdout]
         set replica_pid  [srv 0 pid]
         
-        set load_handle0 [start_one_key_write_load $primary_host $primary_port 100 "mykey1"]
-        set load_handle1 [start_one_key_write_load $primary_host $primary_port 100 "mykey2"]
-        set load_handle2 [start_one_key_write_load $primary_host $primary_port 100 "mykey3"]
+        set load_handle0 [start_write_load $primary_host $primary_port 20]
+        set load_handle1 [start_write_load $primary_host $primary_port 20]
+        set load_handle2 [start_write_load $primary_host $primary_port 20]
 
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
@@ -720,6 +734,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $primary debug populate 1000 primary 100000
         # Set primary with a slow rdb generation, so that we can easily intercept loading
         # 10ms per key, with 1000 keys is 10 seconds
+        $primary config set rdb-key-save-delay 10000
 
         test "Test dual-channel-replication primary gets cob overrun during replica rdb load" {
             set cur_client_closed_count [s -1 client_output_buffer_limit_disconnections]
@@ -736,7 +751,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Primary did not free repl buf block after sync failure"
             }
             wait_and_resume_process 0
-            wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1]
+            set loglines [lindex $res 0]
         }
         stop_write_load $load_handle0
         stop_write_load $load_handle1
@@ -744,6 +760,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     }
 }
 
+foreach dualchannel {yes no} {
 start_server {tags {"dual-channel-replication external:skip"}} {
     set primary [srv 0 client]
     set primary_host [srv 0 host]
@@ -755,53 +772,77 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set loglevel debug
     $primary config set repl-diskless-sync-delay 5
     
-    # Sync should take 1000 seconds
-    $primary debug populate 100000 primary 1
-    $primary config set rdb-key-save-delay 10000
+    # Generating RDB will cost 5s(10000 * 0.0005s)
+    $primary debug populate 10000 primary 1
+    $primary config set rdb-key-save-delay 500
 
-    $primary config set dual-channel-replication-enabled yes
+    $primary config set dual-channel-replication-enabled $dualchannel
 
     start_server {} {
         set replica1 [srv 0 client]
-        $replica1 config set dual-channel-replication-enabled yes
+        $replica1 config set dual-channel-replication-enabled $dualchannel
         $replica1 config set loglevel debug
         start_server {} {
             set replica2 [srv 0 client]
-            $replica2 config set dual-channel-replication-enabled yes
+            $replica2 config set dual-channel-replication-enabled $dualchannel
             $replica2 config set loglevel debug
             $replica2 config set repl-timeout 60
 
             set load_handle [start_one_key_write_load $primary_host $primary_port 100 "mykey1"]
-            test "Sync should continue if not all slaves dropped dual-channel-replication" {
+            test "Sync should continue if not all slaves dropped dual-channel-replication $dualchannel" {
                 $replica1 replicaof $primary_host $primary_port
                 $replica2 replicaof $primary_host $primary_port
 
                 wait_for_condition 50 1000 {
-                    [status $primary rdb_bgsave_in_progress] == 1 &&
-                    [status $primary connected_slaves] == 4
+                    [status $primary rdb_bgsave_in_progress] == 1
                 } else {
                     fail "Sync did not start"
                 }
-                # Wait for both replicas main conns to establish psync
-                wait_for_condition 50 1000 {
-                    [status $primary sync_partial_ok] == 2
-                } else {
-                    fail "Replicas main conns didn't establish psync [status $primary sync_partial_ok]"
+                if {$dualchannel == "yes"} {
+                    # Wait for both replicas main conns to establish psync
+                    wait_for_condition 50 1000 {
+                        [status $primary sync_partial_ok] == 2
+                    } else {
+                        fail "Replicas main conns didn't establish psync [status $primary sync_partial_ok]"
+                    }
                 }
 
                 catch {$replica1 shutdown nosave}
-                # wait for replica1 to disconnect
                 wait_for_condition 50 2000 {
-                    [status $primary connected_slaves] == 2
+                    [status $replica2 master_link_status] == "up" &&
+                    [status $primary sync_full] == 2 &&
+                    (($dualchannel == "yes" && [status $primary sync_partial_ok] == 2) || $dualchannel == "no")
                 } else {
-                    fail "Sync session interapted"
+                    fail "Sync session interapted\n
+                        sync_full:[status $primary sync_full]\n
+                        sync_partial_ok:[status $primary sync_partial_ok]"
                 }
-                # Verify sync session was not interapted
-                assert {[status $primary rdb_bgsave_in_progress] eq 1}
-                assert {[status $primary rdb_last_bgsave_status] eq "ok"}
             }
+            
+            $replica2 replicaof no one
+
+            # Generating RDB will cost 500s(1000000 * 0.0001s)
+            $primary debug populate 1000000 primary 1
+            $primary config set rdb-key-save-delay 100
     
-            test "Primary abort sync if all slaves dropped dual-channel-replication" {
+            test "Primary abort sync if all slaves dropped dual-channel-replication $dualchannel" {
+                set cur_psync [status $primary sync_partial_ok]
+                $replica2 replicaof $primary_host $primary_port
+
+                wait_for_condition 50 1000 {
+                    [status $primary rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+                if {$dualchannel == "yes"} {
+                    # Wait for both replicas main conns to establish psync
+                    wait_for_condition 50 1000 {
+                        [status $primary sync_partial_ok] == $cur_psync + 1
+                    } else {
+                        fail "Replicas main conns didn't establish psync [status $primary sync_partial_ok]"
+                    }
+                }
+
                 catch {$replica2 shutdown nosave}
                 wait_for_condition 50 1000 {
                     [status $primary rdb_bgsave_in_progress] == 0
@@ -812,6 +853,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             stop_write_load $load_handle
         }
     }
+}
 }
 
 start_server {tags {"dual-channel-replication external:skip"}} {
@@ -827,7 +869,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
     # Generating RDB will cost 500s(1000000 * 0.0001s)
     $primary debug populate 1000000 primary 1
-    $primary config set rdb-key-save-delay 10000
+    $primary config set rdb-key-save-delay 100
     
     start_server {} {
         set replica [srv 0 client]
@@ -953,8 +995,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set loglevel debug
     $primary config set repl-diskless-sync-delay 0; # don't wait for other replicas
 
+    # Generating RDB will cost 5s(10000 * 0.0001s)
     $primary debug populate 10000 primary 1
-    $primary config set rdb-key-save-delay 10000
+    $primary config set rdb-key-save-delay 100
     
     start_server {} {
         set replica_1 [srv 0 client]
@@ -982,10 +1025,15 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 wait_for_condition 50 100 {
                     [s -2 rdb_bgsave_in_progress] eq 1
                 } else {
-                    fail "replica didn't start sync session in time"
+                    fail "replica didn't start sync session in time1"
                 }
                 $replica_2 replicaof $primary_host $primary_port
                 wait_for_log_messages -2 {"*Current BGSAVE has socket target. Waiting for next BGSAVE for SYNC*"} $loglines 100 1000
+                $primary config set rdb-key-save-delay 0
+                # Verify second replica needed new session
+                wait_for_sync $replica_2
+                assert {[s -2 sync_partial_ok] eq 2}
+                assert {[s -2 sync_full] eq 2}
             }
             stop_write_load $load_handle
         }
@@ -1003,15 +1051,15 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set loglevel debug
     $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
 
+    # Generating RDB will cost 5s(10000 * 0.0001s)
     $primary debug populate 10000 primary 1
-    $primary config set rdb-key-save-delay 10000
+    $primary config set rdb-key-save-delay 100
     
     start_server {} {
         set replica [srv 0 client]
         set replica_host [srv 0 host]
         set replica_port [srv 0 port]
         set replica_log [srv 0 stdout]
-        set replica_pid [srv 0 pid]
         
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
@@ -1026,8 +1074,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't start sync session in time"
-            }
-            pause_process $replica_pid
+            }            
 
             $primary debug log "killing replica rdb connection"
             set replica_rdb_channel_id [get_client_id_by_last_cmd $primary "sync"]
@@ -1045,8 +1092,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "bgsave did not stop in time"
             }
             # Replica should retry
-            $primary config set rdb-key-save-delay 0
-            resume_process $replica_pid
             verify_replica_online $primary 0 500
             stop_write_load $load_handle
             wait_for_condition 1000 100 {
@@ -1056,7 +1101,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }            
         }
         $replica replicaof no one
-        $primary config set rdb-key-save-delay 10000
 
         test "Replica recover main-connection killed" {
             set load_handle [start_one_key_write_load $primary_host $primary_port 100 "mykey"]
@@ -1068,8 +1112,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 [s -1 rdb_bgsave_in_progress] eq 1
             } else {
                 fail "replica didn't start sync session in time"
-            }
-            pause_process $replica_pid
+            }            
+
             $primary debug log "killing replica main connection"
             set replica_main_conn_id [get_client_id_by_last_cmd $primary "sync"]
             assert {$replica_main_conn_id != ""}
@@ -1086,8 +1130,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "bgsave did not stop in time"
             }
             # Replica should retry
-            $primary config set rdb-key-save-delay 0
-            resume_process $replica_pid
             verify_replica_online $primary 0 500
             stop_write_load $load_handle
             wait_for_condition 1000 100 {


### PR DESCRIPTION
- Fix TLS bug where connection were shutdown by primary's main process while the child process was still writing- causing main process to be blocked.
- TLS connection fix -file descriptors are set to blocking mode in the main thread, followed by a blocking write. This sets the file descriptors to non-blocking if TLS is used (see `connTLSSyncWrite()`) (@xbasel). 
- Improve the reliability of dual-channel tests. Modify the pause mechanism to verify process status directly, rather than relying on log.
- Ensure that `server.repl_offset` and `server.replid` are updated correctly when dual channel synchronization completes successfully. Thist led to failures in replication tests that validate replication IDs or compare replication offsets.