### PR TITLE
Add log about old primary after myself failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4476,7 +4476,7 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     if (clusterNodeIsPrimary(myself) || old_primary == NULL) return;
 
-    serverLog(LL_NOTICE, "Setting myself to primary after failover, my old primary is %.40s", old_primary->name);
+    serverLog(LL_NOTICE, "Setting myself to primary in shard %.40s after failover; my old primary is %.40s (%s)", myself->shard_id, old_primary->name, old_primary->human_nodename);
 
     /* 1) Turn this node into a primary. */
     clusterSetNodeAsPrimary(myself);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4476,7 +4476,9 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     if (clusterNodeIsPrimary(myself) || old_primary == NULL) return;
 
-    /* 1) Turn this node into a primary . */
+    serverLog(LL_NOTICE, "Setting myself to primary after failover, my old primary is %.40s", old_primary->name);
+
+    /* 1) Turn this node into a primary. */
     clusterSetNodeAsPrimary(myself);
     replicationUnsetPrimary();
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4476,7 +4476,8 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     if (clusterNodeIsPrimary(myself) || old_primary == NULL) return;
 
-    serverLog(LL_NOTICE, "Setting myself to primary in shard %.40s after failover; my old primary is %.40s (%s)", myself->shard_id, old_primary->name, old_primary->human_nodename);
+    serverLog(LL_NOTICE, "Setting myself to primary in shard %.40s after failover; my old primary is %.40s (%s)",
+              myself->shard_id, old_primary->name, old_primary->human_nodename);
 
     /* 1) Turn this node into a primary. */
     clusterSetNodeAsPrimary(myself);


### PR DESCRIPTION
Sometims it is hard to see the old primary during a
multi primaries failover, adding this log can help
use to find the old primary node.