### PR TITLE
Fix CI concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on: [push, pull_request]
 
 concurrency:
-    group: ci-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+    group: ci-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'src/**'
 
+concurrency:
+    group: clang-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   clang-format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,8 +6,8 @@ on:
       - 'src/**'
 
 concurrency:
-    group: clang-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: clang-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   clang-format-check:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,6 +4,10 @@ name: "Codecov"
 # where each PR needs to be compared against the coverage of the head commit
 on: [push, pull_request]
 
+concurrency:
+    group: codecov-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   code-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,8 +5,8 @@ name: "Codecov"
 on: [push, pull_request]
 
 concurrency:
-    group: codecov-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: codecov-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   code-coverage:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
   schedule:
     # run weekly new vulnerability was added to the database
-    - cron: '0 0 * * 0'
+    - cron: '0 3 * * 0'
+
+concurrency:
+    group: codeql-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,8 @@ on:
     - cron: '0 3 * * 0'
 
 concurrency:
-    group: codeql-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: codeql-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,11 +3,17 @@ name: Coverity Scan
 on:
   schedule:
     # Run once daily, since below 500k LOC can have 21 builds per week, per https://scan.coverity.com/faq#frequency
-    - cron: '0 0 * * *'
+    - cron: '0 1 * * *'
   # Support manual execution
   workflow_dispatch:
+
+concurrency:
+    group: coverity-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: read
+
 jobs:
   coverity:
     if: github.repository == 'valkey-io/valkey'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-    group: coverity-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: coverity-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,6 +29,10 @@ on:
         description: "git branch or sha to use"
         default: "unstable"
 
+concurrency:
+    group: daily-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,8 +30,8 @@ on:
         default: "unstable"
 
 concurrency:
-    group: daily-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: daily-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 2 * * *'
+
+concurrency:
+    group: external-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -7,8 +7,8 @@ on:
     - cron: '0 2 * * *'
 
 concurrency:
-    group: external-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: external-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -9,8 +9,8 @@ on:
       - 'src/commands/*.json'
 
 concurrency:
-    group: reply-schemas-linter-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: reply-schemas-linter-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'src/commands/*.json'
 
+concurrency:
+    group: reply-schemas-linter-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,6 +9,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+    group: spellcheck-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,8 +10,8 @@ on:
   pull_request:
 
 concurrency:
-    group: spellcheck-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: spellcheck-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Few CI improvements witch will reduce occupation CI queue and eliminate stale runs.

1. Kill CI jobs on PRs once PR branch gets a new push. This will prevent situation happened today - a huge job triggered twice in less than an hour and occupied all **org** (for all repositories) runners queue for the rest of the day (see pic). This completely blocked valkey-glide team.
2. Distribute nightly croned jobs on time to prevent them running together. Keep in mind, cron's TZ is UTC, so midnight tasks incur developers located in other timezones.

This must be backported to all release branches (`valkey-x.y` and `x.y`)

![image](https://github.com/user-attachments/assets/923d8237-3cb7-42f5-80c8-5322b3f5187d)
