### PR TITLE
Prevent later accesses to unallocated memory

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -6401,10 +6401,7 @@ static int clusterManagerCheckCluster(int quiet) {
         clusterManagerOnError(err);
         result = 0;
         if (do_fix /* && result*/) {
-            dictType dtype = clusterManagerDictType;
-            dtype.keyDestructor = dictSdsDestructor;
-            dtype.valDestructor = dictListDestructor;
-            clusterManagerUncoveredSlots = dictCreate(&dtype);
+            clusterManagerUncoveredSlots = dictCreate(&clusterManagerLinkDictType);
             int fixed = clusterManagerFixSlotsCoverage(slots);
             if (fixed > 0) result = 1;
         }


### PR DESCRIPTION
A pointer to dtype is stored in the dict forever.
dtype is stack-allocated while the dict created is global.
The dict (and the pointer to dtype in it) will live past the lifetime of dtype.
clusterManagerLinkDictType is a global object that has the same values as dtype.