### PR TITLE
Fix undefined-santitizer warning in rax test

### DIFF
--- a/src/unit/test_rax.c
+++ b/src/unit/test_rax.c
@@ -165,7 +165,7 @@ static uint32_t int2int(uint32_t input) {
         r = l ^ F;
         l = nl;
     }
-    return (r << 16) | l;
+    return ((uint32_t)r << 16) | l;
 }
 
 /* Turn an uint32_t integer into an alphanumerical key and return its


### PR DESCRIPTION
Fix the warning introduced in #688:

```
unit/test_rax.c:168:15: runtime error: left shift of 36625 by 16 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior unit/test_rax.c:168:15 in 
Fuzz test in mode 1 [7504]: 
```