### PR TITLE
Fix sanitizer builds with clang

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -34,7 +34,7 @@
 
 #if defined(__linux__)
 #define _GNU_SOURCE
-#define _DEFAULT_SOURCE 2
+#define _DEFAULT_SOURCE
 #endif
 
 #if defined(_AIX)

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -34,7 +34,7 @@
 
 #if defined(__linux__)
 #define _GNU_SOURCE
-#define _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE 2
 #endif
 
 #if defined(_AIX)

--- a/src/unit/test_networking.c
+++ b/src/unit/test_networking.c
@@ -1,8 +1,8 @@
-#include <stdatomic.h>
-
 #include "../networking.c"
 #include "../server.c"
 #include "test_help.h"
+
+#include <stdatomic.h>
 
 int test_backupAndUpdateClientArgv(int argc, char **argv, int flags) {
     UNUSED(argc);


### PR DESCRIPTION
By including <stdatomic.h> after the other includes in the unit test, we can avoid redefining a macro which led to a build failure.

Fixes #1394