### PR TITLE
Maintain return value of rdbSaveDb after writing slot-info aux

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1355,6 +1355,7 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter) {
                 sdsfree(slot_info);
                 goto werr;
             }
+            written += res;
             last_slot = curr_slot;
             sdsfree(slot_info);
         }


### PR DESCRIPTION
All other places written in this function are maintained it,
although the caller of rdbSaveDb does not reply on it, it is
maintained to be consistent with other places, is its duty.