### PR TITLE
Fix crash in active defrag

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -941,6 +941,7 @@ void activeDefragCycle(void) {
             defrag_later_cursor = 0;
             current_db = -1;
             cursor = 0;
+            expires_cursor = 0;
             db = NULL;
             goto update_metrics;
         }


### PR DESCRIPTION
This crash would happen if we disable active defrag while it is running, then re-enable active defrag. In this case the `expires_cursor` variable in `activeDefragCycle()` would not be reset to 0 when disabling active defrag, so when re-enabling it, this variable can still be non-zero, which causes the `db` and other variables to not be initialized before starting the defrag process.

**Why is this PR made against the 7.2 branch?**
This issue was fixed in `unstable` as part of [this commit](https://github.com/valkey-io/valkey/commit/0270abda82555ddb3d4a1f5509600725408226ba#diff-5d1e7cac0f87f2558c5cd612adedea707ebdc59c67ccd94ced70b3ad35e9e99f), but was not backported to 7.2 as the commit contains a lot of other changes (slot specific dictionaries).