### PR TITLE
Connection minor fixes

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -203,9 +203,7 @@ static int connSocketAccept(connection *conn, ConnectionCallbackFunc accept_hand
     if (conn->state != CONN_STATE_ACCEPTING) return C_ERR;
     conn->state = CONN_STATE_CONNECTED;
 
-    connIncrRefs(conn);
     if (!callHandler(conn, accept_handler)) ret = C_ERR;
-    connDecrRefs(conn);
 
     return ret;
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -570,7 +570,7 @@ static int updateStateAfterSSLIO(tls_connection *conn, int ret_value, int update
         } else {
             if (ssl_err == SSL_ERROR_ZERO_RETURN || ((ssl_err == SSL_ERROR_SYSCALL && !errno))) {
                 conn->c.state = CONN_STATE_CLOSED;
-                return -1;
+                return 0;
             } else {
                 conn->c.state = CONN_STATE_ERROR;
                 return -1;


### PR DESCRIPTION
1. Remove redundant connIncrRefs/connDecrRefs

    In socket.c, the reference counter is incremented before calling callHandler, but the same reference counter is also incremented inside callHandler before calling the actual callback.

        static inline int callHandler(connection *conn, ConnectionCallbackFunc handler) {
            connIncrRefs(conn);
            if (handler) handler(conn);
            connDecrRefs(conn);
            ...
        }

    This commit removes the redundant incr/decr calls in socket.c

2. Correct return value of connRead for TLS when peer closed

    According to comments in connection.h, connRead returns 0 when the peer has closed the connection. This patch corrects the return value for TLS connections. (Without this patch, it returns -1 which means error.)

    There is an observable difference in what is logged in the verbose level: "Client closed connection" vs "Reading from client: (null)".