### PR TITLE
Fix some unitialized fields in `client` struct

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -232,6 +232,8 @@ client *createClient(connection *conn) {
     c->net_output_bytes = 0;
     c->net_output_bytes_curr_cmd = 0;
     c->commands_processed = 0;
+    c->io_last_reply_block = NULL;
+    c->io_last_bufpos = 0;
     return c;
 }
 


### PR DESCRIPTION
This commit adds initialization code for the fields `io_last_reply_block` and `io_last_bufpos` of the `client` struct.

While in the current code flow, these fields are only accessed after being written in the `trySendWriteToIOThreads`, I discovered that they were not being initialized while doing some changes to the code flow of IO threads.

I believe it's good pratice to initialize all fields of a struct upon creation, and will avoid future bugs which are usually hard to debug.