### PR TITLE
Add debug assert on duplicate freeClientAsync

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1775,6 +1775,7 @@ void freeClient(client *c) {
 void freeClientAsync(client *c) {
     if (c->flag.close_asap || c->flag.script) return;
     c->flag.close_asap = 1;
+    debugServerAssertWithInfo(c, NULL, listSearchKey(server.clients_to_close, c) == NULL);
     listAddNodeTail(server.clients_to_close, c);
 }
 


### PR DESCRIPTION
When debug assert mode enabled, verify that we don't insert the same client twice into server.clients_to_close.