### PR TITLE
Fix primary crash when processing dirty slots during shutdown wait / failover wait / client pause

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6040,6 +6040,9 @@ void removeChannelsInSlot(unsigned int slot) {
 unsigned int delKeysInSlot(unsigned int hashslot) {
     if (!kvstoreDictSize(server.db->keys, hashslot)) return 0;
 
+    /* We may lose a slot during the pause. We need to track this
+     * state so that we don't assert in propagateNow(). */
+    server.server_del_keys_in_slot = 1;
     unsigned int j = 0;
 
     kvstoreDictIterator *kvs_di = NULL;
@@ -6064,6 +6067,7 @@ unsigned int delKeysInSlot(unsigned int hashslot) {
     }
     kvstoreReleaseDictIterator(kvs_di);
 
+    server.server_del_keys_in_slot = 0;
     return j;
 }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6068,6 +6068,7 @@ unsigned int delKeysInSlot(unsigned int hashslot) {
     kvstoreReleaseDictIterator(kvs_di);
 
     server.server_del_keys_in_slot = 0;
+    serverAssert(server.execution_nesting == 0);
     return j;
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -4573,11 +4573,6 @@ void unpauseActions(pause_purpose purpose) {
     updatePausedActions();
 }
 
-/* Returns 1 if clients are currently paused for the specified purpose. */
-int isPausedPurpose(pause_purpose purpose) {
-    return server.client_pause_per_purpose[purpose].end != 0;
-}
-
 /* Returns bitmask of paused actions */
 uint32_t isPausedActions(uint32_t actions_bitmask) {
     return (server.paused_actions & actions_bitmask);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4548,9 +4548,9 @@ static void pauseClientsByClient(mstime_t endTime, int isPauseClientAll) {
  * The function always succeed, even if there is already a pause in progress.
  * The new paused_actions of a given 'purpose' will override the old ones and
  * end time will be updated if new end time is bigger than currently configured */
-void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions_bitmask) {
+void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions) {
     /* Manage pause type and end time per pause purpose. */
-    server.client_pause_per_purpose[purpose].paused_actions = actions_bitmask;
+    server.client_pause_per_purpose[purpose].paused_actions = actions;
 
     /* If currently configured end time bigger than new one, then keep it */
     if (server.client_pause_per_purpose[purpose].end < end) server.client_pause_per_purpose[purpose].end = end;

--- a/src/networking.c
+++ b/src/networking.c
@@ -4536,7 +4536,7 @@ static void pauseClientsByClient(mstime_t endTime, int isPauseClientAll) {
 }
 
 /* Pause actions up to the specified unixtime (in ms) for a given type of
- * commands.
+ * purpose.
  *
  * A main use case of this function is to allow pausing replication traffic
  * so that a failover without data loss to occur. Replicas will continue to receive
@@ -4548,9 +4548,9 @@ static void pauseClientsByClient(mstime_t endTime, int isPauseClientAll) {
  * The function always succeed, even if there is already a pause in progress.
  * The new paused_actions of a given 'purpose' will override the old ones and
  * end time will be updated if new end time is bigger than currently configured */
-void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions) {
+void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions_bitmask) {
     /* Manage pause type and end time per pause purpose. */
-    server.client_pause_per_purpose[purpose].paused_actions = actions;
+    server.client_pause_per_purpose[purpose].paused_actions = actions_bitmask;
 
     /* If currently configured end time bigger than new one, then keep it */
     if (server.client_pause_per_purpose[purpose].end < end) server.client_pause_per_purpose[purpose].end = end;
@@ -4571,6 +4571,11 @@ void unpauseActions(pause_purpose purpose) {
     server.client_pause_per_purpose[purpose].end = 0;
     server.client_pause_per_purpose[purpose].paused_actions = 0;
     updatePausedActions();
+}
+
+/* Returns 1 if the specified purpose is currently pausing. */
+int isPausedPurpose(pause_purpose purpose) {
+    return server.client_pause_per_purpose[purpose].end != 0;
 }
 
 /* Returns bitmask of paused actions */

--- a/src/networking.c
+++ b/src/networking.c
@@ -4573,7 +4573,7 @@ void unpauseActions(pause_purpose purpose) {
     updatePausedActions();
 }
 
-/* Returns 1 if the specified purpose is currently pausing. */
+/* Returns 1 if clients are currently paused for the specified purpose. */
 int isPausedPurpose(pause_purpose purpose) {
     return server.client_pause_per_purpose[purpose].end != 0;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -3243,7 +3243,7 @@ static void propagateNow(int dbid, robj **argv, int argc, int target) {
      * replica pause (otherwise data may be lost during a failover) */
     int is_pause_replica_action = isPausedActions(PAUSE_ACTION_REPLICA);
     int is_pause_shutdown_purpose = isPausedPurpose(PAUSE_DURING_SHUTDOWN);
-    serverAssert(!(is_pause_replica_action && !is_pause_shutdown_purpose && !server.client_pause_in_transaction));
+    serverAssert(!is_pause_replica_action || is_pause_shutdown_purpose || server.client_pause_in_transaction);
 
     if (server.aof_state != AOF_OFF && target & PROPAGATE_AOF) feedAppendOnlyFile(dbid, argv, argc);
     if (target & PROPAGATE_REPL) replicationFeedReplicas(dbid, argv, argc);

--- a/src/server.c
+++ b/src/server.c
@@ -3241,7 +3241,9 @@ static void propagateNow(int dbid, robj **argv, int argc, int target) {
 
     /* This needs to be unreachable since the dataset should be fixed during
      * replica pause (otherwise data may be lost during a failover) */
-    serverAssert(!(isPausedActions(PAUSE_ACTION_REPLICA) && (!server.client_pause_in_transaction)));
+    int is_pause_replica_action = isPausedActions(PAUSE_ACTION_REPLICA);
+    int is_pause_shutdown_purpose = isPausedPurpose(PAUSE_DURING_SHUTDOWN);
+    serverAssert(!(is_pause_replica_action && !is_pause_shutdown_purpose && !server.client_pause_in_transaction));
 
     if (server.aof_state != AOF_OFF && target & PROPAGATE_AOF) feedAppendOnlyFile(dbid, argv, argc);
     if (target & PROPAGATE_REPL) replicationFeedReplicas(dbid, argv, argc);

--- a/src/server.c
+++ b/src/server.c
@@ -3242,7 +3242,7 @@ static void propagateNow(int dbid, robj **argv, int argc, int target) {
     /* This needs to be unreachable since the dataset should be fixed during
      * replica pause (otherwise data may be lost during a failover).
      *
-     * Thought, there are exceptions:
+     * Though, there are exceptions:
      *
      * 1. We allow write commands that were queued up before and after to
      *    execute, if a CLIENT PAUSE executed during a transaction, we will

--- a/src/server.h
+++ b/src/server.h
@@ -2842,7 +2842,7 @@ void flushReplicasOutputBuffers(void);
 void disconnectReplicas(void);
 void evictClients(void);
 int listenToPort(connListener *fds);
-void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions_bitmask);
+void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions);
 void unpauseActions(pause_purpose purpose);
 int isPausedPurpose(pause_purpose purpose);
 uint32_t isPausedActions(uint32_t action_bitmask);

--- a/src/server.h
+++ b/src/server.h
@@ -1682,6 +1682,7 @@ struct valkeyServer {
     const char *busy_module_yield_reply; /* When non-null, we are inside RM_Yield. */
     char *ignore_warnings;               /* Config: warnings that should be ignored. */
     int client_pause_in_transaction;     /* Was a client pause executed during this Exec? */
+    int server_del_keys_in_slot;         /* The server is deleting the keys in the dirty slot. */
     int thp_enabled;                     /* If true, THP is enabled. */
     size_t page_size;                    /* The page size of OS. */
     /* Modules */
@@ -2844,7 +2845,6 @@ void evictClients(void);
 int listenToPort(connListener *fds);
 void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions);
 void unpauseActions(pause_purpose purpose);
-int isPausedPurpose(pause_purpose purpose);
 uint32_t isPausedActions(uint32_t action_bitmask);
 uint32_t isPausedActionsWithUpdate(uint32_t action_bitmask);
 void updatePausedActions(void);

--- a/src/server.h
+++ b/src/server.h
@@ -2844,6 +2844,7 @@ void evictClients(void);
 int listenToPort(connListener *fds);
 void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions_bitmask);
 void unpauseActions(pause_purpose purpose);
+int isPausedPurpose(pause_purpose purpose);
 uint32_t isPausedActions(uint32_t action_bitmask);
 uint32_t isPausedActionsWithUpdate(uint32_t action_bitmask);
 void updatePausedActions(void);

--- a/tests/unit/cluster/slot-ownership.tcl
+++ b/tests/unit/cluster/slot-ownership.tcl
@@ -68,6 +68,7 @@ start_cluster 3 1 {tags {external:skip cluster} overrides {shutdown-timeout 100}
         pause_process [srv -3 pid]
 
         # Incr the key and immediately shutdown the primary.
+        # The primary waits for the replica to replicate before exiting.
         R 0 incr FOO
         exec kill -SIGTERM [srv 0 pid]
         wait_for_condition 50 100 {

--- a/tests/unit/cluster/slot-ownership.tcl
+++ b/tests/unit/cluster/slot-ownership.tcl
@@ -61,7 +61,7 @@ start_cluster 2 2 {tags {external:skip cluster}} {
 }
 
 start_cluster 3 1 {tags {external:skip cluster} overrides {shutdown-timeout 100}} {
-    test "Primary will not crash when processing dirty slots during shutdown waiting" {
+    test "Primary lost a slot during the shutdown waiting" {
         R 0 set FOO 0
 
         # Pause the replica.
@@ -99,7 +99,7 @@ start_cluster 3 1 {tags {external:skip cluster} overrides {shutdown-timeout 100}
 }
 
 start_cluster 3 1 {tags {external:skip cluster}} {
-    test "Primary will not crash when processing dirty slots during manual failover pausing" {
+    test "Primary lost a slot during the manual failover pausing" {
         R 0 set FOO 0
 
         # Set primaries to drop the FAILOVER_AUTH_REQUEST packets, so that
@@ -122,5 +122,25 @@ start_cluster 3 1 {tags {external:skip cluster}} {
 
         R 1 debug drop-cluster-packet-filter -1
         R 2 debug drop-cluster-packet-filter -1
+    }
+}
+
+start_cluster 3 1 {tags {external:skip cluster}} {
+    test "Primary lost a slot during the client pause command" {
+        R 0 set FOO 0
+
+        R 0 client pause 1000000000 write
+
+        # Move the slot to other primary
+        R 1 cluster bumpepoch
+        R 1 cluster setslot [R 1 cluster keyslot FOO] node [R 1 cluster myid]
+
+        # Waiting for dirty slot update.
+        wait_for_log_messages 0 {"*Deleting keys in dirty slot*"} 0 1000 10
+
+        # Make sure primary doesn't crash when deleting the keys.
+        R 0 ping
+
+        R 0 client unpause
     }
 }

--- a/tests/unit/cluster/slot-ownership.tcl
+++ b/tests/unit/cluster/slot-ownership.tcl
@@ -107,7 +107,7 @@ start_cluster 3 1 {tags {external:skip cluster}} {
         R 1 debug drop-cluster-packet-filter 5
         R 2 debug drop-cluster-packet-filter 5
 
-        # Replica doint the manual failover.
+        # Replica doing the manual failover.
         R 3 cluster failover
 
         # Move the slot to other primary

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -280,7 +280,7 @@ start_server {tags {"pause network"}} {
         wait_for_condition 1000 10 {
             [expr $evicted_keys + 1] eq [s 0 evicted_keys]
         } else {
-            fail "The old primary was not converted into replica"
+            fail "Key is not evicted"
         }
 
         r config set maxmemory 0

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -260,6 +260,33 @@ start_server {tags {"pause network"}} {
         r client unpause
     }
 
+    test "Test eviction is skipped during client pause" {
+        r flushall
+        set evicted_keys [s 0 evicted_keys]
+
+        r multi
+        r set foo{t} bar
+        r config set maxmemory-policy allkeys-random
+        r config set maxmemory 1
+        r client PAUSE 50000 WRITE
+        r exec
+
+        # No keys should actually have been evicted.
+        assert_match $evicted_keys [s 0 evicted_keys]
+
+        # The previous config set triggers a time event, but due to the pause,
+        # no eviction has been made. After the unpause, a eviction will happen.
+        r client unpause
+        wait_for_condition 1000 10 {
+            [expr $evicted_keys + 1] eq [s 0 evicted_keys]
+        } else {
+            fail "The old primary was not converted into replica"
+        }
+
+        r config set maxmemory 0
+        r config set maxmemory-policy noeviction
+    }
+
     test "Test both active and passive expires are skipped during client pause" {
         set expired_keys [s 0 expired_keys]
         r multi


### PR DESCRIPTION
We have an assert in propagateNow. If the primary node receives a
CLUSTER UPDATE such as dirty slots during SIGTERM waitting or during
a manual failover pausing or during a client pause, the delKeysInSlot
call will trigger this assert and cause primary crash.

In this case, we added a new server_del_keys_in_slot state just like
client_pause_in_transaction to track the state to avoid the assert
in propagateNow, the dirty slots will be deleted in the end without
affecting the data consistency.