### PR TITLE
Change all the lazyfree configurations to yes by default

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3071,7 +3071,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-server-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_server_del, 0, NULL, NULL),
     createBoolConfig("lazyfree-lazy-user-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_del, 0, NULL, NULL),
-    createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush, 0, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush, 1, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
     createBoolConfig("dual-channel-replication-enabled", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG | PROTECTED_CONFIG, server.dual_channel_replication, 0, NULL, NULL),
@@ -3083,7 +3083,7 @@ standardConfig static_configs[] = {
     createBoolConfig("aof-use-rdb-preamble", NULL, MODIFIABLE_CONFIG, server.aof_use_rdb_preamble, 1, NULL, NULL),
     createBoolConfig("aof-timestamp-enabled", NULL, MODIFIABLE_CONFIG, server.aof_timestamp_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-replica-no-failover", "cluster-slave-no-failover", MODIFIABLE_CONFIG, server.cluster_replica_no_failover, 0, NULL, updateClusterFlags), /* Failover by default. */
-    createBoolConfig("replica-lazy-flush", "slave-lazy-flush", MODIFIABLE_CONFIG, server.repl_replica_lazy_flush, 0, NULL, NULL),
+    createBoolConfig("replica-lazy-flush", "slave-lazy-flush", MODIFIABLE_CONFIG, server.repl_replica_lazy_flush, 1, NULL, NULL),
     createBoolConfig("replica-serve-stale-data", "slave-serve-stale-data", MODIFIABLE_CONFIG, server.repl_serve_stale_data, 1, NULL, NULL),
     createBoolConfig("replica-read-only", "slave-read-only", DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_replica_ro, 1, NULL, NULL),
     createBoolConfig("replica-ignore-maxmemory", "slave-ignore-maxmemory", MODIFIABLE_CONFIG, server.repl_replica_ignore_maxmemory, 1, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3067,10 +3067,10 @@ standardConfig static_configs[] = {
     createBoolConfig("stop-writes-on-bgsave-error", NULL, MODIFIABLE_CONFIG, server.stop_writes_on_bgsave_err, 1, NULL, NULL),
     createBoolConfig("set-proc-title", NULL, IMMUTABLE_CONFIG, server.set_proc_title, 1, NULL, NULL), /* Should setproctitle be used? */
     createBoolConfig("dynamic-hz", NULL, MODIFIABLE_CONFIG, server.dynamic_hz, 1, NULL, NULL), /* Adapt hz to # of clients.*/
-    createBoolConfig("lazyfree-lazy-eviction", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 0, NULL, NULL),
-    createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 0, NULL, NULL),
-    createBoolConfig("lazyfree-lazy-server-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_server_del, 0, NULL, NULL),
-    createBoolConfig("lazyfree-lazy-user-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_del, 0, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-eviction", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_eviction, 1, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-expire", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_expire, 1, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-server-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_server_del, 1, NULL, NULL),
+    createBoolConfig("lazyfree-lazy-user-del", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_del, 1, NULL, NULL),
     createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush, 1, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -368,7 +368,7 @@ start_server {tags {"expire"}} {
                 {set foo10 bar}
                 {pexpireat foo10 *}
                 {set foo11 bar}
-                {del foo11}
+                {unlink foo11}
                 {set foo12 bar}
                 {pexpireat foo12 *}
                 {set foo13 bar}
@@ -500,7 +500,7 @@ start_server {tags {"expire"}} {
             {set foo3 bar}
             {pexpireat foo3 *}
             {pexpireat foo3 *}
-            {del foo3}
+            {unlink foo3}
             {set foo4 bar}
             {pexpireat foo4 *}
             {pexpireat foo4 *}
@@ -629,7 +629,7 @@ start_server {tags {"expire"}} {
        r ttl foo
     } {-1} {needs:debug}
 
-    test {GETEX propagate as to replica as PERSIST, DEL, or nothing} {
+    test {GETEX propagate as to replica as PERSIST, UNLINK, or nothing} {
         # In the above tests, many keys with random expiration times are set, flush
         # the DBs to avoid active expiry kicking in and messing the replication streams.
         r flushall
@@ -642,7 +642,7 @@ start_server {tags {"expire"}} {
            {select *}
            {set foo bar PXAT *}
            {persist foo}
-           {del foo}
+           {unlink foo}
         }
         close_replication_stream $repl
     } {} {needs:repl}
@@ -784,7 +784,7 @@ start_server {tags {"expire"}} {
 
         assert_replication_stream $repl {
             {select *}
-            {del foo}
+            {unlink foo}
             {set x 1}
         }
         close_replication_stream $repl
@@ -805,8 +805,8 @@ start_server {tags {"expire"}} {
 
         assert_replication_stream $repl {
             {select *}
-            {del foo*}
-            {del foo*}
+            {unlink foo*}
+            {unlink foo*}
         }
         close_replication_stream $repl
         assert_equal [r debug set-active-expire 1] {OK}
@@ -826,8 +826,8 @@ start_server {tags {"expire"}} {
 
         assert_replication_stream $repl {
             {select *}
-            {del foo*}
-            {del foo*}
+            {unlink foo*}
+            {unlink foo*}
         }
         close_replication_stream $repl
         assert_equal [r debug set-active-expire 1] {OK}

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -144,6 +144,7 @@ tags {"needs:debug"} {
 
     test {LATENCY of expire events are correctly collected} {
         r config set latency-monitor-threshold 20
+        r config set lazyfree-lazy-expire no
         r flushdb
         if {$::valgrind} {set count 100000} else {set count 1000000}
         r eval {

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -167,6 +167,7 @@ tags {"needs:debug"} {
         }
 
         r config set latency-monitor-threshold 200
+        r config set lazyfree-lazy-expire yes
     }
 
     test {LATENCY HISTORY / RESET with wrong event name is fine} {

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -548,9 +548,9 @@ start_server {tags {"maxmemory" "external:skip"}} {
             {set asdf1 1}
             {set asdf2 2}
             {set asdf3 3}
-            {del asdf*}
-            {del asdf*}
-            {del asdf*}
+            {unlink asdf*}
+            {unlink asdf*}
+            {unlink asdf*}
             {set asdf4 4}
         }
         close_replication_stream $repl
@@ -584,7 +584,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
             {incr x}
             {incr x}
             {exec}
-            {del x}
+            {unlink x}
         }
         close_replication_stream $repl
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -178,7 +178,7 @@ run_solo {defrag} {
         r config set key-load-delay 0
 
         test "Active defrag eval scripts: $type" {
-            r flushdb
+            r flushdb sync
             r script flush sync
             r config resetstat
             r config set hz 100
@@ -264,7 +264,7 @@ run_solo {defrag} {
         } {OK}
 
         test "Active defrag big keys: $type" {
-            r flushdb
+            r flushdb sync
             r config resetstat
             r config set hz 100
             r config set activedefrag no
@@ -407,7 +407,7 @@ run_solo {defrag} {
         # Skip the following two tests if we are running with IO threads, as the IO threads allocate the command arguments in a different arena. As a result, fragmentation is not as expected.
         if {[r config get io-threads] eq 0} {
         test "Active defrag pubsub: $type" {
-            r flushdb
+            r flushdb sync
             r config resetstat
             r config set hz 100
             r config set activedefrag no
@@ -508,7 +508,7 @@ run_solo {defrag} {
 
         if {$type eq "standalone"} { ;# skip in cluster mode
         test "Active defrag big list: $type" {
-            r flushdb
+            r flushdb sync
             r config resetstat
             r config set hz 100
             r config set activedefrag no
@@ -620,7 +620,7 @@ run_solo {defrag} {
             # kept running and not move any allocation.
             # this test is more consistent on a fresh server with no history
             start_server {tags {"defrag"} overrides {save ""}} {
-                r flushdb
+                r flushdb sync
                 r config resetstat
                 r config set hz 100
                 r config set activedefrag no

--- a/tests/unit/moduleapi/async_rm_call.tcl
+++ b/tests/unit/moduleapi/async_rm_call.tcl
@@ -374,7 +374,7 @@ start_server {tags {"modules"}} {
         #
         # Explanation of the second multi exec block:
         # {lpop l} - pop the value by our blocking command 'blpop_and_set_multiple_keys'
-        # {del string_foo} - lazy expiration of string_foo when 'blpop_and_set_multiple_keys' tries to write to it. 
+        # {unlink string_foo} - lazy expiration of string_foo when 'blpop_and_set_multiple_keys' tries to write to it.
         # {set string_foo 1} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {set string_bar 2} - the action of our blocking command 'blpop_and_set_multiple_keys'
         # {incr expired} - the post notification job, registered after string_foo got expired
@@ -398,7 +398,7 @@ start_server {tags {"modules"}} {
             {lpush l a}
             {multi}
             {lpop l}
-            {del string_foo}
+            {unlink string_foo}
             {set string_foo 1}
             {set string_bar 2}
             {incr expired}

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -210,7 +210,7 @@ start_cluster 2 2 [list config_lines $modules] {
         # the {lpush before_deleted count_dels_{4oi}} is a post notification job registered when 'count_dels_{4oi}' was removed
         assert_replication_stream $repl {
             {multi}
-            {del count_dels_{4oi}}
+            {unlink count_dels_{4oi}}
             {keyspace.incr_dels}
             {lpush before_deleted count_dels_{4oi}}
             {exec}

--- a/tests/unit/moduleapi/postnotifications.tcl
+++ b/tests/unit/moduleapi/postnotifications.tcl
@@ -72,7 +72,7 @@ tags "modules" {
                 {set x 1}
                 {pexpireat x *}
                 {multi}
-                {del x}
+                {unlink x}
                 {lpush before_expired x}
                 {incr expired}
                 {exec}
@@ -96,7 +96,7 @@ tags "modules" {
                 {set x 1}
                 {pexpireat x *}
                 {multi}
-                {del x}
+                {unlink x}
                 {lpush before_expired x}
                 {incr expired}
                 {exec}
@@ -122,7 +122,7 @@ tags "modules" {
                 {pexpireat x *}
                 {multi}
                 {set read_x 1}
-                {del x}
+                {unlink x}
                 {lpush before_expired x}
                 {incr expired}
                 {exec}
@@ -162,7 +162,7 @@ tags "modules" {
                 {select *}
                 {set x 1}
                 {multi}
-                {del x}
+                {unlink x}
                 {lpush before_evicted x}
                 {incr evicted}
                 {exec}

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -112,19 +112,19 @@ tags "modules" {
                         {incr notifications}
                         {incr notifications}
                         {incr testkeyspace:expired}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                         {multi}
                         {incr notifications}
                         {incr notifications}
                         {incr testkeyspace:expired}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                         {multi}
                         {incr notifications}
                         {incr notifications}
                         {incr testkeyspace:expired}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                     }
                     close_replication_stream $repl
@@ -211,15 +211,15 @@ tags "modules" {
                         {exec}
                         {multi}
                         {incr notifications}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                         {multi}
                         {incr notifications}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                         {multi}
                         {incr notifications}
-                        {del asdf*}
+                        {unlink asdf*}
                         {exec}
                         {multi}
                         {incr notifications}
@@ -257,11 +257,11 @@ tags "modules" {
                         {exec}
                         {multi}
                         {incr notifications}
-                        {del timer-maxmemory-volatile-*}
+                        {unlink timer-maxmemory-volatile-*}
                         {exec}
                         {multi}
                         {incr notifications}
-                        {del timer-maxmemory-volatile-*}
+                        {unlink timer-maxmemory-volatile-*}
                         {exec}
                     }
                     close_replication_stream $repl
@@ -588,7 +588,7 @@ tags "modules" {
                     assert_replication_stream $repl {
                         {multi}
                         {select *}
-                        {del k1}
+                        {unlink k1}
                         {propagate-test.incr k1}
                         {exec}
                     }
@@ -619,9 +619,9 @@ tags "modules" {
                         fail "Failed to wait for set to be replicated"
                     }
 
-                    # Currently the `del` command comes after the notification.
+                    # Currently the `unlink` command comes after the notification.
                     # When we fix spop to fire notification at the end (like all other commands),
-                    # the `del` will come first.
+                    # the `unlink` will come first.
                     assert_replication_stream $repl {
                         {multi}
                         {select *}
@@ -631,7 +631,7 @@ tags "modules" {
                         {multi}
                         {incr notifications}
                         {incr notifications}
-                        {del s}
+                        {unlink s}
                         {exec}
                     }
                     close_replication_stream $repl

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1176,7 +1176,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             {swapdb 1 9}
             {select 9}
             {set somekey1 someval1}
-            {del k}
+            {unlink k}
             {select 1}
             {set somekey2 someval2}
         }
@@ -1220,7 +1220,7 @@ foreach {pop} {BLPOP BLMPOP_LEFT} {
             {rpush k hello}
             {pexpireat k *}
             {exec}
-            {del k}
+            {unlink k}
         }
         close_replication_stream $repl
         # Restore server and client state

--- a/valkey.conf
+++ b/valkey.conf
@@ -1279,7 +1279,7 @@ acllog-max-len 128
 lazyfree-lazy-eviction no
 lazyfree-lazy-expire no
 lazyfree-lazy-server-del no
-replica-lazy-flush no
+replica-lazy-flush yes
 
 # It is also possible, for the case when to replace the user code DEL calls
 # with UNLINK calls is not easy, to modify the default behavior of the DEL
@@ -1293,7 +1293,7 @@ lazyfree-lazy-user-del no
 # commands. When neither flag is passed, this directive will be used to determine
 # if the data should be deleted asynchronously.
 
-lazyfree-lazy-user-flush no
+lazyfree-lazy-user-flush yes
 
 ################################ THREADED I/O #################################
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1276,9 +1276,9 @@ acllog-max-len 128
 # in order to instead release memory in a non-blocking way like if UNLINK
 # was called, using the following configuration directives.
 
-lazyfree-lazy-eviction no
-lazyfree-lazy-expire no
-lazyfree-lazy-server-del no
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-server-del yes
 replica-lazy-flush yes
 
 # It is also possible, for the case when to replace the user code DEL calls
@@ -1286,7 +1286,7 @@ replica-lazy-flush yes
 # command to act exactly like UNLINK, using the following configuration
 # directive:
 
-lazyfree-lazy-user-del no
+lazyfree-lazy-user-del yes
 
 # FLUSHDB, FLUSHALL, SCRIPT FLUSH and FUNCTION FLUSH support both asynchronous and synchronous
 # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the

--- a/valkey.conf
+++ b/valkey.conf
@@ -1271,10 +1271,9 @@ acllog-max-len 128
 #    its primary, the content of the whole database is removed in order to
 #    load the RDB file just transferred.
 #
-# In all the above cases the default is to delete objects in a blocking way,
-# like if DEL was called. However you can configure each case specifically
-# in order to instead release memory in a non-blocking way like if UNLINK
-# was called, using the following configuration directives.
+# In all the above cases the old default is to delete objects in a blocking way,
+# like if DEL was called. Now the new default is release memory in a non-blocking
+# way like if UNLINK was called.
 
 lazyfree-lazy-eviction yes
 lazyfree-lazy-expire yes
@@ -1292,6 +1291,10 @@ lazyfree-lazy-user-del yes
 # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
 # commands. When neither flag is passed, this directive will be used to determine
 # if the data should be deleted asynchronously.
+
+# There are many problems with running flush synchronously. Even in single CPU
+# environments, the thread managers should balance between the freeing and
+# serving incoming requests. The default value is yes.
 
 lazyfree-lazy-user-flush yes
 


### PR DESCRIPTION
## Set replica-lazy-flush and lazyfree-lazy-user-flush to yes by default.
There are many problems with running flush synchronously. Even in
single CPU environments, the thread managers should balance between
the freeing and serving incoming requests.

## Set lazy eviction, expire, server-del, user-del to yes by default
We now have a del and a lazyfree del, we also have these configuration
items to control: lazyfree-lazy-eviction, lazyfree-lazy-expire,
lazyfree-lazy-server-del, lazyfree-lazy-user-del. In most cases lazyfree
is better since it reduces the risk of blocking the main thread, and
because we have lazyfreeGetFreeEffort, on those with high effor (currently
64) will use lazyfree.

Part of #653.