### PR TITLE
Make replica CLUSTER RESET flush async based on lazyfree-lazy-user-flush

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1230,7 +1230,7 @@ void clusterReset(int hard) {
     if (nodeIsReplica(myself)) {
         clusterSetNodeAsPrimary(myself);
         replicationUnsetPrimary();
-        emptyData(-1, server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS, NULL);
+        emptyData(-1, server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS, NULL);
     }
 
     /* Close slots, reset manual failover state. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1230,7 +1230,7 @@ void clusterReset(int hard) {
     if (nodeIsReplica(myself)) {
         clusterSetNodeAsPrimary(myself);
         replicationUnsetPrimary();
-        emptyData(-1, EMPTYDB_NO_FLAGS, NULL);
+        emptyData(-1, server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS, NULL);
     }
 
     /* Close slots, reset manual failover state. */

--- a/src/server.h
+++ b/src/server.h
@@ -2069,8 +2069,7 @@ struct valkeyServer {
      * the server->primary client structure. */
     char primary_replid[CONFIG_RUN_ID_SIZE + 1]; /* Primary PSYNC runid. */
     long long primary_initial_offset;            /* Primary PSYNC offset. */
-    int repl_replica_lazy_flush;                 /* Lazy FLUSHALL before loading DB?
-                                                  * Lazy FLUSHALL before resetting? */
+    int repl_replica_lazy_flush;                 /* Lazy FLUSHALL before loading DB? */
     /* Synchronous replication. */
     list *clients_waiting_acks; /* Clients waiting in WAIT or WAITAOF. */
     int get_ack_from_replicas;  /* If true we send REPLCONF GETACK. */

--- a/src/server.h
+++ b/src/server.h
@@ -2069,7 +2069,8 @@ struct valkeyServer {
      * the server->primary client structure. */
     char primary_replid[CONFIG_RUN_ID_SIZE + 1]; /* Primary PSYNC runid. */
     long long primary_initial_offset;            /* Primary PSYNC offset. */
-    int repl_replica_lazy_flush;                 /* Lazy FLUSHALL before loading DB? */
+    int repl_replica_lazy_flush;                 /* Lazy FLUSHALL before loading DB?
+                                                  * Lazy FLUSHALL before resetting? */
     /* Synchronous replication. */
     list *clients_waiting_acks; /* Clients waiting in WAIT or WAITAOF. */
     int get_ack_from_replicas;  /* If true we send REPLCONF GETACK. */

--- a/valkey.conf
+++ b/valkey.conf
@@ -1309,9 +1309,9 @@ lazyfree-lazy-user-del yes
 # commands. When neither flag is passed, this directive will be used to determine
 # if the data should be deleted asynchronously.
 #
-# During a resetting, when a replica performs a CLUSTER RESET, the content
-# of the whole database is removed in order to become an empty primary, this
-# directive will be used to determine f the data should be deleted asynchronously.
+# When a replica performs a node reset via CLUSTER RESET, the entire
+# database content is removed to allow the node to become an empty primary.
+# This directive also determines whether the data should be deleted asynchronously.
 #
 # There are many problems with running flush synchronously. Even in single CPU
 # environments, the thread managers should balance between the freeing and

--- a/valkey.conf
+++ b/valkey.conf
@@ -1287,9 +1287,7 @@ acllog-max-len 128
 #    it with the specified string.
 # 4) During replication, when a replica performs a full resynchronization with
 #    its primary, the content of the whole database is removed in order to
-#    load the RDB file just transferred. During a resetting, when a replica
-#    performs a CLUSTER RESET, the content of the whole database is removed
-#    in order to become an empty primary.
+#    load the RDB file just transferred.
 #
 # In all the above cases, the default is to release memory in a non-blocking
 # way.
@@ -1310,7 +1308,11 @@ lazyfree-lazy-user-del yes
 # deletion, which can be controlled by passing the [SYNC|ASYNC] flags into the
 # commands. When neither flag is passed, this directive will be used to determine
 # if the data should be deleted asynchronously.
-
+#
+# During a resetting, when a replica performs a CLUSTER RESET, the content
+# of the whole database is removed in order to become an empty primary, this
+# directive will be used to determine f the data should be deleted asynchronously.
+#
 # There are many problems with running flush synchronously. Even in single CPU
 # environments, the thread managers should balance between the freeing and
 # serving incoming requests. The default value is yes.

--- a/valkey.conf
+++ b/valkey.conf
@@ -1287,7 +1287,9 @@ acllog-max-len 128
 #    it with the specified string.
 # 4) During replication, when a replica performs a full resynchronization with
 #    its primary, the content of the whole database is removed in order to
-#    load the RDB file just transferred.
+#    load the RDB file just transferred. During a resetting, when a replica
+#    performs a CLUSTER RESET, the content of the whole database is removed
+#    in order to become an empty primary.
 #
 # In all the above cases, the default is to release memory in a non-blocking
 # way.


### PR DESCRIPTION
Currently, if the replica has a lot of data, CLUSTER RESET
will block for a while and report the slowlog, and it seems
that there is no harm in making it async so external components
can be easier when monitoring it.