### PR TITLE
Fix module RdbLoad wrongly disable the AOF

### DIFF
--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -80,6 +80,9 @@ start_server {tags {"modules"}} {
             fail "Can't find 'Killing AOF child' in recent log lines"
         }
 
+        # Verify that we have enabled the AOF
+        assert_equal 1 [s aof_enabled]
+
         # Verify the value in the loaded rdb
         assert_equal v1 [r get k]
 

--- a/tests/unit/moduleapi/rdbloadsave.tcl
+++ b/tests/unit/moduleapi/rdbloadsave.tcl
@@ -80,7 +80,7 @@ start_server {tags {"modules"}} {
             fail "Can't find 'Killing AOF child' in recent log lines"
         }
 
-        # Verify that we have enabled the AOF
+        # Verify that AOF is active.
         assert_equal 1 [s aof_enabled]
 
         # Verify the value in the loaded rdb


### PR DESCRIPTION
In module RdbLoad, we will disable the AOF before emptyData and rdbLoad
to avoid the copy-on-write disaster. After rdbLoad is finished, we should
suppose re-enable the AOF, but the code wrongly check server.aof_state,
which had been reset to AOF_OFF in stopAppendOnly. Which resulted in AOF
not being enabled after we disabled it.