### PR TITLE
Minor cleanups in acl-v2 tests

### DIFF
--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -42,19 +42,19 @@ start_server {tags {"acl external:skip"}} {
 
     test {Test selector syntax error reports the error in the selector context} {
         catch {r ACL SETUSER selector-syntax on (this-is-invalid)} e
-        assert_match "*ERR Error in ACL SETUSER modifier '(*)*Syntax*" $e
+        assert_match "ERR Error in ACL SETUSER modifier '(*)*Syntax*" $e
 
         catch {r ACL SETUSER selector-syntax on (&* &fail)} e
-        assert_match "*ERR Error in ACL SETUSER modifier '(*)*Adding a pattern after the*" $e
+        assert_match "ERR Error in ACL SETUSER modifier '(*)*Adding a pattern after the*" $e
 
         catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL} e
-        assert_match "*ERR Unmatched parenthesis in acl selector*" $e
+        assert_match "ERR Unmatched parenthesis in acl selector*" $e
 
         catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL ) ) ) } e
-        assert_match "*ERR Error in ACL SETUSER modifier*" $e
+        assert_match "ERR Error in ACL SETUSER modifier*" $e
 
         catch {r ACL SETUSER selector-syntax on (+PING (+SELECT (+DEL ) } e
-        assert_match "*ERR Error in ACL SETUSER modifier*" $e
+        assert_match "ERR Error in ACL SETUSER modifier*" $e
 
         assert_equal "" [r ACL GETUSER selector-syntax]
     }
@@ -75,11 +75,11 @@ start_server {tags {"acl external:skip"}} {
 
         # Test invalid selector syntax
         catch {r ACL SETUSER invalid-selector " () "} err
-        assert_match "*ERR*Syntax error*" $err
+        assert_match "ERR*Syntax error*" $err
         catch {r ACL SETUSER invalid-selector (} err
-        assert_match "*Unmatched parenthesis*" $err
+        assert_match "ERR*Unmatched parenthesis*" $err
         catch {r ACL SETUSER invalid-selector )} err
-        assert_match "*ERR*Syntax error" $err
+        assert_match "ERR*Syntax error*" $err
     }
 
     test {Test separate read permission} {


### PR DESCRIPTION
1. Make sure to assert the ERR prefix.
2. Match "Syntax error*" in case of the message change.