### PR TITLE
Use `configure-aws-credentials` workflow instead of passing `secret_access_key`

### DIFF
--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/build-release-packages.yml'
       - '.github/workflows/call-build-linux-arm-packages.yml'
       - '.github/workflows/call-build-linux-x86_64-packages.yml'
-      - 'utils/releasetools/**'
+      - 'utils/releasetools/build-config.json'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -39,7 +39,7 @@ jobs:
         id: get_version
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            VERSION="unstable"
+            VERSION=${{ github.base_ref }}
           else
             VERSION="${INPUT_VERSION}"
           fi

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
-      is_test: ${{ steps.check-env.outputs.IS_TEST }}
+      is_test: ${{ steps.check-if-testing.outputs.IS_TEST }}
     steps:
       - run: |
           echo "Version: ${{ inputs.version || github.ref_name }}"
@@ -54,8 +54,8 @@ jobs:
           # only ever be a tag
           INPUT_VERSION: ${{ inputs.version || github.ref_name }}
 
-      - name: Set bucket name
-        id: check-env
+      - name: Check if we are testing
+        id: check-if-testing
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "IS_TEST=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   push:
     paths:
+      - '.github/workflows/build-release-packages.yml'
+      - '.github/workflows/call-build-linux-arm-packages.yml'
+      - '.github/workflows/call-build-linux-x86_64-packages.yml'
       - 'utils/releasetools/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -3,7 +3,7 @@ name: Build Release Packages
 on:
   release:
     types: [published]
-  pull_request:
+  push:
     paths:
       - '.github/workflows/build-release-packages.yml'
       - '.github/workflows/call-build-linux-arm-packages.yml'
@@ -38,7 +38,7 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             VERSION=${{ github.base_ref }}
           else
             VERSION="${INPUT_VERSION}"
@@ -57,7 +57,7 @@ jobs:
       - name: Check if we are testing
         id: check-if-testing
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "IS_TEST=true" >> $GITHUB_OUTPUT
           else
             echo "IS_TEST=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -11,6 +11,7 @@ on:
         required: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -67,11 +68,10 @@ jobs:
       version: ${{ needs.release-build-get-meta.outputs.version }}
       ref: ${{ inputs.version || github.ref_name }}
       build_matrix: ${{ needs.generate-build-matrix.outputs.x86_64-build-matrix }}
+      region: us-west-2
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      bucket: ${{ secrets.AWS_S3_BUCKET }}
-      access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
-      secret_access_key: ${{ secrets.AWS_S3_ACCESS_KEY }}
+      bucket_name: ${{ secrets.AWS_S3_BUCKET }}
+      role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 
   release-build-linux-arm-packages:
     needs:
@@ -82,8 +82,7 @@ jobs:
       version: ${{ needs.release-build-get-meta.outputs.version }}
       ref: ${{ inputs.version || github.ref_name }}
       build_matrix: ${{ needs.generate-build-matrix.outputs.arm64-build-matrix }}
+      region: us-west-2
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      bucket: ${{ secrets.AWS_S3_BUCKET }}
-      access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
-      secret_access_key: ${{ secrets.AWS_S3_ACCESS_KEY }}
+      bucket_name: ${{ secrets.AWS_S3_BUCKET }}
+      role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -3,7 +3,12 @@ name: Build Release Packages
 on:
   release:
     types: [published]
-
+  pull_request:
+    paths:
+      - '.github/workflows/build-release-packages.yml'
+      - '.github/workflows/call-build-linux-arm-packages.yml'
+      - '.github/workflows/call-build-linux-x86_64-packages.yml'
+      - 'utils/releasetools/**'
   workflow_dispatch:
     inputs:
       version:
@@ -21,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
+      is_test: ${{ steps.check-env.outputs.IS_TEST }}
     steps:
-
       - run: |
           echo "Version: ${{ inputs.version || github.ref_name }}"
         shell: bash
@@ -33,8 +38,13 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          VERSION="${INPUT_VERSION}"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            VERSION="unstable"
+          else
+            VERSION="${INPUT_VERSION}"
+          fi
           if [ -z "${VERSION}" ]; then
