### PR TITLE
Add debug-context config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3135,6 +3135,7 @@ standardConfig static_configs[] = {
     createStringConfig("req-res-logfile", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, EMPTY_STRING_IS_NULL, server.req_res_logfile, NULL, NULL, NULL),
 #endif
     createStringConfig("locale-collate", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.locale_collate, "", NULL, updateLocaleCollate),
+    createStringConfig("debug-context", NULL, MODIFIABLE_CONFIG | DEBUG_CONFIG, ALLOW_EMPTY_STRING, server.debug_context, "", NULL, NULL),
 
     /* SDS Configs */
     createSDSConfig("primaryauth", "masterauth", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_auth, NULL, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3135,7 +3135,7 @@ standardConfig static_configs[] = {
     createStringConfig("req-res-logfile", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, EMPTY_STRING_IS_NULL, server.req_res_logfile, NULL, NULL, NULL),
 #endif
     createStringConfig("locale-collate", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.locale_collate, "", NULL, updateLocaleCollate),
-    createStringConfig("debug-context", NULL, MODIFIABLE_CONFIG | DEBUG_CONFIG, ALLOW_EMPTY_STRING, server.debug_context, "", NULL, NULL),
+    createStringConfig("debug-context", NULL, MODIFIABLE_CONFIG | DEBUG_CONFIG | HIDDEN_CONFIG, ALLOW_EMPTY_STRING, server.debug_context, "", NULL, NULL),
 
     /* SDS Configs */
     createSDSConfig("primaryauth", "masterauth", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_auth, NULL, NULL, NULL),

--- a/src/server.h
+++ b/src/server.h
@@ -2219,7 +2219,7 @@ struct valkeyServer {
     sds availability_zone; /* When run in a cloud environment we can configure the availability zone it is running in */
     /* Local environment */
     char *locale_collate;
-    char *debug_context; /* A free-form string that can be used for any purpose. It has no impact on server behavior. */
+    char *debug_context; /* A free-form string that has no impact on server except being included in a crash report. */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -2219,6 +2219,7 @@ struct valkeyServer {
     sds availability_zone; /* When run in a cloud environment we can configure the availability zone it is running in */
     /* Local environment */
     char *locale_collate;
+    char *debug_context; /* A free-form string that can be used by the user for any purpose. It has no impact on server behavior. */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/src/server.h
+++ b/src/server.h
@@ -2219,7 +2219,7 @@ struct valkeyServer {
     sds availability_zone; /* When run in a cloud environment we can configure the availability zone it is running in */
     /* Local environment */
     char *locale_collate;
-    char *debug_context; /* A free-form string that can be used by the user for any purpose. It has no impact on server behavior. */
+    char *debug_context; /* A free-form string that can be used for any purpose. It has no impact on server behavior. */
 };
 
 #define MAX_KEYS_BUFFER 256


### PR DESCRIPTION
A configuration option with zero impact on server operation but is printed out on server crash and can be accessed by gdb for debugging. It can be used by the user/operator to store any free-form string. This string will persist as long as the server is running and will be accessible in the following ways:

Normal config API:
```
$ src/valkey-server --debug-context test
$ src/valkey-cli config get debug-context
1) "debug-context"
2) "test"
$ src/valkey-cli config set debug-context test2
OK
```

Via GDB:
```
$ gdb -batch -ex "file src/valkey-server" -ex "attach $(pgrep valkey-server)" -ex "print server.debug_context" -ex "detach" -ex "quit" | grep " = " | awk -F\" "{print \$2}"
test2
```

And printed in crash reports:
```
------ CONFIG DEBUG OUTPUT ------
lazyfree-lazy-eviction no
...
io-threads-do-reads yes
debug-context "test2"
proto-max-bulk-len 512mb
```