### PR TITLE
Fix argument types of formatting functions

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5544,12 +5544,12 @@ sds representClusterNodeFlags(sds ci, uint16_t flags) {
  * else each slot is added separately. */
 sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pairs_count) {
     for (int i = 0; i < slot_info_pairs_count; i += 2) {
-        unsigned long start = slot_info_pairs[i];
-        unsigned long end = slot_info_pairs[i + 1];
+        unsigned int start = slot_info_pairs[i];
+        unsigned int end = slot_info_pairs[i + 1];
         if (start == end) {
-            ci = sdscatfmt(ci, " %i", start);
+            ci = sdscatfmt(ci, " %u", start);
         } else {
-            ci = sdscatfmt(ci, " %i-%i", start, end);
+            ci = sdscatfmt(ci, " %u-%u", start, end);
         }
     }
     return ci;

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -4395,7 +4395,7 @@ static sds clusterManagerNodeInfo(clusterManagerNode *node, int indent) {
     if (node->replicate != NULL)
         info = sdscatfmt(info, "\n%s   replicates %S", spaces, node->replicate);
     else if (node->replicas_count)
-        info = sdscatfmt(info, "\n%s   %U additional replica(s)", spaces, node->replicas_count);
+        info = sdscatfmt(info, "\n%s   %i additional replica(s)", spaces, node->replicas_count);
     sdsfree(spaces);
     return info;
 }


### PR DESCRIPTION
`cluster_legacy.c`: `slot_info_pairs` has `uint16_t` values, but they were cast to `unsigned long` and `%i` was used.

`valkey-cli.c`: `node->replicas_count` is `int`, not `unsigned long`.