### PR TITLE
Add new flag in `CLIENT LIST` for import-source client

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3209,7 +3209,7 @@ standardConfig static_configs[] = {
     createBoolConfig("enable-debug-assert", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, server.enable_debug_assert, 0, NULL, NULL),
     createBoolConfig("cluster-slot-stats-enabled", NULL, MODIFIABLE_CONFIG, server.cluster_slot_stats_enabled, 0, NULL, NULL),
     createBoolConfig("hide-user-data-from-log", NULL, MODIFIABLE_CONFIG, server.hide_user_data_from_log, 1, NULL, NULL),
-    createBoolConfig("import-mode", NULL, MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
+    createBoolConfig("import-mode", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.import_mode, 0, NULL, NULL),
 
     /* String Configs */
     createStringConfig("aclfile", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, server.acl_filename, "", NULL, NULL),

--- a/src/networking.c
+++ b/src/networking.c
@@ -4103,7 +4103,7 @@ void clientCommand(client *c) {
     } else if (!strcasecmp(c->argv[1]->ptr, "import-source")) {
         /* CLIENT IMPORT-SOURCE ON|OFF */
         if (!server.import_mode && strcasecmp(c->argv[2]->ptr, "off")) {
-            addReplyError(c, "Server is not in import mode and we only allow to close import-source status.");
+            addReplyError(c, "Server is not in import mode");
             return;
         }
         if (!strcasecmp(c->argv[2]->ptr, "on")) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3340,6 +3340,7 @@ sds catClientInfoString(sds s, client *client, int hide_user_data) {
     if (client->flag.readonly) *p++ = 'r';
     if (client->flag.no_evict) *p++ = 'e';
     if (client->flag.no_touch) *p++ = 'T';
+    if (client->flag.import_source) *p++ = 'I';
     if (p == flags) *p++ = 'N';
     *p++ = '\0';
 
@@ -4101,8 +4102,8 @@ void clientCommand(client *c) {
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "import-source")) {
         /* CLIENT IMPORT-SOURCE ON|OFF */
-        if (!server.import_mode) {
-            addReplyError(c, "Server is not in import mode");
+        if (!server.import_mode && strcasecmp(c->argv[2]->ptr, "off")) {
+            addReplyError(c, "Server is not in import mode and we only allow to close import-source status.");
             return;
         }
         if (!strcasecmp(c->argv[2]->ptr, "on")) {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -838,7 +838,7 @@ start_server {tags {"expire"}} {
         set id [r client id]
 
         catch {r client import-source on} err
-        assert_match {*Server is not in import mode and we only allow to close import-source status*} $err
+        assert_match {ERR*} $err
 
         r config set import-mode yes
         assert_equal [r client import-source on] {OK}

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -834,21 +834,16 @@ start_server {tags {"expire"}} {
     } {} {needs:debug}
 
     test {import-source can be closed when import-mode is off} {
-        r flushall
-        set id [r client id]
-
-        catch {r client import-source on} err
-        assert_match {ERR*} $err
+        r config set import-mode no
+        assert_error "ERR Server is not in import mode" {r client import-source on}
 
         r config set import-mode yes
         assert_equal [r client import-source on] {OK}
-
-        assert_match {*flags=I*} [r client list id $id]
+        assert_match {*flags=I*} [r client list id [r client id]]
 
         r config set import-mode no
         assert_equal [r client import-source off] {OK}
-
-        assert_match {*flags=N*} [r client list id $id]
+        assert_match {*flags=N*} [r client list id [r client id]]
     }
 
     test {Import mode should forbid active expiration} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -833,6 +833,24 @@ start_server {tags {"expire"}} {
         assert_equal [r debug set-active-expire 1] {OK}
     } {} {needs:debug}
 
+    test {import-source can be closed when import-mode is off} {
+        r flushall
+        set id [r client id]
+
+        catch {r client import-source on} err
+        assert_match {*Server is not in import mode and we only allow to close import-source status*} $err
+
+        r config set import-mode yes
+        assert_equal [r client import-source on] {OK}
+
+        assert_match {*flags=I*} [r client list id $id]
+
+        r config set import-mode no
+        assert_equal [r client import-source off] {OK}
+
+        assert_match {*flags=N*} [r client list id $id]
+    }
+
     test {Import mode should forbid active expiration} {
         r flushall
 


### PR DESCRIPTION
Fixes #1350 and https://github.com/valkey-io/valkey/pull/1185#discussion_r1851049362.

- Add new flag "I" in `CLIENT LIST` for import-source client
- Add `DEBUG_CONFIG` for import-mode
- Allow import-source status to be turned off when import-mode is off