### PR TITLE
Send MEET packet to node if there is no inbound link to fix inconsistency when handshake timedout

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3240,10 +3240,12 @@ int clusterProcessPacket(clusterLink *link) {
                  * the gossip section here since we have to trust the sender because
                  * of the message type. */
                 clusterProcessGossipSection(hdr, link);
-            } else if (sender->link) {
+            } else if (sender->link && now - sender->ctime > server.cluster_node_timeout) {
                 /* The MEET packet is from a known node, so the sender thinks that I do not know it.
                  * Freeing my outbound link to that node, to force a reconnect and sending a PING.
-                 * Once that node receives our PING, it should recognize the new connection as an inbound link from me. */
+                 * Once that node receives our PING, it should recognize the new connection as an inbound link from me.
+                 * We should only free the outbound link if the node is known for more time than the handshake timeout,
+                 * since during this time, the other side might still be trying to complete the handshake. */
                 serverAssert(link != sender->link); // we should always receive a MEET packet on an inbound link
                 serverLog(LL_NOTICE, "Freeing outbound link to node %.40s after receiving a MEET packet from this known node", sender->name);
                 freeClusterLink(sender->link);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3237,8 +3237,8 @@ int clusterProcessPacket(clusterLink *link) {
                 clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
 
                 /* If this is a MEET packet from an unknown node, we still process
-                * the gossip section here since we have to trust the sender because
-                * of the message type. */
+                 * the gossip section here since we have to trust the sender because
+                 * of the message type. */
                 clusterProcessGossipSection(hdr, link);
             } else if (sender->link) {
                 /* The MEET packet is from a known node, so the sender thinks that I do not know it.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3241,13 +3241,17 @@ int clusterProcessPacket(clusterLink *link) {
                  * of the message type. */
                 clusterProcessGossipSection(hdr, link);
             } else if (sender->link && now - sender->ctime > server.cluster_node_timeout) {
-                /* The MEET packet is from a known node, so the sender thinks that I do not know it.
+                /* The MEET packet is from a known node, after the handshake timeout, so the sender thinks that I do not
+                 * know it.
                  * Freeing my outbound link to that node, to force a reconnect and sending a PING.
                  * Once that node receives our PING, it should recognize the new connection as an inbound link from me.
                  * We should only free the outbound link if the node is known for more time than the handshake timeout,
                  * since during this time, the other side might still be trying to complete the handshake. */
-                serverAssert(link != sender->link); // we should always receive a MEET packet on an inbound link
-                serverLog(LL_NOTICE, "Freeing outbound link to node %.40s after receiving a MEET packet from this known node", sender->name);
+
+                /* We should always receive a MEET packet on an inbound link. */
+                serverAssert(link != sender->link);
+                serverLog(LL_NOTICE, "Freeing outbound link to node %.40s after receiving a MEET packet from this known node",
+                          sender->name);
                 freeClusterLink(sender->link);
             }
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3952,9 +3952,10 @@ void clusterSetGossipEntry(clusterMsg *hdr, int i, clusterNode *n) {
 /* Send a PING or PONG packet to the specified node, making sure to add enough
  * gossip information. */
 void clusterSendPing(clusterLink *link, int type) {
-    serverLog(LL_DEBUG, "Sending %s packet to node %.40s (%s)",
+    serverLog(LL_DEBUG, "Sending %s packet to node %.40s (%s) on %s link",
               clusterGetMessageTypeString(type),
               link->node ? link->node->name : "<unknown>",
+              link->node ? link->node->human_nodename : "<unknown>",
               link->inbound ? "inbound" : "outbound");
 
     static unsigned long long cluster_pings_sent = 0;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4959,7 +4959,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t handshake_
         !nodeInHandshake(node) && !nodeIsMeeting(node) && !nodeTimedOut(node) &&
         now - node->inbound_link_freed_time > handshake_timeout) {
         /* Node has an outbound link, but no inbound link for more than the handshake timeout.
-         * This probably means this node does not know us yet, wherease we know it.
+         * This probably means this node does not know us yet, whereas we know it.
          * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view. */
         node->flags |= CLUSTER_NODE_MEET;
         serverLog(LL_NOTICE, "Sending MEET packet to node %.40s because there is no inbound link for it", node->name);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -61,13 +61,14 @@ typedef struct clusterLink {
 #define nodeIsPrimary(n) ((n)->flags & CLUSTER_NODE_PRIMARY)
 #define nodeIsReplica(n) ((n)->flags & CLUSTER_NODE_REPLICA)
 #define nodeInHandshake(n) ((n)->flags & CLUSTER_NODE_HANDSHAKE)
-#define nodeIsMeeting(n) ((n)->flags & CLUSTER_NODE_MEET)
+#define nodeInMeetState(n) ((n)->flags & CLUSTER_NODE_MEET)
 #define nodeHasAddr(n) (!((n)->flags & CLUSTER_NODE_NOADDR))
 #define nodeTimedOut(n) ((n)->flags & CLUSTER_NODE_PFAIL)
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 #define nodeSupportsLightMsgHdr(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_SUPPORTED)
+#define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
 
 /* This structure represent elements of node->fail_reports. */
 typedef struct clusterNodeFailReport {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -61,6 +61,7 @@ typedef struct clusterLink {
 #define nodeIsPrimary(n) ((n)->flags & CLUSTER_NODE_PRIMARY)
 #define nodeIsReplica(n) ((n)->flags & CLUSTER_NODE_REPLICA)
 #define nodeInHandshake(n) ((n)->flags & CLUSTER_NODE_HANDSHAKE)
+#define nodeIsMeeting(n) ((n)->flags & CLUSTER_NODE_MEET)
 #define nodeHasAddr(n) (!((n)->flags & CLUSTER_NODE_NOADDR))
 #define nodeTimedOut(n) ((n)->flags & CLUSTER_NODE_PFAIL)
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
@@ -343,6 +344,8 @@ struct _clusterNode {
                                              * failover scenarios. */
     mstime_t repl_offset_time;              /* Unix time we received offset for this node */
     mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
+    mstime_t inbound_link_freed_time;       /* Last time we freed the inbound link for this node.
+                                               If it was never freed, it is the same as ctime */
     long long repl_offset;                  /* Last known repl offset for this node. */
     char ip[NET_IP_STR_LEN];                /* Latest known IP address of this node */
     sds announce_client_ipv4;               /* IPv4 for clients only. */

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -323,6 +323,15 @@ proc get_cluster_nodes {id {status "*"}} {
     return $nodes
 }
 
+# Returns the parsed myself node entry as a dictionary.
+proc get_myself id {
+    set nodes [get_cluster_nodes $id]
+    foreach n $nodes {
+        if {[cluster_has_flag $n myself]} {return $n}
+    }
+    return {}
+}
+
 # Returns 1 if no node knows node_id, 0 if any node knows it.
 proc node_is_forgotten {node_id} {
     for {set j 0} {$j < [llength $::servers]} {incr j} {

--- a/tests/unit/cluster/cluster-multiple-meets.tcl
+++ b/tests/unit/cluster/cluster-multiple-meets.tcl
@@ -58,7 +58,7 @@ tags {tls:skip external:skip cluster} {
             } else {
                 fail "Node 1 recognizes node 0 even though it drops PONGs from node 0"
             }
-            assert {[llength [get_cluster_nodes 0 connected]] == 2}
+            assert {[llength [get_cluster_nodes 0]] == 2}
 
             # Drop incoming and outgoing links from/to 1
             R 0 DEBUG CLUSTERLINK KILL ALL [R 1 CLUSTER MYID]
@@ -77,6 +77,8 @@ tags {tls:skip external:skip cluster} {
             # Both a and b will turn to cluster state ok
             wait_for_condition 1000 50 {
                 [CI 1 cluster_state] eq {ok} && [CI 0 cluster_state] eq {ok} &&
+                [llength [get_cluster_nodes 0 connected]] == 2 &&
+                [llength [get_cluster_nodes 1 connected]] == 2 &&
                 [CI 1 cluster_stats_messages_meet_sent] == [CI 0 cluster_stats_messages_meet_received]
             } else {
                 fail "1 cluster_state:[CI 1 cluster_state], 0 cluster_state: [CI 0 cluster_state]"

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -3,6 +3,12 @@ set old_singledb $::singledb
 set ::singledb 1
 
 tags {tls:skip external:skip cluster} {
+    set CLUSTER_PACKET_TYPE_PING 0
+    set CLUSTER_PACKET_TYPE_PONG 1
+    set CLUSTER_PACKET_TYPE_MEET 2
+    set CLUSTER_PACKET_TYPE_NONE -1
+    set CLUSTER_PACKET_TYPE_ALL -2
+
     set base_conf [list cluster-enabled yes]
     start_multiple_servers 2 [list overrides $base_conf] {
         test "Cluster nodes are reachable" {
@@ -21,9 +27,6 @@ tags {tls:skip external:skip cluster} {
         test "Before slots allocation, all nodes report cluster failure" {
             wait_for_cluster_state fail
         }
-
-        set CLUSTER_PACKET_TYPE_MEET 2
-        set CLUSTER_PACKET_TYPE_NONE -1
 
         test "Cluster nodes haven't met each other" {
             assert {[llength [get_cluster_nodes 1]] == 1}
@@ -75,3 +78,162 @@ tags {tls:skip external:skip cluster} {
 
 set ::singledb $old_singledb
 
+proc cluster_get_first_node_in_handshake id {
+    set nodes [get_cluster_nodes $id]
+    foreach n $nodes {
+        if {[cluster_has_flag $n handshake]} {
+            return [dict get $n id]
+        }
+    }
+    return {}
+}
+
+start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 4000 cluster-replica-no-failover yes}} {
+    set CLUSTER_PACKET_TYPE_PING 0
+    set CLUSTER_PACKET_TYPE_PONG 1
+    set CLUSTER_PACKET_TYPE_MEET 2
+    set CLUSTER_PACKET_TYPE_NONE -1
+    set CLUSTER_PACKET_TYPE_ALL -2
+
+    test "Handshake eventually succeeds after node handshake timeout on both sides with inconsistent view of the cluster" {
+        set cluster_port [find_available_port $::baseport $::portcount]
+        start_server [list overrides [list cluster-enabled yes cluster-node-timeout 4000 cluster-port $cluster_port]] {
+            # In this test we will trigger a handshake timeout on both sides of the handshake.
+            # Node 1 and 2 already know each other, then we make node 1 meet node 0:
+            #
+            # Node 1 -- MEET -> Node 0 [Node 0 might learn about Node 2 from the gossip section of the msg]
+            # Node 1 <- PONG -- Node 0 [we drop this message, so Node 1 will eventually mark the handshake as timed out]
+            # Node 1 <- PING -- Node 0 [we drop this message, so Node 1 will never send a PONG and Node 0 will eventually mark the handshake as timed out]
+            #
+            # After the handshake is timed out, we allow all cluster bus messages to go through.
+            # Eventually Node 0 should send a MEET packet to the other nodes to complete the handshake.
+
+            # Drop all cluster bus messages
+            R 1 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_ALL
+            # Drop MEET cluster bus messages, so that Node 0 cannot start a handshake with Node 2.
+            R 2 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_MEET
+
+            R 1 CLUSTER MEET [srv 0 host] [srv 0 port] $cluster_port
+
+            # We want Node 0 to learn about Node 2 through the gossip section of the MEET message
+            set meet_retry 0
+            set node2_id [dict get [get_myself 2] id]
+            while {[cluster_get_node_by_id 0 $node2_id] eq {}} {
+                if {$meet_retry == 10} {
+                    error "assertion: Retried to meet Node 0 too many times"
+                }
+                # If Node 0 doesn't know about Node 1 & 2, it means Node 1 did not gossip about node 2 in its MEET message.
+                # So we kill the outbound link from Node 1 to Node 0, to force a reconnect and a re-send of the MEET message.
+                after 100
+                # Since we are in handshake, we use a randomly generated ID we have to find
+                R 1 DEBUG CLUSTERLINK KILL ALL [cluster_get_first_node_in_handshake 1]
+                incr meet_retry 1
+            }
+
+            # Wait for Node 1's handshake to timeout
+            wait_for_condition 50 100 {
+                [cluster_get_first_node_in_handshake 1] eq {}
+            } else {
+                fail "Node 1 never exited handshake state"
+            }
+
+            # Wait for Node 0's handshake to timeout
+            wait_for_condition 50 100 {
+                [cluster_get_first_node_in_handshake 1] eq {}
+            } else {
+                fail "Node 0 never exited handshake state"
+            }
+
+            # At this point Node 0 knows Node 1 & 2 through the gossip, but they don't know Node 0.
+            wait_for_condition 50 100 {
+                [llength [R 0 CLUSTER NODES]] == 25 &&
+                [llength [R 1 CLUSTER NODES]] == 18 &&
+                [llength [R 2 CLUSTER NODES]] == 18
+            } else {
+                fail "Unexpected CLUSTER NODES output, nodes 1 & 2 should not know node 0."
+            }
+
+            # Allow all messages to go through again
+            R 1 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+            R 2 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+
+            # Now Node 0 will send a MEET packet to Node 1 & 2 since it has an outbound link to these nodes but no inblound link.
+            # Handshake should now complete successfully.
+            wait_for_condition 50 200 {
+                [llength [R 0 CLUSTER NODES]] == 26 &&
+                [llength [R 1 CLUSTER NODES]] == 26 &&
+                [llength [R 2 CLUSTER NODES]] == 26
+            } else {
+                fail "Unexpected CLUSTER NODES output, all nodes should know each other."
+            }
+        } ;# stop Node 0
+    } ;# test
+} ;# stop cluster
+
+start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 4000 cluster-replica-no-failover yes}} {
+    set CLUSTER_PACKET_TYPE_PING 0
+    set CLUSTER_PACKET_TYPE_PONG 1
+    set CLUSTER_PACKET_TYPE_MEET 2
+    set CLUSTER_PACKET_TYPE_NONE -1
+    set CLUSTER_PACKET_TYPE_ALL -2
+
+    test "Handshake eventually succeeds after node handshake timeout on one side with inconsistent view of the cluster" {
+        set cluster_port [find_available_port $::baseport $::portcount]
+        start_server [list overrides [list cluster-enabled yes cluster-node-timeout 4000 cluster-port $cluster_port]] {
+            # In this test we will trigger a handshake timeout on one side of the handshake.
+            # Node 1 and 2 already know each other, then we make node 0 meet node 1:
+            #
+            # Node 0 -- MEET -> Node 1
+            # Node 0 <- PONG -- Node 1
+            # Node 0 <- PING -- Node 1 [Node 0 will mark the handshake as successful]
+            # Node 0 -- PONG -> Node 1 [we drop this message, so node 1 will eventually mark the handshake as timed out]
+            #
+            # After the handshake is timed out, we allow all cluster bus messages to go through.
+            # Eventually Node 0 should send a MEET packet to the other nodes to complete the handshake.
+
+            # Drop PONG messages
+            R 1 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_PONG
+            # Drop MEET cluster bus messages, so that Node 0 cannot start a handshake with Node 2.
+            R 2 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_MEET
+
+            # Node 0 meets node 1
+            R 0 CLUSTER MEET [srv -1 host] [srv -1 port]
+
+            # Wait for node 0 to know about the other nodes in the cluster
+            wait_for_condition 50 100 {
+                [llength [R 0 CLUSTER NODES]] == 26
+            } else {
+                fail "Node 0 never learned about node 1 and 2"
+            }
+            # At this point, node 0 learned about the other nodes in the cluster from meeting node 1.
+            wait_for_condition 50 100 {
+                [cluster_get_first_node_in_handshake 0] eq {}
+            } else {
+                fail "Node 1 never exited handshake state"
+            }
+            # At this point, from node 0 point of view, the handshake with node 1 succeeded.
+
+            wait_for_condition 50 100 {
+                [cluster_get_first_node_in_handshake 1] eq {}
+            } else {
+                fail "Node 1 never exited handshake state"
+            }
+            assert {[llength [R 1 CLUSTER NODES]] == 18}
+            # At this point, from node 1 point of view, the handshake with node 0 timed out.
+
+            # Allow all messages
+            R 1 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+            R 2 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+
+            # Now Node 0 will send a MEET packet to Node 1 & 2 since it has an outbound link to these nodes but no inblound link.
+            # Handshake should now complete successfully.
+            wait_for_condition 50 200 {
+                [llength [R 0 CLUSTER NODES]] == 26 &&
+                [llength [R 1 CLUSTER NODES]] == 26 &&
+                [llength [R 2 CLUSTER NODES]] == 26
+            } else {
+                fail "Unexpected CLUSTER NODES output, all nodes should know each other."
+            }
+        } ;# stop Node 0
+    } ;# test
+} ;# stop cluster


### PR DESCRIPTION
In some cases, when meeting a new node, if the handshake times out, we can end up with an inconsistent view of the cluster where the new node knows about all the nodes in the cluster, but the cluster does not know about this new node (or vice versa).
To detect this inconsistency, we now check if a node has an outbound link but no inbound link, in this case it probably means this node does not know us. In this case we (re-)send a MEET packet to this node to do a new handshake with it.
If we receive a MEET packet from a known node, we disconnect the outbound link to force a reconnect and sending of a PING packet so that the other node recognizes the link as belonging to us. This prevents cases where a node could send MEET packets in a loop because it thinks the other node does not have an inbound link.

This fixes the bug described in #1251.