### PR TITLE
Update code of conduct maintainers email address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ representative at an online or offline event.
 Enforcement
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-this email address: placeholderkv@gmail.com.
+this email address: maintainers@lists.valkey.io.
 All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
Some sent an email to the old email we have setup, so just fixing that.