### PR TITLE
Fix invalid escape sequence in utils, minor cleanup in python script 

### DIFF
--- a/utils/generate-unit-test-header.py
+++ b/utils/generate-unit-test-header.py
@@ -4,7 +4,7 @@ import re
 
 UNIT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + '/../src/unit')
 TEST_FILE = UNIT_DIR + '/test_files.h'
-TEST_PROTOTYPE = '(int (test_[a-zA-Z0-9_]*)\(.*\)).*{'
+TEST_PROTOTYPE = r'(int (test_[a-zA-Z0-9_]*)\(.*\)).*{'
 
 if __name__ == '__main__':
     with open(TEST_FILE, 'w') as output:


### PR DESCRIPTION
According to the Python document[1], any invalid escape sequences in string literals now generate a DeprecationWarning (SyntaxWarning as of 3.12) and in the future this will become a SyntaxError.

This Change uses Python’s raw string notation for regular expression patterns to avoid it.

[1]: https://docs.python.org/3.10/library/re.html