### PR TITLE
Run RDMA builtin in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: make
+      - name: prepare-development-libraries
+        run: sudo apt-get install librdmacm-dev libibverbs-dev
+      - name: make-rdma-module
+        run: make -j4 BUILD_RDMA=module
+      - name: make-rdma-builtin
         run: |
-          sudo apt-get install librdmacm-dev libibverbs-dev
-          make -j4 BUILD_RDMA=module
+          make distclean
+          make -j4 BUILD_RDMA=yes
       - name: clone-rxe-kmod
         run: |
           mkdir -p tests/rdma/rxe

--- a/tests/rdma/run.py
+++ b/tests/rdma/run.py
@@ -60,10 +60,9 @@ def test_rdma(ipaddr):
 
     # step 2, start server
     svrpath = valkeydir + "/src/valkey-server"
-    rdmapath = valkeydir + "/src/valkey-rdma.so"
     svrcmd = [svrpath, "--port", "0", "--loglevel", "verbose", "--protected-mode", "yes",
              "--appendonly", "no", "--daemonize", "no", "--dir", valkeydir + "/tests/rdma/tmp",
-             "--loadmodule", rdmapath, "--rdma-port", "6379", "--rdma-bind", ipaddr]
+             "--rdma-port", "6379", "--rdma-bind", ipaddr]
 
     svr = subprocess.Popen(svrcmd, shell=False, stdout=subprocess.PIPE)
     try:


### PR DESCRIPTION
Since 4695d118dd("RDMA builtin support (#1209)"), RDMA supports builtin. And module connection type may be removed in future. So run a builtin RDMA support for CI workflow.

RDMA module is complied only in CI, keep it building check only until module connection type gets obsolete.