### PR TITLE
Fix FUNCTION KILL error message being displayed as SCRIPT KILL

### DIFF
--- a/src/script_lua.c
+++ b/src/script_lua.c
@@ -1609,7 +1609,13 @@ static void luaMaskCountHook(lua_State *lua, lua_Debug *ar) {
     scriptRunCtx *rctx = luaGetFromRegistry(lua, REGISTRY_RUN_CTX_NAME);
     serverAssert(rctx); /* Only supported inside script invocation */
     if (scriptInterrupt(rctx) == SCRIPT_KILL) {
-        serverLog(LL_NOTICE, "Lua script killed by user with SCRIPT KILL.");
+        char *err = NULL;
+        if (rctx->flags & SCRIPT_EVAL_MODE) {
+            err = "Script killed by user with SCRIPT KILL.";
+        } else {
+            err = "Script killed by user with FUNCTION KILL.";
+        }
+        serverLog(LL_NOTICE, "%s", err);
 
         /*
          * Set the hook to invoke all the time so the user
@@ -1618,7 +1624,7 @@ static void luaMaskCountHook(lua_State *lua, lua_Debug *ar) {
          */
         lua_sethook(lua, luaMaskCountHook, LUA_MASKLINE, 0);
 
-        luaPushError(lua, "Script killed by user with SCRIPT KILL...");
+        luaPushError(lua, err);
         luaError(lua);
     }
 }

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -246,6 +246,8 @@ start_server {tags {"scripting"}} {
         r function kill
         after 200 ; # Give some time to Lua to call the hook again...
         assert_equal [r ping] "PONG"
+        assert_error {ERR Script killed by user with FUNCTION KILL*} {$rd read}
+        $rd close
     }
 
     test {FUNCTION - test script kill not working on function} {
@@ -261,6 +263,8 @@ start_server {tags {"scripting"}} {
         r function kill
         after 200 ; # Give some time to Lua to call the hook again...
         assert_equal [r ping] "PONG"
+        assert_error {ERR Script killed by user with FUNCTION KILL*} {$rd read}
+        $rd close
     }
 
     test {FUNCTION - test function kill not working on eval} {
@@ -275,6 +279,8 @@ start_server {tags {"scripting"}} {
         r script kill
         after 200 ; # Give some time to Lua to call the hook again...
         assert_equal [r ping] "PONG"
+        assert_error {ERR Script killed by user with SCRIPT KILL*} {$rd read}
+        $rd close
     }
 
     test {FUNCTION - test function flush} {


### PR DESCRIPTION
The client that was killed by FUNCTION KILL received a reply of
SCRIPT KILL and the server log also showed SCRIPT KILL.