### PR TITLE
fix typo in valkey.conf file's shutdown section

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -1580,7 +1580,7 @@ aof-timestamp-enabled no
 # Maximum time to wait for replicas when shutting down, in seconds.
 #
 # During shut down, a grace period allows any lagging replicas to catch up with
-# the latest replication offset before the primary exists. This period can
+# the latest replication offset before the primary exits. This period can
 # prevent data loss, especially for deployments without configured disk backups.
 #
 # The 'shutdown-timeout' value is the grace period's duration in seconds. It is


### PR DESCRIPTION
Found another typo in valkey.conf in shutdown section.