### PR TITLE
Remove `dual-channel-replication` Feature Flag's Protection

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3074,7 +3074,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush, 0, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
-    createBoolConfig("dual-channel-replication-enabled", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG | PROTECTED_CONFIG, server.dual_channel_replication, 0, NULL, NULL),
+    createBoolConfig("dual-channel-replication-enabled", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.dual_channel_replication, 0, NULL, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("no-appendfsync-on-rewrite", NULL, MODIFIABLE_CONFIG, server.aof_no_fsync_on_rewrite, 0, NULL, NULL),
     createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -199,6 +199,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Toggle dual-channel-replication-enabled: $enable start" {    
                 populate 1000 primary 10000
+                $primary config set rdb-key-save-delay 0
                 set prev_sync_full [s 0 sync_full]
                 set prev_sync_partial [s 0 sync_partial_ok]
 
@@ -250,6 +251,63 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                     assert {$cur_sync_partial == [expr $prev_sync_partial + 1]}
                 }
                 $replica replicaof no one
+            }
+
+            foreach test_instance {primary replica} {
+                $primary config set dual-channel-replication-enabled $enable
+                $replica config set dual-channel-replication-enabled $enable
+                test "Online toggle dual-channel-replication-enabled: $enable start, toggle on $test_instance" {    
+                    populate 1000 primary 10000
+                    $primary config set rdb-key-save-delay 100000   
+
+                    $replica replicaof $primary_host $primary_port
+                    # wait for sync to start
+                    if {$enable == "yes"} {
+                        wait_for_condition 500 1000 {
+                            [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
+                            [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
+                            [s 0 rdb_bgsave_in_progress] eq 1
+                        } else {
+                            fail "replica didn't start sync session in time"
+                        }
+                    } else {
+                        wait_for_condition 500 1000 {
+                            [string match "*slave*,state=wait_bgsave*,type=replica*" [$primary info replication]] &&
+                            [s 0 rdb_bgsave_in_progress] eq 1
+                        } else {
+                            fail "replica didn't start sync session in time"
+                        }
+                    }
+                    # Toggle config
+                    set new_value "yes"
+                    if {$enable == "yes"} {
+                        set new_value "no"
+                    }
+                    set instance $primary
+                    if {$test_instance == "replica"} {
+                        set instnace $replica
+                    }
+                    $instance config set dual-channel-replication-enabled $new_value
+                    # Wait for at least one server cron
+                    after 1
+
+                    if {$enable == "yes"} {
+                        # Verify that dual channel replication sync is still in progress
+                        assert [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]]
+                        assert [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]]
+                        assert {[s 0 rdb_bgsave_in_progress] eq 1}
+                    } else {
+                        # Verify that normal sync is still in progress
+                        assert [string match "*slave*,state=wait_bgsave*,type=replica*" [$primary info replication]]
+                        assert {[s 0 rdb_bgsave_in_progress] eq 1}
+                    }
+                    $replica replicaof no one
+                    wait_for_condition 500 1000 {
+                        [s -1 rdb_bgsave_in_progress] eq 0
+                    } else {
+                        fail "Primary should abort sync"
+                    }
+                }
             }
         }
     }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -256,7 +256,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             foreach test_instance {primary replica} {
                 $primary config set dual-channel-replication-enabled $enable
                 $replica config set dual-channel-replication-enabled $enable
-                test "Online toggle dual-channel-replication-enabled: $enable start, toggle on $test_instance" {    
+                test "Online toggle dual-channel-replication-enabled on $test_instance, starting with '$enable'" {    
                     populate 1000 primary 10000
                     $primary config set rdb-key-save-delay 100000   
 
@@ -268,14 +268,14 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                             [string match "*slave*,state=bg_transfer*,type=main-channel*" [$primary info replication]] &&
                             [s 0 rdb_bgsave_in_progress] eq 1
                         } else {
-                            fail "replica didn't start sync session in time"
+                            fail "replica didn't start a dual-channel sync session in time"
                         }
                     } else {
                         wait_for_condition 500 1000 {
                             [string match "*slave*,state=wait_bgsave*,type=replica*" [$primary info replication]] &&
                             [s 0 rdb_bgsave_in_progress] eq 1
                         } else {
-                            fail "replica didn't start sync session in time"
+                            fail "replica didn't start a normal full sync session in time"
                         }
                     }
                     # Toggle config
@@ -289,7 +289,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                     }
                     $instance config set dual-channel-replication-enabled $new_value
                     # Wait for at least one server cron
-                    after 1
+                    after 1000
 
                     if {$enable == "yes"} {
                         # Verify that dual channel replication sync is still in progress

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -285,7 +285,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                     }
                     set instance $primary
                     if {$test_instance == "replica"} {
-                        set instnace $replica
+                        set instance $replica
                     }
                     $instance config set dual-channel-replication-enabled $new_value
                     # Wait for at least one server cron

--- a/valkey.conf
+++ b/valkey.conf
@@ -687,6 +687,12 @@ repl-diskless-load disabled
 # memory to accommodate the buffer during synchronization. However, this tradeoff is 
 # generally beneficial as it prevents potential performance degradation on the primary 
 # server, which is typically handling more critical operations.
+#
+# Additionally, it's important to note that when toggling this configuration on or off 
+# during an ongoing synchronization process, it does not change the already running 
+# sync method. The new configuration will take effect only for subsequent 
+# synchronization processes.
+
 dual-channel-replication-enabled no
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to

--- a/valkey.conf
+++ b/valkey.conf
@@ -688,10 +688,9 @@ repl-diskless-load disabled
 # generally beneficial as it prevents potential performance degradation on the primary 
 # server, which is typically handling more critical operations.
 #
-# Additionally, it's important to note that when toggling this configuration on or off 
-# during an ongoing synchronization process, it does not change the already running 
-# sync method. The new configuration will take effect only for subsequent 
-# synchronization processes.
+# When toggling this configuration on or off during an ongoing synchronization process,
+# it does not change the already running sync method. The new configuration will take
+# effect only for subsequent synchronization processes.
 
 dual-channel-replication-enabled no
 


### PR DESCRIPTION
Currently, the `dual-channel-replication` feature flag is immutable if `enable-protected-configs` is enabled, which is the default behavior. This PR proposes to make the `dual-channel-replication` flag mutable, allowing it to be changed dynamically without restarting the cluster.

**Motivation:**
The ability to change the `dual-channel-replication` flag dynamically is essential for testing and validating the feature on real clusters running in production environments. By making the flag mutable, we can enable or disable the feature without disrupting the cluster's operations, facilitating easier testing and experimentation. Additionally, this change would provide more flexibility for users to enable or disable the feature based on their specific requirements or operational needs without requiring a cluster restart.