### PR TITLE
Configuration option to output logs in logfmt

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -122,6 +122,15 @@ configEnum propagation_error_behavior_enum[] = {{"ignore", PROPAGATION_ERR_BEHAV
                                                 {"panic-on-replicas", PROPAGATION_ERR_BEHAVIOR_PANIC_ON_REPLICAS},
                                                 {NULL, 0}};
 
+configEnum log_format_enum[] = {{"default", LOG_FORMAT_DEFAULT},
+                                {"logfmt", LOG_FORMAT_LOGFMT},
+                                {NULL, 0}};
+
+configEnum log_timestamp_format_enum[] = {{"default", LOG_TIMESTAMP_DEFAULT},
+                                          {"iso8601", LOG_TIMESTAMP_ISO8601},
+                                          {"unix",LOG_TIMESTAMP_UNIX},
+                                          {NULL, 0}};
+
 /* Output buffer limits presets. */
 clientBufferLimitsConfig clientBufferLimitsDefaults[CLIENT_TYPE_OBUF_COUNT] = {
     {0, 0, 0},                                 /* normal */
@@ -3161,6 +3170,8 @@ standardConfig static_configs[] = {
     createEnumConfig("propagation-error-behavior", NULL, MODIFIABLE_CONFIG, propagation_error_behavior_enum, server.propagation_error_behavior, PROPAGATION_ERR_BEHAVIOR_IGNORE, NULL, NULL),
     createEnumConfig("shutdown-on-sigint", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigint, 0, isValidShutdownOnSigFlags, NULL),
     createEnumConfig("shutdown-on-sigterm", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, shutdown_on_sig_enum, server.shutdown_on_sigterm, 0, isValidShutdownOnSigFlags, NULL),
+    createEnumConfig("log-format", NULL, MODIFIABLE_CONFIG, log_format_enum, server.log_format, LOG_FORMAT_DEFAULT, NULL, NULL),
+    createEnumConfig("log-timestamp-format", NULL, MODIFIABLE_CONFIG, log_timestamp_format_enum, server.log_timestamp_format, LOG_TIMESTAMP_DEFAULT, NULL, NULL),
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, server.dbnum, 16, INTEGER_CONFIG, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -109,11 +109,35 @@ const char *replstateToString(int replstate);
  * function of the server may be called from other threads. */
 void nolocks_localtime(struct tm *tmp, time_t t, time_t tz, int dst);
 
+/* Formats the timezone offset into a string.
+ * 
+ * Assumes:
+ * - size of `buf` is 7 or larger
+ * - `timezone` is valid, within the range of [-50400, +43200].
+ * - `daylight_active` indicates whether dst is active (1) or not (0). */
+
+void format_timezone(char *buf, int timezone, int daylight_active) {
+    // Adjust the timezone for daylight saving, if active
+    int total_offset = (-1)*timezone + 3600*daylight_active;
+    int hours = abs(total_offset / 3600);
+    int minutes = abs(total_offset % 3600) / 60;
+    buf[0] = total_offset >= 0 ? '+' : '-';
+    buf[1] = '0' + hours / 10;
+    buf[2] = '0' + hours % 10;
+    buf[3] = ':';
+    buf[4] = '0' + minutes / 10;
+    buf[5] = '0' + minutes % 10;
+    buf[6] = '\0';
+}
+
 /* Low level logging. To use only for very big messages, otherwise
  * serverLog() is to prefer. */
 void serverLogRaw(int level, const char *msg) {
     const int syslogLevelMap[] = {LOG_DEBUG, LOG_INFO, LOG_NOTICE, LOG_WARNING};
     const char *c = ".-*#";
+    const char* verbose_level[] = {"debug", "info", "notice", "warning"};
+    const char* roles[] = {"sentinel", "RDB/AOF", "replica", "master"};
+    const char* role_chars = "XCSM";
     FILE *fp;
     char buf[64];
     int rawmode = (level & LL_RAW);
@@ -133,23 +157,53 @@ void serverLogRaw(int level, const char *msg) {
     } else {
         int off;
         struct timeval tv;
-        int role_char;
         pid_t pid = getpid();
         int daylight_active = atomic_load_explicit(&server.daylight_active, memory_order_relaxed);
 
         gettimeofday(&tv, NULL);
         struct tm tm;
         nolocks_localtime(&tm, tv.tv_sec, server.timezone, daylight_active);
-        off = strftime(buf, sizeof(buf), "%d %b %Y %H:%M:%S.", &tm);
-        snprintf(buf + off, sizeof(buf) - off, "%03d", (int)tv.tv_usec / 1000);
-        if (server.sentinel_mode) {
-            role_char = 'X'; /* Sentinel. */
-        } else if (pid != server.pid) {
-            role_char = 'C'; /* RDB / AOF writing child. */
-        } else {
-            role_char = (server.primary_host ? 'S' : 'M'); /* replica or Primary. */
+        switch(server.log_timestamp_format) {
+            case LOG_TIMESTAMP_DEFAULT:
+                off = strftime(buf,sizeof(buf),"%d %b %Y %H:%M:%S.",&tm);
+                snprintf(buf+off,sizeof(buf)-off,"%03d",(int)tv.tv_usec/1000);
+                break;
+
+            case LOG_TIMESTAMP_ISO8601:
+                off = strftime(buf,sizeof(buf),"%Y-%m-%dT%H:%M:%S.",&tm);
+                char tzbuf[7];
+                format_timezone(tzbuf, server.timezone, server.daylight_active);
+                snprintf(buf + off, sizeof(buf) - off, "%03d%s",
+                         (int)tv.tv_usec/1000, tzbuf);
+                break;
+
+            case LOG_TIMESTAMP_UNIX:
+                snprintf(buf,sizeof(buf),"%ld",tv.tv_sec);
+                break;
+            default:
+                break;
         }
-        fprintf(fp, "%d:%c %s %c %s\n", (int)getpid(), role_char, buf, c[level], msg);
+        int role_index;
+        if (server.sentinel_mode) {
+            role_index = 0; /* Sentinel. */
+        } else if (pid != server.pid) {
+            role_index = 1; /* RDB / AOF writing child. */
+        } else {
+            role_index = (server.primary_host ? 2 : 3); /* Slave or Master. */
+        }
+        switch (server.log_format) {
+            case LOG_FORMAT_LOGFMT: {
+                fprintf(fp, "pid=%d role=%s timestamp=\"%s\" level=%s message=\"%s\"\n",
+                        (int)getpid(),roles[role_index],buf,verbose_level[level],msg);
+                break;
+            }
+
+            default: {
+                fprintf(fp,"%d:%c %s %c %s\n",
+                        (int)getpid(),role_chars[role_index], buf,c[level],msg);
+                break;
+            }
+        }
     }
     fflush(fp);
 

--- a/src/server.h
+++ b/src/server.h
@@ -581,6 +581,18 @@ typedef enum {
 #define PAUSE_ACTION_EVICT (1 << 3)
 #define PAUSE_ACTION_REPLICA (1 << 4) /* pause replica traffic */
 
+/* Sets log format */
+typedef enum {
+    LOG_FORMAT_DEFAULT = 0,
+    LOG_FORMAT_LOGFMT
+} log_format_type;
+
+/* Sets log timestamp format */
+/* Also update LOG_TIMESTAMP_FORMATS */
+#define LOG_TIMESTAMP_DEFAULT 0
+#define LOG_TIMESTAMP_ISO8601 1
+#define LOG_TIMESTAMP_UNIX 2
+
 /* common sets of actions to pause/unpause */
 #define PAUSE_ACTIONS_CLIENT_WRITE_SET                                                                                 \
     (PAUSE_ACTION_CLIENT_WRITE | PAUSE_ACTION_EXPIRE | PAUSE_ACTION_EVICT | PAUSE_ACTION_REPLICA)
@@ -1998,6 +2010,8 @@ struct valkeyServer {
     int memcheck_enabled;  /* Enable memory check on crash. */
     int use_exit_on_panic; /* Use exit() on panic and assert rather than
                             * abort(). useful for Valgrind. */
+    int log_format;              /* Print log in specific format */
+    int log_timestamp_format;    /* Timestamp format in log */
     /* Shutdown */
     int shutdown_timeout;    /* Graceful shutdown time limit in seconds. */
     int shutdown_on_sigint;  /* Shutdown flags configured for SIGINT. */


### PR DESCRIPTION
See more disscussion:
https://github.com/redis/redis/pull/12934

Add ability to configure Redis to output logs in logfmt (See https://brandur.org/logfmt) as well as configure timestamp format options to more standard ISO 8601 or unix timestamp.

This change is implemented by two configs:
`log-format`: Either default or logfmt.
`log-timestamp-format`: default, iso8601, or unix.

#1006 

```text
$ ./valkey-server  /home/zhaoz12/git/valkey/valkey/valkey.conf
pid=109463 role=RDB/AOF timestamp="2024-09-10T20:37:25.738-04:00" level=warning message="WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect."
pid=109463 role=RDB/AOF timestamp="2024-09-10T20:37:25.738-04:00" level=notice message="oO0OoO0OoO0Oo Valkey is starting oO0OoO0OoO0Oo"
pid=109463 role=RDB/AOF timestamp="2024-09-10T20:37:25.738-04:00" level=notice message="Valkey version=255.255.255, bits=64, commit=affbea5d, modified=1, pid=109463, just started"
pid=109463 role=RDB/AOF timestamp="2024-09-10T20:37:25.738-04:00" level=notice message="Configuration loaded"
pid=109463 role=master timestamp="2024-09-10T20:37:25.738-04:00" level=notice message="monotonic clock: POSIX clock_gettime"
pid=109463 role=master timestamp="2024-09-10T20:37:25.739-04:00" level=warning message="Failed to write PID file: Permission denied"

```