### PR TITLE
Stabilize replica migration test to make sure cluster config is consistent

### DIFF
--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -90,6 +90,8 @@ proc test_migrated_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 3 cluster slots] eq [R 4 cluster slots] &&
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 3 cluster_state] eq "ok" &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"
@@ -187,6 +189,7 @@ proc test_nonempty_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"
         } else {
@@ -306,6 +309,8 @@ proc test_sub_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 3 cluster slots] eq [R 4 cluster slots] &&
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 3 cluster_state] eq "ok" &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"


### PR DESCRIPTION
CI report this failure:
```
[exception]: Executing test client: MOVED 1 127.0.0.1:22128.
MOVED 1 127.0.0.1:22128
    while executing
"wait_for_condition 1000 50 {
            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
            [R 4 get key_991803] == 1024 && ..."
```

This may be because, even though the cluster state becomes OK,
The cluster still has inconsistent configuration for a short period
of time. We make sure to wait for the config to be consistent.