### PR TITLE
Output Module config value of module list command

### DIFF
--- a/src/commands/module-list.json
+++ b/src/commands/module-list.json
@@ -39,6 +39,13 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "configs": {
+                        "type": "array",
+                        "description": "Module configs.",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/src/config.c
+++ b/src/config.c
@@ -2218,6 +2218,21 @@ static void numericConfigRewrite(standardConfig *config, const char *name, struc
     }
 }
 
+sds getConfigValue(sds config_name) {
+    standardConfig *config = lookupConfig(config_name);
+    switch (config->type) {
+    case BOOL_CONFIG:
+        return boolConfigGet(config);
+    case SDS_CONFIG:
+        return sdsConfigGet(config);
+    case NUMERIC_CONFIG:
+        return numericConfigGet(config);
+    case ENUM_CONFIG:
+        return enumConfigGet(config);
+    default: serverPanic("Config type of module config is not allowed.");
+    }
+}
+
 #define embedCommonNumericalConfig(name, alias, _flags, lower, upper, config_addr, default, num_conf_flags, is_valid, \
                                    apply)                                                                             \
     {                                                                                                                 \

--- a/src/server.h
+++ b/src/server.h
@@ -3473,6 +3473,7 @@ void freeServerClientMemUsageBuckets(void);
 
 /* Module Configuration */
 typedef struct ModuleConfig ModuleConfig;
+sds getConfigValue(sds config_name);
 int performModuleConfigSetFromName(sds name, sds value, const char **err);
 int performModuleConfigSetDefaultFromName(sds name, const char **err);
 void addModuleBoolConfig(const char *module_name, const char *name, int flags, void *privdata, int default_val);

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -15,6 +15,16 @@ start_server {tags {"modules"}} {
         assert_equal [r config get moduleconfigs.numeric] "moduleconfigs.numeric -1"
     }
 
+     test {check config value output correctly from module list} {
+        set config_value [lindex [lmap x [r module list] {dict get $x configs}] 0]
+        assert_equal [lindex $config_value 0] "moduleconfigs.mutable_bool"
+        assert_equal [lindex $config_value 1] "yes"
+        assert_equal [lindex $config_value 2] "moduleconfigs.immutable_bool"
+        assert_equal [lindex $config_value 3] "no"
+        assert_equal [lindex $config_value 4] "moduleconfigs.string"
+        assert_equal [lindex $config_value 5] "secret password"
+    }
+
     test {Config set commands work} {
         # Make sure that config sets work during runtime
         r config set moduleconfigs.mutable_bool no


### PR DESCRIPTION
Since Redis OSS 7.0, module loadex command was introduced, and we could set config for the module.  However, there is no way to display these configs when client run the module list or hello command.

This PR solves above the problem and provides module config name and value in the output as below:

![image](https://github.com/user-attachments/assets/d83b743d-c4b3-4cb6-a7b2-d454da0c511c)


