### PR TITLE
Disable empty shard slot migration test until test is de-flaked

### DIFF
--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -216,6 +216,9 @@ proc create_empty_shard {p r} {
     wait_for_role $p master
 }
 
+# Temporarily disable empty shard migration tests while we
+# work to reduce their flakiness. See https://github.com/valkey-io/valkey/issues/858.
+if {0} {
 start_cluster 3 5 {tags {external:skip cluster} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
 
     set node_timeout [lindex [R 0 CONFIG GET cluster-node-timeout] 1]
@@ -291,6 +294,7 @@ start_cluster 3 5 {tags {external:skip cluster} overrides {cluster-allow-replica
         wait_for_slot_state 3 "\[609->-$R6_id\]"
         wait_for_slot_state 7 "\[609-<-$R0_id\]"
     }
+}
 }
 
 proc migrate_slot {from to slot} {


### PR DESCRIPTION
We have a number of test failures in the empty shard migration which seem to be related to race conditions in the failover, but could be more pervasive. For now disable the tests to prevent so many false negative test failures.

See https://github.com/valkey-io/valkey/issues/858 for more information.