### PR TITLE
Avoid .c, .d and .o files from being copied to the binary tar.gz releases

### DIFF
--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
-          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"          
+          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"
           rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-* "$TAR_FILE_NAME/bin/"
           cp -v /home/runner/work/valkey/valkey/COPYING "$TAR_FILE_NAME/share/LICENSE"
           tar -czvf $TAR_FILE_NAME.tar.gz $TAR_FILE_NAME

--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
-          mkdir -p $TAR_FILE_NAME/bin $TAR_FILE_NAME/share
-          cp -rfv src/valkey-* $TAR_FILE_NAME/bin
-          cp -v /home/runner/work/valkey/valkey/COPYING $TAR_FILE_NAME/share/LICENSE
+          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"          
+          rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-* "$TAR_FILE_NAME/bin/"
+          cp -v /home/runner/work/valkey/valkey/COPYING "$TAR_FILE_NAME/share/LICENSE"
           tar -czvf $TAR_FILE_NAME.tar.gz $TAR_FILE_NAME
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
-          mkdir -p $TAR_FILE_NAME/bin $TAR_FILE_NAME/share
-          cp -rfv src/valkey-* $TAR_FILE_NAME/bin
-          cp -v /home/runner/work/valkey/valkey/COPYING $TAR_FILE_NAME/share/LICENSE
+          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"
+          rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-* "$TAR_FILE_NAME/bin/"
+          cp -v /home/runner/work/valkey/valkey/COPYING "$TAR_FILE_NAME/share/LICENSE"
           tar -czvf $TAR_FILE_NAME.tar.gz $TAR_FILE_NAME
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files


### PR DESCRIPTION
As discussed here: https://github.com/orgs/valkey-io/discussions/1103#discussioncomment-10814006

`cp` can't be used anymore, `rsync` is more powerful and allow to exclude files.

Alternatively:

1. Remove the c, d and o files. Which isn't ideal either.
2. Improve the build. Eg. by building inside a `build` directory instead of in the src folder.

Ps. I know these workflows aren't triggered in this PR. Only via "Build Release Packages" workflow action: https://github.com/valkey-io/valkey/actions/workflows/build-release-packages.yml.. So I can't fully test in this PR. But it should work ^^

Ps. ps. I did test `rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-*` command in isolation and that works as expected!