### PR TITLE
Directly store score as double in the dict of zset.

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1893,7 +1893,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
 
         while ((de = dictNext(di)) != NULL) {
             sds ele = dictGetKey(de);
-            double *score = dictGetVal(de);
+            double score = dictGetDoubleVal(de);
 
             if (count == 0) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
@@ -1904,7 +1904,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                     return 0;
                 }
             }
-            if (!rioWriteBulkDouble(r, *score) || !rioWriteBulkString(r, ele, sdslen(ele))) {
+            if (!rioWriteBulkDouble(r, score) || !rioWriteBulkString(r, ele, sdslen(ele))) {
                 dictReleaseIterator(di);
                 return 0;
             }

--- a/src/db.c
+++ b/src/db.c
@@ -922,7 +922,7 @@ void scanCallback(void *privdata, const dictEntry *de) {
         key = sdsdup(keysds);
         if (!data->only_keys) {
             char buf[MAX_LONG_DOUBLE_CHARS];
-            int len = ld2string(buf, sizeof(buf), *(double *)dictGetVal(de), LD_STR_AUTO);
+            int len = ld2string(buf, sizeof(buf), dictGetDoubleVal(de), LD_STR_AUTO);
             val = sdsnewlen(buf, len);
         }
     } else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -208,8 +208,8 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
 
             while ((de = dictNext(di)) != NULL) {
                 sds sdsele = dictGetKey(de);
-                double *score = dictGetVal(de);
-                const int len = fpconv_dtoa(*score, buf);
+                double score = dictGetDoubleVal(de);
+                const int len = fpconv_dtoa(score, buf);
                 buf[len] = '\0';
                 memset(eledigest, 0, 20);
                 mixDigest(eledigest, sdsele, sdslen(sdsele));

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -237,7 +237,7 @@ void zslUpdateNode(zskiplist *zsl, zskiplistNode *oldnode, zskiplistNode *newnod
  * only need to defrag the skiplist, but not update the obj pointer.
  * When return value is non-NULL, it is the score reference that must be updated
  * in the dict record. */
-double *zslDefrag(zskiplist *zsl, double score, sds oldele, sds newele) {
+void zslDefrag(zskiplist *zsl, double score, sds oldele, sds newele) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x, *newx;
     int i;
     sds ele = newele ? newele : oldele;
@@ -264,22 +264,16 @@ double *zslDefrag(zskiplist *zsl, double score, sds oldele, sds newele) {
     newx = activeDefragAlloc(x);
     if (newx) {
         zslUpdateNode(zsl, x, newx, update);
-        return &newx->score;
     }
-    return NULL;
 }
 
 /* Defrag helper for sorted set.
  * Defrag a single dict entry key name, and corresponding skiplist struct */
 void activeDefragZsetEntry(zset *zs, dictEntry *de) {
     sds newsds;
-    double *newscore;
     sds sdsele = dictGetKey(de);
     if ((newsds = activeDefragSds(sdsele))) dictSetKey(zs->dict, de, newsds);
-    newscore = zslDefrag(zs->zsl, *(double *)dictGetVal(de), sdsele, newsds);
-    if (newscore) {
-        dictSetVal(zs->dict, de, newscore);
-    }
+    zslDefrag(zs->zsl, dictGetDoubleVal(de), sdsele, newsds);
 }
 
 #define DEFRAG_SDS_DICT_NO_VAL 0

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -231,12 +231,10 @@ void zslUpdateNode(zskiplist *zsl, zskiplistNode *oldnode, zskiplistNode *newnod
 }
 
 /* Defrag helper for sorted set.
- * Update the robj pointer, defrag the skiplist struct and return the new score
- * reference. We may not access oldele pointer (not even the pointer stored in
- * the skiplist), as it was already freed. Newele may be null, in which case we
- * only need to defrag the skiplist, but not update the obj pointer.
- * When return value is non-NULL, it is the score reference that must be updated
- * in the dict record. */
+ * Update the robj pointer and defrag the skiplist struct. We may not access oldele
+ * pointer (not even the pointer stored in the skiplist), as it was already freed.
+ * Newele may be null, in which case we only need to defrag the skiplist,
+ * but not update the obj pointer. */
 void zslDefrag(zskiplist *zsl, double score, sds oldele, sds newele) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x, *newx;
     int i;

--- a/src/geo.c
+++ b/src/geo.c
@@ -765,7 +765,6 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         }
 
         for (i = 0; i < returned_items; i++) {
-            zskiplistNode *znode;
             geoPoint *gp = ga->array + i;
             gp->dist /= shape.conversion; /* Fix according to unit. */
             double score = storedist ? gp->dist : gp->score;
@@ -773,8 +772,10 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
             if (maxelelen < elelen) maxelelen = elelen;
             totelelen += elelen;
-            znode = zslInsert(zs->zsl, score, gp->member);
-            serverAssert(dictAdd(zs->dict, gp->member, &znode->score) == DICT_OK);
+            zslInsert(zs->zsl, score, gp->member);
+            dictEntry *entry = dictAddRaw(zs->dict, gp->member, NULL);
+            serverAssert(entry != NULL);
+            dictSetDoubleVal(entry, score);
             gp->member = NULL;
         }
 

--- a/src/module.c
+++ b/src/module.c
@@ -11007,8 +11007,8 @@ static void moduleScanKeyCallback(void *privdata, const dictEntry *de) {
         sds val = dictGetVal(de);
         value = createStringObject(val, sdslen(val));
     } else if (o->type == OBJ_ZSET) {
-        double *val = (double *)dictGetVal(de);
-        value = createStringObjectFromLongDouble(*val, 0);
+        double val = dictGetDoubleVal(de);
+        value = createStringObjectFromLongDouble(val, 0);
     }
 
     data->fn(data->key, field, value, data->user_data);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2007,7 +2007,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
         while (zsetlen--) {
             sds sdsele;
             double score;
-            zskiplistNode *znode;
 
             if ((sdsele = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL)) == NULL) {
                 decrRefCount(o);
@@ -2039,13 +2038,15 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             if (sdslen(sdsele) > maxelelen) maxelelen = sdslen(sdsele);
             totelelen += sdslen(sdsele);
 
-            znode = zslInsert(zs->zsl, score, sdsele);
-            if (dictAdd(zs->dict, sdsele, &znode->score) != DICT_OK) {
+            zslInsert(zs->zsl, score, sdsele);
+            dictEntry *entry = dictAddRaw(zs->dict, sdsele, NULL);
+            if (entry == NULL) {
                 rdbReportCorruptRDB("Duplicate zset fields detected");
                 decrRefCount(o);
                 /* no need to free 'sdsele', will be released by zslFree together with 'o' */
                 return NULL;
             }
+            dictSetDoubleVal(entry, score);
         }
 
         /* Convert *after* loading, since sorted sets are not stored ordered. */


### PR DESCRIPTION
In the past, we used `void *` for dict to store the score of elements in zset. This mean we had to dereference the score ervey time we accesse it. For example, `*(double *)dictGetVal(de)`. This added extra dereference overhead, and for `zunion[store]` command, value of dict has been set twice. like this :

```
else if (op == SET_OP_UNION) {
    ...
    dictSetDoubleVal(de, score);
    ...
    dictSetVal(dstzset->dict, de, &znode->score);
    ...
}
``` 
Since double field has been add in dictEntry value union by [commit](https://github.com/redis/redis/commit/d1cb6a0fc40a63238e3090c5ac5c6334a4a1af1f), and for zset, the value stored in dict will always be double type, we can directly store score as double, which can improves the code's readability and reduces extra dereferencing overhead.