### PR TITLE
Update sentinel conf access string to allow hello channel access

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -120,7 +120,7 @@ sentinel monitor mymaster 127.0.0.1 6379 2
 # Sentinel instances, should be configured along the following lines:
 #
 #     user sentinel-user >somepassword +client +subscribe +publish \
-#                        +ping +info +multi +slaveof +config +client +exec on
+#                        +ping +info +multi +slaveof +config +client +exec &__sentinel__:hello on
 
 # sentinel down-after-milliseconds <master-name> <milliseconds>
 #


### PR DESCRIPTION
This example of a minimal user account in your Valkey server
for Sentinel is incorrect. If you add this ACL as-is to your
valkey users.acl, valkey will add resetchannels -@all before
the +client which prevents sentinel from publishing messages
to the __sentinel__:hello pubsub for sentinel discovery.

Fix #744.