### PR TITLE
Limit CLUSTER_CANT_FAILOVER_DATA_AGE log to 10 times period

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4439,6 +4439,12 @@ void clusterLogCantFailover(int reason) {
         time(NULL) - lastlog_time < CLUSTER_CANT_FAILOVER_RELOG_PERIOD)
         return;
 
+    /* If data age is too old, this log may be printed repeatedly since it
+     * can not be automatically recovered. In this case, limit its frequency. */
+    if (reason == server.cluster->cant_failover_reason && reason == CLUSTER_CANT_FAILOVER_DATA_AGE &&
+        time(NULL) - lastlog_time < 10 * CLUSTER_CANT_FAILOVER_RELOG_PERIOD)
+        return;
+
     server.cluster->cant_failover_reason = reason;
 
     switch (reason) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4433,22 +4433,19 @@ int clusterGetReplicaRank(void) {
 void clusterLogCantFailover(int reason) {
     char *msg;
     static time_t lastlog_time = 0;
-
-    /* Don't log if we have the same reason for some time. */
-    if (reason == server.cluster->cant_failover_reason &&
     time_t now = time(NULL);
-    
+
     /* General logging suppression if the same reason has occurred recently. */
-    if (now - lastlog_time < CLUSTER_CANT_FAILOVER_RELOG_PERIOD) {
+    if (reason == server.cluster->cant_failover_reason && now - lastlog_time < CLUSTER_CANT_FAILOVER_RELOG_PERIOD) {
         return;
     }
 
     /* Special case: If the failure reason is due to data age, log 10 times less frequently. */
-    if (reason == CLUSTER_CANT_FAILOVER_DATA_AGE &&
+    if (reason == server.cluster->cant_failover_reason && reason == CLUSTER_CANT_FAILOVER_DATA_AGE &&
         now - lastlog_time < 10 * CLUSTER_CANT_FAILOVER_RELOG_PERIOD) {
         return;
     }
-}
+
     server.cluster->cant_failover_reason = reason;
 
     switch (reason) {


### PR DESCRIPTION
If a replica is step into data_age too old stage, it can not
trigger the failover and currently it can not be automatically
recovered and we will print a log every CLUSTER_CANT_FAILOVER_RELOG_PERIOD,
which is every second. If the primary has not recovered or there is
no manual failover, this log will flood the log file.

In this case, limit its frequency to 10 times period, which is
10 seconds in our code. Also in this data_age too old stage,
the repeated logs also can stand for the progress of the failover.

See also #780 for more details about it.