### PR TITLE
Set repl-backlog-size from 1mb to 10mb by default

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3224,7 +3224,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024 * 1024, LONG_MAX, server.proto_max_bulk_len, 512ll * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 1mb */
+    createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 10 * 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 10mb */
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),

--- a/tests/integration/shutdown.tcl
+++ b/tests/integration/shutdown.tcl
@@ -85,8 +85,8 @@ foreach how {sigterm shutdown} {
 }
 
 test {Shutting down master waits for replica timeout} {
-    start_server {overrides {save ""}} {
-        start_server {overrides {save ""}} {
+    start_server {overrides {save "" repl-backlog-size 1MB}} {
+        start_server {overrides {save "" repl-backlog-size 1MB}} {
             set master [srv -1 client]
             set master_host [srv -1 host]
             set master_port [srv -1 port]

--- a/tests/integration/shutdown.tcl
+++ b/tests/integration/shutdown.tcl
@@ -19,8 +19,8 @@ proc fill_up_os_socket_send_buffer_for_repl {idx} {
 
 foreach how {sigterm shutdown} {
     test "Shutting down master waits for replica to catch up ($how)" {
-        start_server {overrides {save ""}} {
-            start_server {overrides {save ""}} {
+        start_server {overrides {save "" repl-backlog-size 1MB}} {
+            start_server {overrides {save "" repl-backlog-size 1MB}} {
                 set master [srv -1 client]
                 set master_host [srv -1 host]
                 set master_port [srv -1 port]

--- a/tests/integration/shutdown.tcl
+++ b/tests/integration/shutdown.tcl
@@ -134,8 +134,8 @@ test {Shutting down master waits for replica timeout} {
 } {} {repl external:skip}
 
 test "Shutting down master waits for replica then fails" {
-    start_server {overrides {save ""}} {
-        start_server {overrides {save ""}} {
+    start_server {overrides {save "" repl-backlog-size 1MB}} {
+        start_server {overrides {save "" repl-backlog-size 1MB}} {
             set master [srv -1 client]
             set master_host [srv -1 host]
             set master_port [srv -1 port]
@@ -193,8 +193,8 @@ test "Shutting down master waits for replica then fails" {
 } {} {repl external:skip}
 
 test "Shutting down master waits for replica then aborted" {
-    start_server {overrides {save ""}} {
-        start_server {overrides {save ""}} {
+    start_server {overrides {save "" repl-backlog-size 1MB}} {
+        start_server {overrides {save "" repl-backlog-size 1MB}} {
             set master [srv -1 client]
             set master_host [srv -1 host]
             set master_port [srv -1 port]

--- a/valkey.conf
+++ b/valkey.conf
@@ -734,7 +734,7 @@ repl-disable-tcp-nodelay no
 #
 # The backlog is only allocated if there is at least one replica connected.
 #
-# repl-backlog-size 1mb
+# repl-backlog-size 10mb
 
 # After a primary has no connected replicas for some time, the backlog will be
 # freed. The following option configures the amount of seconds that need to


### PR DESCRIPTION
The repl-backlog-size 1mb is too small in most cases, now network
transmission and bandwidth performance have improved rapidly in more
than ten years.

The bigger the replication backlog, the longer the replica can endure
the disconnect and later be able to perform a partial resynchronization.

Part of #653.