### PR TITLE
Updated zfree to zfree_with_size to improve performance

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1753,7 +1753,7 @@ void freeClient(client *c) {
     /* Free data structures. */
     listRelease(c->reply);
     c->reply = NULL;
-    zfree(c->buf);
+    zfree_with_size(c->buf, c->buf_usable_size);
     c->buf = NULL;
     freeReplicaReferencedReplBuffer(c);
     freeClientArgv(c);

--- a/src/server.c
+++ b/src/server.c
@@ -889,9 +889,10 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
 
     if (new_buffer_size) {
         oldbuf = c->buf;
+        size_t oldbuf_size = c->buf_usable_size;
         c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
         memcpy(c->buf, oldbuf, c->bufpos);
-        zfree(oldbuf);
+        zfree_with_size(oldbuf, oldbuf_size);
     }
     return 0;
 }


### PR DESCRIPTION
`zfree_with_size` performs better than regular `zfree` as it doesn't ask 'zmalloc_size' about buffer's size, and it uses optimized zmalloc deallocation function.
So there are 2 placed where zfree is updated to zfree_with_size.