### PR TITLE
Build binary releases with systemd support

### DIFF
--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -36,7 +36,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
@@ -51,8 +51,8 @@ jobs:
         with:
           arch: aarch64
           distro: ${{matrix.distro.target}}
-          install: apt-get update && apt-get install -y build-essential libssl-dev
-          run: make -C src all BUILD_TLS=yes
+          install: apt-get update && apt-get install -y build-essential libssl-dev libsystemd-dev
+          run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
 
       - name: Create Tarball and SHA256sums
         run: |

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -36,7 +36,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
@@ -47,10 +47,10 @@ jobs:
           ref: ${{ inputs.version }}
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev jq wget awscli
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libsystemd-dev
 
       - name: Make Valkey
-        run: make -C src all BUILD_TLS=yes
+        run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
 
       - name: Create Tarball and SHA256sums
         run: |
@@ -62,6 +62,10 @@ jobs:
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files
           cp -rfv $TAR_FILE_NAME.tar* packages-files/
+
+      - name: Install AWS cli.
+        run: |
+          sudo apt-get install -y awscli
 
       - name: Configure AWS credentials
         run: |


### PR DESCRIPTION
 - Add systemd support to the build artifact tarballs, so people can use it under systemd compatible distros. As discussed here: https://github.com/orgs/valkey-io/discussions/1103#discussioncomment-10815549. Adding `libsystemd-dev` to install and add `USE_SYSTEMD=yes` to the build.
 -  Cleanup & bring the arm & x86 workflow files in-sync. It was a bit of a mess ;) (removing `jq wget awscli` from the 'Tarball' step)