### PR TITLE
Change return value of aeTimeProc callback function to long long.

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -363,7 +363,7 @@ static int processTimeEvents(aeEventLoop *eventLoop) {
         }
 
         if (te->when <= now) {
-            int retval;
+            long long retval;
 
             id = te->id;
             te->refcount++;

--- a/src/ae.h
+++ b/src/ae.h
@@ -68,7 +68,7 @@ struct aeEventLoop;
 
 /* Types and data structures */
 typedef void aeFileProc(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask);
-typedef int aeTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData);
+typedef long long aeTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData);
 typedef void aeEventFinalizerProc(struct aeEventLoop *eventLoop, void *clientData);
 typedef void aeBeforeSleepProc(struct aeEventLoop *eventLoop);
 typedef void aeAfterSleepProc(struct aeEventLoop *eventLoop, int numevents);

--- a/src/evict.c
+++ b/src/evict.c
@@ -447,7 +447,7 @@ int overMaxmemoryAfterAlloc(size_t moremem) {
  * eviction cycles until the "maxmemory" condition has resolved or there are no
  * more evictable items.  */
 static int isEvictionProcRunning = 0;
-static int evictionTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+static long long evictionTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
     UNUSED(clientData);

--- a/src/module.c
+++ b/src/module.c
@@ -9114,7 +9114,7 @@ typedef struct ValkeyModuleTimer {
 
 /* This is the timer handler that is called by the main event loop. We schedule
  * this timer to be called when the nearest of our module timers will expire. */
-int moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+long long moduleTimerHandler(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
     UNUSED(clientData);

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -672,7 +672,7 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
     }
 }
 
-static int rdmaKeepaliveTimeProc(struct aeEventLoop *el, long long id, void *clientData) {
+static long long rdmaKeepaliveTimeProc(struct aeEventLoop *el, long long id, void *clientData) {
     struct rdma_cm_id *cm_id = clientData;
     RdmaContext *ctx = cm_id->context;
     connection *conn = ctx->conn;

--- a/src/server.c
+++ b/src/server.c
@@ -1257,7 +1257,7 @@ void cronUpdateMemoryStats(void) {
  * a macro is used: run_with_period(milliseconds) { .... }
  */
 
-int serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     int j;
     UNUSED(eventLoop);
     UNUSED(id);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -195,7 +195,7 @@ static redisContext *getRedisContext(const char *ip, int port, const char *hosts
 static void freeServerConfig(serverConfig *cfg);
 static int fetchClusterSlotsConfiguration(client c);
 static void updateClusterSlotsConfiguration(void);
-int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
+static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
 
 /* Dict callbacks */
 static uint64_t dictSdsHash(const void *key);
@@ -1607,7 +1607,7 @@ tls_usage,
     exit(exit_status);
 }
 
-int showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
     benchmarkThread *thread = (benchmarkThread *)clientData;


### PR DESCRIPTION
moduleTimerHandler is aeTimeProc handler and event loop gets created with this. However, found that the function return type is int but actually returns "long long" value(i.e., next_period). and return value being assigned to int variable in processTimeEvents(where time events are processed), this might cause an overflow of the timer values. So changed the return type of the function to long long. And also updated other callback function return type to be consistent.

I found this when I was checking functions reported in https://github.com/valkey-io/valkey/issues/1054 issue stacktrace. (FYI, this is just to update the return type to be consistent and it will not the fix for the issue reported)