### PR TITLE
Fix timing issue in replica migration test

### DIFF
--- a/tests/unit/cluster/manual-takeover.tcl
+++ b/tests/unit/cluster/manual-takeover.tcl
@@ -79,6 +79,9 @@ test "Instance #0, #1, #2 gets converted into a slaves" {
     wait_for_condition 1000 50 {
         [s 0 role] eq {slave} && [s -1 role] eq {slave} && [s -2 role] eq {slave}
     } else {
+        puts "s 0 role: [s 0 role]"
+        puts "s -1 role: [s -1 role]"
+        puts "s -2 role: [s -2 role]"
         fail "Old masters not converted into slaves"
     }
 }

--- a/tests/unit/cluster/manual-takeover.tcl
+++ b/tests/unit/cluster/manual-takeover.tcl
@@ -79,9 +79,6 @@ test "Instance #0, #1, #2 gets converted into a slaves" {
     wait_for_condition 1000 50 {
         [s 0 role] eq {slave} && [s -1 role] eq {slave} && [s -2 role] eq {slave}
     } else {
-        puts "s 0 role: [s 0 role]"
-        puts "s -1 role: [s -1 role]"
-        puts "s -2 role: [s -2 role]"
         fail "Old masters not converted into slaves"
     }
 }

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -339,11 +339,6 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
         R 3 config set cluster-allow-replica-migration no
         R 7 config set cluster-allow-replica-migration yes
 
-        # Record the current primary node, server 7 will be migrated later.
-        set old_role_response [R 7 role]
-        set old_primary_ip [lindex [R 7 role] 1]
-        set old_primary_port [lindex [R 7 role] 2]
-
         # Move slot 0 from primary 3 to primary 0.
         set addr "[srv 0 host]:[srv 0 port]"
         set myid [R 3 CLUSTER MYID]
@@ -354,26 +349,14 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"
         }
 
-        # Wait for server 7 role response to change.
+        # Make sure server 3 lost its replica (server 7) and server 7 becomes a replica of primary 0.
         wait_for_condition 1000 50 {
-            [R 7 role] ne $old_role_response
+            [s -3 connected_slaves] eq 0 &&
+            [get_my_primary_peer 7] eq $addr
         } else {
             puts "R 3 role: [R 3 role]"
             puts "R 7 role: [R 7 role]"
-            fail "Server 7 role response has not changed"
+            fail "Server 3 and 7 role response has not changed"
         }
-
-        wait_for_cluster_propagation
-        wait_for_cluster_state "ok"
-
-        # Make sure server 3 is still a primary and has no replicas.
-        assert_equal [s -3 role] {master}
-        assert_equal [lindex [R 3 role] 2] {}
-
-        # And server 7 becomes a replica of another primary.
-        set new_primary_ip [lindex [R 7 role] 1]
-        set new_primary_port [lindex [R 7 role] 2]
-        assert_equal [s -7 role] {slave}
-        assert_not_equal "$old_primary_ip:$old_primary_port" "new_primary_ip:new_primary_port"
     }
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -351,7 +351,9 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
         # Make sure server 3 lost its replica (server 7) and server 7 becomes a replica of primary 0.
         wait_for_condition 1000 50 {
+            [s -3 role] eq {master} &&
             [s -3 connected_slaves] eq 0 &&
+            [s -7 role] eq {slave} &&
             [get_my_primary_peer 7] eq $addr
         } else {
             puts "R 3 role: [R 3 role]"


### PR DESCRIPTION
The reason is the server 3 still have the server 7 as its replica
due to a short wait, the wait is not enough, we should wait for
server loss its replica.
```
*** [err]: valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT
Expected '{127.0.0.1 21497 267}' to be equal to '' (context: type eval line 34 cmd {assert_equal [lindex [R 3 role] 2] {}} proc ::test)
```