### PR TITLE
Replica flush the old data after RDB file is ok in disk-based replication

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2253,6 +2253,7 @@ void readSyncBulkPayload(connection *conn) {
                 serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding temporary DB in background");
             } else {
                 /* Remove the half-loaded data in case we started with an empty replica. */
+                serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data");
                 emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
             }
 
@@ -2352,6 +2353,7 @@ void readSyncBulkPayload(connection *conn) {
             }
 
             /* If disk-based RDB loading fails, remove the half-loaded dataset. */
+                serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data");
             emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
 
             /* Note that there's no point in restarting the AOF on sync failure,

--- a/src/replication.c
+++ b/src/replication.c
@@ -2353,7 +2353,7 @@ void readSyncBulkPayload(connection *conn) {
             }
 
             /* If disk-based RDB loading fails, remove the half-loaded dataset. */
-                serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data");
+            serverLog(LL_NOTICE, "PRIMARY <-> REPLICA sync: Discarding the half-loaded data");
             emptyData(-1, empty_db_flags, replicationEmptyDbCallback);
 
             /* Note that there's no point in restarting the AOF on sync failure,

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1477,3 +1477,43 @@ start_server {tags {"repl external:skip"}} {
         }
     }
 }
+
+start_server {tags {"repl external:skip"}} {
+    set replica [srv 0 client]
+    $replica set replica_key replica_value
+
+    start_server {} {
+        set primary [srv 0 client]
+        set primary_host [srv 0 host]
+        set primary_port [srv 0 port]
+        $primary set primary_key primary_value
+
+        test {Replica keep the old data if RDB file save fails in disk-based replication} {
+            # Create a folder called 'dump.rdb' to trigger temp-rdb rename failure
+            # and it will cause RDB file save to fail at the rename.
+            set dump_rdb [file join [lindex [$replica config get dir] 1] dump.rdb]
+            if {[file exists $dump_rdb]} { exec rm -f $dump_rdb }
+            exec mkdir -p $dump_rdb
+
+            $replica replicaof $primary_host $primary_port
+
+            # Waiting for the rename to fail.
+            wait_for_log_messages -1 {"*Failed trying to rename the temp DB into dump.rdb*"} 0 100 10
+
+            # Make sure the replica has not completed sync and keep the old data.
+            assert_equal {} [$replica get primary_key]
+            assert_equal {replica_value} [$replica get replica_key]
+
+            # Remove the test folder and make the rename success
+            exec rm -rf $dump_rdb
+            wait_for_condition 500 100 {
+                [$replica get primary_key] == {primary_value} &&
+                [$replica get replica_key] == {}
+            } else {
+                puts [$primary keys *]
+                puts [$replica keys *]
+                fail "Replication failed."
+            }
+        }
+    }
+}

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1498,7 +1498,7 @@ start_server {tags {"repl external:skip"}} {
             $replica replicaof $primary_host $primary_port
 
             # Waiting for the rename to fail.
-            wait_for_log_messages -1 {"*Failed trying to rename the temp DB into dump.rdb*"} 0 100 10
+            wait_for_log_messages -1 {"*Failed trying to rename the temp DB into dump.rdb*"} 0 1000 10
 
             # Make sure the replica has not completed sync and keep the old data.
             assert_equal {} [$replica get primary_key]


### PR DESCRIPTION
Call emptyData right before rdbLoad to prevent errors in the middle
and we drop the replication stream and leaving an empty database.
The real changes is in disk-based part, the rest is just code movement.