### PR TITLE
Use sdsAllocSize instead of sdsZmallocSize

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -38,6 +38,7 @@
 #include "cluster.h"
 #include "threads_mngr.h"
 #include "io_threads.h"
+#include "sds.h"
 
 #include <arpa/inet.h>
 #include <signal.h>
@@ -673,7 +674,7 @@ void debugCommand(client *c) {
             addReplyStatusFormat(c,
                                  "key_sds_len:%lld, key_sds_avail:%lld, key_zmalloc: %lld, "
                                  "val_sds_len:%lld, val_sds_avail:%lld, val_zmalloc: %lld",
-                                 (long long)sdslen(key), (long long)sdsavail(key), (long long)sdsZmallocSize(key),
+                                 (long long)sdslen(key), (long long)sdsavail(key), (long long)sdsAllocSize(key),
                                  (long long)sdslen(val->ptr), (long long)sdsavail(val->ptr),
                                  (long long)getStringObjectSdsUsedMemory(val));
         }

--- a/src/eval.c
+++ b/src/eval.c
@@ -42,6 +42,7 @@
 #include "monotonic.h"
 #include "resp_parser.h"
 #include "script_lua.h"
+#include "sds.h"
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -490,7 +491,7 @@ sds luaCreateFunction(client *c, robj *body, int evalsha) {
     l->node = luaScriptsLRUAdd(c, sha, evalsha);
     int retval = dictAdd(lctx.lua_scripts, sha, l);
     serverAssertWithInfo(c ? c : lctx.lua_client, NULL, retval == DICT_OK);
-    lctx.lua_scripts_mem += sdsZmallocSize(sha) + getStringObjectSdsUsedMemory(body);
+    lctx.lua_scripts_mem += sdsAllocSize(sha) + getStringObjectSdsUsedMemory(body);
     incrRefCount(body);
     return sha;
 }