+            echo "Error: No version specified"
             exit 1
           fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
@@ -43,6 +53,16 @@ jobs:
           # Use the dispatch variable in preference, if empty use the context ref_name which should
           # only ever be a tag
           INPUT_VERSION: ${{ inputs.version || github.ref_name }}
+
+      - name: Set bucket name
+        id: check-env
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "IS_TEST=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_TEST=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
 
   generate-build-matrix:
     name: Generating build matrix
@@ -57,7 +77,7 @@ jobs:
       - uses: ./.github/actions/generate-package-build-matrix
         id: set-matrix
         with:
-          ref: ${{ inputs.version || github.ref_name }}
+          ref: ${{ needs.release-build-get-meta.outputs.version }}
 
   release-build-linux-x86-packages:
     needs:
@@ -70,7 +90,7 @@ jobs:
       build_matrix: ${{ needs.generate-build-matrix.outputs.x86_64-build-matrix }}
       region: us-west-2
     secrets:
-      bucket_name: ${{ secrets.AWS_S3_BUCKET }}
+      bucket_name: ${{ needs.release-build-get-meta.outputs.is_test == 'true' && secrets.AWS_TEST_BUCKET || secrets.AWS_S3_BUCKET }}
       role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 
   release-build-linux-arm-packages:
@@ -84,5 +104,5 @@ jobs:
       build_matrix: ${{ needs.generate-build-matrix.outputs.arm64-build-matrix }}
       region: us-west-2
     secrets:
-      bucket_name: ${{ secrets.AWS_S3_BUCKET }}
+      bucket_name: ${{ needs.release-build-get-meta.outputs.is_test == 'true' && secrets.AWS_TEST_BUCKET || secrets.AWS_S3_BUCKET }}
       role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -5,9 +5,6 @@ on:
     types: [published]
   push:
     paths:
-      - '.github/workflows/build-release-packages.yml'
-      - '.github/workflows/call-build-linux-arm-packages.yml'
-      - '.github/workflows/call-build-linux-x86_64-packages.yml'
       - 'utils/releasetools/**'
   workflow_dispatch:
     inputs:
@@ -39,7 +36,7 @@ jobs:
         id: get_version
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION=${{ github.base_ref }}
+            VERSION=${{ github.ref_name }}
           else
             VERSION="${INPUT_VERSION}"
           fi

--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -15,21 +15,20 @@ on:
         description: The build targets to produce as a JSON matrix.
         type: string
         required: true
-    secrets:
-      token:
-        description: The Github token or similar to authenticate with.
+      region:
+        description: The AWS region to push packages into.
+        type: string
         required: true
-      bucket:
-        description: The name of the S3 bucket to push packages into.
-        required: false
-      access_key_id:
-        description: The S3 access key id for the bucket.
-        required: false
-      secret_access_key:
-        description: The S3 secret access key for the bucket.
-        required: false
+    secrets:
+      bucket_name:
+        description: The S3 bucket to push packages into.
+        required: true
+      role_to_assume:
+        description: The role to assume for the S3 bucket.
+        required: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -45,6 +44,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.region }}
+          role-to-assume: ${{ secrets.role_to_assume }}
 
       - name: Make Valkey
         uses: uraimo/run-on-arch-action@v2
@@ -65,15 +70,5 @@ jobs:
           mkdir -p packages-files
           cp -rfv $TAR_FILE_NAME.tar* packages-files/
 
-      - name: Install AWS cli.
-        run: |
-          sudo apt-get install -y awscli
-
-      - name: Configure AWS credentials
-        run: |
-          aws configure set region us-west-2
-          aws configure set aws_access_key_id ${{ secrets.access_key_id }}
-          aws configure set aws_secret_access_key ${{ secrets.secret_access_key }}
-
       - name: Sync to S3
