### PR TITLE
Make ./runtest --dump-logs dump logs on crash

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -697,8 +697,8 @@ proc start_server {options {code undefined}} {
             dict set srv "skipleaks" 1
             kill_server $srv
 
-            if {$::dump_logs && $assertion} {
-                # if we caught an assertion ($::num_failed isn't incremented yet)
+            if {$::dump_logs} {
+                # crash or assertion ($::num_failed isn't incremented yet)
                 # this happens when the test spawns a server and not the other way around
                 dump_server_log $srv
             } else {


### PR DESCRIPTION
Until now, this flag only dumped logs on a failed assert in test case. It is useful that this flag dumps logs on a crash as well.