### PR TITLE
Fix race in test "CLUSTER SLOT-STATS cpu-usec for blocking commands, unblocked on timeout"

### DIFF
--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -228,11 +228,11 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
     R 0 FLUSHALL
 
     test "CLUSTER SLOT-STATS cpu-usec for blocking commands, unblocked on timeout." {
-        # Blocking command with 1 second timeout.
+        # Blocking command with 0.5 seconds timeout.
         set rd [valkey_deferring_client]
-        $rd BLPOP $key 1
+        $rd BLPOP $key 0.5
 
-        # Confirm that the client is blocked, then unblocked after 1 second timeout.
+        # Confirm that the client is blocked, then unblocked within 1 second.
         wait_for_blocked_clients_count 1
         wait_for_blocked_clients_count 0
 


### PR DESCRIPTION
This fix changes the timeout for BLPOP in this test case from 1 second to 0.5 seconds.

In the test case quoted below, the procedure `wait_for_blocked_clients_count` waits for one second by default. If BLPOP has 1 second timeout and the first `wait_for_blocked_clients_count` finishes very fast, then the second `wait_for_blocked_clients_count` can time out before the BLPOP has been unblocked.

```TCL
    test "CLUSTER SLOT-STATS cpu-usec for blocking commands, unblocked on timeout." {
        # Blocking command with 1 second timeout.
        set rd [valkey_deferring_client]
        $rd BLPOP $key 1

        # Confirm that the client is blocked, then unblocked after 1 second timeout.
        wait_for_blocked_clients_count 1
        wait_for_blocked_clients_count 0
```

As seen in the definition of `wait_for_blocked_clients_count`, the total time to wait is 1 second by default.

```TCL
proc wait_for_blocked_clients_count {count {maxtries 100} {delay 10} {idx 0}} {
    wait_for_condition $maxtries $delay  {
        [s $idx blocked_clients] == $count
    } else {
        fail "Timeout waiting for blocked clients"
    }
}
```

Fixes #1121