### PR TITLE
Trigger the election immediately when doing a manual failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4607,9 +4607,9 @@ void clusterHandleReplicaFailover(void) {
          * if our offset is better. */
         clusterBroadcastPong(CLUSTER_BROADCAST_LOCAL_REPLICAS);
 
-        /* Return ASAP if we can't start the election. Doing this allow us to, for example,
-         * a manual failover, we can get it to the next state ASAP instead of waiting for
-         * the next beforeSleep to kick in. */
+        /* Return ASAP if we can't start the election now. In a manual failover,
+         * we can start the election immediately, so in this case we continue to
+         * the next state without waiting for the next beforeSleep. */
         if (now < server.cluster->failover_auth_time) return;
     }
 


### PR DESCRIPTION
Currently when a manual failover is triggeded, we will set a
CLUSTER_TODO_HANDLE_FAILOVER to start the election as soon as
possible in the next beforeSleep. But in fact, we won't delay
the election in manual failover, waitting for the next beforeSleep
to kick in will delay the election a some milliseconds.

We can trigger the election immediately in this case in the
same function call, without waitting for beforeSleep, which
can save us some milliseconds.