### PR TITLE
Fix bug for CLUSTER SLOTS from EVAL over TLS

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1433,7 +1433,7 @@ void clusterCommandSlots(client *c) {
      *           ... continued until done
      */
     int conn_type = 0;
-    if (connIsTLS(c->conn)) conn_type |= CACHE_CONN_TYPE_TLS;
+    if (shouldReturnTlsInfo()) conn_type |= CACHE_CONN_TYPE_TLS;
     if (isClientConnIpV6(c)) conn_type |= CACHE_CONN_TYPE_IPv6;
     if (c->resp == 3) conn_type |= CACHE_CONN_TYPE_RESP3;
 

--- a/tests/unit/cluster/cluster-response-tls.tcl
+++ b/tests/unit/cluster/cluster-response-tls.tcl
@@ -24,6 +24,15 @@ proc get_port_from_node_info {line} {
 
 proc cluster_response_tls {tls_cluster} {
 
+    test "CLUSTER SLOTS cached using EVAL over TLS -- tls-cluster $tls_cluster" {
+        set client_tcp [valkey 127.0.0.1 [srv 0 pport] 0 0]
+        set client_tls [valkey 127.0.0.1 [srv 0 port] 0 1]
+        set slots1 [$client_tls EVAL {return server.call('CLUSTER', 'SLOTS')} 0]
+        set slots2 [$client_tcp CLUSTER SLOTS]
+        # Compare the ports in the first row
+        assert_no_match [lindex $slots1 0 2 1] [lindex $slots2 0 2 1]
+    }
+
     test "CLUSTER SLOTS with different connection type -- tls-cluster $tls_cluster" {
         set slots1 [R 0 cluster slots]
         set pport [srv 0 pport]


### PR DESCRIPTION
For fake clients like the ones used for Lua and modules, we don't determine TLS in the right way, causing CLUSTER SLOTS from EVAL over TLS to fail a debug-assert.

This error was introduced when the caching of CLUSTER SLOTS was introduced, i.e. in 8.0.0.