### PR TITLE
Add io-threads-do-reads config to deprecated config table to have no effect.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -444,6 +444,7 @@ void loadServerConfigFromString(char *config) {
         {"list-max-ziplist-entries", 2, 2},
         {"list-max-ziplist-value", 2, 2},
         {"lua-replicate-commands", 2, 2},
+        {"io-threads-do-reads", 2, 2},
         {NULL, 0},
     };
     char buf[1024];
@@ -3086,7 +3087,6 @@ standardConfig static_configs[] = {
     /* Bool configs */
     createBoolConfig("rdbchecksum", NULL, IMMUTABLE_CONFIG, server.rdb_checksum, 1, NULL, NULL),
     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, server.daemonize, 0, NULL, NULL),
-    createBoolConfig("io-threads-do-reads", NULL, DEBUG_CONFIG | IMMUTABLE_CONFIG, server.io_threads_do_reads, 1, NULL, NULL), /* Read + parse from threads */
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, server.always_show_logo, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, server.protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, server.rdb_compression, 1, NULL, NULL),

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -319,7 +319,6 @@ void initIOThreads(void) {
 
 int trySendReadToIOThreads(client *c) {
     if (server.active_io_threads_num <= 1) return C_ERR;
-    if (!server.io_threads_do_reads) return C_ERR;
     /* If IO thread is areadty reading, return C_OK to make sure the main thread will not handle it. */
     if (c->io_read_state != CLIENT_IDLE) return C_OK;
     /* Currently, replica/master writes are not offloaded and are processed synchronously. */

--- a/src/server.h
+++ b/src/server.h
@@ -1744,7 +1744,6 @@ struct valkeyServer {
     _Atomic uint64_t next_client_id;          /* Next client unique ID. Incremental. */
     int protected_mode;                       /* Don't accept external connections. */
     int io_threads_num;                       /* Number of IO threads to use. */
-    int io_threads_do_reads;                  /* Read and parse from IO threads? */
     int active_io_threads_num;                /* Current number of active IO threads, includes main thread. */
     int events_per_io_thread;                 /* Number of events on the event loop to trigger IO threads activation. */
     int prefetch_batch_max_size;              /* Maximum number of keys to prefetch in a single batch */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -514,7 +514,6 @@ start_server {tags {"introspection"}} {
         set skip_configs {
             rdbchecksum
             daemonize
-            io-threads-do-reads
             tcp-backlog
             always-show-logo
             syslog-enabled

--- a/valkey.conf
+++ b/valkey.conf
@@ -1355,7 +1355,7 @@ lazyfree-lazy-user-flush yes
 # prefetch-batch-max-size 16
 #
 # NOTE:
-# 1. 'io-threads-do-reads' config is depricated and will be removed in the future,
+# 1. 'io-threads-do-reads' config is deprecated and will be removed in the future,
 # please avoid using this option if possible.
 #
 # 2. If you want to test the server speedup using valkey-benchmark, make

--- a/valkey.conf
+++ b/valkey.conf
@@ -1355,8 +1355,8 @@ lazyfree-lazy-user-flush yes
 # prefetch-batch-max-size 16
 #
 # NOTE:
-# 1. 'io-threads-do-reads' config is deprecated and will be removed in the future,
-# please avoid using this option if possible.
+# 1. The 'io-threads-do-reads' config is deprecated and has no effect.
+# It will be removed in the future. Please avoid using this option if possible.
 #
 # 2. If you want to test the server speedup using valkey-benchmark, make
 # sure you also run the benchmark itself in threaded mode, using the

--- a/valkey.conf
+++ b/valkey.conf
@@ -1354,7 +1354,11 @@ lazyfree-lazy-user-flush yes
 #
 # prefetch-batch-max-size 16
 #
-# NOTE: If you want to test the server speedup using valkey-benchmark, make
+# NOTE:
+# 1. 'io-threads-do-reads' config is depricated and will be removed in the future,
+# please avoid using this option if possible.
+#
+# 2. If you want to test the server speedup using valkey-benchmark, make
 # sure you also run the benchmark itself in threaded mode, using the
 # --threads option to match the number of server threads, otherwise you'll not
 # be able to notice the improvements.


### PR DESCRIPTION
this fixes: https://github.com/valkey-io/valkey/issues/1116

_Issue details from #1116 by @zuiderkwast_ 

> This config is undocumented since #758. The default was changed to "yes" and it is quite useless to set it to "no". Yet, it can happen that some user has an old config file where it is explicitly set to "no". The result will be bad performace, since I/O threads will not do all the I/O.
> 
> It's indeed confusing.
> 
> 1. Either remove the whole option from the code. And thus no need for documentation. _OR:_
> 2. Introduce the option back in the configuration,  just as a comment is fine. And showing the default value "yes": `# io-threads-do-reads yes` with additional text.
> 
> _Originally posted by @melroy89 in [#1019 (reply in thread)](https://github.com/orgs/valkey-io/discussions/1019#discussioncomment-10824778)_
