### PR TITLE
Migrate the redis name to server in benchmark code

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -238,7 +238,7 @@ static redisContext *getRedisContext(const char *ip, int port, const char *hosts
     else
         ctx = redisConnectUnix(hostsocket);
     if (ctx == NULL || ctx->err) {
-        fprintf(stderr, "Could not connect to Redis at ");
+        fprintf(stderr, "Could not connect to server at ");
         char *err = (ctx != NULL ? ctx->errstr : "");
         if (hostsocket == NULL)
             fprintf(stderr, "%s:%d: %s\n", ip, port, err);
@@ -648,7 +648,7 @@ static client createClient(char *cmd, size_t len, client from, int thread_id) {
         c->context = redisConnectUnixNonBlock(config.hostsocket);
     }
     if (c->context->err) {
-        fprintf(stderr, "Could not connect to Redis at ");
+        fprintf(stderr, "Could not connect to server at ");
         if (config.hostsocket == NULL || is_cluster_client)
             fprintf(stderr, "%s:%d: %s\n", ip, port, c->context->errstr);
         else


### PR DESCRIPTION
I was trying to run valkey-benchmark and missed to start server prior to the benchmark and oberved that it reports it is not able to connect to Redis as below
![image](https://github.com/user-attachments/assets/5e706b64-5990-4780-9ac8-a9f45ce82a9d)

So changed the ouput log to server as below.
![image](https://github.com/user-attachments/assets/c398a4df-f504-4078-a474-6ef448297429)
