### PR TITLE
Deflake test sync should continue if not all slaves dropped dual-channel-replication

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -834,11 +834,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set dual-channel-replication-enabled yes
     $primary config set loglevel debug
     $primary config set repl-diskless-sync-delay 5
-    
+    $primary config set client-output-buffer-limit "replica 0 0 0"
+
     # Generating RDB will cost 5s(10000 * 0.0005s)
     $primary debug populate 10000 primary 1
     $primary config set rdb-key-save-delay 500
-
+    
     $primary config set dual-channel-replication-enabled $dualchannel
 
     start_server {} {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -839,7 +839,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     # Generating RDB will cost 5s(10000 * 0.0005s)
     $primary debug populate 10000 primary 1
     $primary config set rdb-key-save-delay 500
-    
     $primary config set dual-channel-replication-enabled $dualchannel
 
     start_server {} {


### PR DESCRIPTION
sometimes when dual-channel is turned off the tested replica might disconnect on COB overrun. disable the replica COB limit in order to prevent such cases.

fixes: #1153 