### PR TITLE
Fix flaky init_test proc in maxmemory test suite

### DIFF
--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -4,7 +4,7 @@ start_server {tags {"maxmemory" "external:skip"}} {
     set server_pid [s process_id]
 
     proc init_test {client_eviction} {
-        r flushdb
+        r flushdb sync
 
         set prev_maxmemory_clients [r config get maxmemory-clients]
         if $client_eviction {


### PR DESCRIPTION
The following error has been seen, but not reliably reproduced:

```
*** [err]: eviction due to output buffers of pubsub, client eviction: true in tests/unit/maxmemory.tcl
Expected '42' to be equal to '50' (context: type proc line 17 cmd {assert_equal [r dbsize] 50} proc ::init_test level 2)
```

The reason is probably that FLUSHDB is asynchronous and when we start populating new keys, they are evicted because the background flush is too slow. Changing this to FLUSHDB SYNC prevents this.