### PR TITLE
Add tags into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ redis.code-workspace
 nodes*.conf
 tests/cluster/tmp/*
 tests/rdma/rdma-test
+tags


### PR DESCRIPTION
ctags is used widely on a linux platform, add tags into .gitignore.