### PR TITLE
Remove empty DB check branch in KEYS command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -837,6 +837,11 @@ void keysCommand(client *c) {
         }
         kvs_di = kvstoreGetDictSafeIterator(c->db->keys, pslot);
     } else {
+        if (!kvstoreSize(c->db->keys)) {
+            /* Requested db is empty. */
+            setDeferredArrayLen(c, replylen, 0);
+            return;
+        }
         kvs_it = kvstoreIteratorInit(c->db->keys);
     }
     robj keyobj;

--- a/src/db.c
+++ b/src/db.c
@@ -830,18 +830,8 @@ void keysCommand(client *c) {
     kvstoreDictIterator *kvs_di = NULL;
     kvstoreIterator *kvs_it = NULL;
     if (pslot != -1) {
-        if (!kvstoreDictSize(c->db->keys, pslot)) {
-            /* Requested slot is empty */
-            setDeferredArrayLen(c, replylen, 0);
-            return;
-        }
         kvs_di = kvstoreGetDictSafeIterator(c->db->keys, pslot);
     } else {
-        if (!kvstoreSize(c->db->keys)) {
-            /* Requested db is empty. */
-            setDeferredArrayLen(c, replylen, 0);
-            return;
-        }
         kvs_it = kvstoreIteratorInit(c->db->keys);
     }
     robj keyobj;

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -47,6 +47,10 @@ start_server {tags {"keyspace"}} {
         r dbsize
     } {0}
 
+    test {KEYS with empty DB} {
+        assert_equal {} [r keys *]
+    }
+
     test "DEL against expired key" {
         r debug set-active-expire 0
         r setex keyExpire 1 valExpire

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -558,3 +558,14 @@ foreach {type large} [array get largevalue] {
         r KEYS [string repeat "*?" 50000]
     } {}
 }
+
+start_cluster 1 0 {tags {"keyspace external:skip cluster"}} {
+    test {KEYS with empty DB in cluster mode} {
+        assert_equal {} [r keys *]
+        assert_equal {} [r keys foo*]
+    }
+
+    test {KEYS with empty slot in cluster mode} {
+        assert_equal {} [r keys foo]
+    }
+}


### PR DESCRIPTION
We don't think we really care about optimizing for the empty DB case,
which should be uncommon. Adding branches hurts branch prediction.