### PR TITLE
Add command "Client Capa subv2" to change behavior for SUBSCRIBE and SSUBSCRIBE commands: one call with only one response

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4037,6 +4037,8 @@ void clientCommand(client *c) {
         for (int i = 2; i < c->argc; i++) {
             if (!strcasecmp(c->argv[i]->ptr, "redirect")) {
                 c->capa |= CLIENT_CAPA_REDIRECT;
+            } else if (!strcasecmp(c->argv[i]->ptr, "subv2")) {
+                c->capa |= CLIENT_CAPA_SUBV2;
             }
         }
         addReply(c, shared.ok);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -551,6 +551,8 @@ void subscribeCommand(client *c) {
         return;
     }
 
+    struct ClientFlags old_flags = c->flag;
+    c->flag.pushing = 1;
     int number = (c->argc-1) * 3;
     
     if (c->resp == 2)
@@ -561,10 +563,6 @@ void subscribeCommand(client *c) {
     for (j = 1; j < c->argc; j++) { 
         pubsubSubscribeChannel(c, c->argv[j], pubSubType);
     }
-
-
-    struct ClientFlags old_flags = c->flag;
-    c->flag.pushing = 1;
 
     for (j = 1; j < c->argc; j++) { 
         addReply(c, *pubSubType.subscribeMsg);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -279,14 +279,11 @@ void pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
             clients = dictCreate(&clientDictType);
             kvstoreDictSetVal(*type.serverPubSubChannels, slot, de, clients);
             incrRefCount(channel);
-            serverLog(LL_WARNING, "The channel count is %d", type.subscriptionCount(c));
         }
 
         serverAssert(dictAdd(clients, c, NULL) != DICT_ERR);
         serverAssert(dictInsertAtPosition(type.clientPubSubChannels(c), channel, position));
         incrRefCount(channel);
-        serverLog(LL_WARNING, "The channel count is %d", type.subscriptionCount(c));
-	
     }
 }
 

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -550,8 +550,8 @@ void subscribeCommand(client *c) {
 
     struct ClientFlags old_flags = c->flag;
     c->flag.pushing = 1;
-    int number = (c->argc-1) * 3;
-    
+    int number = (c->argc - 1) * 3;
+
     if (c->resp == 2)
         addReply(c, shared.mbulkhdr[number]);
     else

--- a/src/server.h
+++ b/src/server.h
@@ -343,6 +343,7 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
 
 /* Client capabilities */
 #define CLIENT_CAPA_REDIRECT (1 << 0) /* Indicate that the client can handle redirection */
+#define CLIENT_CAPA_SUBV2 (1 << 1)    /* Indicate that the client can handle pubsub v2 version */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2296,7 +2296,6 @@ static void cliWaitForMessagesOrStdin(void) {
 }
 
 static int cliSendCommand(int argc, char **argv, long repeat) {
-    printf("We are in the cliSendCommand function, argc is %d, and repeat is %ld\n", argc, repeat);
     char *command = argv[0];
     size_t *argvlen;
     int j, output_raw;
@@ -2391,7 +2390,6 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         }
 
         /* Read response, possibly skipping pubsub/push messages. */
