### PR TITLE
Initialize all the fields for the test kvstore

### DIFF
--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -10,7 +10,17 @@ void freeTestCallback(dict *d, void *val) {
     zfree(val);
 }
 
-dictType KvstoreDictTestType = {hashTestCallback, NULL, NULL, freeTestCallback, NULL, NULL};
+dictType KvstoreDictTestType = {
+    hashTestCallback,
+    NULL,
+    NULL,
+    freeTestCallback,
+    NULL,
+    NULL,
+    kvstoreDictRehashingStarted,
+    kvstoreDictRehashingCompleted,
+    kvstoreDictMetadataSize
+};
 
 char *stringFromInt(int value) {
     char buf[32];

--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -10,17 +10,15 @@ void freeTestCallback(dict *d, void *val) {
     zfree(val);
 }
 
-dictType KvstoreDictTestType = {
-    hashTestCallback,
-    NULL,
-    NULL,
-    freeTestCallback,
-    NULL,
-    NULL,
-    kvstoreDictRehashingStarted,
-    kvstoreDictRehashingCompleted,
-    kvstoreDictMetadataSize
-};
+dictType KvstoreDictTestType = {hashTestCallback,
+                                NULL,
+                                NULL,
+                                freeTestCallback,
+                                NULL,
+                                NULL,
+                                kvstoreDictRehashingStarted,
+                                kvstoreDictRehashingCompleted,
+                                kvstoreDictMetadataSize};
 
 char *stringFromInt(int value) {
     char buf[32];


### PR DESCRIPTION
Follow up to https://github.com/valkey-io/valkey/pull/966, which didn't update the kvstore tests. I'm not actually entirely clear why it fixes it, but this consistency prevents the crash very reliably so will merge it now and maybe see if Zhao has a better explanation.