### PR TITLE
Save open's errno when opening temp rdb fails to prevent it from being modified

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3684,18 +3684,17 @@ void syncWithPrimary(connection *conn) {
 
     /* Prepare a suitable temp file for bulk transfer */
     if (!useDisklessLoad()) {
-        /* We save the errno of open to prevent some systems from modifying it after
-         * the sleep call. For example, sleep in Mac will change errno to ETIMEDOUT. */
-        int saved_errno;
         while (maxtries--) {
             snprintf(tmpfile, 256, "temp-%d.%ld.rdb", (int)server.unixtime, (long int)getpid());
             dfd = open(tmpfile, O_CREAT | O_WRONLY | O_EXCL, 0644);
             if (dfd != -1) break;
-            saved_errno = errno;
+            /* We save the errno of open to prevent some systems from modifying it after
+             * the sleep call. For example, sleep in Mac will change errno to ETIMEDOUT. */
+            int saved_errno = errno;
             sleep(1);
+            errno = saved_errno;
         }
         if (dfd == -1) {
-            errno = saved_errno;
             serverLog(LL_WARNING, "Opening the temp file needed for PRIMARY <-> REPLICA synchronization: %s",
                       strerror(errno));
             goto error;


### PR DESCRIPTION
Apparently on Mac, sleep will modify errno to ETIMEDOUT, and then it
prints the misleading message: Operation timed out.