### PR TITLE
Make use of a single listNode pointer for blocking utility lists

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -212,7 +212,6 @@ client *createClient(connection *conn) {
     c->peerid = NULL;
     c->sockname = NULL;
     c->client_list_node = NULL;
-    c->postponed_list_node = NULL;
     c->io_read_state = CLIENT_IDLE;
     c->io_write_state = CLIENT_IDLE;
     c->nwritten = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -1012,7 +1012,7 @@ typedef struct blockingState {
                              is deleted or does not exist anymore */
     union {
         listNode *client_waiting_acks_list_node; /* list node in server.clients_waiting_acks list. */
-        listNode *postponed_list_node;           /* list node within the postponed list */
+        listNode *postponed_list_node;           /* list node in server.postponed_clients */
         listNode *generic_blocked_list_node;     /* generic placeholder for blocked clients utility lists.
                                                     Since a client cannot be blocked multiple times, we can assume
                                                     it will be held in only one extra utility list, so it is O.K maintain a

--- a/src/server.h
+++ b/src/server.h
@@ -1015,8 +1015,8 @@ typedef struct blockingState {
         listNode *postponed_list_node;           /* list node in server.postponed_clients */
         listNode *generic_blocked_list_node;     /* generic placeholder for blocked clients utility lists.
                                                     Since a client cannot be blocked multiple times, we can assume
-                                                    it will be held in only one extra utility list, so it is ok to maintain a
-                                                    union of these listNode references. */
+                                                    it will be held in only one extra utility list, so it is ok to maintain
+                                                    a union of these listNode references. */
     };
 
     /* BLOCKED_LIST, BLOCKED_ZSET and BLOCKED_STREAM or any other Keys related blocking */

--- a/src/server.h
+++ b/src/server.h
@@ -1015,7 +1015,7 @@ typedef struct blockingState {
         listNode *postponed_list_node;           /* list node in server.postponed_clients */
         listNode *generic_blocked_list_node;     /* generic placeholder for blocked clients utility lists.
                                                     Since a client cannot be blocked multiple times, we can assume
-                                                    it will be held in only one extra utility list, so it is O.K maintain a
+                                                    it will be held in only one extra utility list, so it is ok to maintain a
                                                     union of these listNode references. */
     };
 

--- a/src/server.h
+++ b/src/server.h
@@ -1015,17 +1015,17 @@ typedef struct blockingState {
         listNode *postponed_list_node;           /* list node within the postponed list */
         listNode *generic_blocked_list_node;     /* generic placeholder for blocked clients utility lists.
                                                     Since a client cannot be blocked multiple times, we can assume
-                                                    It will be held in only one extra utility list, so it is O.K maintain a union of these 
-                                                    listNode references. */
+                                                    it will be held in only one extra utility list, so it is O.K maintain a
+                                                    union of these listNode references. */
     };
 
     /* BLOCKED_LIST, BLOCKED_ZSET and BLOCKED_STREAM or any other Keys related blocking */
     dict *keys; /* The keys we are blocked on */
 
     /* BLOCKED_WAIT and BLOCKED_WAITAOF */
-    int numreplicas;                         /* Number of replicas we are waiting for ACK. */
-    int numlocal;                            /* Indication if WAITAOF is waiting for local fsync. */
-    long long reploffset;                    /* Replication offset to reach. */
+    int numreplicas;      /* Number of replicas we are waiting for ACK. */
+    int numlocal;         /* Indication if WAITAOF is waiting for local fsync. */
+    long long reploffset; /* Replication offset to reach. */
 
     /* BLOCKED_MODULE */
     void *module_blocked_handle; /* ValkeyModuleBlockedClient structure.

--- a/src/server.h
+++ b/src/server.h
@@ -1010,6 +1010,14 @@ typedef struct blockingState {
                            * is > timeout then the operation timed out. */
     int unblock_on_nokey; /* Whether to unblock the client when at least one of the keys
                              is deleted or does not exist anymore */
+    union {
+        listNode *client_waiting_acks_list_node; /* list node in server.clients_waiting_acks list. */
+        listNode *postponed_list_node;           /* list node within the postponed list */
+        listNode *generic_blocked_list_node;     /* generic placeholder for blocked clients utility lists.
+                                                    Since a client cannot be blocked multiple times, we can assume
+                                                    It will be held in only one extra utility list, so it is O.K maintain a union of these 
+                                                    listNode references. */
+    };
 
     /* BLOCKED_LIST, BLOCKED_ZSET and BLOCKED_STREAM or any other Keys related blocking */
     dict *keys; /* The keys we are blocked on */
@@ -1018,7 +1026,6 @@ typedef struct blockingState {
     int numreplicas;                         /* Number of replicas we are waiting for ACK. */
     int numlocal;                            /* Indication if WAITAOF is waiting for local fsync. */
     long long reploffset;                    /* Replication offset to reach. */
-    listNode *client_waiting_acks_list_node; /* list node in server.clients_waiting_acks list. */
 
     /* BLOCKED_MODULE */
     void *module_blocked_handle; /* ValkeyModuleBlockedClient structure.
@@ -1321,7 +1328,6 @@ typedef struct client {
     sds peerid;                          /* Cached peer ID. */
     sds sockname;                        /* Cached connection target address. */
     listNode *client_list_node;          /* list node in client list */
-    listNode *postponed_list_node;       /* list node within the postponed list */
     void *module_blocked_client;         /* Pointer to the ValkeyModuleBlockedClient associated with this
                                           * client. This is set in case of module authentication before the
                                           * unblocked client is reprocessed to handle reply callbacks. */


### PR DESCRIPTION
Saves some memory (one pointer) in the client struct.

Since a client cannot be blocked multiple times, we can assume
it will be held in only one extra utility list, so it is ok to maintain
a union of these listNode references. 

This is to address [This comment](https://github.com/valkey-io/valkey/pull/787#issuecomment-2267490603) which was left as part of #787.