### PR TITLE
Upgrade macos-12 to macos-13 in workflows

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -990,7 +990,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' ||
@@ -1019,7 +1019,7 @@ jobs:
         run: make SERVER_CFLAGS='-Werror'
 
   test-freebsd:
-    runs-on: macos-12
+    runs-on: macos-13
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||

--- a/deps/hiredis/.github/workflows/build.yml
+++ b/deps/hiredis/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         run: $GITHUB_WORKSPACE/test.sh
 
   freebsd:
-    runs-on: macos-12
+    runs-on: macos-13
     name:  FreeBSD
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Problem
GitHub Actions is starting the deprecation process for macOS 12. Deprecation will begin on 10/7/24 and the image will be fully unsupported by 12/3/24.
For more details, see https://github.com/actions/runner-images/issues/10721