### PR TITLE
Fix coredump when use hellodict example module

### DIFF
--- a/src/modules/hellodict.c
+++ b/src/modules/hellodict.c
@@ -109,13 +109,13 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 
     if (ValkeyModule_Init(ctx, "hellodict", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR) return VALKEYMODULE_ERR;
 
-    if (ValkeyModule_CreateCommand(ctx, "hellodict.set", cmd_SET, "write deny-oom", 1, 1, 0) == VALKEYMODULE_ERR)
+    if (ValkeyModule_CreateCommand(ctx, "hellodict.set", cmd_SET, "write deny-oom", 1, 1, 1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    if (ValkeyModule_CreateCommand(ctx, "hellodict.get", cmd_GET, "readonly", 1, 1, 0) == VALKEYMODULE_ERR)
+    if (ValkeyModule_CreateCommand(ctx, "hellodict.get", cmd_GET, "readonly", 1, 1, 1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    if (ValkeyModule_CreateCommand(ctx, "hellodict.keyrange", cmd_KEYRANGE, "readonly", 1, 1, 0) == VALKEYMODULE_ERR)
+    if (ValkeyModule_CreateCommand(ctx, "hellodict.keyrange", cmd_KEYRANGE, "readonly", 1, 1, 1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     /* Create our global dictionary. Here we'll set our keys and values. */


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/50bffbdc-77ee-4b78-8b02-304664ac8dff)

 In the ValkeyModule_OnLoad method of the file hellodict.c, the parameter keystep of ValkeyModule_CreateCommand should be 1. Otherwise, execute command will coredump.
```
MODULE LOAD /home/tiger/valkey/src/modules/hellodict.so
COMMAND GETKEYS HELLODICT.SET key value
```
