### PR TITLE
Check if the server is currently running the feature before cron run

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1420,8 +1420,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     }
 
     /* Run the Cluster cron. */
-    run_with_period(100) {
-        if (server.cluster_enabled) clusterCron();
+    if (server.cluster_enabled) {
+        run_with_period(100) clusterCron();
     }
 
     /* Run the Sentinel timer if we are in sentinel mode. */
@@ -1453,8 +1453,8 @@ int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
             server.rdb_bgsave_scheduled = 0;
     }
 
-    run_with_period(100) {
-        if (moduleCount()) modulesCron();
+    if (moduleCount()) {
+        run_with_period(100) modulesCron();
     }
 
     /* Fire the cron loop modules event. */


### PR DESCRIPTION
I think we should first check if the server is currently enabled in cluster mode or if it has modules loaded prior to the throttled cron run (`run_with_period`) condition.