### PR TITLE
free client's multi state when it becomes dirty

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -105,7 +105,13 @@ void discardTransaction(client *c) {
 /* Flag the transaction as DIRTY_EXEC so that EXEC will fail.
  * Should be called every time there is an error while queueing a command. */
 void flagTransaction(client *c) {
-    if (c->flag.multi) c->flag.dirty_exec = 1;
+    if (c->flag.multi) {
+        c->flag.dirty_exec = 1;
+        if (c->mstate.commands) {
+            freeClientMultiState(c);
+            initClientMultiState(c);
+        }
+    }
 }
 
 void multiCommand(client *c) {
@@ -391,6 +397,10 @@ void touchWatchedKey(serverDb *db, robj *key) {
         }
 
         c->flag.dirty_cas = 1;
+        if (c->mstate.commands) {
+            freeClientMultiState(c);
+            initClientMultiState(c);
+        }
         /* As the client is marked as dirty, there is no point in getting here
          * again in case that key (or others) are modified again (or keep the
          * memory overhead till EXEC). */
@@ -442,6 +452,10 @@ void touchAllWatchedKeysInDb(serverDb *emptied, serverDb *replaced_with) {
                 }
                 client *c = wk->client;
                 c->flag.dirty_cas = 1;
+                if (c->mstate.commands) {
+                    freeClientMultiState(c);
+                    initClientMultiState(c);
+                }
                 /* Note - we could potentially call unwatchAllKeys for this specific client in order to reduce
                  * the total number of iterations. BUT this could also free the current next entry pointer
                  * held by the iterator and can lead to use-after-free. */


### PR DESCRIPTION
Release the client's MULTI state when the transaction becomes dirty to save memory.