### PR TITLE
Fix wrong dbnum showed in cli after client reconnected

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -3055,6 +3055,9 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
                 config.cluster_reissue_command = 0;
                 return REDIS_ERR;
             }
+            /* Reset dbnum after reconnecting so we can re-select the previous db in cliSelect(). */
+            config.dbnum = 0;
+            cliSelect();
         }
         config.cluster_reissue_command = 0;
         if (config.cluster_send_asking) {


### PR DESCRIPTION
When the server restarts while the CLI is connecting, the reconnection does not automatically select the previous db.
This may lead users to believe they are still in the previous db, in fact, they are in db0.

This PR will automatically reset the current dbnum and `cliSelect()` again when reconnecting.


### Steps for reproducing bug

1. start server and client:
```shell
./src/valkey-server
./src/valkey-cli
```

2. set value in db0 and db5:
```shell
127.0.0.1:6379> set a 0
OK
127.0.0.1:6379> get a
"0"
127.0.0.1:6379> select 5
OK
127.0.0.1:6379[5]> set a 5
OK
127.0.0.1:6379[5]> get a
"5"
127.0.0.1:6379[5]> 
```

3. Ctrl+C to stop server:
```shell
127.0.0.1:6379[5]> get a
Error: Connection reset by peer
not connected> 
```

4. restart server then in valkey-cli:
```shell
not connected> get a
"0"
127.0.0.1:6379[5]> 
```
The valkey-cli run command at db0 but showed db5.


### Solution

valkey-cli will re-select db5 after reconnected:
```shell
127.0.0.1:6379> get a
"0"
127.0.0.1:6379> select 5
OK
127.0.0.1:6379[5]> get a
"5"
127.0.0.1:6379[5]> get a
Error: Connection reset by peer
not connected> get a
"5"
127.0.0.1:6379[5]> 
```