### PR TITLE
Back-porting release workflow changes from unstable. 

### DIFF
--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -36,7 +36,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
@@ -51,9 +51,9 @@ jobs:
         with:
           arch: aarch64
           distro: ${{matrix.distro.target}}
-          install: apt-get update && apt-get install -y build-essential libssl-dev
-          run: make -C src all BUILD_TLS=yes
-      
+          install: apt-get update && apt-get install -y build-essential libssl-dev libsystemd-dev
+          run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
+
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}

--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
-          mkdir -p $TAR_FILE_NAME/bin $TAR_FILE_NAME/share
-          cp -rfv src/valkey-* $TAR_FILE_NAME/bin
-          cp -v /home/runner/work/valkey/valkey/COPYING $TAR_FILE_NAME/share/LICENSE
+          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"
+          rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-* "$TAR_FILE_NAME/bin/"
+          cp -v /home/runner/work/valkey/valkey/COPYING "$TAR_FILE_NAME/share/LICENSE"
           tar -czvf $TAR_FILE_NAME.tar.gz $TAR_FILE_NAME
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
-          mkdir -p $TAR_FILE_NAME/bin $TAR_FILE_NAME/share
-          cp -rfv src/valkey-* $TAR_FILE_NAME/bin
-          cp -v /home/runner/work/valkey/valkey/COPYING $TAR_FILE_NAME/share/LICENSE
+          mkdir -p "$TAR_FILE_NAME/bin" "$TAR_FILE_NAME/share"
+          rsync -av --exclude='*.c' --exclude='*.d' --exclude='*.o' src/valkey-* "$TAR_FILE_NAME/bin/"
+          cp -v /home/runner/work/valkey/valkey/COPYING "$TAR_FILE_NAME/share/LICENSE"
           tar -czvf $TAR_FILE_NAME.tar.gz $TAR_FILE_NAME
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -36,7 +36,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
@@ -47,11 +47,11 @@ jobs:
           ref: ${{ inputs.version }}
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev jq wget awscli
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libsystemd-dev
 
       - name: Make Valkey
-        run: make -C src all BUILD_TLS=yes
-      
+        run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
+
       - name: Create Tarball and SHA256sums
         run: |
           TAR_FILE_NAME=valkey-${{inputs.version}}-${{matrix.distro.platform}}-${{ matrix.distro.arch}}
@@ -62,6 +62,10 @@ jobs:
           sha256sum $TAR_FILE_NAME.tar.gz > $TAR_FILE_NAME.tar.gz.sha256
           mkdir -p packages-files
           cp -rfv $TAR_FILE_NAME.tar* packages-files/
+
+      - name: Install AWS cli.
+        run: |
+          sudo apt-get install -y awscli
 
       - name: Configure AWS credentials
         run: |


### PR DESCRIPTION
This PR back ports https://github.com/valkey-io/valkey/pull/1107/ and https://github.com/valkey-io/valkey/pull/1106 which adds `systemd` support to the build artifact tarballs and excludes  `.c`, `.d` and `.o` files from the website release files.

I have tested this workflow in my fork to trigger automatically on a release. 

https://github.com/roshkhatri/valkey/actions/runs/11149196519