### PR TITLE
Fix replica unable trigger migration when it received CLUSTER SETSLOT in advance

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6405,7 +6405,7 @@ void clusterCommandSetSlot(client *c) {
                       "as a replica of %.40s (%s) in shard %.40s",
                       n->name, n->human_nodename, n->shard_id);
             /* `c` is the primary client if `myself` is a replica, prevent it
-             * from being freed by clusterSetPrimary.
+             * from being freed by clusterSetPrimary. */
             if (nodeIsReplica(myself)) protectClient(c);
             /* We are migrating to a different shard that has a completely different
              * replication history, so a full sync is required. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6405,7 +6405,7 @@ void clusterCommandSetSlot(client *c) {
                       "as a replica of %.40s (%s) in shard %.40s",
                       n->name, n->human_nodename, n->shard_id);
             /* `c` is the primary client if `myself` is a replica, prevent it
-             * from being freed by clusterSetPrimary. No need to unprotect it
+             * from being freed by clusterSetPrimary.
              * since we will free it soon. */
             if (nodeIsReplica(myself)) protectClient(c);
             /* We are migrating to a different shard that has a completely different

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6406,7 +6406,6 @@ void clusterCommandSetSlot(client *c) {
                       n->name, n->human_nodename, n->shard_id);
             /* `c` is the primary client if `myself` is a replica, prevent it
              * from being freed by clusterSetPrimary.
-             * since we will free it soon. */
             if (nodeIsReplica(myself)) protectClient(c);
             /* We are migrating to a different shard that has a completely different
              * replication history, so a full sync is required. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6202,6 +6202,8 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
         return 0;
     }
 
+    if (nodeIsReplica(myself)) serverAssert(c == server.primary);
+
     if ((slot = getSlotOrReply(c, c->argv[2])) == -1) return 0;
 
     if (!strcasecmp(c->argv[3]->ptr, "migrating") && c->argc >= 5) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6391,40 +6391,26 @@ void clusterCommandSetSlot(client *c) {
         }
 
         clusterNode *my_primary = clusterNodeGetPrimary(myself);
-        int slot_was_mine = server.cluster->slots[slot] == myself;
-        int slot_was_my_primary = server.cluster->slots[slot] == my_primary;
+        int slot_was_mine = server.cluster->slots[slot] == my_primary;
         clusterDelSlot(slot);
         clusterAddSlot(n, slot);
 
-        /* If we are a primary left without slots, we should turn into a
-         * replica of the new primary. */
-        if (slot_was_mine && n != myself && myself->numslots == 0 && server.cluster_allow_replica_migration) {
+        /* If replica migration is allowed, check if the primary of this shard
+         * loses its last slot and the shard becomes empty. In this case, we
+         * should turn into a replica of the new primary. */
+        if (server.cluster_allow_replica_migration && slot_was_mine && my_primary->numslots == 0) {
+            serverAssert(n != my_primary);
             serverLog(LL_NOTICE,
                       "Lost my last slot during slot migration. Reconfiguring myself "
                       "as a replica of %.40s (%s) in shard %.40s",
                       n->name, n->human_nodename, n->shard_id);
+            /* `c` is the primary client if `myself` is a replica, prevent it
+             * from being freed by clusterSetPrimary. No need to unprotect it
+             * since we will free it soon. */
+            if (nodeIsReplica(myself)) protectClient(c);
             /* We are migrating to a different shard that has a completely different
              * replication history, so a full sync is required. */
             clusterSetPrimary(n, 1, 1);
-            clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
-        }
-
-        /* If we are a replica and executing the CLUSTER SETSLOT command from
-         * my primary, and my primary left without slots, we should turn into a
-         * replica of the new primary. */
-        if (nodeIsReplica(myself) && slot_was_my_primary && my_primary->numslots == 0 &&
-            server.cluster_allow_replica_migration) {
-            serverLog(LL_NOTICE,
-                      "Lost my last slot during slot migration. Reconfiguring myself "
-                      "as a replica of %.40s (%s) in shard %.40s",
-                      n->name, n->human_nodename, n->shard_id);
-            /* We are a replica and the client is actually my primary, the following
-             * clusterSetPrimary will free the client so we need to protect it. */
-            protectClient(c);
-            /* We are migrating to a different shard that has a completely different
-             * replication history, so a full sync is required. */
-            clusterSetPrimary(n, 1, 1);
-            unprotectClient(c);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
         }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6411,6 +6411,7 @@ void clusterCommandSetSlot(client *c) {
             /* We are migrating to a different shard that has a completely different
              * replication history, so a full sync is required. */
             clusterSetPrimary(n, 1, 1);
+            if (nodeIsReplica(myself)) unprotectClient(c);
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
         }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6405,7 +6405,8 @@ void clusterCommandSetSlot(client *c) {
         /* If we are a replica and executing the CLUSTER SETSLOT command from
          * my primary, and my primary left without slots, we should turn into a
          * replica of the new primary. */
-        if (nodeIsReplica(myself) && slot_was_my_primary && my_primary->numslots == 0 && server.cluster_allow_replica_migration) {
+        if (nodeIsReplica(myself) && slot_was_my_primary && my_primary->numslots == 0 &&
+            server.cluster_allow_replica_migration) {
             serverLog(LL_NOTICE,
                       "Lost my last slot during slot migration. Reconfiguring myself "
                       "as a replica of %.40s (%s) in shard %.40s",

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6202,7 +6202,8 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
         return 0;
     }
 
-    if (nodeIsReplica(myself)) serverAssert(c == server.primary);
+    /* If 'myself' is a replica, 'c' must be the primary client. */
+    serverAssert(!nodeIsReplica(myself) || c == server.primary);
 
     if ((slot = getSlotOrReply(c, c->argv[2])) == -1) return 0;
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -1671,7 +1671,7 @@ void freeClient(client *c) {
      * some unexpected state, by checking its flags. */
     if (server.primary && c->flag.primary) {
         serverLog(LL_NOTICE, "Connection with primary lost.");
-        if (!(c->flag.protocol_error || c->flag.blocked)) {
+        if (!c->flag.dont_cache_primary && !(c->flag.protocol_error || c->flag.blocked)) {
             c->flag.close_asap = 0;
             c->flag.close_after_reply = 0;
             replicationCachePrimary(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2560,7 +2560,7 @@ void freeSharedQueryBuf(void) {
  *
  * * DEBUG RELOAD and similar.
  * * When a Lua script is in -BUSY state.
- * * A cluster replica doing CLUSTER SETSLOT and doing migration.
+ * * A cluster replica executing CLUSTER SETSLOT during slot migration.
  *
  * So the function will protect the client by doing two things:
  *

--- a/src/networking.c
+++ b/src/networking.c
@@ -2559,6 +2559,7 @@ void freeSharedQueryBuf(void) {
  *
  * * DEBUG RELOAD and similar.
  * * When a Lua script is in -BUSY state.
+ * * A cluster replica doing CLUSTER SETSLOT and doing migration.
  *
  * So the function will protect the client by doing two things:
  *

--- a/src/replication.c
+++ b/src/replication.c
@@ -3740,12 +3740,12 @@ void replicationSetPrimary(char *ip, int port, int full_sync_required) {
     sdsfree(server.primary_host);
     server.primary_host = NULL;
     if (server.primary) {
-    /* When joining 'myself' to a new primary, set the dont_cache_primary flag
-     * if a full sync is required. This happens when 'myself' was previously
-     * part of a different shard from the new primary. Since 'myself' does not
-     * have the replication history of the shard it is joining, clearing the 
-     * cached primary is necessary to ensure proper replication behavior. */
-    server.primary->flag.dont_cache_primary = full_sync_required;
+        /* When joining 'myself' to a new primary, set the dont_cache_primary flag
+         * if a full sync is required. This happens when 'myself' was previously
+         * part of a different shard from the new primary. Since 'myself' does not
+         * have the replication history of the shard it is joining, clearing the
+         * cached primary is necessary to ensure proper replication behavior. */
+        server.primary->flag.dont_cache_primary = full_sync_required;
         freeClient(server.primary);
     }
     disconnectAllBlockedClients(); /* Clients blocked in primary, now replica. */

--- a/src/server.h
+++ b/src/server.h
@@ -1239,7 +1239,10 @@ typedef struct ClientFlags {
                                     * By using this flag, we ensure that the RDB client remains intact until the replica
                                     * \ has successfully initiated PSYNC. */
     uint64_t repl_rdb_channel : 1; /* Dual channel replication sync: track a connection which is used for rdb snapshot */
-    uint64_t reserved : 7;         /* Reserved for future use */
+    uint64_t dont_cache_primary : 1; /* In some cases we don't want to cache the primary. For example, the replica
+                                      * knows that it does not need the cache and required a full sync. With this
+                                      * flag, we won't cache the primary in freeClient. */
+    uint64_t reserved : 6;           /* Reserved for future use */
 } ClientFlags;
 
 typedef struct client {

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -334,10 +334,16 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test_sub_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
-start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
-    test "valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT" {
+proc test_cluster_setslot {type} {
+    test "valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT - $type" {
         R 3 config set cluster-allow-replica-migration no
         R 7 config set cluster-allow-replica-migration yes
+
+        if {$type == "setslot"} {
+            # Make R 7 drop the PING message so that we have a higher
+            # chance to trigger the migration from CLUSTER SETSLOT.
+            R 7 DEBUG DROP-CLUSTER-PACKET-FILTER 1
+        }
 
         # Move slot 0 from primary 3 to primary 0.
         set addr "[srv 0 host]:[srv 0 port]"
@@ -347,6 +353,13 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
         } result]
         if {$code != 0} {
             fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"
+        }
+
+        # Wait for R 3 to report that it is an empty replica (cluster-allow-replica-migration no)
+        wait_for_log_messages -3 {"*I am now an empty primary*"} 0 1000 50
+
+        if {$type == "setslot"} {
+            R 7 DEBUG DROP-CLUSTER-PACKET-FILTER -1
         }
 
         # Make sure server 3 lost its replica (server 7) and server 7 becomes a replica of primary 0.
@@ -361,4 +374,12 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
             fail "Server 3 and 7 role response has not changed"
         }
     }
+}
+
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+    test_cluster_setslot "gossip"
+} my_slot_allocation cluster_allocate_replicas ;# start_cluster
+
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+    test_cluster_setslot "setslot"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster


### PR DESCRIPTION
When the primary and replica cluster-allow-replica-migration configuration items are
different, the replica migration does not meet expectations.

Originally: primary not allow, replica allow. In this case, the code will migrate the
replica away, and the primary will keep as an empty primary. However, in #970, we found
a timing issue. For example, if the replica receives CLUSTER SETSLOT first and then receives
the gossip change, it will not trigger the replica-migration.

We perform replica migration explicitly in CLUSTER SETSLOT in this case.

Closes #970.