### PR TITLE
Fix default value of primary-reboot-down-after-period in sentinel.conf

### DIFF
--- a/sentinel.conf
+++ b/sentinel.conf
@@ -355,4 +355,4 @@ SENTINEL announce-hostnames no
 # accept a -LOADING response after a primary has been rebooted, before failing
 # over.
 
-SENTINEL primary-reboot-down-after-period myprimary 0
+SENTINEL primary-reboot-down-after-period mymaster 0


### PR DESCRIPTION
Since in here the monitor value is mymaster, we need to make sure the primary
name is the same, otherwise the default configuration cannot start sentinel.
```
sentinel monitor mymaster 127.0.0.1 6379 2
```

The following error occurs when the default configuration is started:
```
*** FATAL CONFIG FILE ERROR (Version 255.255.255) ***
Reading the configuration file, at line 358
>>> 'SENTINEL primary-reboot-down-after-period myprimary 0'
No such master with specified name.
```

Introduced in #647.