### PR TITLE
Skip reclaim file page cache test in valgrind

### DIFF
--- a/src/unit/README.md
+++ b/src/unit/README.md
@@ -12,6 +12,7 @@ Tests flags:
 * UNIT_TEST_ACCURATE: Corresponds to the --accurate flag. This flag indicates the test should use extra computation to more accurately validate the tests.
 * UNIT_TEST_LARGE_MEMORY: Corresponds to the --large-memory flag. This flag indicates whether or not tests should use more than 100mb of memory.
 * UNIT_TEST_SINGLE: Corresponds to the --single flag. This flag indicates that a single test is being executed.
+* UNIT_TEST_VALGRIND: Corresponds to the --valgrind flag. This flag is just a hint passed to the test to indicate that we are running it under valgrind.
 
 Tests are allowed to be passed in additional arbitrary argv/argc, which they can access from the argc and argv arguments of the test.
 

--- a/src/unit/test_help.h
+++ b/src/unit/test_help.h
@@ -18,10 +18,12 @@
 /* The flags are the following:
  * --accurate:     Runs tests with more iterations.
  * --large-memory: Enables tests that consume more than 100mb.
- * --single:       A flag to indicate a specific test file was executed. */
+ * --single:       A flag to indicate a specific test file was executed.
+ * --valgrind:     Runs tests with valgrind. */
 #define UNIT_TEST_ACCURATE (1 << 0)
 #define UNIT_TEST_LARGE_MEMORY (1 << 1)
 #define UNIT_TEST_SINGLE (1 << 2)
+#define UNIT_TEST_VALGRIND (1 << 3)
 
 #define KRED "\33[31m"
 #define KGRN "\33[32m"

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -49,6 +49,8 @@ int main(int argc, char **argv) {
         else if (!strcasecmp(arg, "--single") && (j + 1 < argc)) {
             flags |= UNIT_TEST_SINGLE;
             file = argv[j + 1];
+        } else if (!strcasecmp(arg, "--valgrind")) {
+            flags |= UNIT_TEST_VALGRIND;
         }
     }
 

--- a/src/unit/test_util.c
+++ b/src/unit/test_util.c
@@ -286,7 +286,9 @@ static int cache_exist(int fd) {
 int test_reclaimFilePageCache(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
-    UNUSED(flags);
+
+    /* The test is incompatible with valgrind, skip it. */
+    if (flags & UNIT_TEST_VALGRIND) return 0;
 
 #if defined(__linux__)
     char *tmpfile = "/tmp/redis-reclaim-cache-test";


### PR DESCRIPTION
The test is incompatible with valgrind. Added a new `--valgrind`
argument to test suite, which will cause that test to be skipped.

We skipped it in the past, see https://github.com/valkey-io/valkey/commit/5b61b0dc6d2579ee484fa6cf29bfac59513f84ab.