### PR TITLE
Rename z{malloc,calloc,realloc,free} into valkey_{malloc,calloc,realloc,free}

### DIFF
--- a/deps/hdr_histogram/hdr_redis_malloc.h
+++ b/deps/hdr_histogram/hdr_redis_malloc.h
@@ -1,13 +1,13 @@
 #ifndef HDR_MALLOC_H__
 #define HDR_MALLOC_H__
 
-void *zmalloc(size_t size);
+void *valkey_malloc(size_t size);
 void *zcalloc_num(size_t num, size_t size);
-void *zrealloc(void *ptr, size_t size);
-void zfree(void *ptr);
+void *valkey_realloc(void *ptr, size_t size);
+void valkey_free(void *ptr);
 
-#define hdr_malloc zmalloc
+#define hdr_malloc valkey_malloc
 #define hdr_calloc zcalloc_num
-#define hdr_realloc zrealloc
-#define hdr_free zfree
+#define hdr_realloc valkey_realloc
+#define hdr_free valkey_free
 #endif

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -107,6 +107,15 @@
 #define HAVE_DEFRAG
 #endif
 
+/* The zcalloc symbol is a symbol name already used by zlib, which is defining
+ * other names using the "z" prefix specific to zlib. In practice, linking
+ * valkey with a static openssl, which itself might depend on a static libz
+ * will result in link time error rejecting multiple symbol definitions. */
+#define zmalloc valkey_malloc
+#define zcalloc valkey_calloc
+#define zrealloc valkey_realloc
+#define zfree valkey_free
+
 /* 'noinline' attribute is intended to prevent the `-Wstringop-overread` warning
  * when using gcc-12 later with LTO enabled. It may be removed once the
  * bug[https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96503] is fixed. */


### PR DESCRIPTION
The zcalloc symbol is a symbol name already used by zlib, which is defining other names using the "z" prefix specific to zlib. In practice, linking valkey with a static openssl, which itself might depend on a static libz will result in link time error rejecting multiple symbol definitions.

Fixes: #1157