### PR TITLE
RDMA: use protected mode for test

### DIFF
--- a/tests/rdma/run.py
+++ b/tests/rdma/run.py
@@ -61,7 +61,7 @@ def test_rdma(ipaddr):
     # step 2, start server
     svrpath = valkeydir + "/src/valkey-server"
     rdmapath = valkeydir + "/src/valkey-rdma.so"
-    svrcmd = [svrpath, "--port", "0", "--loglevel", "verbose", "--protected-mode", "no",
+    svrcmd = [svrpath, "--port", "0", "--loglevel", "verbose", "--protected-mode", "yes",
              "--appendonly", "no", "--daemonize", "no", "--dir", valkeydir + "/tests/rdma/tmp",
              "--loadmodule", rdmapath, "port=6379", "bind=" + ipaddr]
 


### PR DESCRIPTION
Since a7cbca40661 ("RDMA: Support .is_local method (#1089)"), valkey-server started to support auto-detect local connection, then we can use protected mode for local RDMA device for test.