### PR TITLE
Remove redundant dict_index calculations

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -59,6 +59,7 @@ int keyIsExpired(serverDb *db, robj *key);
 static void dbSetValue(serverDb *db, robj *key, robj *val, int overwrite, dictEntry *de);
 static int getKVStoreIndexForKey(sds key);
 dictEntry *dbFindExpiresWithDictIndex(serverDb *db, void *key, int dict_index);
+dictEntry *dbFindWithDictIndex(serverDb *db, void *key, int dict_index);
 
 /* Update LFU when an object is accessed.
  * Firstly, decrement the counter if the decrement time is reached.
@@ -97,7 +98,7 @@ void updateLFU(robj *val) {
  * expired on replicas even if the primary is lagging expiring our key via DELs
  * in the replication link. */
 robj *lookupKey(serverDb *db, robj *key, int flags) {
-    int dict_index = getKVStoreIndexForKey(key);
+    int dict_index = getKVStoreIndexForKey(key->ptr);
     dictEntry *de = dbFindWithDictIndex(db, key->ptr, dict_index);
     robj *val = NULL;
     if (de) {


### PR DESCRIPTION
We need to start making use of the new `WithDictIndex` APIs which allow us to reuse the dict_index calculation (avoid over-calling `getKeySlot` for no good reason).

In this PR I optimized `lookupKey` so it now calls `getKeySlot` to reuse the dict_index two additional times.

The benefit here is reduced if the slot is cached in the client, which is generally the case.