### PR TITLE
Revert "Decline unsubscribe related command in non-subscribed mode"

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4165,12 +4165,6 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Not allow several UNSUBSCRIBE commands executed under non-pubsub mode */
-    if (!c->flag.pubsub && (c->cmd->proc == unsubscribeCommand || c->cmd->proc == sunsubscribeCommand ||
-                            c->cmd->proc == punsubscribeCommand)) {
-        rejectCommandFormat(c, "-NOSUB '%s' command executed not in subscribed mode", c->cmd->fullname);
-        return C_OK;
-    }
     /* Only allow commands with flag "t", such as INFO, REPLICAOF and so on,
      * when replica-serve-stale-data is no and we are a replica with a broken
      * link with primary. */

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -424,8 +424,7 @@ start_server {tags {"info" "external:skip"}} {
             set info [r info clients]
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # non-pubsub clients should not be involved
-            catch {unsubscribe $rd2 {non-exist-chan}} e
-            assert_match {*NOSUB*} $e
+            assert_equal {0} [unsubscribe $rd2 {non-exist-chan}]
             set info [r info clients]
             assert_equal [getInfoProperty $info pubsub_clients] {1}
             # close all clients

--- a/tests/unit/pubsubshard.tcl
+++ b/tests/unit/pubsubshard.tcl
@@ -74,8 +74,9 @@ start_server {tags {"pubsubshard external:skip"}} {
 
     test "SUNSUBSCRIBE from non-subscribed channels" {
         set rd1 [valkey_deferring_client]
-        catch {sunsubscribe $rd1 {foo}} e
-        assert_match {*NOSUB*} $e
+        assert_equal {0} [sunsubscribe $rd1 {foo}]
+        assert_equal {0} [sunsubscribe $rd1 {bar}]
+        assert_equal {0} [sunsubscribe $rd1 {quux}]
 
         # clean up clients
         $rd1 close


### PR DESCRIPTION
This PR goal is to revert the changes on PR https://github.com/valkey-io/valkey/pull/759

Recently, we got some reports that in Valkey 8.0 the PR  https://github.com/valkey-io/valkey/pull/759 (Decline unsubscribe related command in non-subscribed mode) causes break change.   (https://github.com/valkey-io/valkey/issues/1228)

Although from my thought, call commands "unsubscribeCommand", "sunsubscribeCommand", "punsubscribeCommand" in request-response mode make no sense.  This is why I created PR https://github.com/valkey-io/valkey/pull/759

But breaking change is always no good,  @valkey-io/core-team How do you think we revert this PR code changes?