### PR TITLE
Fix timing issue in cluster-shards tests

### DIFF
--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -117,7 +117,7 @@ test "Kill a node and tell the replica to immediately takeover" {
 
 # Primary 0 node should report as fail, wait until the new primary acknowledges it.
 test "Verify health as fail for killed node" {
-    wait_for_condition 50 100 {
+    wait_for_condition 1000 50 {
         "fail" eq [dict get [get_node_info_from_shard $node_0_id 4 "node"] "health"]
     } else {
         fail "New primary never detected the node failed"

--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -42,7 +42,7 @@ start_cluster 3 3 {tags {external:skip cluster}} {
     }
 
     test "Verify health as fail for killed node" {
-        wait_for_condition 50 100 {
+        wait_for_condition 1000 50 {
             "fail" eq [dict get [get_node_info_from_shard $node_0_id $validation_node "node"] "health"]
         } else {
             fail "New primary never detected the node failed"


### PR DESCRIPTION
The cluster-node-timeout is 3000 in our tests, the timing test wasn't succeeding, so extending the wait_for made them much more reliable.