### PR TITLE
Refactor return and goto statements

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2644,7 +2644,7 @@ static int dualChannelReplHandleAuthReply(connection *conn, char **err) {
     return C_OK;
 }
 
-static int dualChannelReplHandleReplconfReply(connection *conn, char **err) {
+static int dualChannelReplHandleReplconfReply(connection *conn, sds *err) {
     *err = receiveSynchronousResponse(conn);
     if (*err == NULL) {
         serverLog(LL_WARNING, "Primary did not respond to replconf command during SYNC handshake");

--- a/src/replication.c
+++ b/src/replication.c
@@ -2622,7 +2622,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
 
     if (connSetReadHandler(conn, dualChannelFullSyncWithPrimary) == C_ERR) {
         char conninfo[CONN_INFO_LEN];
-        serverLog(LL_WARNING, "Can't create readable event for SYNC: %s (%s)", *err,
+        serverLog(LL_WARNING, "Can't create readable event for SYNC: %s (%s)", strerror(errno),
                   connGetInfo(conn, conninfo, sizeof(conninfo)));
         return C_ERR;
     }
@@ -3315,7 +3315,7 @@ void dualChannelSetupMainConnForPsync(connection *conn) {
     }
 
     if (ret == C_ERR) {
-        serverLog(LL_WARNING, "Aborting dual channel sync. Main channel psync result %d, %s", ret, err);
+        serverLog(LL_WARNING, "Aborting dual channel sync. Main channel psync result %d %s", ret, err ? err : "");
         cancelReplicationHandshake(1);
     }
     sdsfree(err);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3284,8 +3284,6 @@ void dualChannelSetupMainConnForPsync(connection *conn) {
     char *err = NULL;
     int ret;
 
- REPL_STATE_RECEIVE_PING_REPLY && server.repl_state <= REPL_STATE_RECEIVE_PSYNC_REPLY;
-
     switch (server.repl_state) {
     case REPL_STATE_SEND_HANDSHAKE:
         ret = dualChannelReplMainConnSendHandshake(conn, &err);
@@ -3306,7 +3304,8 @@ void dualChannelSetupMainConnForPsync(connection *conn) {
         break;
     case REPL_STATE_RECEIVE_PSYNC_REPLY:
         ret = dualChannelReplMainConnRecvPsyncReply(conn, &err);
-        if (ret == C_OK && server.repl_rdb_channel_state != REPL_DUAL_CHANNEL_STATE_NONE) server.repl_state = REPL_STATE_TRANSFER;
+        if (ret == C_OK && server.repl_rdb_channel_state != REPL_DUAL_CHANNEL_STATE_NONE)
+            server.repl_state = REPL_STATE_TRANSFER;
         /*  In case the RDB is already loaded, the repl_state will be set during establishPrimaryConnection. */
         break;
     default:

--- a/src/server.h
+++ b/src/server.h
@@ -110,6 +110,7 @@ struct hdr_histogram;
 /* Error codes */
 #define C_OK 0
 #define C_ERR -1
+#define C_RETRY -2
 
 /* Static server configuration */
 #define CONFIG_DEFAULT_HZ 10 /* Time interrupt calls/sec. */


### PR DESCRIPTION
Consolidate the cleanup of local variables to a single point within the method, ensuring proper resource management and p
reventing memory leaks or double-free issues.

Previoslly descused here:
- https://github.com/valkey-io/valkey/pull/60#discussion_r1667872633
- https://github.com/valkey-io/valkey/pull/60#discussion_r1668045666