### PR TITLE
Set fail-fast to false in daily CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -607,6 +607,7 @@ jobs:
       !contains(github.event.inputs.skipjobs, 'sanitizer')
     timeout-minutes: 14400
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc, clang]
     env:
@@ -659,6 +660,7 @@ jobs:
       !contains(github.event.inputs.skipjobs, 'sanitizer')
     timeout-minutes: 14400
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc, clang]
     env:
@@ -1001,6 +1003,7 @@ jobs:
 
   build-macos:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-12, macos-14]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Currently in our daily, if a job fails, it will cancel the other jobs
in the same matrix, we want to avoid this so that all jobs in a matrix
can eventually run to completion.

Docs: jobs.<job_id>.strategy.fail-fast applies to the entire matrix.
If jobs.<job_id>.strategy.fail-fast is set to true or its expression
evaluates to true, GitHub will cancel all in-progress and queued jobs
in the matrix if any job in the matrix fails. This property defaults
to true.