### PR TITLE
Trigger the election as soon as possible when doing a forced manual failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6725,6 +6725,9 @@ int clusterCommandSpecial(client *c) {
              * it without coordination. */
             serverLog(LL_NOTICE, "Forced failover user request accepted (user request from '%s').", client);
             server.cluster->mf_can_start = 1;
+            /* We can start a manual failover as soon as possible, setting a flag
+             * here so that we don't need to waiting for the cron to kick in. */
+            clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_MANUALFAILOVER);
         } else {
             serverLog(LL_NOTICE, "Manual failover user request accepted (user request from '%s').", client);
             clusterSendMFStart(myself->replicaof);


### PR DESCRIPTION
In CLUSTER FAILOVER FORCE case, we will set mf_can_start to
1 and wait for a cron to trigger the election. We can also set
a CLUSTER_TODO_HANDLE_MANUALFAILOVER flag so that we can start
the election as soon as possible instead of waiting for the cron,
so that we won't have a 100ms delay (clusterCron).