-        run: aws s3 sync packages-files s3://${{secrets.bucket}}/releases/
+        run: aws s3 sync packages-files s3://${{ secrets.bucket_name }}/releases/

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -15,21 +15,20 @@ on:
         description: The build targets to produce as a JSON matrix.
         type: string
         required: true
-    secrets:
-      token:
-        description: The Github token or similar to authenticate with.
+      region:
+        description: The AWS region to upload the packages to.
+        type: string
         required: true
-      bucket:
-        description: The name of the S3 bucket to push packages into.
-        required: false
-      access_key_id:
-        description: The S3 access key id for the bucket.
-        required: false
-      secret_access_key:
-        description: The S3 secret access key for the bucket.
-        required: false
+    secrets:
+      bucket_name:
+        description: The name of the S3 bucket to upload the packages to.
+        required: true
+      role_to_assume:
+        description: The role to assume for the S3 bucket.
+        required: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -45,6 +44,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.region }}
+          role-to-assume: ${{ secrets.role_to_assume }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libsystemd-dev
@@ -63,15 +68,5 @@ jobs:
           mkdir -p packages-files
           cp -rfv $TAR_FILE_NAME.tar* packages-files/
 
-      - name: Install AWS cli.
-        run: |
-          sudo apt-get install -y awscli
-
-      - name: Configure AWS credentials
-        run: |
-          aws configure set region us-west-2
-          aws configure set aws_access_key_id ${{ secrets.access_key_id }}
-          aws configure set aws_secret_access_key ${{ secrets.secret_access_key }}
-
       - name: Sync to S3
-        run: aws s3 sync packages-files s3://${{secrets.bucket}}/releases/
+        run: aws s3 sync packages-files s3://${{ secrets.bucket_name }}/releases/


### PR DESCRIPTION
## Summary
This PR fixes #1346 where we can get rid of the long term credentials by using OpenID Connect. OpenID Connect (OIDC) allows your GitHub Actions workflows to access resources in Amazon Web Services (AWS), without needing to store the AWS credentials as long-lived GitHub secrets.

## Changes
We can remove these secrets that were passed in previously:
```
token: ${{ secrets.GITHUB_TOKEN }}
      bucket: ${{ secrets.AWS_S3_BUCKET }}
      access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
      secret_access_key: ${{ secrets.AWS_S3_ACCESS_KEY }}
```

Instead we only need the `role-to-assume` arn. For more information [OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect).

## Prerequisites
Before merging this PR, we need to make sure to set up the proper Identity providers on the production AWS account. Follow this [guides](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services). 
 **Quick guide**:
1. Create an Identity provider with OpenID Connect.
Provider url: `https://token.actions.githubusercontent.com` <br/>
Audience: `sts.amazonaws.com`
<img alt="Screenshot 2024-11-26 at 1 02 23 PM" src="https://github.com/user-attachments/assets/8d606827-16dd-489d-80de-0bfd3ef1e4b5">

2. Assign the role into this new provider with this trust policy like below
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::<aws_account_id>:oidc-provider/token.actions.githubusercontent.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringLike": {
                    "token.actions.githubusercontent.com:sub": [
                        "repo:valkey-io/valkey:ref:refs/heads/unstable",
                        "repo:valkey-io/valkey:ref:refs/tags/*"
                    ],
                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
                }
            }
        }
    ]
}
```
3. In Github secrets, Add these secrets:
<img width="752" alt="Screenshot 2024-11-26 at 2 11 02 PM" src="https://github.com/user-attachments/assets/27aee260-3224-4838-8473-f9bbe4df8e53">

## Results
**Github action run:**
<img width="1093" alt="Screenshot 2024-11-26 at 2 06 17 PM" src="https://github.com/user-attachments/assets/f8be16b1-a75d-446e-b4ba-b14b3e844d0a">


**Files in S3 Dev env:**
<img width="797" alt="Screenshot 2024-11-26 at 2 09 42 PM" src="https://github.com/user-attachments/assets/a12cdbb2-83e8-4acb-8da0-27db562d8e4c">

> Note: the failed workflow can be found in this issue #1343 which will be in a separate PR.