### PR TITLE
Fix BGSAVE CANCEL since and history fields

### DIFF
--- a/src/commands/bgsave.json
+++ b/src/commands/bgsave.json
@@ -12,7 +12,7 @@
                 "Added the `SCHEDULE` option."
             ],
             [
-                "8.0.0",
+                "8.1.0",
                 "Added the `CANCEL` option."
             ]
         ],

--- a/src/commands/bgsave.json
+++ b/src/commands/bgsave.json
@@ -37,7 +37,7 @@
                         "name": "cancel",
                         "token": "CANCEL",
                         "type": "pure-token",
-                        "since": "8.0.0"
+                        "since": "8.1.0"
                     }
                 ]
             }


### PR DESCRIPTION
Fixes wrong "since" and "history" introduced in #757.