### PR TITLE
Revert repl backlog size back to 1mb for dual channel tests

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -704,6 +704,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
         $replica config set repl-timeout 10
+        $primary config set repl-backlog-size 1mb
 
         test "Test dual-channel-replication primary gets cob overrun before established psync" {
             # Pause primary main process after fork


### PR DESCRIPTION
There is a test that assumes that the backlog will get overrun, but because of the recent changes to the default it no longer fails. It seems like it is a bit flakey now though, so resetting the value in the test back to 1mb. (This relates to the CoB of 1100k. So it should consistently work with a 1mb limit).

See https://github.com/valkey-io/valkey/actions/runs/10511002242/job/29120964645.