### PR TITLE
Deflake test Primary COB growth with inactive replica

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -500,7 +500,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $primary config set dual-channel-replication-enabled yes
         $primary config set repl-backlog-size $backlog_size
         $primary config set loglevel debug
-        $primary config set repl-timeout 10
+        if {$::valgrind} {
+            $primary config set repl-timeout 100
+        } else {
+            $primary config set repl-timeout 10
+        }
         $primary config set rdb-key-save-delay 200
         populate 10000 primary 10000
         
@@ -510,7 +514,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
-        $replica config set repl-timeout 10
+        if {$::valgrind} {
+            $primary config set repl-timeout 100
+        } else {
+            $primary config set repl-timeout 10
+        }
         # Pause replica after primary fork
         $replica debug pause-after-fork 1
 


### PR DESCRIPTION
in case of valgrind run, the replica might get disconnected from the primary due to repl-timeout reached. Fix is to configure larger timeout in case of valgrind test.

Example failure: https://github.com/valkey-io/valkey/actions/runs/11283922852/job/31417235022

**Partially** fixes: #1152