-	printf("is_subscribe is %d and num_expected_pubsub_push is %d\n",is_subscribe, num_expected_pubsub_push);
         while (1) {
             if (cliReadReply(output_raw) != REDIS_OK) {
                 zfree(argvlen);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2375,7 +2375,6 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
              * an in-band message is received, but these commands are confirmed
              * using push replies only. There is one push reply per channel if
              * channels are specified, otherwise at least one. */
-            //num_expected_pubsub_push = argc > 1 ? argc - 1 : 1;
             num_expected_pubsub_push = 1;
             /* Unset our default PUSH handler so this works in RESP2/RESP3 */
             redisSetPushCallback(context, NULL);
@@ -2402,7 +2401,6 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                         /* This pushed message confirms the
                          * [p|s][un]subscribe command. */
                         if (is_subscribe && !config.pubsub_mode) {
-			    printf("--------- We assign config.pubsub_mode = 1\n");
                             config.pubsub_mode = 1;
                             cliRefreshPrompt();
                         }

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2296,6 +2296,7 @@ static void cliWaitForMessagesOrStdin(void) {
 }
 
 static int cliSendCommand(int argc, char **argv, long repeat) {
+    printf("We are in the cliSendCommand function, argc is %d, and repeat is %ld\n", argc, repeat);
     char *command = argv[0];
     size_t *argvlen;
     int j, output_raw;
@@ -2375,7 +2376,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
              * an in-band message is received, but these commands are confirmed
              * using push replies only. There is one push reply per channel if
              * channels are specified, otherwise at least one. */
-            num_expected_pubsub_push = argc > 1 ? argc - 1 : 1;
+            //num_expected_pubsub_push = argc > 1 ? argc - 1 : 1;
+            num_expected_pubsub_push = 1;
             /* Unset our default PUSH handler so this works in RESP2/RESP3 */
             redisSetPushCallback(context, NULL);
         }
@@ -2389,6 +2391,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         }
 
         /* Read response, possibly skipping pubsub/push messages. */
+	printf("is_subscribe is %d and num_expected_pubsub_push is %d\n",is_subscribe, num_expected_pubsub_push);
         while (1) {
             if (cliReadReply(output_raw) != REDIS_OK) {
                 zfree(argvlen);
@@ -2401,6 +2404,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                         /* This pushed message confirms the
                          * [p|s][un]subscribe command. */
                         if (is_subscribe && !config.pubsub_mode) {
+			    printf("--------- We assign config.pubsub_mode = 1\n");
                             config.pubsub_mode = 1;
                             cliRefreshPrompt();
                         }

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -272,6 +272,7 @@ static struct config {
     char *test_hint_file;
     int prefer_ipv4; /* Prefer IPv4 over IPv6 on DNS lookup. */
     int prefer_ipv6; /* Prefer IPv6 over IPv4 on DNS lookup. */
+    int pubsub_version;
 } config;
 
 /* User preferences. */
@@ -2345,6 +2346,15 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         config.output = OUTPUT_RAW;
     }
 
+    if (!strcasecmp(command, "client") && argc >= 3 && !strcasecmp(argv[1], "capa")) {
+        for (int index = 2; index < argc; index++) {
+            if (!strcasecmp(argv[index], "subv2")) {
+                config.pubsub_version = 2;
+                break;
+            }
+        }
+    }
+
     /* Setup argument length */
     argvlen = zmalloc(argc * sizeof(size_t));
     for (j = 0; j < argc; j++) argvlen[j] = sdslen(argv[j]);
@@ -2375,7 +2385,11 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
              * an in-band message is received, but these commands are confirmed
              * using push replies only. There is one push reply per channel if
              * channels are specified, otherwise at least one. */
-            num_expected_pubsub_push = 1;
+            if (config.pubsub_version == 2) {
+                num_expected_pubsub_push = 1;
+            } else {
+                num_expected_pubsub_push = argc > 1 ? argc - 1 : 1;
+            }
             /* Unset our default PUSH handler so this works in RESP2/RESP3 */
             redisSetPushCallback(context, NULL);
         }
@@ -9535,6 +9549,7 @@ int main(int argc, char **argv) {
     config.server_version = NULL;
     config.prefer_ipv4 = 0;
     config.prefer_ipv6 = 0;
+    config.pubsub_version = 1;
     config.cluster_manager_command.name = NULL;
     config.cluster_manager_command.argc = 0;
     config.cluster_manager_command.argv = NULL;

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -204,8 +204,8 @@ start_server {tags {"cli"}} {
 
         # Subscribe to some channels.
         set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
-        set sub2 "1) \"subscribe\"\n2) \"ch2\"\n3) (integer) 2\n"
-        set sub3 "1) \"subscribe\"\n2) \"ch3\"\n3) (integer) 3\n"
+        set sub2 "4) \"subscribe\"\n5) \"ch2\"\n6) (integer) 2\n"
+        set sub3 "7) \"subscribe\"\n8) \"ch3\"\n9) (integer) 3\n"
         assert_equal $sub1$sub2$sub3$reading \
             [run_command $fd "subscribe ch1 ch2 ch3"]
 

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -204,11 +204,13 @@ start_server {tags {"cli"}} {
 
         # Subscribe to some channels.
         set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
-        set sub2 "4) \"subscribe\"\n5) \"ch2\"\n6) (integer) 2\n"
-        set sub3 "7) \"subscribe\"\n8) \"ch3\"\n9) (integer) 3\n"
+	set sub2 "1) \"subscribe\"\n2) \"ch2\"\n3) (integer) 2\n"
+        set sub3 "1) \"subscribe\"\n2) \"ch3\"\n3) (integer) 3\n"
         assert_equal $sub1$sub2$sub3$reading \
             [run_command $fd "subscribe ch1 ch2 ch3"]
 
+        # set sub2 "4) \"subscribe\"\n5) \"ch2\"\n6) (integer) 2\n"
+        # set sub3 "7) \"subscribe\"\n8) \"ch3\"\n9) (integer) 3\n"
         # Receive pubsub message.
         r publish ch2 hello
         set message "1) \"message\"\n2) \"ch2\"\n3) \"hello\"\n"
@@ -239,6 +241,10 @@ start_server {tags {"cli"}} {
         set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
         assert_equal $sub1$reading \
             [run_command $fd "subscribe ch1"]
+    }
+
+    test_interactive_cli "Subscribed mode" {
+        	    
     }
 
     test_interactive_nontty_cli "Subscribed mode" {

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -194,8 +194,8 @@ start_server {tags {"cli"}} {
         assert_equal "bar" [r get key]
     }
 
-    test_interactive_cli "Subscribed mode" {
-        if {$::force_resp3} {
+    test_interactive_cli "Subscribed mode -- deprecated" {
+	if {$::force_resp3} {
             run_command $fd "hello 3"
         }
 
@@ -204,13 +204,37 @@ start_server {tags {"cli"}} {
 
         # Subscribe to some channels.
         set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
-	set sub2 "1) \"subscribe\"\n2) \"ch2\"\n3) (integer) 2\n"
+        set sub2 "1) \"subscribe\"\n2) \"ch2\"\n3) (integer) 2\n"
         set sub3 "1) \"subscribe\"\n2) \"ch3\"\n3) (integer) 3\n"
         assert_equal $sub1$sub2$sub3$reading \
             [run_command $fd "subscribe ch1 ch2 ch3"]
 
-        # set sub2 "4) \"subscribe\"\n5) \"ch2\"\n6) (integer) 2\n"
-        # set sub3 "7) \"subscribe\"\n8) \"ch3\"\n9) (integer) 3\n"
+        # Unsubscribe all.
+        set unsub1 "1) \"unsubscribe\"\n2) \"ch1\"\n3) (integer) 2\n"
+        set unsub2 "1) \"unsubscribe\"\n2) \"ch2\"\n3) (integer) 1\n"
+        set unsub3 "1) \"unsubscribe\"\n2) \"ch3\"\n3) (integer) 0\n"
+        assert_equal $erase$unsub1$unsub2$unsub3$reading \
+            [run_command $fd "unsubscribe ch1 ch2 ch3"]
+
+    }
+
+    test_interactive_cli "Subscribed mode" {
+        if {$::force_resp3} {
+            run_command $fd "hello 3"
+        }
+
+        set reading "Reading messages... (press Ctrl-C to quit or any key to type command)\r"
+        set erase "\033\[K"; # Erases the "Reading messages..." line.
+
+        run_command $fd "client capa subv2"
+
+        # Subscribe to some channels.
+        set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
+        set sub2 "4) \"subscribe\"\n5) \"ch2\"\n6) (integer) 2\n"
+        set sub3 "7) \"subscribe\"\n8) \"ch3\"\n9) (integer) 3\n"
+        assert_equal $sub1$sub2$sub3$reading \
+            [run_command $fd "subscribe ch1 ch2 ch3"]
+
         # Receive pubsub message.
         r publish ch2 hello
         set message "1) \"message\"\n2) \"ch2\"\n3) \"hello\"\n"
@@ -241,10 +265,6 @@ start_server {tags {"cli"}} {
         set sub1 "1) \"subscribe\"\n2) \"ch1\"\n3) (integer) 1\n"
         assert_equal $sub1$reading \
             [run_command $fd "subscribe ch1"]
-    }
-
-    test_interactive_cli "Subscribed mode" {
-        	    
     }
 
     test_interactive_nontty_cli "Subscribed mode" {

--- a/tests/unit/cluster/pubsubshard.tcl
+++ b/tests/unit/cluster/pubsubshard.tcl
@@ -59,8 +59,10 @@ test "sunsubscribe without specifying any channel would unsubscribe all shard ch
     set publishclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
 
-    set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
-    assert_equal [list 1 2 3] $sub_res
+    assert_equal {1} [ssubscribe $subscribeclient {"\{channel.0\}1"}]				
+    assert_equal {2} [ssubscribe $subscribeclient {"\{channel.0\}2"}]				
+    assert_equal {3} [ssubscribe $subscribeclient {"\{channel.0\}3"}]				
+
     sunsubscribe $subscribeclient
     
     # wait for the unsubscribe to take effect

--- a/tests/unit/cluster/pubsubshard.tcl
+++ b/tests/unit/cluster/pubsubshard.tcl
@@ -59,9 +59,6 @@ test "sunsubscribe without specifying any channel would unsubscribe all shard ch
     set publishclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
 
-    # assert_equal {1} [ssubscribe $subscribeclient {"\{channel.0\}1"}]				
-    # assert_equal {2} [ssubscribe $subscribeclient {"\{channel.0\}2"}]				
-    # assert_equal {3} [ssubscribe $subscribeclient {"\{channel.0\}3"}]				
     set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
     assert_equal [list 1 2 3] $sub_res
 

--- a/tests/unit/cluster/pubsubshard.tcl
+++ b/tests/unit/cluster/pubsubshard.tcl
@@ -59,9 +59,11 @@ test "sunsubscribe without specifying any channel would unsubscribe all shard ch
     set publishclient [valkey_client_by_addr $publishnode(host) $publishnode(port)]
     set subscribeclient [valkey_deferring_client_by_addr $publishnode(host) $publishnode(port)]
 
-    assert_equal {1} [ssubscribe $subscribeclient {"\{channel.0\}1"}]				
-    assert_equal {2} [ssubscribe $subscribeclient {"\{channel.0\}2"}]				
-    assert_equal {3} [ssubscribe $subscribeclient {"\{channel.0\}3"}]				
+    # assert_equal {1} [ssubscribe $subscribeclient {"\{channel.0\}1"}]				
+    # assert_equal {2} [ssubscribe $subscribeclient {"\{channel.0\}2"}]				
+    # assert_equal {3} [ssubscribe $subscribeclient {"\{channel.0\}3"}]				
+    set sub_res [ssubscribe $subscribeclient [list "\{channel.0\}1" "\{channel.0\}2" "\{channel.0\}3"]]
+    assert_equal [list 1 2 3] $sub_res
 
     sunsubscribe $subscribeclient
     

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -45,7 +45,9 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two channels
-        assert_equal {1 2} [subscribe $rd1 {chan1 chan2}]
+        # assert_equal {1 2} [subscribe $rd1 {chan1 chan2}]
+        assert_equal {1} [subscribe $rd1 {chan1}]
+        assert_equal {2} [subscribe $rd1 {chan2}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal 1 [r publish chan2 world]
         assert_equal {message chan1 hello} [$rd1 read]
@@ -83,7 +85,10 @@ start_server {tags {"pubsub network"}} {
 
     test "PUBLISH/SUBSCRIBE after UNSUBSCRIBE without arguments" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
+        # assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
+        assert_equal {1} [subscribe $rd1 {chan1}]
+        assert_equal {2} [subscribe $rd1 {chan2}]
+        assert_equal {3} [subscribe $rd1 {chan3}]
         unsubscribe $rd1
         # wait for the unsubscribe to take effect
         wait_for_condition 50 100 {
@@ -101,7 +106,23 @@ start_server {tags {"pubsub network"}} {
 
     test "SUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
+        assert_equal {1} [subscribe $rd1 {chan1}]
+        assert_equal {2} [subscribe $rd1 {chan2}]
+        assert_equal {3} [subscribe $rd1 {chan3}]
+        #assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
+        assert_equal 1 [r publish chan1 hello]
+        assert_equal {message chan1 hello} [$rd1 read]
+
+        # clean up clients
+        $rd1 close
+    }
+
+    test "SUBSCRIBE to one channel more than once" {
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [subscribe $rd1 {chan1}]
+        assert_equal {2} [subscribe $rd1 {chan2}]
+        assert_equal {3} [subscribe $rd1 {chan3}]
+        #assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal {message chan1 hello} [$rd1 read]
 
@@ -123,7 +144,9 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two patterns
-        assert_equal {1 2} [psubscribe $rd1 {foo.* bar.*}]
+        # assert_equal {1 2} [psubscribe $rd1 {foo.* bar.*}]
+        assert_equal {1} [psubscribe $rd1 {foo.*}]
+        assert_equal {2} [psubscribe $rd1 {bar.*}]
         assert_equal 1 [r publish foo.1 hello]
         assert_equal 1 [r publish bar.1 hello]
         assert_equal 0 [r publish foo1 hello]
@@ -479,13 +502,12 @@ start_server {tags {"pubsub network"}} {
         r hello 3
 
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,
-        # breaks the multi response, see Redis OSS issue: https://github.com/redis/redis/issues/12207
-        # this is just a temporary sanity test to detect unintended breakage.
+        # Only one response is returned 
+	# This update matches with Redis response: one command always returns one response
 
-        # subscribe for 3 channels actually emits 3 "responses"
-        assert_equal "subscribe foo 1" [r subscribe foo bar baz]
-        assert_equal "subscribe bar 2" [r read]
-        assert_equal "subscribe baz 3" [r read]
+        assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
+        # assert_equal "subscribe bar 2" [r read]
+        # assert_equal "subscribe baz 3" [r read]
 
         r multi
         r ping abc

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -45,7 +45,6 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two channels
-        # assert_equal {1 2} [subscribe $rd1 {chan1 chan2}]
         assert_equal {1} [subscribe $rd1 {chan1}]
         assert_equal {2} [subscribe $rd1 {chan2}]
         assert_equal 1 [r publish chan1 hello]
@@ -85,7 +84,6 @@ start_server {tags {"pubsub network"}} {
 
     test "PUBLISH/SUBSCRIBE after UNSUBSCRIBE without arguments" {
         set rd1 [valkey_deferring_client]
-        # assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
         assert_equal {1} [subscribe $rd1 {chan1}]
         assert_equal {2} [subscribe $rd1 {chan2}]
         assert_equal {3} [subscribe $rd1 {chan3}]
@@ -109,20 +107,6 @@ start_server {tags {"pubsub network"}} {
         assert_equal {1} [subscribe $rd1 {chan1}]
         assert_equal {2} [subscribe $rd1 {chan2}]
         assert_equal {3} [subscribe $rd1 {chan3}]
-        #assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
-        assert_equal 1 [r publish chan1 hello]
-        assert_equal {message chan1 hello} [$rd1 read]
-
-        # clean up clients
-        $rd1 close
-    }
-
-    test "SUBSCRIBE to one channel more than once" {
-        set rd1 [valkey_deferring_client]
-        assert_equal {1} [subscribe $rd1 {chan1}]
-        assert_equal {2} [subscribe $rd1 {chan2}]
-        assert_equal {3} [subscribe $rd1 {chan3}]
-        #assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal {message chan1 hello} [$rd1 read]
 
@@ -504,10 +488,7 @@ start_server {tags {"pubsub network"}} {
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,
         # Only one response is returned 
 	# This update matches with Redis response: one command always returns one response
-
         assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
-        # assert_equal "subscribe bar 2" [r read]
-        # assert_equal "subscribe baz 3" [r read]
 
         r multi
         r ping abc

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -45,8 +45,9 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two channels
-        assert_equal {1} [subscribe $rd1 {chan1}]
-        assert_equal {2} [subscribe $rd1 {chan2}]
+        #assert_equal {1} [subscribe $rd1 {chan1}]
+        #assert_equal {2} [subscribe $rd1 {chan2}]
+	assert_equal {1 2} [subscribe $rd1 {chan1 chan2}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal 1 [r publish chan2 world]
         assert_equal {message chan1 hello} [$rd1 read]
@@ -84,9 +85,10 @@ start_server {tags {"pubsub network"}} {
 
     test "PUBLISH/SUBSCRIBE after UNSUBSCRIBE without arguments" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1} [subscribe $rd1 {chan1}]
-        assert_equal {2} [subscribe $rd1 {chan2}]
-        assert_equal {3} [subscribe $rd1 {chan3}]
+        #assert_equal {1} [subscribe $rd1 {chan1}]
+        #assert_equal {2} [subscribe $rd1 {chan2}]
+        #assert_equal {3} [subscribe $rd1 {chan3}]
+	assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
         unsubscribe $rd1
         # wait for the unsubscribe to take effect
         wait_for_condition 50 100 {
@@ -104,9 +106,10 @@ start_server {tags {"pubsub network"}} {
 
     test "SUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1} [subscribe $rd1 {chan1}]
-        assert_equal {2} [subscribe $rd1 {chan2}]
-        assert_equal {3} [subscribe $rd1 {chan3}]
+        #assert_equal {1} [subscribe $rd1 {chan1}]
+        #assert_equal {2} [subscribe $rd1 {chan2}]
+        #assert_equal {3} [subscribe $rd1 {chan3}] 
+	assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal {message chan1 hello} [$rd1 read]
 
@@ -128,9 +131,9 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two patterns
-        # assert_equal {1 2} [psubscribe $rd1 {foo.* bar.*}]
-        assert_equal {1} [psubscribe $rd1 {foo.*}]
-        assert_equal {2} [psubscribe $rd1 {bar.*}]
+        assert_equal {1 2} [psubscribe $rd1 {foo.* bar.*}]
+        #assert_equal {1} [psubscribe $rd1 {foo.*}]
+        #assert_equal {2} [psubscribe $rd1 {bar.*}]
         assert_equal 1 [r publish foo.1 hello]
         assert_equal 1 [r publish bar.1 hello]
         assert_equal 0 [r publish foo1 hello]
@@ -488,7 +491,10 @@ start_server {tags {"pubsub network"}} {
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,
         # Only one response is returned 
 	# This update matches with Redis response: one command always returns one response
-        assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
+        #assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
+	assert_equal "subscribe foo 1" [r subscribe foo bar baz]
+        assert_equal "subscribe bar 2" [r read]
+        assert_equal "subscribe baz 3" [r read]
 
         r multi
         r ping abc

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -45,8 +45,6 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
 
         # subscribe to two channels
-        #assert_equal {1} [subscribe $rd1 {chan1}]
-        #assert_equal {2} [subscribe $rd1 {chan2}]
 	assert_equal {1 2} [subscribe $rd1 {chan1 chan2}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal 1 [r publish chan2 world]
@@ -85,9 +83,6 @@ start_server {tags {"pubsub network"}} {
 
     test "PUBLISH/SUBSCRIBE after UNSUBSCRIBE without arguments" {
         set rd1 [valkey_deferring_client]
-        #assert_equal {1} [subscribe $rd1 {chan1}]
-        #assert_equal {2} [subscribe $rd1 {chan2}]
-        #assert_equal {3} [subscribe $rd1 {chan3}]
 	assert_equal {1 2 3} [subscribe $rd1 {chan1 chan2 chan3}]
         unsubscribe $rd1
         # wait for the unsubscribe to take effect
@@ -106,9 +101,6 @@ start_server {tags {"pubsub network"}} {
 
     test "SUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        #assert_equal {1} [subscribe $rd1 {chan1}]
-        #assert_equal {2} [subscribe $rd1 {chan2}]
-        #assert_equal {3} [subscribe $rd1 {chan3}] 
 	assert_equal {1 1 1} [subscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r publish chan1 hello]
         assert_equal {message chan1 hello} [$rd1 read]
@@ -132,8 +124,6 @@ start_server {tags {"pubsub network"}} {
 
         # subscribe to two patterns
         assert_equal {1 2} [psubscribe $rd1 {foo.* bar.*}]
-        #assert_equal {1} [psubscribe $rd1 {foo.*}]
-        #assert_equal {2} [psubscribe $rd1 {bar.*}]
         assert_equal 1 [r publish foo.1 hello]
         assert_equal 1 [r publish bar.1 hello]
         assert_equal 0 [r publish foo1 hello]
@@ -491,10 +481,8 @@ start_server {tags {"pubsub network"}} {
         # Note: SUBSCRIBE and UNSUBSCRIBE with multiple channels in the same command,
         # Only one response is returned 
 	# This update matches with Redis response: one command always returns one response
-        #assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
-	assert_equal "subscribe foo 1" [r subscribe foo bar baz]
-        assert_equal "subscribe bar 2" [r read]
-        assert_equal "subscribe baz 3" [r read]
+	r client capa subv2
+	assert_equal "subscribe foo 1 subscribe bar 2 subscribe baz 3" [r subscribe foo bar baz]
 
         r multi
         r ping abc

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -64,7 +64,10 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SSUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1 1 1} [ssubscribe $rd1 {chan1 chan1 chan1}]
+        #assert_equal {1 1 1} [ssubscribe $rd1 {chan1 chan1 chan1}]
+        assert_equal {1} [ssubscribe $rd1 {chan1}]
+        assert_equal {1} [ssubscribe $rd1 {chan1}]
+        assert_equal {1} [ssubscribe $rd1 {chan1}]
         assert_equal 1 [r SPUBLISH chan1 hello]
         assert_equal {smessage chan1 hello} [$rd1 read]
 

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -64,7 +64,6 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SSUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        #assert_equal {1 1 1} [ssubscribe $rd1 {chan1 chan1 chan1}]
         assert_equal {1} [ssubscribe $rd1 {chan1}]
         assert_equal {1} [ssubscribe $rd1 {chan1}]
         assert_equal {1} [ssubscribe $rd1 {chan1}]

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -64,9 +64,6 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SSUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        #assert_equal {1} [ssubscribe $rd1 {chan1}]
-        #assert_equal {1} [ssubscribe $rd1 {chan1}]
-        #assert_equal {1} [ssubscribe $rd1 {chan1}]
 	assert_equal {1 1 1} [ssubscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r SPUBLISH chan1 hello]
         assert_equal {smessage chan1 hello} [$rd1 read]

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -64,9 +64,10 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SSUBSCRIBE to one channel more than once" {
         set rd1 [valkey_deferring_client]
-        assert_equal {1} [ssubscribe $rd1 {chan1}]
-        assert_equal {1} [ssubscribe $rd1 {chan1}]
-        assert_equal {1} [ssubscribe $rd1 {chan1}]
+        #assert_equal {1} [ssubscribe $rd1 {chan1}]
+        #assert_equal {1} [ssubscribe $rd1 {chan1}]
+        #assert_equal {1} [ssubscribe $rd1 {chan1}]
+	assert_equal {1 1 1} [ssubscribe $rd1 {chan1 chan1 chan1}]
         assert_equal 1 [r SPUBLISH chan1 hello]
         assert_equal {smessage chan1 hello} [$rd1 read]
 


### PR DESCRIPTION
Now for the command SUBSCRIBE and SSUBSCRIBE, if any client call with multiply channels, multiply responses come back.

![image](https://github.com/user-attachments/assets/4ac31af8-766f-4df2-8e1f-00b335db489e)

It does not match with the Valkey command response logic, it causes client side to parse the response with extra effort on them. The problem exists long time.

Thus, to fix this design error, I add a **new command parameter:  client capa subv2** 
**The command "client capa" is imported in Valkey 8, and I add a new parameter "subv2" for it 
Note: subv2 is just a temporarily name, I have no idea which name is better, welcome any suggestion.**

The update behavior  as below:  one call with one response

![image](https://github.com/user-attachments/assets/9f09e442-2c02-471a-beb4-23c155c67132)

Note: for existing users, I think this is a break change. If any client chooses the behavior that one call with one response, the command "client capa subv2" can be called first.

