### PR TITLE
fix: clean up refactoring leftovers

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3237,7 +3237,6 @@ int dualChannelReplMainConnSendHandshake(connection *conn, sds *err) {
     ull2string(llstr, sizeof(llstr), server.rdb_client_id);
     *err = sendCommand(conn, "REPLCONF", "set-rdb-client-id", llstr, NULL);
     if (*err) return C_ERR;
-    server.repl_state = REPL_STATE_RECEIVE_CAPA_REPLY;
     return C_OK;
 }
 
@@ -3248,7 +3247,6 @@ int dualChannelReplMainConnRecvCapaReply(connection *conn, sds *err) {
         serverLog(LL_NOTICE, "Primary does not understand REPLCONF identify: %s", *err);
         return C_ERR;
     }
-    server.repl_state = REPL_STATE_SEND_PSYNC;
     return C_OK;
 }
 
@@ -3259,7 +3257,6 @@ int dualChannelReplMainConnSendPsync(connection *conn, sds *err) {
         *err = sdsnew(connGetLastError(conn));
         return C_ERR;
     }
-    server.repl_state = REPL_STATE_RECEIVE_PSYNC_REPLY;
     return C_OK;
 }
 


### PR DESCRIPTION
This commit addresses issues that were likely introduced during a rebase related to: https://github.com/valkey-io/valkey/commit/b0f23df16522e91a769c75646166045ae70e8d4e

Change dual channel replication state in main handler only