### PR TITLE
correct type internal to kvstore (minor)

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -54,8 +54,8 @@ struct _kvstore {
     int flags;
     dictType *dtype;
     dict **dicts;
-    long long num_dicts;
-    long long num_dicts_bits;
+    int num_dicts;
+    int num_dicts_bits;
     list *rehashing;                     /* List of dictionaries in this kvstore that are currently rehashing. */
     int resize_cursor;                   /* Cron job uses this cursor to gradually resize dictionaries (only used if num_dicts > 1). */
     int allocated_dicts;                 /* The number of allocated dicts. */


### PR DESCRIPTION
All of the internal variables related to number of dicts in the kvstore are type `int`.  Not sure why these 2 items were declared as `long long`.