### PR TITLE
Add newline to argv in crash report when doing redact

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1062,7 +1062,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (shouldRedactArg(c, j)) {
-            serverLog(LL_WARNING, "client->argv[%d]: %zu bytes ", j, sdslen((sds)c->argv[j]->ptr));
+            serverLog(LL_WARNING, "client->argv[%d]: %zu bytes", j, sdslen((sds)c->argv[j]->ptr));
             continue;
         }
         char buf[128];
@@ -1885,7 +1885,7 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING | LL_RAW, "argc: '%d'\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (shouldRedactArg(cc, j)) {
-            serverLog(LL_WARNING | LL_RAW, "client->argv[%d]: %zu bytes ", j, sdslen((sds)cc->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "argv[%d]: %zu bytes\n", j, sdslen((sds)cc->argv[j]->ptr));
             continue;
         }
         robj *decoded;

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -317,8 +317,6 @@ void setCommand(client *c) {
 
     c->argv[2] = tryObjectEncoding(c->argv[2]);
     setGenericCommand(c,flags,c->argv[1],c->argv[2],expire,unit,NULL,NULL);
-
-    serverAssert(1==0);
 }
 
 void setnxCommand(client *c) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -317,6 +317,8 @@ void setCommand(client *c) {
 
     c->argv[2] = tryObjectEncoding(c->argv[2]);
     setGenericCommand(c,flags,c->argv[1],c->argv[2],expire,unit,NULL,NULL);
+
+    serverAssert(1==0);
 }
 
 void setnxCommand(client *c) {


### PR DESCRIPTION
Minor cleanup, introduced in #877.