### PR TITLE
Fix empty response for ACL CAT category subcommand for module defined categories

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2760,7 +2760,6 @@ void aclCatWithFlags(client *c, dict *commands, uint64_t cflag, int *arraylen) {
 
     while ((de = dictNext(di)) != NULL) {
         struct serverCommand *cmd = dictGetVal(de);
-        if (cmd->flags & CMD_MODULE) continue;
         if (cmd->acl_categories & cflag) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             (*arraylen)++;

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -143,6 +143,11 @@ start_server {tags {"modules acl"}} {
         assert_equal [r acl DRYRUN j8 aclcheck.module.command.test.add.new.aclcategories] OK
     }
 
+    test {test if ACL CAT output for the new category is correct} {
+        set cmds_in_cat [r ACL CAT foocategory]
+        assert {$cmds_in_cat eq {aclcheck.module.command.test.add.new.aclcategories}}
+    }
+
     test {test permission compaction and simplification for categories added by a module} {
         r acl SETUSER j9 on >password -@all +@foocategory -@foocategory
         catch {r ACL GETUSER j9} res

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -144,8 +144,7 @@ start_server {tags {"modules acl"}} {
     }
 
     test {test if ACL CAT output for the new category is correct} {
-        set cmds_in_cat [r ACL CAT foocategory]
-        assert {$cmds_in_cat eq {aclcheck.module.command.test.add.new.aclcategories}}
+        assert_equal [r ACL CAT foocategory] aclcheck.module.command.test.add.new.aclcategories
     }
 
     test {test permission compaction and simplification for categories added by a module} {


### PR DESCRIPTION
The module commands which were added to acl categories were getting skipped when `ACL CAT category` command was executed. 

This PR fixes the bug.
Before:
```
127.0.0.1:6379> ACL CAT foocategory
(empty array)
```
After:
```
127.0.0.1:6379> ACL CAT foocategory
aclcheck.module.command.test.add.new.aclcategories
```