### PR TITLE
Try to stabilize the failover call in the slot migration test

### DIFF
--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -277,6 +277,14 @@ proc cluster_get_myself id {
     return {}
 }
 
+# Returns the parsed "myself's primary" node entry as a dictionary.
+proc cluster_get_myself_primary id {
+    set myself [cluster_get_myself $id]
+    set replicaof [dict get $myself slaveof]
+    set node [cluster_get_node_by_id $id $replicaof]
+    return $node
+}
+
 # Get a specific node by ID by parsing the CLUSTER NODES output
 # of the instance Number 'instance_id'
 proc cluster_get_node_by_id {instance_id node_id} {

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -277,7 +277,7 @@ proc cluster_get_myself id {
     return {}
 }
 
-# Returns the parsed "myself's primary" node entry as a dictionary.
+# Returns the parsed "myself's primary" CLUSTER NODES entry as a dictionary.
 proc cluster_get_myself_primary id {
     set myself [cluster_get_myself $id]
     set replicaof [dict get $myself slaveof]


### PR DESCRIPTION
The CI report replica will return the error when performing CLUSTER FAILOVER:
-ERR Master is down or failed, please use CLUSTER FAILOVER FORCE

This may because the primary state is fail or the cluster connection
is disconnected during the primary pause. In this PR, we added some
waits in wait_for_role, if the role is replica, we will wait for the
replication link and the cluster link to be ok.