### PR TITLE
Update replica version comparison to handle version 8 RC candidates

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6284,7 +6284,7 @@ void clusterCommandSetSlot(client *c) {
      * the process. */
     if (nodeIsPrimary(myself) && myself->num_replicas != 0 && !c->flag.replication_done) {
         /* Iterate through the list of replicas to check if there are any running
-         * a version older than 8.0.0. Replicas with versions older than 8.0.0 do
+         * version 7.2 or older. Replicas running on these versions do
          * not support the CLUSTER SETSLOT command on replicas. If such a replica
          * is found, we should skip the replication and fall back to the old
          * non-replicated behavior.*/
@@ -6294,7 +6294,7 @@ void clusterCommandSetSlot(client *c) {
         listRewind(server.replicas, &li);
         while ((ln = listNext(&li))) {
             client *r = ln->value;
-            if (r->replica_version < 0x80000 /* 8.0.0 */) {
+            if (r->replica_version < 0x702ff /* 7.2.255 */) {
                 legacy_replica_found++;
                 break;
             }


### PR DESCRIPTION
Release candidates have a version that is lower than 8.0.0 to allow for 8.0.0 to have 0x080000 as a release number. However, we did an explicit check to make sure a version was 8.0 or greater to validate a replica supports a feature. Now we are using the highest patch version of latest minor to do the comparison to accommodate future versions.