### PR TITLE
Change errno from EEXIST to EALREADY in serverFork if child process exists

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6396,7 +6396,7 @@ void closeChildUnusedResourceAfterFork(void) {
 int serverFork(int purpose) {
     if (isMutuallyExclusiveChildType(purpose)) {
         if (hasActiveChildProcess()) {
-            errno = EEXIST;
+            errno = EALREADY;
             return -1;
         }
 

--- a/tests/unit/moduleapi/fork.tcl
+++ b/tests/unit/moduleapi/fork.tcl
@@ -26,7 +26,7 @@ start_server {tags {"modules"}} {
 
         # module fork twice
         assert_error {Fork failed} {r fork.create 0 1}
-        assert {[count_log_message 0 "Can't fork for module: File exists"] eq "1"}
+        assert {[count_log_message 0 "Can't fork for module: Operation already in progress"] eq "1"}
 
         r fork.kill
 


### PR DESCRIPTION
We set this to EEXIST in 568c2e039bac388003068cd8debb2f93619dd462,
it prints "File exists" which is not quite accurate,
change it to EALREADY, it will print "Operation already in progress".
