### PR TITLE
Log unexpected $ENDOFF responses in dual channel replication

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2677,6 +2677,7 @@ static void fullSyncWithPrimary(connection *conn) {
         /* Parse end offset response */
         char *endoff_format = "$ENDOFF:%lld %40s %d %llu";
         if (sscanf(err, endoff_format, &reploffset, primary_replid, &dbid, &rdb_client_id) != 4) {
+            serverLog(LL_WARNING, "Received unexpected $ENDOFF response: %s", err);
             goto error;
         }
         sdsfree(err);


### PR DESCRIPTION
I've tried to test a dual channel replication but forgot to add +sync for my replication user. As a result replica entered silent cycle like this:
```
* Connecting to PRIMARY 127.0.0.1:6379
* PRIMARY <-> REPLICA sync started
* Non blocking connect for SYNC fired the event.
* Primary replied to PING, replication can continue...
* Trying a partial resynchronization (request ...)
* PSYNC is not possible, initialize RDB channel.
* Aborting dual channel sync
```

And primary got endless cycle like this:
```
* Replica 127.0.0.1:6380 asks for synchronization
* Partial resynchronization not accepted: Replication ID mismatch (Replica asked for '...', my replication IDs are '...' and '...')
* Replica 127.0.0.1:6380 is capable of dual channel synchronization, and partial sync isn't possible. Full sync will continue with dedicated RDB channel.
```

There was no way to understand that replication user is missing +sync acl on notice log level. With this one-line change we get a warning message in our replica log.

---------

Signed-off-by: secwall <secwall@yandex-team.ru>