### PR TITLE
Fix the election was reset wrongly before failover epoch was obtained

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3147,7 +3147,8 @@ int clusterProcessPacket(clusterLink *link) {
             sender->configEpoch = sender_claimed_config_epoch;
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG);
 
-            if (server.cluster->failover_auth_time && sender->configEpoch >= server.cluster->failover_auth_epoch) {
+            if (server.cluster->failover_auth_time && server.cluster->failover_auth_sent &&
+                sender->configEpoch >= server.cluster->failover_auth_epoch) {
                 /* Another node has claimed an epoch greater than or equal to ours.
                  * If we have an ongoing election, reset it because we cannot win
                  * with an epoch smaller than or equal to the incoming claim. This

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -86,6 +86,11 @@ start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval
             fail "No failover detected"
         }
 
+        # Make sure there is no false epoch 0.
+        verify_no_log_message -7 "*Failover election in progress for epoch 0*" 0
+        verify_no_log_message -8 "*Failover election in progress for epoch 0*" 0
+        verify_no_log_message -9 "*Failover election in progress for epoch 0*" 0
+
         # Make sure there is no failover timeout.
         verify_no_log_message -7 "*Failover attempt expired*" 0
         verify_no_log_message -8 "*Failover attempt expired*" 0


### PR DESCRIPTION
After #1009, we will reset the election when we received
a claim with an equal or higher epoch since a node can win
an election in the past.

But we need to consider the time before the node actually
obtains the failover_auth_epoch. The failover_auth_epoch
default is 0, so before the node actually get the failover
epoch, we might wrongly reset the election.

This is probably harmless, but will produce misleading log
output and may delay election by a cron cycle or beforesleep.
Now we will only reset the election when a node is actually
obtains the failover epoch.