### PR TITLE
Document log format configs in valkey.conf

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -348,18 +348,22 @@ pidfile /var/run/valkey_6379.pid
 # nothing (nothing is logged)
 loglevel notice
 
-# Specifies the format used for logging Redis server messages.
+# Specify the logging format.
 # This can be one of:
-# legacy (traditional Redis log format)
-# logfmt (Structured log format "logfmt")
-log-format legacy
+#
+# - legacy: the default, traditional log format
+# - logfmt: a structured log format; see https://www.brandur.org/logfmt
+#
+# log-format legacy
 
-# log_timestamp_format - Specifies the timestamp format used in Redis logs.
-# This can be one of:
-# legacy       (traditional Redis timestamp format)
-# iso8601      (ISO 8601)
-# milliseconds (milliseconds since the epoch)
-log-timestamp-format legacy
+# Specify the timestamp format used in logs using 'log-timestamp-format'.
+#
+# - legacy: default format
+# - iso8601: ISO 8601 extended date and time with time zone, on the form
+#   yyyy-mm-ddThh:mm:ss.sss±hh:mm
+# - milliseconds: milliseconds since the epoch
+#
+# log-timestamp-format legacy
 
 # Specify the log file name. Also the empty string can be used to force
 # the server to log on the standard output. Note that if you use standard

--- a/valkey.conf
+++ b/valkey.conf
@@ -348,6 +348,19 @@ pidfile /var/run/valkey_6379.pid
 # nothing (nothing is logged)
 loglevel notice
 
+# Specifies the format used for logging Redis server messages.
+# This can be one of:
+# legacy (traditional Redis log format)
+# logfmt (Structured log format "logfmt")
+log-format legacy
+
+# log_timestamp_format - Specifies the timestamp format used in Redis logs.
+# This can be one of:
+# legacy       (traditional Redis timestamp format)
+# iso8601      (ISO 8601)
+# milliseconds (milliseconds since the epoch)
+log-timestamp-format legacy
+
 # Specify the log file name. Also the empty string can be used to force
 # the server to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null


### PR DESCRIPTION
Add config options for log format and timestamp format introduced by #1022 
Related to #1225

This change adds two new configs into valkey.conf:
log-format
log-timestamp-format
