### PR TITLE
Add SLOT-STATS under CLUSTER HELP string.

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -831,6 +831,8 @@ void clusterCommandHelp(client *c) {
         "SLOTS",
         "    Return information about slots range mappings. Each range is made of:",
         "    start, end, primary and replicas IP addresses, ports and ids",
+        "SLOT-STATS",
+        "    Return an array of slot usage statistics for slots assigned to the current node.",
         "SHARDS",
         "    Return information about slot range mappings and the nodes associated with them.",
         NULL};


### PR DESCRIPTION
Help wording is directly derived from `cluster-slot-stats.json` command template.