### PR TITLE
Reuse `obey_client` variable in `processCommand()` function

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -3889,7 +3889,7 @@ int processCommand(client *c) {
         (c->cmd->proc == execCommand && (c->mstate.cmd_flags & (CMD_WRITE | CMD_MAY_REPLICATE)));
     int is_deny_async_loading_command = (cmd_flags & CMD_NO_ASYNC_LOADING) ||
                                         (c->cmd->proc == execCommand && (c->mstate.cmd_flags & CMD_NO_ASYNC_LOADING));
-    int obey_client = mustObeyClient(c);
+    const int obey_client = mustObeyClient(c);
 
     if (authRequired(c)) {
         /* AUTH and HELLO and no auth commands are valid even in
@@ -3922,7 +3922,7 @@ int processCommand(client *c) {
      * However we don't perform the redirection if:
      * 1) The sender of this command is our primary.
      * 2) The command has no key arguments. */
-    if (server.cluster_enabled && !mustObeyClient(c) &&
+    if (server.cluster_enabled && !obey_client &&
         !(!(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand)) {
         int error_code;
         clusterNode *n = getNodeByQuery(c, c->cmd, c->argv, c->argc, &c->slot, &error_code);
@@ -3939,7 +3939,7 @@ int processCommand(client *c) {
         }
     }
 
-    if (!server.cluster_enabled && c->capa & CLIENT_CAPA_REDIRECT && server.primary_host && !mustObeyClient(c) &&
+    if (!server.cluster_enabled && c->capa & CLIENT_CAPA_REDIRECT && server.primary_host && !obey_client &&
         (is_write_command || (is_read_command && !c->flag.readonly))) {
         if (server.failover_state == FAILOVER_IN_PROGRESS) {
             /* During the FAILOVER process, when conditions are met (such as


### PR DESCRIPTION
Hi, it's pleasure for me to make this PR.

I’ve prepared a minor fix for `processCommand()` function. 

In `processCommand()`, the `obey_client` variable is created, but some conditional statements call the `mustObeyClient()` function instead of reusing `obey_client`. 

I’ve modified these statements to `reuse obey_client`.

Since I’m relatively new to Redis, please let me know if there are any reasons why the conditional statements need to call `mustObeyClient()` again.

Thank you for taking the time to review my PR.