### PR TITLE
Dual-channel-replication: set connection to blocking after blocking-w…

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3557,15 +3557,15 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
             if (replica->replica_req != req) continue;
 
             conns[connsnum++] = replica->conn;
-            if (dual_channel) {
-                /* Put the socket in blocking mode to simplify RDB transfer. */
-                connBlock(replica->conn);
+            if (dual_channel) {                
                 connSendTimeout(replica->conn, server.repl_timeout * 1000);
                 /* This replica uses diskless dual channel sync, hence we need
                  * to inform it with the save end offset.*/
                 sendCurrentOffsetToReplica(replica);
                 /* Make sure repl traffic is appended to the replication backlog */
                 addRdbReplicaToPsyncWait(replica);
+                /* Put the socket in blocking mode to simplify RDB transfer. */
+                connBlock(replica->conn);
             } else {
                 server.rdb_pipe_numconns++;
             }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3557,7 +3557,7 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
             if (replica->replica_req != req) continue;
 
             conns[connsnum++] = replica->conn;
-            if (dual_channel) {                
+            if (dual_channel) {
                 connSendTimeout(replica->conn, server.repl_timeout * 1000);
                 /* This replica uses diskless dual channel sync, hence we need
                  * to inform it with the save end offset.*/


### PR DESCRIPTION
…rite.

Dual-channel file descriptors are set to blocking mode in the main thread, followed by a blocking write. This sets the file descriptors to non-blocking if TLS is used (see `connTLSSyncWrite()`).

The child process runs in blocking mode. If a write operation fails to write the entire buffer, SSL returns `SSL_ERROR_WANT_WRITE`. This error is ignored, causing the replica to fail in loading the RDB.

This change sets file descriptors after the blocking write.