### PR TITLE
[WIP] Skip the checksum for diskless replication

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1407,7 +1407,8 @@ int rdbSaveRio(int req, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
     long key_counter = 0;
     int j;
 
-    if (server.rdb_checksum) rdb->update_cksum = rioGenericUpdateChecksum;
+    if (server.rdb_checksum && !(rdbflags & RDBFLAGS_CKSUM_SKIP))
+        rdb->update_cksum = rioGenericUpdateChecksum;
     snprintf(magic, sizeof(magic), "REDIS%04d", RDB_VERSION);
     if (rdbWriteRaw(rdb, magic, 9) == -1) goto werr;
     if (rdbSaveInfoAuxFields(rdb, rdbflags, rsi) == -1) goto werr;
@@ -1451,13 +1452,16 @@ werr:
  * without doing any processing of the content. */
 int rdbSaveRioWithEOFMark(int req, rio *rdb, int *error, rdbSaveInfo *rsi) {
     char eofmark[RDB_EOF_MARK_SIZE];
-
+    int skip_cksum_repl = RDBFLAGS_REPLICATION;
     startSaving(RDBFLAGS_REPLICATION);
     getRandomHexChars(eofmark, RDB_EOF_MARK_SIZE);
     if (error) *error = 0;
     if (rioWrite(rdb, "$EOF:", 5) == 0) goto werr;
     if (rioWrite(rdb, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
     if (rioWrite(rdb, "\r\n", 2) == 0) goto werr;
+    if (server.repl_diskless_sync && req & REPLICA_REQ_CHKSUM_SKIP)
+        skip_cksum_repl |= RDBFLAGS_CKSUM_SKIP;
+    if (rdbSaveRio(req, rdb, error, skip_cksum_repl, rsi) == C_ERR) goto werr;
     if (rdbSaveRio(req, rdb, error, RDBFLAGS_REPLICATION, rsi) == C_ERR) goto werr;
     if (rioWrite(rdb, eofmark, RDB_EOF_MARK_SIZE) == 0) goto werr;
     stopSaving(1);

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -133,6 +133,7 @@
 #define RDBFLAGS_ALLOW_DUP (1 << 2)    /* Allow duplicated keys when loading.*/
 #define RDBFLAGS_FEED_REPL (1 << 3)    /* Feed replication stream when loading.*/
 #define RDBFLAGS_KEEP_CACHE (1 << 4)   /* Don't reclaim cache after rdb file is generated */
+#define RDBFLAGS_CKSUM_SKIP (1 << 5)   /* Skip checksum for diskless sync. */
 
 /* When rdbLoadObject() returns NULL, the err flag is
  * set to hold the type of error that occurred */

--- a/src/server.h
+++ b/src/server.h
@@ -438,6 +438,7 @@ typedef enum {
 #define REPLICA_REQ_RDB_EXCLUDE_DATA (1 << 0)      /* Exclude data from RDB */
 #define REPLICA_REQ_RDB_EXCLUDE_FUNCTIONS (1 << 1) /* Exclude functions from RDB */
 #define REPLICA_REQ_RDB_CHANNEL (1 << 2)           /* Use dual-channel-replication */
+#define REPLICA_REQ_CHKSUM_SKIP (1 << 3)           /* Exclude checksum from RDB */
 /* Mask of all bits in the replica requirements bitfield that represent non-standard (filtered) RDB requirements */
 #define REPLICA_REQ_RDB_MASK (REPLICA_REQ_RDB_EXCLUDE_DATA | REPLICA_REQ_RDB_EXCLUDE_FUNCTIONS)
 


### PR DESCRIPTION
fixes: #1129 
Below is the background information from #1129 by @madolson 

> When we are not writing to disk (either on the primary or replica) there isn't a lot of sense in doing CRC64 checksumming during fullsync. We do checking summing at the TCP layer already. At AWS we've seen it can take up to 15% overhead for not much of a benefit. We should look into a mechanism so that a replica can indicate that it will load something directly into memory, since today we only indicate we support the EOF marker. The replica might still choose to save the RDB file to disk unless repl-diskless-load is enabled. With this mechanism in place, we should be able to skip the checksum for replication, while still using it for RDB.

Here is my understanding and proposal as a fix for the issue. Please correct me if my understanding is wrong or missing something!

![image](https://github.com/user-attachments/assets/0b57e6d9-1952-476f-b102-7b39481e26ce)

- Added 'replication-diskless-load' to sendCommand replica details in syncWithPrimary and FullSyncWithPrimary.
- Added rdbFlag to skip checksum based on 'replica-diskless-load' configuaration from the replica.
  