### PR TITLE
Cancel activedefrag in case we empty db

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -559,6 +559,10 @@ long long emptyData(int dbnum, int flags, void(callback)(dict *)) {
         return -1;
     }
 
+    /* In case we are in the process of activedefrag, the db keys and expire might be in the stage of defrag.
+     * we thus cancel the active defrag so that it will be restarted from the beginning. */
+    cancelActiveDefrag();
+
     /* Fire the flushdb modules event. */
     moduleFireServerEvent(VALKEYMODULE_EVENT_FLUSHDB, VALKEYMODULE_SUBEVENT_FLUSHDB_START, &fi);
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1367,6 +1367,12 @@ static void updateDefragCpuPercent(void) {
     }
 }
 
+void cancelActiveDefrag(void) {
+    if (defragIsRunning()) {
+        // Defrag has been disabled while running
+        endDefragCycle(false);
+    }
+}
 
 void monitorActiveDefrag(void) {
     if (!server.active_defrag_enabled) return;
@@ -1381,6 +1387,10 @@ void monitorActiveDefrag(void) {
 }
 
 #else /* HAVE_DEFRAG */
+
+void cancelActiveDefrag(void) {
+    /* Not implemented yet. */
+}
 
 void monitorActiveDefrag(void) {
     /* Not implemented yet. */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1369,7 +1369,7 @@ static void updateDefragCpuPercent(void) {
 
 void cancelActiveDefrag(void) {
     if (defragIsRunning()) {
-        // Defrag has been disabled while running
+        // Defrag is requested to stop while running
         endDefragCycle(false);
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -3354,6 +3354,7 @@ void enterExecutionUnit(int update_cached_time, long long us);
 void exitExecutionUnit(void);
 void resetServerStats(void);
 void monitorActiveDefrag(void);
+void cancelActiveDefrag(void);
 void defragWhileBlocked(void);
 unsigned int getLRUClock(void);
 unsigned int LRU_CLOCK(void);


### PR DESCRIPTION
In case we empty database (eg user triggers flushdb command) the activedefrag might be in the process of scanning over the db kvstore. 
Example:
```
Logged sanitizer errors (pid 53103):
=================================================================
==53103==ERROR: AddressSanitizer: heap-use-after-free on address 0x6080000026b8 at pc 0x0001006130d0 bp 0x00016fa72ec0 sp 0x00016fa72eb8
READ of size 4 at 0x6080000026b8 thread T0
    #0 0x1006130cc in defragStageKvstoreHelper+0x650 (valkey-server:arm64+0x1002870cc)
    #1 0x100610d64 in activeDefragTimeProc+0x2e0 (valkey-server:arm64+0x100284d64)
    #2 0x1003c128c in aeProcessEvents+0x630 (valkey-server:arm64+0x10003528c)
    #3 0x10040334c in main+0x6d7c (valkey-server:arm64+0x10007734c)
    #4 0x19d1ff150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

0x6080000026b8 is located 24 bytes inside of 96-byte region [0x6080000026a0,0x608000002700)
freed by thread T3 here:
    #0 0x101338d40 in free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54d40)
    #1 0x1005bed10 in lazyfreeFreeDatabase+0x54 (valkey-server:arm64+0x100232d10)
    #2 0x100578750 in bioProcessBackgroundJobs+0x4e8 (valkey-server:arm64+0x1001ec750)
    #3 0x101335858 in asan_thread_start(void*)+0x40 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x51858)
    #4 0x19d589f90 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6f90)
    #5 0x19d584d30 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1d30)

previously allocated by thread T0 here:
    #0 0x101338fd0 in calloc+0x9c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x54fd0)
    #1 0x1004120a0 in valkey_calloc+0x3c (valkey-server:arm64+0x1000860a0)
    #2 0x1003cd844 in kvstoreCreate+0xa8 (valkey-server:arm64+0x100041844)
    #3 0x1005bf778 in emptyDbAsync+0xbc (valkey-server:arm64+0x100233778)
    #4 0x100458ce8 in emptyData+0x354 (valkey-server:arm64+0x1000ccce8)
    #5 0x100459cd4 in flushallCommand+0x1c0 (valkey-server:arm64+0x1000cdcd4)
    #6 0x1003e9500 in call+0x3cc (valkey-server:arm64+0x10005d500)
    #7 0x1003ec7a4 in processCommand+0x17b4 (valkey-server:arm64+0x1000607a4)
    #8 0x100424358 in processInputBuffer+0x498 (valkey-server:arm64+0x100098358)
    #9 0x100422204 in readQueryFromClient+0xd4 (valkey-server:arm64+0x100096204)
    #10 0x100668688 in connSocketEventHandler+0x160 (valkey-server:arm64+0x1002dc688)
    #11 0x1003c0fb8 in aeProcessEvents+0x35c (valkey-server:arm64+0x100034fb8)
    #12 0x10040334c in main+0x6d7c (valkey-server:arm64+0x10007734c)
    #13 0x19d1ff150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

Thread T3 created by T0 here:
    #0 0x1013301c8 in pthread_create+0x5c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x4c1c8)
    #1 0x100578104 in bioInit+0x28c (valkey-server:arm64+0x1001ec104)
    #2 0x1003ff6b4 in main+0x30e4 (valkey-server:arm64+0x1000736b4)
    #3 0x19d1ff150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)
``` 

In order to avoid such issues we will reset activedefrag to start all over again.