### PR TITLE
Fix wrong count for replica's tot-net-out

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2129,11 +2129,6 @@ int _writeToClient(client *c) {
     return tot_written > 0 ? C_OK : C_ERR;
 }
 
-static void postWriteToReplica(client *c) {
-    serverAssert(inMainThread());
-    if (c->nwritten > 0) c->net_output_bytes += c->nwritten;
-}
-
 static void _postWriteToClient(client *c) {
     if (c->nwritten <= 0) return;
 
@@ -2180,9 +2175,7 @@ int postWriteToClient(client *c) {
     c->io_last_bufpos = 0;
     /* Update total number of writes on server */
     server.stat_total_writes_processed++;
-    if (getClientType(c) == CLIENT_TYPE_REPLICA) {
-        postWriteToReplica(c);
-    } else {
+    if (getClientType(c) != CLIENT_TYPE_REPLICA) {
         _postWriteToClient(c);
     }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -867,8 +867,8 @@ start_server {tags {"introspection"}} {
                     }
                 }
 
-                assert {$out > 0}
-                assert {$out < [expr $value_size + 1000]}
+                assert_morethan $out 0
+                assert_lessthan $out [expr $value_size + 1000]
             }
         }
     } {} {external:skip}

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -836,6 +836,43 @@ start_server {tags {"introspection"}} {
         assert_match {*'replicaof "--127.0.0.1"'*wrong number of arguments*} $err
     } {} {external:skip}
 
+    test {tot-net-out for replica client}  {
+        start_server {} {
+            start_server {} {
+                set primary [srv -1 client]
+                set primary_host [srv -1 host]
+                set primary_port [srv -1 port]
+                set primary_pid [srv -1 pid]
+                set replica [srv 0 client]
+                set replica_pid [srv 0 pid]
+    
+                $replica replicaof $primary_host $primary_port
+    
+                # Wait for replica to be connected before proceeding.
+                wait_for_ofs_sync $primary $replica
+    
+                # Send a command to the primary.
+                set value_size 10000
+                $primary set foo [string repeat "a" $value_size]
+    
+                # Wait for the replica to receive the command.
+                wait_for_ofs_sync $primary $replica
+    
+                # Get the tot-net-out of the replica.
+                set info_list [$primary client list]
+                foreach info [split $info_list "\r\n"] {
+                    if {[string match "* flags=S *" $info]} {
+                        set out [get_field_in_client_info $info "tot-net-out"]
+                        break
+                    }
+                }
+
+                assert {$out > 0}
+                assert {$out < [expr $value_size + 1000]}
+            }
+        }
+    } {} {external:skip}
+
     test {valkey-server command line arguments - allow passing option name and option value in the same arg} {
         start_server {config "default.conf" args {"--maxmemory 700mb" "--maxmemory-policy volatile-lru"}} {
             assert_match [r config get maxmemory] {maxmemory 734003200}


### PR DESCRIPTION
Fix duplicate calculation of replica's `net_output_bytes`

- Remove redundant calculation leftover from previous refactor
- Add test to prevent regression