### PR TITLE
Fix link-time optimization to work correctly for unit tests (i.e. -flto flag) (#1290)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,7 @@ ifeq ($(OPTIMIZATION),-O3)
 	else
 		OPTIMIZATION+=-flto=auto
 	endif
+	OPTIMIZATION += -ffat-lto-objects
 endif
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,9 +25,8 @@ ifeq ($(OPTIMIZATION),-O3)
 	ifeq (clang,$(CLANG))
 		OPTIMIZATION+=-flto
 	else
-		OPTIMIZATION+=-flto=auto
+		OPTIMIZATION+=-flto=auto -ffat-lto-objects
 	endif
-	OPTIMIZATION += -ffat-lto-objects
 endif
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,18 +16,33 @@ release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
+# Extract clang version using grep and then trim the spaces around it 
+# using firstword to get clean version number.  
+CLANG_VERSION := $(firstword $(shell clang --version | grep -o " [0-9].[0-9].[0-9] "))
 
 # Optimization flags. To override, the OPTIMIZATION variable can be passed, but
 # some automatic defaults are added to it. To specify optimization flags
 # explicitly without any defaults added, pass the OPT variable instead.
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
+	# Clang does not support -ffat-lto-objects before 17.0.0. It also
+	# only supports it for ELF(i.e. linux) binary format only. Therefore,
+	# we will only enable this for linux and clang version >= 17. 
+	# More info at https://gcc.gnu.org/onlinedocs/gccint/LTO-Overview.html
+	# and https://llvm.org/docs/FatLTO.html
 	ifeq (clang,$(CLANG))
-		OPTIMIZATION+=-flto
+		OPTIMIZATION += -flto
+		CLANG_GTE_17 := $(shell expr $(CLANG_VERSION) \>= 17)
+		ifeq (1, $(CLANG_GTE_17))
+			ifeq (Linux, $(uname_S))
+				OPTIMIZATION += -ffat-lto-objects
+			endif
+		endif
 	else
-		OPTIMIZATION+=-flto=auto -ffat-lto-objects
+		OPTIMIZATION += -flto=auto -ffat-lto-objects
 	endif
 endif
+
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,33 +16,18 @@ release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
 CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
-# Extract clang version using grep and then trim the spaces around it 
-# using firstword to get clean version number.  
-CLANG_VERSION := $(firstword $(shell clang --version | grep -o " [0-9].[0-9].[0-9] "))
 
 # Optimization flags. To override, the OPTIMIZATION variable can be passed, but
 # some automatic defaults are added to it. To specify optimization flags
 # explicitly without any defaults added, pass the OPT variable instead.
 OPTIMIZATION?=-O3
 ifeq ($(OPTIMIZATION),-O3)
-	# Clang does not support -ffat-lto-objects before 17.0.0. It also
-	# only supports it for ELF(i.e. linux) binary format only. Therefore,
-	# we will only enable this for linux and clang version >= 17. 
-	# More info at https://gcc.gnu.org/onlinedocs/gccint/LTO-Overview.html
-	# and https://llvm.org/docs/FatLTO.html
 	ifeq (clang,$(CLANG))
-		OPTIMIZATION += -flto
-		CLANG_GTE_17 := $(shell expr $(CLANG_VERSION) \>= 17)
-		ifeq (1, $(CLANG_GTE_17))
-			ifeq (Linux, $(uname_S))
-				OPTIMIZATION += -ffat-lto-objects
-			endif
-		endif
+		OPTIMIZATION+=-flto
 	else
-		OPTIMIZATION += -flto=auto -ffat-lto-objects
+		OPTIMIZATION+=-flto=auto -ffat-lto-objects
 	endif
 endif
-
 ifneq ($(OPTIMIZATION),-O0)
 	OPTIMIZATION+=-fno-omit-frame-pointer
 endif


### PR DESCRIPTION
* We compile various c files into object and package them into library (.a file) using ar to feed to unit tests. With new GCC versions, the objects inside such library don't participate in LTO process without additional flags.
* Here is a direct quote from gcc documentation explaining this issue: "If you are not using a linker with plugin support and/or do not enable the linker plugin, then the objects inside libfoo.a are extracted and linked as usual, but they do not participate in the LTO optimization process. In order to make a static library suitable for both LTO optimization and usual linkage, compile its object files with -flto-ffat-lto-objects."
* Read full documentation about -flto at https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
* Without this additional flag, I get following errors while executing "make test-unit". With this change, those errors go away.

```
ARCHIVE libvalkey.a
ar: threads_mngr.o: plugin needed to handle lto object
...
..
.
/tmp/ccDYbMXL.ltrans0.ltrans.o: In function `dictClear':
/local/workplace/elasticache/valkey/src/unit/../dict.c:776: undefined
reference to `valkey_free'
/local/workplace/elasticache/valkey/src/unit/../dict.c:770: undefined
reference to `valkey_free'
/tmp/ccDYbMXL.ltrans0.ltrans.o: In function `dictGetVal':
```

Fixes #1290