### PR TITLE
RDMA: Fix dead loop when transfer large data (20KB)

### DIFF
--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1816,7 +1816,7 @@ static ConnectionType CT_RDMA = {
     .has_pending_data = rdmaHasPendingData,
     .process_pending_data = rdmaProcessPendingData,
     .postpone_update_state = postPoneUpdateRdmaState,
-    .update_state = updateRdmaState
+    .update_state = updateRdmaState,
 };
 
 ConnectionType *connectionTypeRdma(void) {

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -81,8 +81,8 @@ typedef enum ValkeyRdmaOpcode {
 
 typedef struct rdma_connection {
     connection c;
-    int flags;
     struct rdma_cm_id *cm_id;
+    int flags;
     int last_errno;
     listNode *pending_list_node;
 } rdma_connection;

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -678,6 +678,7 @@ static connection *connCreateAcceptedRdma(int fd, void *priv) {
 static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientData, int mask) {
     rdma_connection *rdma_conn = (rdma_connection *)clientData;
     connection *conn = &rdma_conn->c;
+    client *c = connGetPrivateData(conn);
     struct rdma_cm_id *cm_id = rdma_conn->cm_id;
     RdmaContext *ctx = cm_id->context;
     int ret = 0;
@@ -694,6 +695,9 @@ static void connRdmaEventHandler(struct aeEventLoop *el, int fd, void *clientDat
 
     /* uplayer should read all */
     while (ctx->rx.pos < ctx->rx.offset) {
+        if (c->io_read_state == CLIENT_COMPLETED_IO || c->io_write_state == CLIENT_COMPLETED_IO) {
+            break;
+        }
         if (conn->read_handler && (callHandler(conn, conn->read_handler) == C_ERR)) {
             return;
         }


### PR DESCRIPTION
Determine the status of the Client when attempting to read data. If state=CLIENT_COMPLETED_IO, no read attempt is made and I/O operations on the Client are rescheduled by the main thread.

> And 20474 Byte = PROTO_IOBUF_LEN(16KB) + SDS_HDR_VAR(16, s)(4090 Byte)

Fixes #1385