### PR TITLE
Fix dual-channel replication test

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -717,14 +717,14 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             pause_process $replica_pid
             wait_and_resume_process -1
             $primary debug pause-after-fork 0
-            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 2000 1
+            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
             resume_process $replica_pid
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1]
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
             set loglines [lindex $res 1]
         }
         $replica replicaof no one

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -697,9 +697,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set replica_log [srv 0 stdout]
         set replica_pid  [srv 0 pid]
         
-        set load_handle0 [start_write_load $primary_host $primary_port 20]
-        set load_handle1 [start_write_load $primary_host $primary_port 20]
-        set load_handle2 [start_write_load $primary_host $primary_port 20]
+        set load_handle0 [start_write_load $primary_host $primary_port 60]
+        set load_handle1 [start_write_load $primary_host $primary_port 60]
+        set load_handle2 [start_write_load $primary_host $primary_port 60]
 
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -709,7 +709,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Pause primary main process after fork
             $primary debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 2000 1
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
 
             # At this point rdb is loaded but psync hasn't been established yet. 
             # Pause the replica so the primary main process will wake up while the


### PR DESCRIPTION
`Test dual-channel-replication primary gets cob overrun during replica rdb load` fails during the Valgrind run. This is due to the load handlers disconnecting before the tests complete, resulting in a low primary COB. Increasing the handlers' timeout should resolve this issue.

Failure: https://github.com/valkey-io/valkey/actions/runs/10361286333/job/28681321393

Server logs reveals that the load handler clients were disconnected before the test started

```
### Starting test Test dual-channel-replication primary gets cob overrun during replica rdb load in tests/integration/dual-channel-replication.tcl
83785:M 13 Aug 2024 02:12:21.492 - Accepted 127.0.0.1:44614
83785:M 13 Aug 2024 02:12:22.978 * Replica 127.0.0.1:21989 asks for synchronization
83785:M 13 Aug 2024 02:12:22.978 * Partial resynchronization not accepted: Replication ID mismatch (Replica asked for '253001bfea8f994d5b572de5594a985e715c3f29', my replication IDs are '02fd15619b3cdc137f1d599cf3b1688ad7e56002' and '0000000000000000000000000000000000000000')
83785:M 13 Aug 2024 02:12:22.978 * Replica 127.0.0.1:21989 is capable of dual channel synchronization, and partial sync isn't possible. Full sync will continue with dedicated RDB channel.
83785:M 13 Aug 2024 02:12:23.233 - Accepted 127.0.0.1:44620
**83785:M 13 Aug 2024 02:12:23.501 - Error writing to client: Connection reset by peer**
83785:M 13 Aug 2024 02:12:23.680 * Replica 127.0.0.1:21989 asks for synchronization
83785:M 13 Aug 2024 02:12:23.681 * Starting BGSAVE for SYNC with target: replicas sockets using: dual-channel
83785:M 13 Aug 2024 02:12:23.681 * Sending to replica 127.0.0.1:21989 RDB end offset 2219131 and client-id 12
83785:M 13 Aug 2024 02:12:23.682 . Add rdb replica 127.0.0.1:21989 to waiting psync, with cid 12, tracking repl-backlog tail 
83785:M 13 Aug 2024 02:12:23.687 * Background RDB transfer started by pid 87261 to direct socket to replica
87261:C 13 Aug 2024 02:12:23.747 - Fork CoW for RDB: current 11 MB, peak 11 MB, average 11 MB
**83785:M 13 Aug 2024 02:12:24.059 - Error writing to client: Connection reset by peer**
**83785:M 13 Aug 2024 02:12:24.239 - Error writing to client: Connection reset by peer**
```

Also the two previus test took about 20 seconds which is the handler timeout. 