### PR TITLE
Remove the restriction that cli --cluster create requires at least 3 primary nodes

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -6688,9 +6688,11 @@ static int clusterManagerCommandCreate(int argc, char **argv) {
     if (primaries_count < 3) {
         int ignore_force = 0;
         clusterManagerLogInfo("Requested to create a cluster with %d primaries and "
-                              "%d replicas per primary.\n", primaries_count, replicas);
+                              "%d replicas per primary.\n",
+                              primaries_count, replicas);
         if (!confirmWithYes("Valkey cluster requires at least 3 primary nodes for "
-                            "automatic failover. Are you sure?", ignore_force))
+                            "automatic failover. Are you sure?",
+                            ignore_force))
             return 0;
     }
     clusterManagerLogInfo(">>> Performing hash slots allocation "

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -6686,15 +6686,15 @@ static int clusterManagerCommandCreate(int argc, char **argv) {
     int replicas = config.cluster_manager_command.replicas;
     int primaries_count = CLUSTER_MANAGER_PRIMARIES_COUNT(node_len, replicas);
     if (primaries_count < 3) {
-        clusterManagerLogErr("*** ERROR: Invalid configuration for cluster creation.\n"
-                             "*** Valkey Cluster requires at least 3 primary nodes.\n"
-                             "*** This is not possible with %d nodes and %d replicas per node.",
-                             node_len, replicas);
-        clusterManagerLogErr("\n*** At least %d nodes are required.\n", 3 * (replicas + 1));
-        return 0;
+        int ignore_force = 0;
+        clusterManagerLogInfo("Requested to create a cluster with %d primaries and "
+                              "%d replicas per primary.\n", primaries_count, replicas);
+        if (!confirmWithYes("Valkey cluster requires at least 3 primary nodes for "
+                            "automatic failover. Are you sure?", ignore_force))
+            return 0;
     }
     clusterManagerLogInfo(">>> Performing hash slots allocation "
-                          "on %d nodes...\n",
+                          "on %d node(s)...\n",
                           node_len);
     int interleaved_len = 0, ip_count = 0;
     clusterManagerNode **interleaved = zcalloc(node_len * sizeof(**interleaved));

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -9,6 +9,33 @@ set ::singledb 1
 # cluster creation is complicated with TLS, and the current tests don't really need that coverage
 tags {tls:skip external:skip cluster} {
 
+set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
+start_multiple_servers 3 [list overrides $base_conf] {
+    test {Create 1 node cluster} {
+        exec src/valkey-cli --cluster-yes --cluster create \
+                            127.0.0.1:[srv 0 port]
+
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize"
+        }
+    }
+
+    test {Create 2 node cluster} {
+        exec src/valkey-cli --cluster-yes --cluster create \
+                            127.0.0.1:[srv -1 port] \
+                            127.0.0.1:[srv -2 port]
+
+        wait_for_condition 1000 50 {
+            [CI 1 cluster_state] eq {ok} &&
+            [CI 2 cluster_state] eq {ok}
+        } else {
+            fail "Cluster doesn't stabilize"
+        }
+    }
+}
+
 # start three servers
 set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
 start_multiple_servers 3 [list overrides $base_conf] {


### PR DESCRIPTION
There is no limitation in Valkey to create a cluster with 1 or 2 primaries,
only that it cannot do automatic failover. Remove this restriction and
add `are you sure` prompt to prompt the user.

This allow we use it to create a test cluster by cli or by create-cluster.