### PR TITLE
Log clusterbus handshake timeout failures

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4872,6 +4872,8 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t handshake_
     /* A Node in HANDSHAKE state has a limited lifespan equal to the
      * configured node timeout. */
     if (nodeInHandshake(node) && now - node->ctime > handshake_timeout) {
+        serverLog(LL_WARNING, "Clusterbus handshake timeout [%s]:%d after a timeout of %lld", node->ip,
+                  node->cport, handshake_timeout);
         clusterDelNode(node);
         return 1;
     }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4872,7 +4872,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t handshake_
     /* A Node in HANDSHAKE state has a limited lifespan equal to the
      * configured node timeout. */
     if (nodeInHandshake(node) && now - node->ctime > handshake_timeout) {
-        serverLog(LL_WARNING, "Clusterbus handshake timeout [%s]:%d after a timeout of %lld", node->ip,
+        serverLog(LL_WARNING, "Clusterbus handshake timeout %s:%d after %lldms", node->ip,
                   node->cport, handshake_timeout);
         clusterDelNode(node);
         return 1;


### PR DESCRIPTION
This adds a log when a handshake fails for a timeout. This can help troubleshoot cluster asymmetry issues caused by failed MEETs