### PR TITLE
Creates an empty lua table with specified initial capacity as much as possible

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -361,7 +361,7 @@ static void redisProtocolToLuaType_Map(struct ReplyParser *parser, void *ctx, si
         }
         lua_newtable(lua);
         lua_pushstring(lua, "map");
-        lua_newtable(lua);
+        lua_createtable(lua, 0, len);
     }
     for (size_t j = 0; j < len; j++) {
         parseReply(parser, lua);
@@ -383,7 +383,7 @@ static void redisProtocolToLuaType_Set(struct ReplyParser *parser, void *ctx, si
         }
         lua_newtable(lua);
         lua_pushstring(lua, "set");
-        lua_newtable(lua);
+        lua_createtable(lua, 0, len);
     }
     for (size_t j = 0; j < len; j++) {
         parseReply(parser, lua);
@@ -412,7 +412,7 @@ static void redisProtocolToLuaType_Array(struct ReplyParser *parser, void *ctx, 
              * to push elements to the stack. On failure, exit with panic. */
             serverPanic("lua stack limit reach when parsing server.call reply");
         }
-        lua_newtable(lua);
+        lua_createtable(lua, len, 0);
     }
     for (size_t j = 0; j < len; j++) {
         if (lua) lua_pushnumber(lua, j + 1);
@@ -1534,7 +1534,7 @@ void luaRegisterServerAPI(lua_State *lua) {
 static void luaCreateArray(lua_State *lua, robj **elev, int elec) {
     int j;
 
-    lua_newtable(lua);
+    lua_createtable(lua, elec, 0);
     for (j = 0; j < elec; j++) {
         lua_pushlstring(lua, (char *)elev[j]->ptr, sdslen(elev[j]->ptr));
         lua_rawseti(lua, -2, j + 1);


### PR DESCRIPTION

Currently, we create a Lua table without initial capacity even when the capacity is known. As a result, we need to resize the Lua tables repeatedly when converting RESP serialized object to Lua object and it consumes extra cpu resources a bit when we need to transfer RESP-serialized data to Lua world.


<img width="1195" alt="スクリーンショット 2024-09-30 16 33 52" src="https://github.com/user-attachments/assets/d5856882-0523-42dd-ad4c-915cb117c0c2">

This patch try to remove this extra resize to reduce (re-)allocation overhead.



| name | unstable bb57dfe6303 (rps) | this patch(rps) | improvements |
| --------------- | -------- | --------- | -------------- |
| evalsha - hgetall h1 | 60565.68 | 64487.01 |  6.47% |
| evalsha - hgetall h10 | 47023.41 | 50602.17 | 7.61% |
| evalsha - hgetall h25 | 33572.82 | 37345.48 | 11.23% |
| evalsha - hgetall h50 | 24206.63 | 25276.14 | 4.42% |
| evalsha - hgetall h100 | 15068.87 | 15656.8 | 3.90% |
| evalsha - hgetall h300 | 5948.56 | 6094.74 | 2.46% |


reproducer:
- taskset -c 0-3 ./src/valkey-server ./valkey-tmp.conf
- valkey-tmp.conf
```
bind * -::*
daemonize no
protected-mode no
save ""
```

- load generator:
```
K100=""
for i in `seq 1 100`; do
    #echo h100-${i}
    K100="$K100 k$i"
    $D/valkey-cli -h $H -p $P hset h100 "k$i" "v$i" > /dev/null
done
$D/valkey-cli -h $H -p $P eval "return redis.call('hgetall', KEYS[1])" 1 h100

$D/valkey-benchmark -h $H -p $P --csv -d 100 -r 1000000 -n 1000000 -c 50 --threads 4 evalsha 806e3d16e04e2e736b75848654372f49477d6236 1 h100
```