### PR TITLE
Fix typo in test_helper.tcl

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -533,7 +533,7 @@ proc the_end {} {
     }
 }
 
-# The client is not even driven (the test server is instead) as we just need
+# The client is not event driven (the test server is instead) as we just need
 # to read the command, execute, reply... all this in a loop.
 proc test_client_main server_port {
     set ::test_server_fd [socket localhost $server_port]


### PR DESCRIPTION
fix typo in test_helper.tcl: even driven => event driven