### PR TITLE
Test configuration override

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3106,6 +3106,7 @@ standardConfig static_configs[] = {
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),
     createBoolConfig("enable-debug-assert", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
+    createBoolConfig("hide-client-log", NULL, MODIFIABLE_CONFIG, server.hide_client_log, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3106,6 +3106,7 @@ standardConfig static_configs[] = {
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),
     createBoolConfig("enable-debug-assert", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
+    createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),
@@ -3198,7 +3199,6 @@ standardConfig static_configs[] = {
     createIntConfig("watchdog-period", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.watchdog_period, 0, INTEGER_CONFIG, NULL, updateWatchdogPeriod),
     createIntConfig("shutdown-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.shutdown_timeout, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-diskless-sync-max-replicas", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_max_replicas, 0, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, -1, INT_MAX, server.hide_user_data_from_log, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.c
+++ b/src/config.c
@@ -3106,7 +3106,7 @@ standardConfig static_configs[] = {
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),
     createBoolConfig("enable-debug-assert", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
-    createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 0, NULL, NULL),
+    createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3106,7 +3106,6 @@ standardConfig static_configs[] = {
     createBoolConfig("extended-redis-compatibility", NULL, MODIFIABLE_CONFIG, server.extended_redis_compat, 0, NULL, updateExtendedRedisCompat),
     createBoolConfig("enable-debug-assert", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
-    createBoolConfig("hide-client-log", NULL, MODIFIABLE_CONFIG, server.hide_client_log, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),
@@ -3199,6 +3198,7 @@ standardConfig static_configs[] = {
     createIntConfig("watchdog-period", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.watchdog_period, 0, INTEGER_CONFIG, NULL, updateWatchdogPeriod),
     createIntConfig("shutdown-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.shutdown_timeout, 10, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-diskless-sync-max-replicas", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_max_replicas, 0, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, -1, INT_MAX, server.hide_user_data_from_log, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/debug.c
+++ b/src/debug.c
@@ -1052,7 +1052,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (shouldRedactArg(c, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
+            serverLog(LL_WARNING, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
             continue;
         }
         char buf[128];

--- a/src/debug.c
+++ b/src/debug.c
@@ -1872,7 +1872,7 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (canLogClientArg(cc, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, strlen((sds)cc->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)cc->argv[j]->ptr));
             continue;
         }
         robj *decoded;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1031,12 +1031,14 @@ __attribute__((noinline)) void _serverAssert(const char *estr, const char *file,
     bugReportEnd(0, 0);
 }
 
-/* Checks if logging the provided argument is permitted based on the current
- * configuration for hiding user data from logs. */
-int canLogClientArg(const client *c, int idx) {
+/* Checks if the argument at the given index should be redacted from logs. */
+int shouldRedactArg(const client *c, int idx) {
     serverAssert(idx < c->argc);
-    if (server.hide_user_data_from_log < 0) return 1;
-    return idx < server.hide_user_data_from_log;
+    /* Don't redact if the config is disabled */
+    if (!server.hide_user_data_from_log) return 0;
+    /* first_sensitive_arg_idx value should be changed based on the command type. */
+    int first_sensitive_arg_idx = 1;
+    return idx >= first_sensitive_arg_idx;
 }
 
 void _serverAssertPrintClientInfo(const client *c) {
@@ -1049,7 +1051,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
-        if (!canLogClientArg(c, j)) {
+        if (!shouldRedactArg(c, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
             continue;
         }
@@ -1253,7 +1255,7 @@ static void *getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 
 VALKEY_NO_SANITIZE("address")
 void logStackContent(void **sp) {
-    if (server.hide_user_data_from_log > 0) {
+    if (server.hide_user_data_from_log) {
         serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging stack content to avoid spilling PII.");
         return;
     }
@@ -1872,7 +1874,7 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
-        if (!canLogClientArg(cc, j)) {
+        if (!shouldRedactArg(cc, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)cc->argv[j]->ptr));
             continue;
         }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1051,7 +1051,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
-        if (!shouldRedactArg(c, j)) {
+        if (shouldRedactArg(c, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
             continue;
         }
@@ -1874,7 +1874,7 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
-        if (!shouldRedactArg(cc, j)) {
+        if (shouldRedactArg(cc, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)cc->argv[j]->ptr));
             continue;
         }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1031,6 +1031,11 @@ __attribute__((noinline)) void _serverAssert(const char *estr, const char *file,
     bugReportEnd(0, 0);
 }
 
+/* Returns the amount of client's command arguments we allow logging */
+int clientArgsToLog(const client *c) {
+    return server.hide_client_log ? 1 : c->argc;
+}
+
 void _serverAssertPrintClientInfo(const client *c) {
     int j;
     char conninfo[CONN_INFO_LEN];
@@ -1041,6 +1046,10 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
+        if (j >= clientArgsToLog(c)) {
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: *redacted*\n", j);
+            continue;
+        }
         char buf[128];
         char *arg;
 
@@ -1241,6 +1250,10 @@ static void *getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 
 VALKEY_NO_SANITIZE("address")
 void logStackContent(void **sp) {
+    if (server.hide_client_log) {
+        serverLog(LL_NOTICE, "hide-client-log is on, skip logging stack content to avid spilling PII.");
+        return;
+    }
     int i;
     for (i = 15; i >= 0; i--) {
         unsigned long addr = (unsigned long)sp + i;
@@ -1856,6 +1869,10 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
+        if (j >= clientArgsToLog(cc)) {
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: *redacted*\n", j);
+            continue;
+        }
         robj *decoded;
         decoded = getDecodedObject(cc->argv[j]);
         sds repr = sdscatrepr(sdsempty(), decoded->ptr, min(sdslen(decoded->ptr), 128));

--- a/src/debug.c
+++ b/src/debug.c
@@ -1049,7 +1049,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (canLogClientArg(c, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes ", j, strlen((sds)c->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, strlen((sds)c->argv[j]->ptr));
             continue;
         }
         char buf[128];
@@ -1872,7 +1872,7 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (canLogClientArg(cc, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes ", j, strlen((sds)cc->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, strlen((sds)cc->argv[j]->ptr));
             continue;
         }
         robj *decoded;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1031,9 +1031,11 @@ __attribute__((noinline)) void _serverAssert(const char *estr, const char *file,
     bugReportEnd(0, 0);
 }
 
-/* Returns the amount of client's command arguments we allow logging */
-int clientArgsToLog(const client *c) {
-    return server.hide_client_log ? 1 : c->argc;
+/* Checks if logging the provided argument is permitted based on the current
+ * configuration for hiding user data from logs. */
+int canLogClientArg(const client *c, int idx) {
+    serverAssert(idx < c->argc);
+    return idx >= server.hide_user_data_from_log ? 1 : c->argc;
 }
 
 void _serverAssertPrintClientInfo(const client *c) {
@@ -1046,8 +1048,8 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
-        if (j >= clientArgsToLog(c)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: *redacted*\n", j);
+        if (canLogClientArg(c, j)) {
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes", j, strlen(c->argv[j]));
             continue;
         }
         char buf[128];
@@ -1250,8 +1252,8 @@ static void *getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 
 VALKEY_NO_SANITIZE("address")
 void logStackContent(void **sp) {
-    if (server.hide_client_log) {
-        serverLog(LL_NOTICE, "hide-client-log is on, skip logging stack content to avid spilling PII.");
+    if (server.hide_user_data_from_log) {
+        serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging stack content to avoid spilling PII.");
         return;
     }
     int i;
@@ -1869,8 +1871,8 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
-        if (j >= clientArgsToLog(cc)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: *redacted*\n", j);
+        if (canLogClientArg(cc, j)) {
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes", j, strlen(cc->argv[j]));
             continue;
         }
         robj *decoded;

--- a/src/debug.c
+++ b/src/debug.c
@@ -1035,7 +1035,8 @@ __attribute__((noinline)) void _serverAssert(const char *estr, const char *file,
  * configuration for hiding user data from logs. */
 int canLogClientArg(const client *c, int idx) {
     serverAssert(idx < c->argc);
-    return idx >= server.hide_user_data_from_log ? 1 : c->argc;
+    if (server.hide_user_data_from_log < 0) return 1;
+    return idx < server.hide_user_data_from_log;
 }
 
 void _serverAssertPrintClientInfo(const client *c) {
@@ -1048,7 +1049,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
-        if (canLogClientArg(c, j)) {
+        if (!canLogClientArg(c, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, strlen((sds)c->argv[j]->ptr));
             continue;
         }
@@ -1252,7 +1253,7 @@ static void *getAndSetMcontextEip(ucontext_t *uc, void *eip) {
 
 VALKEY_NO_SANITIZE("address")
 void logStackContent(void **sp) {
-    if (server.hide_user_data_from_log) {
+    if (server.hide_user_data_from_log > 0) {
         serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging stack content to avoid spilling PII.");
         return;
     }
@@ -1871,7 +1872,7 @@ void logCurrentClient(client *cc, const char *title) {
     sdsfree(client);
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
-        if (canLogClientArg(cc, j)) {
+        if (!canLogClientArg(cc, j)) {
             serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)cc->argv[j]->ptr));
             continue;
         }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1050,7 +1050,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (!canLogClientArg(c, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, strlen((sds)c->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
             continue;
         }
         char buf[128];

--- a/src/debug.c
+++ b/src/debug.c
@@ -1049,7 +1049,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (canLogClientArg(c, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes", j, strlen(c->argv[j]));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes ", j, strlen((sds)c->argv[j]->ptr));
             continue;
         }
         char buf[128];
@@ -1872,7 +1872,7 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (canLogClientArg(cc, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes", j, strlen(cc->argv[j]));
+            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %lu bytes ", j, strlen((sds)cc->argv[j]->ptr));
             continue;
         }
         robj *decoded;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3276,14 +3276,15 @@ sds catClientInfoString(sds s, client *client) {
         replBufBlock *cur = listNodeValue(client->ref_repl_buf_node);
         used_blocks_of_repl_buf = last->id - cur->id + 1;
     }
-
+    
+    int hide_data = server.hide_user_data_from_log > 0;
     /* clang-format off */
     sds ret = sdscatfmt(s, FMTARGS(
         "id=%U", (unsigned long long) client->id,
         " addr=%s", getClientPeerId(client),
         " laddr=%s", getClientSockname(client),
         " %s", connGetInfo(client->conn, conninfo, sizeof(conninfo)),
-        " name=%s", client->name ? (char*)client->name->ptr : "",
+        " name=%s", hide_data ? "*redacted*" : (client->name ? (char*)client->name->ptr : ""),
         " age=%I", (long long)(commandTimeSnapshot() / 1000 - client->ctime),
         " idle=%I", (long long)(server.unixtime - client->last_interaction),
         " flags=%s", flags,
@@ -3305,7 +3306,7 @@ sds catClientInfoString(sds s, client *client) {
         " tot-mem=%U", (unsigned long long) total_mem,
         " events=%s", events,
         " cmd=%s", client->lastcmd ? client->lastcmd->fullname : "NULL",
-        " user=%s", client->user ? client->user->name : "(superuser)",
+        " user=%s", hide_data ? "*redacted*" : (client->user ? client->user->name : "(superuser)"),
         " redir=%I", (client->flag.tracking) ? (long long) client->client_tracking_redirection : -1,
         " resp=%i", client->resp,
         " lib-name=%s", client->lib_name ? (char*)client->lib_name->ptr : "",

--- a/src/networking.c
+++ b/src/networking.c
@@ -3276,7 +3276,6 @@ sds catClientInfoString(sds s, client *client) {
         replBufBlock *cur = listNodeValue(client->ref_repl_buf_node);
         used_blocks_of_repl_buf = last->id - cur->id + 1;
     }
-    
     /* clang-format off */
     sds ret = sdscatfmt(s, FMTARGS(
         "id=%U", (unsigned long long) client->id,

--- a/src/networking.c
+++ b/src/networking.c
@@ -3277,14 +3277,13 @@ sds catClientInfoString(sds s, client *client) {
         used_blocks_of_repl_buf = last->id - cur->id + 1;
     }
     
-    int hide_data = server.hide_user_data_from_log > 0;
     /* clang-format off */
     sds ret = sdscatfmt(s, FMTARGS(
         "id=%U", (unsigned long long) client->id,
         " addr=%s", getClientPeerId(client),
         " laddr=%s", getClientSockname(client),
         " %s", connGetInfo(client->conn, conninfo, sizeof(conninfo)),
-        " name=%s", hide_data ? "*redacted*" : (client->name ? (char*)client->name->ptr : ""),
+        " name=%s", server.hide_user_data_from_log ? "*redacted*" : (client->name ? (char*)client->name->ptr : ""),
         " age=%I", (long long)(commandTimeSnapshot() / 1000 - client->ctime),
         " idle=%I", (long long)(server.unixtime - client->last_interaction),
         " flags=%s", flags,
@@ -3306,7 +3305,7 @@ sds catClientInfoString(sds s, client *client) {
         " tot-mem=%U", (unsigned long long) total_mem,
         " events=%s", events,
         " cmd=%s", client->lastcmd ? client->lastcmd->fullname : "NULL",
-        " user=%s", hide_data ? "*redacted*" : (client->user ? client->user->name : "(superuser)"),
+        " user=%s", server.hide_user_data_from_log ? "*redacted*" : (client->user ? client->user->name : "(superuser)"),
         " redir=%I", (client->flag.tracking) ? (long long) client->client_tracking_redirection : -1,
         " resp=%i", client->resp,
         " lib-name=%s", client->lib_name ? (char*)client->lib_name->ptr : "",

--- a/src/replication.c
+++ b/src/replication.c
@@ -615,7 +615,7 @@ void showLatestBacklog(void) {
     if (server.repl_backlog == NULL) return;
     if (listLength(server.repl_buffer_blocks) == 0) return;
     if (server.hide_user_data_from_log > 0) {
-        serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling PII.");
+        serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling user data.");
         return;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -615,7 +615,8 @@ void showLatestBacklog(void) {
     if (server.repl_backlog == NULL) return;
     if (listLength(server.repl_buffer_blocks) == 0) return;
     if (server.hide_user_data_from_log) {
-        serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling user data.");
+        serverLog(LL_NOTICE,
+                  "hide-user-data-from-log is on, skip logging backlog content to avoid spilling user data.");
         return;
     }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -614,8 +614,8 @@ void replicationFeedReplicas(int dictid, robj **argv, int argc) {
 void showLatestBacklog(void) {
     if (server.repl_backlog == NULL) return;
     if (listLength(server.repl_buffer_blocks) == 0) return;
-    if (server.hide_client_log) {
-        serverLog(LL_NOTICE, "hide-client-log is on, skip logging backlog content to avid spilling PII.");
+    if (server.hide_user_data_from_log) {
+        serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling PII.");
         return;
     }
 
@@ -649,7 +649,7 @@ void replicationFeedStreamFromPrimaryStream(char *buf, size_t buflen) {
     /* Debugging: this is handy to see the stream sent from primary
      * to replicas. Disabled with if(0). */
     if (0) {
-        if (!server.hide_client_log) {
+        if (server.hide_user_data_from_log < 0) {
             printf("%zu:", buflen);
             for (size_t j = 0; j < buflen; j++) {
                 printf("%c", isprint(buf[j]) ? buf[j] : '.');

--- a/src/replication.c
+++ b/src/replication.c
@@ -614,7 +614,7 @@ void replicationFeedReplicas(int dictid, robj **argv, int argc) {
 void showLatestBacklog(void) {
     if (server.repl_backlog == NULL) return;
     if (listLength(server.repl_buffer_blocks) == 0) return;
-    if (server.hide_user_data_from_log > 0) {
+    if (server.hide_user_data_from_log) {
         serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling user data.");
         return;
     }
@@ -649,7 +649,7 @@ void replicationFeedStreamFromPrimaryStream(char *buf, size_t buflen) {
     /* Debugging: this is handy to see the stream sent from primary
      * to replicas. Disabled with if(0). */
     if (0) {
-        if (server.hide_user_data_from_log < 0) {
+        if (server.hide_user_data_from_log) {
             printf("%zu:", buflen);
             for (size_t j = 0; j < buflen; j++) {
                 printf("%c", isprint(buf[j]) ? buf[j] : '.');

--- a/src/replication.c
+++ b/src/replication.c
@@ -614,7 +614,7 @@ void replicationFeedReplicas(int dictid, robj **argv, int argc) {
 void showLatestBacklog(void) {
     if (server.repl_backlog == NULL) return;
     if (listLength(server.repl_buffer_blocks) == 0) return;
-    if (server.hide_user_data_from_log) {
+    if (server.hide_user_data_from_log > 0) {
         serverLog(LL_NOTICE, "hide-user-data-from-log is on, skip logging backlog content to avoid spilling PII.");
         return;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1850,6 +1850,7 @@ struct valkeyServer {
 
     /* Configuration */
     int verbosity;             /* Loglevel verbosity */
+    int hide_client_log;       /* In the event of an assertion failure, hide command arguments from the operator */
     int maxidletime;           /* Client timeout in seconds */
     int tcpkeepalive;          /* Set SO_KEEPALIVE if non-zero. */
     int active_expire_enabled; /* Can be disabled for testing purposes. */

--- a/src/server.h
+++ b/src/server.h
@@ -1849,13 +1849,13 @@ struct valkeyServer {
     durationStats duration_stats[EL_DURATION_TYPE_NUM];
 
     /* Configuration */
-    int verbosity;             /* Loglevel verbosity */
-    int hide_client_log;       /* In the event of an assertion failure, hide command arguments from the operator */
-    int maxidletime;           /* Client timeout in seconds */
-    int tcpkeepalive;          /* Set SO_KEEPALIVE if non-zero. */
-    int active_expire_enabled; /* Can be disabled for testing purposes. */
-    int active_expire_effort;  /* From 1 (default) to 10, active effort. */
-    int lazy_expire_disabled;  /* If > 0, don't trigger lazy expire */
+    int verbosity;               /* Loglevel verbosity */
+    int hide_user_data_from_log; /* In the event of an assertion failure, hide command arguments from the operator */
+    int maxidletime;             /* Client timeout in seconds */
+    int tcpkeepalive;            /* Set SO_KEEPALIVE if non-zero. */
+    int active_expire_enabled;   /* Can be disabled for testing purposes. */
+    int active_expire_effort;    /* From 1 (default) to 10, active effort. */
+    int lazy_expire_disabled;    /* If > 0, don't trigger lazy expire */
     int active_defrag_enabled;
     int sanitize_dump_payload;    /* Enables deep sanitization for ziplist and listpack in RDB and RESTORE. */
     int skip_checksum_validation; /* Disable checksum validation for RDB and RESTORE payload. */

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -271,6 +271,18 @@ proc cleanup {} {
 proc test_server_main {} {
     if {!$::dont_pre_clean} cleanup
     set tclsh [info nameofexecutable]
+    
+    # Load the test override configuration file
+    set config_file "tests/test_override.conf"
+    set fp [open $config_file r]
+    set config_data [read $fp]
+    close $fp
+    foreach line [split $config_data "\n"] {
+        lappend ::global_overrides {*}$line
+    }
+    # Pass the configuration overrides to the test clients
+    lappend ::argv "--config" {*}$::global_overrides
+
     # Open a listening socket, trying different ports in order to find a
     # non busy one.
     set clientport [find_available_port [expr {$::baseport - 32}] 32]

--- a/tests/test_override.conf
+++ b/tests/test_override.conf
@@ -1,0 +1,1 @@
+hide-user-data-from-log no

--- a/valkey.conf
+++ b/valkey.conf
@@ -389,8 +389,8 @@ always-show-logo no
 # To prevent sensitive user information, such as PII, from being recorded in the 
 # server log file, this feature is enabled by default. If you need to log user 
 # data for debugging or troubleshooting purposes, you can disable this feature
-# by changing the config value to -1.
-hide-user-data-from-log 1
+# by changing the config value to no.
+hide-user-data-from-log yes
 
 # By default, the server modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave

--- a/valkey.conf
+++ b/valkey.conf
@@ -386,10 +386,10 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
-# To prevent sensitive user information, such as PII, from being recorded in the 
-# server log file, this feature is enabled by default. If you need to log user 
-# data for debugging or troubleshooting purposes, you can disable this feature
-# by changing the config value to no.
+# To prevent sensitive user information, such as PII, from being recorded in the
+# server log file, user data is hidden from the log by default. If you need to
+# log user data for debugging or troubleshooting purposes, you can disable this
+# feature by changing the config value to no.
 hide-user-data-from-log yes
 
 # By default, the server modifies the process title (as seen in 'top' and 'ps') to

--- a/valkey.conf
+++ b/valkey.conf
@@ -386,10 +386,11 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
-# To avoid logging personal identifiable information (PII) into server log file,
-# uncomment the following:
-#
-# hide-client-log yes
+# To prevent sensitive user information, such as PII, from being recorded in the 
+# server log file, this feature is enabled by default. If you need to log user 
+# data for debugging or troubleshooting purposes, you can disable this feature
+# by changing the config value to -1.
+hide-user-data-from-log 1
 
 # By default, the server modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave

--- a/valkey.conf
+++ b/valkey.conf
@@ -386,6 +386,11 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo no
 
+# To avoid logging personal identifiable information (PII) into server log file,
+# uncomment the following:
+#
+# hide-client-log yes
+
 # By default, the server modifies the process title (as seen in 'top' and 'ps') to
 # provide some runtime information. It is possible to disable this and leave
 # the process name as executed by setting the following to no.


### PR DESCRIPTION
This pull request introduces the ability to use a configuration override file for the Valkey tcl tests suite. The configuration file allows specifying custom configuration directives that should be applied to the Valkey server instances spawned during the test run.

I built it ontop of **Secure logs: Mask user data**, so #877 should be merged first. 