### PR TITLE
Fix false sharing issue between main thread and io-threads when access `used_memory_thread`.

### DIFF
--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -102,7 +102,7 @@ static thread_local int thread_index = -1;
  * For the other architecture, lets fall back to the atomic operation to keep safe. */
 #if defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || defined(__POWERPC__) || defined(__arm__) || \
     defined(__arm64__)
-static __attribute__((aligned(CACHE_LINE_SIZE))) size_t __used_memory_thread[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
+static __attribute__((aligned(CACHE_LINE_SIZE))) size_t used_memory_thread_padded[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #else
 static __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t __used_memory_thread[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #endif

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -90,6 +90,7 @@ void zlibc_free(void *ptr) {
 
 #define thread_local _Thread_local
 
+#define PADDING_ELEMENT_NUM CACHE_LINE_SIZE / sizeof(size_t) - 1
 #define MAX_THREADS_NUM (IO_THREADS_MAX_NUM + 3 + 1)
 /* A thread-local storage which keep the current thread's index in the used_memory_thread array. */
 static thread_local int thread_index = -1;
@@ -101,10 +102,11 @@ static thread_local int thread_index = -1;
  * For the other architecture, lets fall back to the atomic operation to keep safe. */
 #if defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || defined(__POWERPC__) || defined(__arm__) || \
     defined(__arm64__)
-static __attribute__((aligned(sizeof(size_t)))) size_t used_memory_thread[MAX_THREADS_NUM];
+static __attribute__((aligned(CACHE_LINE_SIZE))) size_t __used_memory_thread[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #else
-static _Atomic size_t used_memory_thread[MAX_THREADS_NUM];
+static __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t __used_memory_thread[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #endif
+static size_t *used_memory_thread = &__used_memory_thread[PADDING_ELEMENT_NUM];
 static atomic_int total_active_threads = 0;
 /* This is a simple protection. It's used only if some modules create a lot of threads. */
 static atomic_size_t used_memory_for_additional_threads = 0;

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -104,9 +104,9 @@ static thread_local int thread_index = -1;
     defined(__arm64__)
 static __attribute__((aligned(CACHE_LINE_SIZE))) size_t used_memory_thread_padded[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #else
-static __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t __used_memory_thread[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
+static __attribute__((aligned(CACHE_LINE_SIZE))) _Atomic size_t used_memory_thread_padded[MAX_THREADS_NUM + PADDING_ELEMENT_NUM];
 #endif
-static size_t *used_memory_thread = &__used_memory_thread[PADDING_ELEMENT_NUM];
+static size_t *used_memory_thread = &used_memory_thread_padded[PADDING_ELEMENT_NUM];
 static atomic_int total_active_threads = 0;
 /* This is a simple protection. It's used only if some modules create a lot of threads. */
 static atomic_size_t used_memory_for_additional_threads = 0;

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -90,7 +90,7 @@ void zlibc_free(void *ptr) {
 
 #define thread_local _Thread_local
 
-#define PADDING_ELEMENT_NUM CACHE_LINE_SIZE / sizeof(size_t) - 1
+#define PADDING_ELEMENT_NUM (CACHE_LINE_SIZE / sizeof(size_t) - 1)
 #define MAX_THREADS_NUM (IO_THREADS_MAX_NUM + 3 + 1)
 /* A thread-local storage which keep the current thread's index in the used_memory_thread array. */
 static thread_local int thread_index = -1;


### PR DESCRIPTION
## Description
When profiling some workloads with `io-threads` enabled. We found the false sharing issue is heavy(**Fig 2**). 

This patch try to split the the elements accessed by main thread and io-threads into different cache line by padding the elements in the head of `used_memory_thread_padded` array. The implementation should be like **Fig 1** demoed. 

Design like below will help mitigate the false sharing between main thread and io-threads, because the main thread has been the bottleneck with io-threads enabled.  We didn't put each element in an individual cache line is that we don't want to bring the additional cache line fetch operation (3 vs 16 cache line) when call function like `zmalloc_used_memory()`.

![image](https://github.com/user-attachments/assets/ad760d93-585c-407c-9b4a-695c4ca7f225)
Fig 1. `used_memory_thread_padded` element distribution in cache line.
 
![image](https://github.com/user-attachments/assets/05317c8d-4704-4292-88cf-0151c4f8d050)

Fig 2. perf c2c report with io-threads enabled.

## Perf Boost
With benchmark of **`XADD`**
 `taskset -c 40-55 ~/valkey/src/valkey-benchmark -h 127.0.0.1 -p 9001 -n 10000000 -c 100 --threads 16 -t xadd`.
We can observe around **2%-4%** perf boost.

**Notes:** This optimization should benefit more if the high percentage of cycles of `zmalloc_usable` and `zfree`. 

#### Test Env
- OS: Ubuntu 22.04.4 LTS
- Platform: Intel Xeon Platinum 8380
- Server and Client in same socket

#### Valkey-server configuration
```
taskset -c 0-15 ~/valkey/src/valkey-server ~/tmp_valkey.conf
port 9001
bind * -::*
daemonize no
protected-mode no
save
io-threads 16
```