### PR TITLE
Make clang-format insert a newline at end of file if missing

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -30,3 +30,4 @@ SortIncludes: false
 AllowAllParametersOfDeclarationOnNextLine: false
 BinPackParameters: false
 AlignAfterOpenBracket: Align
+InsertNewlineAtEOF: true


### PR DESCRIPTION
clang generates warning if there is no newline at the end of the source file.

Update .clang-format to handle the missing newline at eof.