### PR TITLE
Add --moduleapi option to better use runtest-moduleapi

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -14,47 +14,4 @@ then
 fi
 
 $MAKE -C tests/modules && \
-$TCLSH tests/test_helper.tcl \
---single unit/moduleapi/commandfilter \
---single unit/moduleapi/basics \
---single unit/moduleapi/fork \
---single unit/moduleapi/testrdb \
---single unit/moduleapi/infotest \
---single unit/moduleapi/moduleconfigs \
---single unit/moduleapi/infra \
---single unit/moduleapi/propagate \
---single unit/moduleapi/hooks \
---single unit/moduleapi/misc \
---single unit/moduleapi/blockonkeys \
---single unit/moduleapi/blockonbackground \
---single unit/moduleapi/scan \
---single unit/moduleapi/datatype \
---single unit/moduleapi/auth \
---single unit/moduleapi/keyspace_events \
---single unit/moduleapi/blockedclient \
---single unit/moduleapi/getkeys \
---single unit/moduleapi/test_lazyfree \
---single unit/moduleapi/defrag \
---single unit/moduleapi/keyspecs \
---single unit/moduleapi/hash \
---single unit/moduleapi/zset \
---single unit/moduleapi/list \
---single unit/moduleapi/stream \
---single unit/moduleapi/mallocsize \
---single unit/moduleapi/datatype2 \
---single unit/moduleapi/cluster \
---single unit/moduleapi/aclcheck \
---single unit/moduleapi/subcommands \
---single unit/moduleapi/reply \
---single unit/moduleapi/cmdintrospection \
---single unit/moduleapi/eventloop \
---single unit/moduleapi/timer \
---single unit/moduleapi/publish \
---single unit/moduleapi/usercall \
---single unit/moduleapi/postnotifications \
---single unit/moduleapi/async_rm_call \
---single unit/moduleapi/moduleauth \
---single unit/moduleapi/rdbloadsave \
---single unit/moduleapi/crash \
---single unit/moduleapi/getchannels \
-"${@}"
+$TCLSH tests/test_helper.tcl --moduleapi "${@}"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -15,21 +15,30 @@ source tests/support/util.tcl
 
 set dir [pwd]
 set ::all_tests []
+set ::module_api_all_tests []
 
 set test_dirs {
     unit
     unit/type
     unit/cluster
     integration
+    unit/moduleapi
 }
 
 foreach test_dir $test_dirs {
     set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
 
-    foreach file $files {
-        lappend ::all_tests $test_dir/[file root [file tail $file]]
+    if {$test_dir eq "unit/moduleapi"} {
+        foreach file $files {
+            lappend ::module_api_all_tests $test_dir/[file root [file tail $file]]
+        }
+    } else {
+        foreach file $files {
+            lappend ::all_tests $test_dir/[file root [file tail $file]]
+        }
     }
 }
+
 # Index to the next test to run in the ::all_tests list.
 set ::next_test 0
 
@@ -550,6 +559,7 @@ proc send_data_packet {fd status data {elapsed 0}} {
 
 proc print_help_screen {} {
     puts [join {
+        "--moduleapi        Run the module API tests, this option should only be used in runtest-moduleapi which will build the test module."
         "--valgrind         Run the test over valgrind."
         "--durable          suppress test crashes and keep running"
         "--stack-logging    Enable OSX leaks/malloc stack logging."
@@ -606,6 +616,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
             }
         }
         incr j
+    } elseif {$opt eq {--moduleapi}} {
+        set ::all_tests $::module_api_all_tests
     } elseif {$opt eq {--config}} {
         set arg2 [lindex $argv [expr $j+2]]
         lappend ::global_overrides $arg

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -22,21 +22,19 @@ set test_dirs {
     unit/type
     unit/cluster
     integration
-    unit/moduleapi
 }
 
 foreach test_dir $test_dirs {
     set files [glob -nocomplain $dir/tests/$test_dir/*.tcl]
 
-    if {$test_dir eq "unit/moduleapi"} {
-        foreach file $files {
-            lappend ::module_api_all_tests $test_dir/[file root [file tail $file]]
-        }
-    } else {
-        foreach file $files {
-            lappend ::all_tests $test_dir/[file root [file tail $file]]
-        }
+    foreach file $files {
+        lappend ::all_tests $test_dir/[file root [file tail $file]]
     }
+}
+
+set moduleapi_test_dir unit/moduleapi
+foreach file [glob -nocomplain $dir/tests/$moduleapi_test_dir/*.tcl] {
+   lappend ::module_api_all_tests $moduleapi_test_dir/[file root [file tail $file]]
 }
 
 # Index to the next test to run in the ::all_tests list.


### PR DESCRIPTION
This allows us to avoid error #1002 and enables us to actually
use `./runtest-moduleapi --single xxx`.