### PR TITLE
Update the argument of clusterNodeGetReplica declaration.

### DIFF
--- a/src/cluster.h
+++ b/src/cluster.h
@@ -96,7 +96,7 @@ int clusterNodeIsFailing(clusterNode *node);
 int clusterNodeIsNoFailover(clusterNode *node);
 char *clusterNodeGetShardId(clusterNode *node);
 int clusterNodeNumReplicas(clusterNode *node);
-clusterNode *clusterNodeGetReplica(clusterNode *node, int slave_idx);
+clusterNode *clusterNodeGetReplica(clusterNode *node, int replica_idx);
 clusterNode *getMigratingSlotDest(int slot);
 clusterNode *getImportingSlotSource(int slot);
 clusterNode *getNodeBySlot(int slot);


### PR DESCRIPTION
clusterNodeGetReplica agrumnets are missed to migrate during the slave to replication migration so updated the argument slave to replica.