### PR TITLE
Minor fix to debug logging in replicationFeedStreamFromPrimaryStream

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -651,7 +651,7 @@ void replicationFeedStreamFromPrimaryStream(char *buf, size_t buflen) {
     /* Debugging: this is handy to see the stream sent from primary
      * to replicas. Disabled with if(0). */
     if (0) {
-        if (server.hide_user_data_from_log) {
+        if (!server.hide_user_data_from_log) {
             printf("%zu:", buflen);
             for (size_t j = 0; j < buflen; j++) {
                 printf("%c", isprint(buf[j]) ? buf[j] : '.');


### PR DESCRIPTION
We should only print logs when hide-user-data-from-log is off.