### PR TITLE
Introduce new configuration for limiting replica's local replication buffer during dual-channel replication sync

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3243,6 +3243,7 @@ standardConfig static_configs[] = {
     createSizeTConfig("hll-sparse-max-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.hll_sparse_max_bytes, 3000, MEMORY_CONFIG, NULL, NULL),
     createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, INTEGER_CONFIG, NULL, NULL), /* Default: 1 million keys max. */
     createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024 * 1024, LONG_MAX, server.client_max_querybuf_len, 1024 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
+    createSizeTConfig("replicas-dual-channel-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 0, LONG_MAX, server.pending_repl_data.limit_bytes, 1024 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
     createSSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, -100, SSIZE_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG | PERCENT_CONFIG, NULL, applyClientMaxMemoryUsage),
 
     /* Other configs */

--- a/src/replication.c
+++ b/src/replication.c
@@ -2797,7 +2797,7 @@ void bufferReplData(connection *conn) {
             remaining_bytes = readIntoReplDataBlock(conn, tail, remaining_bytes);
         }
         if (readlen && remaining_bytes == 0) {
-            if (server.pending_repl_data.len > server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes) {
+            if (server.pending_repl_data.len > server.pending_repl_data.limit_bytes) {
                 serverLog(LL_NOTICE, "Replication buffer limit reached, stopping buffering.");
                 /* Stop accumulating primary commands. */
                 connSetReadHandler(conn, NULL);

--- a/src/server.h
+++ b/src/server.h
@@ -1118,6 +1118,7 @@ typedef struct replDataBuf {
     list *blocks; /* List of replDataBufBlock */
     size_t len;   /* Number of bytes stored in all blocks */
     size_t peak;
+    size_t limit_bytes; /* Configurable buffer limit */
 } replDataBuf;
 
 typedef struct {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -328,7 +328,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 # We expect that the next full sync will take 100 seconds (10k*10000)ms
                 # It will give us enough time to fill the replica buffer.
                 $replica1 config set dual-channel-replication-enabled yes
-                $replica1 config set client-output-buffer-limit "replica 16383 16383 0"
+                $replica1 config set replicas-dual-channel-buffer-limit "16383"
 
                 $replica1 replicaof $primary_host $primary_port
                 # Wait for replica to establish psync using main channel
@@ -356,7 +356,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             $replica1 replicaof no one
-            $replica1 config set client-output-buffer-limit "replica 256mb 256mb 0"; # remove repl buffer limitation
+            $replica1 config set replicas-dual-channel-buffer-limit [expr {1024 * 1024 * 1024}]; # remove repl buffer limitation
             $primary config set rdb-key-save-delay 0
 
             wait_for_condition 500 1000 {

--- a/valkey.conf
+++ b/valkey.conf
@@ -689,6 +689,13 @@ repl-diskless-load disabled
 # server, which is typically handling more critical operations.
 dual-channel-replication-enabled no
 
+# This configuration option sets the maximum size of the local replication
+# buffer on the replica during dual-channel-replication syncronization.
+# The local replication buffer is used to store data received from the primary
+# during the sync, before it is written to the replica's database.
+#
+# replicas-dual-channel-buffer-limit <bytes>
+
 # Master send PINGs to its replicas in a predefined interval. It's possible to
 # change this interval with the repl_ping_replica_period option. The default
 # value is 10 seconds.


### PR DESCRIPTION
This PR introduces a new configuration option, `replicas-dual-channel-buffer-limit`, to better control the size of the replica's local replication buffer during dual-channel replication sync. This configuration will allow for more precise adjustment of the buffer size, ensuring that the sync process can succeed while optimizing resource usage on the replica.

Motivation:
Currently, during dual-channel replication sync, the replica's local replication buffer size is limited by the `replica's client_obuf_limits` configuration. However, this configuration is not specifically designed for dual-channel replication and may impose unnecessary restrictions on the buffer size, leading to suboptimal performance or even sync failures in certain scenarios.

By introducing a dedicated configuration option for the local replication buffer limit, we can decouple it from the output buffer limit and tailor it specifically for the dual-channel replication sync process. This will enable more accurate estimation and adjustment of the buffer size based on factors such as the total free space on the replica's machine and the estimated snapshot size.

Proposed Changes:
1. Add a new configuration option, `replicas-dual-channel-buffer-limit`, to the Redis configuration file.
2. Modify the dual-channel replication sync process to respect the new configuration option when setting the local replication buffer size on the replica.

Future Enhancements:
In the future, we will be able to enhance the `replicas-dual-channel-buffer-limit` configuration by introducing dynamic adjustment capabilities. This will allow the buffer size to be automatically adjusted based on the total free space on the replica's machine and the estimated snapshot size, further optimizing resource usage and sync performance.