### PR TITLE
Fix memory leak in the new hashtable unittest

### DIFF
--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -303,6 +303,7 @@ int test_two_phase_insert_and_pop(int argc, char **argv, int flags) {
         TEST_ASSERT(hashtableSize(ht) == size_before_find);
         hashtableTwoPhasePopDelete(ht, &position);
         TEST_ASSERT(hashtableSize(ht) == size_before_find - 1);
+        free(e);
     }
     TEST_ASSERT(hashtableSize(ht) == 0);
 


### PR DESCRIPTION
There is a leak in here, hashtableTwoPhasePopDelete won't call the entry destructor and like hashtablePop we need to call it by myself.