### PR TITLE
Fix cluster replica unable to establish replication link in race condition

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2275,6 +2275,23 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
                 node->tls_port = msg_tls_port;
                 node->cport = ntohs(g->cport);
                 node->flags &= ~CLUSTER_NODE_NOADDR;
+
+                serverLog(LL_NOTICE, "Address updated for node %.40s (%s), now %s:%d", node->name, node->human_nodename,
+                          node->ip, getNodeDefaultClientPort(node));
+
+                /* Check if this is our primary and we have to change the
+                 * replication target as well.
+                 *
+                 * This is needed in case the check in nodeUpdateAddressIfNeeded
+                 * failed due to a race condition. For example, if the replica just
+                 * received a packet from another node that contains new address
+                 * about the primary, we will update primary node address in here,
+                 * when the replica receive the packet from the primary, the check
+                 * in nodeUpdateAddressIfNeeded will fail since the address has been
+                 * updated correctly, and we will not have the opportunity to call
+                 * replicationSetPrimary and update the primary host. */
+                if (nodeIsReplica(myself) && myself->replicaof == node)
+                    replicationSetPrimary(node->ip, getNodeDefaultReplicationPort(node), 0);
             }
         } else if (!node) {
             /* If it's not in NOADDR state and we don't have it, we


### PR DESCRIPTION
In d00b8af89265c501fb4a0cdd546702b90432a896, we fixed the bug that the
replica may set the primary host to '?'. Normally, we will correct '?'
to the correct IP when processing the next packet from primary, because
we will call nodeUpdateAddressIfNeeded when processing the packet.
```
int clusterProcessPacket(clusterLink *link) {
    ...
    /* Update the node address if it changed. */
    if (sender && type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender) &&
        nodeUpdateAddressIfNeeded(sender, link, hdr)) {
        clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
    }
    ...
}
```

But there is a race will casue it to be unable to correct the primary host,
see the associated issue for more details about the race.

Simply put, if the replica just received a packet from another node that
contains new address about the primary, we will update primary node address
in here (the code i touched), when the replica receives the packet from
the primary, the check in nodeUpdateAddressIfNeeded will fail since the
address has been updated correctly, and we will not have the opportunity
to call replicationSetPrimary and update the primary host.

In places where the node address may be updated, we need to add this
replicationSetPrimary check to avoid this race.