### PR TITLE
Unprotect rdb channel when bgsave child fails in dual channel replication

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1745,6 +1745,10 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
             struct valkey_stat buf;
 
             if (bgsaveerr != C_OK) {
+                if (replica->flag.protected_rdb_channel) {
+                    /* If bgsaveerr is error, there is no need to protect the rdb channel. */
+                    replica->flag.protected_rdb_channel = 0;
+                }
                 freeClientAsync(replica);
                 serverLog(LL_WARNING, "SYNC failed. BGSAVE child returned an error");
                 continue;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1745,10 +1745,8 @@ void updateReplicasWaitingBgsave(int bgsaveerr, int type) {
             struct valkey_stat buf;
 
             if (bgsaveerr != C_OK) {
-                if (replica->flag.protected_rdb_channel) {
-                    /* If bgsaveerr is error, there is no need to protect the rdb channel. */
-                    replica->flag.protected_rdb_channel = 0;
-                }
+                /* If bgsaveerr is error, there is no need to protect the rdb channel. */
+                replica->flag.protected_rdb_channel = 0;
                 freeClientAsync(replica);
                 serverLog(LL_WARNING, "SYNC failed. BGSAVE child returned an error");
                 continue;


### PR DESCRIPTION
If bgsaveerr is error, there is no need to protect the rdb channel.
The impact of this may be that when bgsave fails, we will protect
the rdb channel for 60s. It may occupy the reference of the repl
buf block, making it impossible to recycle it until we free the
client due to COB or free the client after 60s.

We kept the RDB channel open as long as the replica hadn't established
a main connection, even if the snapshot process failed. There is no
value in keeping the RDB client in this case.