### PR TITLE
Optimize sdscatrepr by batch processing printable characters

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -954,23 +954,30 @@ void sdsfreesplitres(sds *tokens, int count) {
 sds sdscatrepr(sds s, const char *p, size_t len) {
     s = sdsMakeRoomFor(s, len + 2);
     s = sdscatlen(s, "\"", 1);
-    while (len--) {
-        switch (*p) {
-        case '\\':
-        case '"': s = sdscatprintf(s, "\\%c", *p); break;
-        case '\n': s = sdscatlen(s, "\\n", 2); break;
-        case '\r': s = sdscatlen(s, "\\r", 2); break;
-        case '\t': s = sdscatlen(s, "\\t", 2); break;
-        case '\a': s = sdscatlen(s, "\\a", 2); break;
-        case '\b': s = sdscatlen(s, "\\b", 2); break;
-        default:
-            if (isprint(*p))
-                s = sdscatlen(s, p, 1);
-            else
+    while (len) {
+        if (isprint(*p)) {
+            const char *start = p;
+            while (len && isprint(*p)) {
+                len--;
+                p++;
+            }
+            s = sdscatlen(s, start, p - start);
+        } else {
+            switch (*p) {
+            case '\\':
+            case '"': s = sdscatprintf(s, "\\%c", *p); break;
+            case '\n': s = sdscatlen(s, "\\n", 2); break;
+            case '\r': s = sdscatlen(s, "\\r", 2); break;
+            case '\t': s = sdscatlen(s, "\\t", 2); break;
+            case '\a': s = sdscatlen(s, "\\a", 2); break;
+            case '\b': s = sdscatlen(s, "\\b", 2); break;
+            default:
                 s = sdscatprintf(s, "\\x%02x", (unsigned char)*p);
-            break;
+                break;
+            }
+            p++;
+            len--;
         }
-        p++;
     }
     return sdscatlen(s, "\"", 1);
 }


### PR DESCRIPTION
[#11725](https://github.com/redis/redis/pull/11725 ) optimize sdscatrepr by reducing realloc calls, furthermore, we can reduce memcpy calls by batch processing of consecutive printable characters.