### PR TITLE
Make runtest-cluster support --io-threads option

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -20,6 +20,7 @@ set ::verbose 0
 set ::valgrind 0
 set ::tls 0
 set ::tls_module 0
+set ::io_threads 0
 set ::pause_on_error 0
 set ::dont_clean 0
 set ::simulate_error 0
@@ -105,6 +106,11 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             puts $cfg [format "tls-ca-cert-file %s/../../tls/ca.crt" [pwd]]
         } else {
             puts $cfg "port $port"
+        }
+
+        if {$::io_threads} {
+            puts $cfg "io-threads 2"
+            puts $cfg "events-per-io-thread 0"
         }
 
         if {$::log_req_res} {
@@ -297,6 +303,8 @@ proc parse_options {} {
             if {$opt eq {--tls-module}} {
                 set ::tls_module 1
             }
+        } elseif {$opt eq {--io-threads}} {
+            set ::io_threads 1
         } elseif {$opt eq {--config}} {
             set val2 [lindex $::argv [expr $j+2]]
             dict set ::global_config $val $val2
@@ -319,6 +327,7 @@ proc parse_options {} {
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
             puts "--tls-module            Run tests in TLS mode with Valkey module."
+            puts "--io-threads            Run tests with IO threads."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
             puts "--fast-fail             Exit immediately once the first test fails."


### PR DESCRIPTION
In #764, we add a --io-threads mode in test, but forgot
to handle runtest-cluster, they are different framework.

Currently runtest-cluster does not support tags, and we
don't have plan to support it. And currently cluster tests
does not have any io-threads tests, so this PR just align
--io-threads option with #764.