### PR TITLE
[Minor] Remove 'posting in the mailing list' in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,9 @@ you need to ensure that the contribution is in accordance with the DCO.
 
 1. If it is a major feature or a semantical change, please don't start coding
 straight away: if your feature is not a conceptual fit you'll lose a lot of
-time writing the code without any reason. Start by posting in the mailing list
-and creating an issue at Github with the description of, exactly, what you want
-to accomplish and why. Use cases are important for features to be accepted.
-Here you can see if there is consensus about your idea.
+time writing the code without any reason. Start by creating an issue at Github with the
+description of, exactly, what you want to accomplish and why. Use cases are important for
+features to be accepted. Here you can see if there is consensus about your idea.
 
 2. If in step 1 you get an acknowledgment from the project leaders, use the following
 procedure to submit a patch:


### PR DESCRIPTION
With referece of below slack discussion: I have created this PR to remove the statemnet about mailing list and updated the file.


> Mateusz Warzynski
>   Yesterday at 7:44 AM
> Hello everyone! It's nice to meet you.
> I've discussed possible observability enhancements in Valkey with 
> [@Irfan Ahmad](https://valkey-oss-developer.slack.com/team/U0732AEK8LT)
> , which lead to drafting the design proposal. I believe the process of contribution is outlined [here](https://github.com/valkey-io/valkey/blob/unstable/CONTRIBUTING.md#how-to-provide-a-patch-or-a-new-feature).
> Start by posting in the mailing list and creating an issue at GitHub with the description of, exactly, what you want to accomplish and why.
> I've published a draft proposal for observability enhancements in Valkey: https://github.com/valkey-io/valkey/issues/1167.  Does this message satisfy the 'posting in the mailing list'?

> Viktor Söderqvist (Ericsson)
>   [Yesterday at 8:00 AM](https://valkey-oss-developer.slack.com/archives/CHP5YRRAR/p1728907239860219?thread_ts=1728906273.478699&cid=CHP5YRRAR)
>  'posting in the mailing list'
> We've never had a mailing list. :joy: This must be left from redis times. We need to delete this sentence.
> Posting an issue is a great first step. Thanks!













