### PR TITLE
Adds wasmtime-c-api dependency to support WASM scripts/functions

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -74,6 +74,12 @@ fpconv: .make-prerequisites
 
 .PHONY: fpconv
 
+download-wasm-binary-deps: .make-prerequisites
+	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
+	cd wasmtime-c-api && $(MAKE)
+
+.PHONY: download-wasm-binary-deps
+
 ifeq ($(uname_S),SunOS)
 	# Make isinf() available
 	LUA_CFLAGS= -D__C99FEATURES__=1

--- a/deps/wasmtime-c-api/.gitignore
+++ b/deps/wasmtime-c-api/.gitignore
@@ -1,0 +1,5 @@
+LICENSE
+README*
+lib
+include
+min

--- a/deps/wasmtime-c-api/Makefile
+++ b/deps/wasmtime-c-api/Makefile
@@ -1,0 +1,22 @@
+WASMTIME_VERSION=v25.0.2
+WASMTIME_PLATFORM=$(shell sh -c 'uname -s 2>/dev/null | tr A-Z a-z || echo not')
+WASMTIME_ARCH=$(shell sh -c 'uname -m 2>/dev/null || echo not')
+
+WASMTIME_PKG_NAME=wasmtime-$(WASMTIME_VERSION)-$(WASMTIME_ARCH)-$(WASMTIME_PLATFORM)-c-api
+WASMTIME_PKG_URL=https://github.com/bytecodealliance/wasmtime/releases/download/$(WASMTIME_VERSION)/$(WASMTIME_PKG_NAME).tar.xz
+
+WASTIME_FILE_LIST=lib min include LICENSE README.md
+
+$(WASTIME_FILE_LIST):
+	curl -L -O $(WASMTIME_PKG_URL)
+	tar -xf $(WASMTIME_PKG_NAME).tar.xz
+	mv $(WASMTIME_PKG_NAME)/* .
+	rm -r $(WASMTIME_PKG_NAME)
+	rm $(WASMTIME_PKG_NAME).tar.xz
+
+
+clean:
+	rm -rf $(WASTIME_FILE_LIST)
+
+
+.PHONY: clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -318,6 +318,30 @@ else
 	LIBCRYPTO_LIBS=-lcrypto
 endif
 
+# WASM Support
+WASM_STATIC_LIB=
+ifeq ($(BUILD_WITH_WASM),yes)
+	WASMTIME_ROOT?=../deps/wasmtime-c-api
+
+	WASM_LIB_EXISTS=$(shell test -f $(WASMTIME_ROOT)/lib/libwasmtime.a && echo $$?)
+	ifeq ($(WASM_LIB_EXISTS),0)
+		WASM_STATIC_LIB= $(WASMTIME_ROOT)/lib/libwasmtime.a
+		WASM_CFLAGS+= -I$(WASMTIME_ROOT)/include -DWASM_ENABLED -Wno-strict-prototypes
+	else
+		ifneq ($(MAKECMDGOALS), clean)
+		ifneq ($(MAKECMDGOALS), distclean)
+		ifneq ($(MAKECMDGOALS), download-wasm-binary-deps)
+			ifeq ($(WASMTIME_ROOT), ../deps/wasmtime-c-api)
+$(error "WASMTIME library cannot be found in '$(WASMTIME_ROOT)', please run 'make download-wasm-binary-deps' to download wasmtime library.")
+			else
+$(error "WASMTIME library cannot be found in '$(WASMTIME_ROOT)'.")
+			endif
+		endif
+		endif
+		endif
+  endif
+endif
+
 BUILD_NO:=0
 BUILD_YES:=1
 BUILD_MODULE:=2
@@ -467,6 +491,7 @@ persist-settings: distclean
 	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
+	echo BUILD_WITH_WASM=$(BUILD_WITH_WASM) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))
 
 .PHONY: persist-settings
@@ -486,7 +511,7 @@ endif
 
 # valkey-server
 $(SERVER_NAME): $(ENGINE_SERVER_OBJ)
-	$(SERVER_LD) -o $@ $^ ../deps/hiredis/libhiredis.a ../deps/lua/src/liblua.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
+	$(SERVER_LD) -o $@ $^ ../deps/hiredis/libhiredis.a ../deps/lua/src/liblua.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(WASM_STATIC_LIB) $(FINAL_LIBS)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
@@ -535,6 +560,9 @@ DEP = $(ENGINE_SERVER_OBJ:%.o=%.d) $(ENGINE_CLI_OBJ:%.o=%.d) $(ENGINE_BENCHMARK_
 
 unit/%.o: unit/%.c .make-prerequisites
 	$(SERVER_CC) -MMD -o $@ -c $<
+
+wasm.o: wasm.c
+	$(SERVER_CC) $(WASM_CFLAGS) -MMD -o $@ -c $<
 
 # The following files are checked in and don't normally need to be rebuilt. They
 # are built only if python is available and their prereqs are modified.
@@ -639,3 +667,8 @@ uninstall:
 	$(call MAYBE_UNINSTALL_REDIS_SYMLINK,$(INSTALL_BIN),$(ENGINE_CHECK_RDB_NAME))
 	$(call MAYBE_UNINSTALL_REDIS_SYMLINK,$(INSTALL_BIN),$(ENGINE_CHECK_AOF_NAME))
 	$(call MAYBE_UNINSTALL_REDIS_SYMLINK,$(INSTALL_BIN),$(ENGINE_SENTINEL_NAME))
+
+download-wasm-binary-deps:
+	cd ../deps; $(MAKE) $@
+
+.PHONY: download-wasm-binary-deps


### PR DESCRIPTION
This commit introduces a new dependency on the `wasmtime-c-api` library.

https://github.com/bytecodealliance/wasmtime

Wasmtime is a standalone runtime for WebAssembly (aka WASM), and we will use it to run WASM binaries inside the Valkey engine.

To enable WASM support in Valkey we need to build Valkey with:

```
make BUILD_WITH_WASM=yes
```

If you have your own `wasmtime-c-api` local build, you can specify its location so that our build system can pick it up:

```
make BUILD_WITH_WASM=yes WASMTIME_ROOT=path
```

If you just want to use the upstream `wasmtime-c-api` binary, you can run:

```
make download-wasm-binary-deps
```

before building valkey to download the upstream binary.