### PR TITLE
[Backporting]Fix empty response for ACL CAT category subcommand for module defined…

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2682,7 +2682,6 @@ void aclCatWithFlags(client *c, dict *commands, uint64_t cflag, int *arraylen) {
 
     while ((de = dictNext(di)) != NULL) {
         struct redisCommand *cmd = dictGetVal(de);
-        if (cmd->flags & CMD_MODULE) continue;
         if (cmd->acl_categories & cflag) {
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             (*arraylen)++;

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -131,7 +131,19 @@ start_server {tags {"modules acl"}} {
         assert_equal {User j7 has no permissions to run the 'aclcheck.module.command.aclcategories.write.function.read.category' command} $e
     }
 
-    test "Unload the module - aclcheck" {
+    test {test if foocategory acl categories is added} {
+        r acl SETUSER j8 on >password -@all +@foocategory
+        assert_equal [r acl DRYRUN j8 aclcheck.module.command.test.add.new.aclcategories] OK
+    }
+
+    test {test if ACL CAT output for the new category is correct} {
+        assert_equal [r ACL CAT foocategory] aclcheck.module.command.test.add.new.aclcategories
+    }
+
+    test {test permission compaction and simplification for categories added by a module} {
+        r acl SETUSER j9 on >password -@all +@foocategory -@foocategory
+        catch {r ACL GETUSER j9} res
+        assert_equal {-@all -@foocategory} [lindex $res 5]
         assert_equal {OK} [r module unload aclcheck]
     }
 }


### PR DESCRIPTION
[Backporting]Fix empty response for ACL CAT category subcommand for module defined categories (#1140)

The module commands which were added to acl categories were getting skipped when `ACL CAT category` command was executed.

This PR fixes the bug.
Before:
```
127.0.0.1:6379> ACL CAT foocategory
(empty array)
```
After:
```
127.0.0.1:6379> ACL CAT foocategory
aclcheck.module.command.test.add.new.aclcategories
```