### PR TITLE
Fix replica online timing issue in failover test

### DIFF
--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -33,6 +33,8 @@ start_server {overrides {save {}}} {
         $node_2 replicaof $node_0_host $node_0_port
         wait_for_sync $node_1
         wait_for_sync $node_2
+        verify_replica_online $node_0 0 50
+        verify_replica_online $node_0 1 50
     }
 
     test {failover command fails with invalid host} {


### PR DESCRIPTION
Ci reported this failure:
```
[exception]: Executing test client: ERR FAILOVER target replica is not online..
ERR FAILOVER target replica is not online.
    while executing
"$node_0 failover to $node_1_host $node_1_port"
```

We can see somehow the replica is not online in time and
casuing this failure, added a verify_replica_online to make
sure the replica is online for the test.