### PR TITLE
Preserve original fd blocking state in TLS I/O operations

### DIFF
--- a/src/anet.h
+++ b/src/anet.h
@@ -61,6 +61,7 @@ int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port)
 int anetUnixAccept(char *err, int serversock);
 int anetNonBlock(char *err, int fd);
 int anetBlock(char *err, int fd);
+int anetIsBlock(char *err, int fd);
 int anetCloexec(int fd);
 int anetEnableTcpNoDelay(char *err, int fd);
 int anetDisableTcpNoDelay(char *err, int fd);

--- a/src/tls.c
+++ b/src/tls.c
@@ -967,6 +967,10 @@ static int connTLSSetReadHandler(connection *conn, ConnectionCallbackFunc func) 
     return C_OK;
 }
 
+static int isBlocking(tls_connection *conn) {
+    return anetIsBlock(NULL, conn->c.fd);
+}
+
 static void setBlockingTimeout(tls_connection *conn, long long timeout) {
     anetBlock(NULL, conn->c.fd);
     anetSendTimeout(NULL, conn->c.fd, timeout);
@@ -1005,26 +1009,30 @@ static int connTLSBlockingConnect(connection *conn_, const char *addr, int port,
 
 static ssize_t connTLSSyncWrite(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     SSL_clear_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
     ERR_clear_error();
     int ret = SSL_write(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
     SSL_set_mode(conn->ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
 
 static ssize_t connTLSSyncRead(connection *conn_, char *ptr, ssize_t size, long long timeout) {
     tls_connection *conn = (tls_connection *)conn_;
-
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
     ERR_clear_error();
     int ret = SSL_read(conn->ssl, ptr, size);
     ret = updateStateAfterSSLIO(conn, ret, 0);
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
 
     return ret;
 }
@@ -1033,6 +1041,7 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
     tls_connection *conn = (tls_connection *)conn_;
     ssize_t nread = 0;
 
+    int blocking = isBlocking(conn);
     setBlockingTimeout(conn, timeout);
 
     size--;
@@ -1058,7 +1067,9 @@ static ssize_t connTLSSyncReadLine(connection *conn_, char *ptr, ssize_t size, l
         size--;
     }
 exit:
-    unsetBlockingTimeout(conn);
+    if (!blocking) {
+        unsetBlockingTimeout(conn);
+    }
     return nread;
 }
 


### PR DESCRIPTION
This change prevents unintended side effects on connection state and improves consistency with non-TLS sync operations.

For example, when invoking `connTLSSyncRead` with a blocking file descriptor, the mode is switched to non-blocking upon `connTLSSyncRead` exit. If the code assumes the file descriptor remains blocking and calls the normal `read` expecting it to block, it may result in a short read.

This caused a crash in dual-channel, which was fixed in this PR by relocating `connBlock()`:
https://github.com/valkey-io/valkey/pull/837