### PR TITLE
Removing incorrect comment about a warning

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -227,12 +227,8 @@ static clusterNode *clusterNodeIterNext(ClusterNodeIterator *iter) {
         /* Return the value associated with the node, or NULL if no more nodes */
         return ln ? listNodeValue(ln) : NULL;
     }
-    /* This line is unreachable but added to avoid compiler warnings */
-    default: {
-        serverPanic("bad type");
-        return NULL;
     }
-    }
+    serverPanic("Unknown iterator type %d", iter->type);
 }
 
 static void clusterNodeIterReset(ClusterNodeIterator *iter) {


### PR DESCRIPTION
There is a lot of bad legacy usage of `default:` with enums, which is an anti-pattern. If you omit the default, the compiler will tell you if a new enum value was added and that it is missing from a switch statement.

Someone mentioned on another PR they used `default:` because of this warning, so just removing it, but might create an issue to do a wider cleanup.