### PR TITLE
Speed up AOF rewrite test case

### DIFF
--- a/tests/unit/aofrw.tcl
+++ b/tests/unit/aofrw.tcl
@@ -9,6 +9,9 @@ start_server {tags {"aofrw external:skip logreqres:skip"} overrides {save {}}} {
     foreach rdbpre {yes no} {
         r config set aof-use-rdb-preamble $rdbpre
         test "AOF rewrite during write load: RDB preamble=$rdbpre" {
+            # Start with an empty db
+            r flushall
+
             # Start a write load for 10 seconds
             set master [srv 0 client]
             set master_host [srv 0 host]


### PR DESCRIPTION
These two test cases run in a loop:

* AOF rewrite during write load: RDB preamble=yes
* AOF rewrite during write load: RDB preamble=no

Both of the test cases build up a lot of data (3-4 million keys when I run locally) so we should empty the data before the second test case. Otherwise, the second test cases adds keys on top of the keys added in the first test case, resulting in the double number of keys and takes more time.

Before this commit:

    [ok]: AOF rewrite during write load: RDB preamble=yes (18225 ms)
    [ok]: AOF rewrite during write load: RDB preamble=no (37249 ms)

After:

    [ok]: AOF rewrite during write load: RDB preamble=yes (18777 ms)
    [ok]: AOF rewrite during write load: RDB preamble=no (19940 ms)