### PR TITLE
Fix RDMA build dependence

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -513,7 +513,7 @@ $(TLS_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) -o $@ tls.c -shared -fPIC $(TLS_MODULE_CFLAGS) $(TLS_CLIENT_LIBS)
 
 # valkey-rdma.so
-$(RDMA_MODULE_NAME): $(REDIS_SERVER_NAME)
+$(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
 # valkey-cli


### PR DESCRIPTION
RDMA module has dependence on '$(SERVER_NAME)' rather than the old style '$(REDIS_SERVER_NAME)'.