@@ -516,7 +517,7 @@ void luaDeleteFunction(client *c, sds sha) {
     /* We only delete `EVAL` scripts, which must exist in the LRU list. */
     serverAssert(l->node);
     listDelNode(lctx.lua_scripts_lru_list, l->node);
-    lctx.lua_scripts_mem -= sdsZmallocSize(sha) + getStringObjectSdsUsedMemory(l->body);
+    lctx.lua_scripts_mem -= sdsAllocSize(sha) + getStringObjectSdsUsedMemory(l->body);
     dictFreeUnlinkedEntry(lctx.lua_scripts, de);
 }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -114,12 +114,12 @@ static dict *engines = NULL;
 static functionsLibCtx *curr_functions_lib_ctx = NULL;
 
 static size_t functionMallocSize(functionInfo *fi) {
-    return zmalloc_size(fi) + sdsZmallocSize(fi->name) + (fi->desc ? sdsZmallocSize(fi->desc) : 0) +
+    return zmalloc_size(fi) + sdsAllocSize(fi->name) + (fi->desc ? sdsAllocSize(fi->desc) : 0) +
            fi->li->ei->engine->get_function_memory_overhead(fi->function);
 }
 
 static size_t libraryMallocSize(functionLibInfo *li) {
-    return zmalloc_size(li) + sdsZmallocSize(li->name) + sdsZmallocSize(li->code);
+    return zmalloc_size(li) + sdsAllocSize(li->name) + sdsAllocSize(li->code);
 }
 
 static void engineStatsDispose(dict *d, void *obj) {
@@ -417,7 +417,7 @@ int functionsRegisterEngine(const char *engine_name, engine *engine) {
 
     dictAdd(engines, engine_name_sds, ei);
 
-    engine_cache_memory += zmalloc_size(ei) + sdsZmallocSize(ei->name) + zmalloc_size(engine) +
+    engine_cache_memory += zmalloc_size(ei) + sdsAllocSize(ei->name) + zmalloc_size(engine) +
                            engine->get_engine_memory_overhead(engine->engine_ctx);
 
     return C_OK;

--- a/src/object.c
+++ b/src/object.c
@@ -108,7 +108,7 @@ robj *createEmbeddedStringObject(const char *ptr, size_t len) {
     sh->alloc = usable;
     /* Overflow check. Must not happen as we use embedded strings only
      * for sds strings that fit into SDS_TYPE_8. */
-    assert(usable == sh->alloc);
+    serverAssert(usable == sh->alloc);
     sh->flags = SDS_TYPE_8;
     if (ptr == SDS_NOINIT)
         sh->buf[len] = '\0';

--- a/src/object.c
+++ b/src/object.c
@@ -106,7 +106,7 @@ robj *createEmbeddedStringObject(const char *ptr, size_t len) {
     sh->len = len;
     size_t usable = bufsize - (sizeof(robj) + sds_hdrlen + 1);
     sh->alloc = usable;
-    /* Overflow check. Must not happen as we use embedded strings only
+    /* Overflow check. This must not happen as we use embedded strings only
      * for sds strings that fit into SDS_TYPE_8. */
     serverAssert(usable == sh->alloc);
     sh->flags = SDS_TYPE_8;

--- a/src/sds.c
+++ b/src/sds.c
@@ -344,11 +344,7 @@ sds sdsRemoveFreeSpace(sds s, int would_regrow) {
  * if the size is smaller than currently used len, the data will be truncated.
  *
  * The when the would_regrow argument is set to 1, it prevents the use of
- * SDS_TYPE_5, which is desired when the sds is likely to be changed again.
- *
- * The sdsAlloc size will be set to the requested size regardless of the actual
- * allocation size, this is done in order to avoid repeated calls to this
- * function when the caller detects that it has excess space. */
+ * SDS_TYPE_5, which is desired when the sds is likely to be changed again. */
 sds sdsResize(sds s, size_t size, int would_regrow) {
     void *sh, *newsh = NULL;
     char type, oldtype = s[-1] & SDS_TYPE_MASK;

--- a/src/server.c
+++ b/src/server.c
@@ -41,6 +41,7 @@
 #include "threads_mngr.h"
 #include "fmtargs.h"
 #include "io_threads.h"
+#include "sds.h"
 
 #include <time.h>
 #include <signal.h>
@@ -812,7 +813,7 @@ size_t ClientsPeakMemInput[CLIENTS_PEAK_MEM_USAGE_SLOTS] = {0};
 size_t ClientsPeakMemOutput[CLIENTS_PEAK_MEM_USAGE_SLOTS] = {0};
 
 int clientsCronTrackExpansiveClients(client *c, int time_idx) {
-    size_t qb_size = c->querybuf ? sdsZmallocSize(c->querybuf) : 0;
+    size_t qb_size = c->querybuf ? sdsAllocSize(c->querybuf) : 0;
     size_t argv_size = c->argv ? zmalloc_size(c->argv) : 0;
     size_t in_usage = qb_size + c->argv_len_sum + argv_size;
     size_t out_usage = getClientOutputBufferMemoryUsage(c);

--- a/src/server.h
+++ b/src/server.h
@@ -2807,7 +2807,6 @@ void addReplyLoadedModules(client *c);
 void copyReplicaOutputBuffer(client *dst, client *src);
 void addListRangeReply(client *c, robj *o, long start, long end, int reverse);
 void deferredAfterErrorReply(client *c, list *errors);
-size_t sdsZmallocSize(sds s);
 size_t getStringObjectSdsUsedMemory(robj *o);
 void freeClientReplyValue(void *o);
 void *dupClientReplyValue(void *o);


### PR DESCRIPTION
sdsAllocSize returns the correct size without consulting the
allocator. Which is much faster than consulting the allocator.
The only exception is SDS_TYPE_5, for which it has to
consult the allocator.

This PR also sets alloc field correctly for embedded string objects.
It assumes that no allocator would allocate a buffer larger
than `259 + sizeof(robj)` for embedded string. We use embedded strings
for strings up to 44 bytes. If this assumption is wrong, the whole
function would require a rewrite. In general case sds type adjustment
might be needed. Such logic should go to sds.c.