### PR TITLE
RESP3 PUSH support for MONITOR command

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -705,10 +705,12 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     while ((ln = listNext(&li))) {
         client *monitor = ln->value;
         if (monitor->resp > 2) {
+            struct ClientFlags old_flags = monitor->flag;
             monitor->flag.pushing = 1;
             addReplyPushLen(monitor, 2);
             addReply(monitor, shared.monitorbulk);
             addReply(monitor, cmdobj);
+            if (!old_flags.pushing) monitor->flag.pushing = 0;
         } else {
             addReply(monitor, cmdobj);
         }

--- a/src/replication.c
+++ b/src/replication.c
@@ -704,7 +704,14 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listRewind(monitors, &li);
     while ((ln = listNext(&li))) {
         client *monitor = ln->value;
-        addReply(monitor, cmdobj);
+        if(monitor->resp > 2) {
+            monitor->flag.pushing = 1;
+            addReplyPushLen(monitor,2);
+            addReply(monitor,shared.monitorbulk);
+            addReply(monitor,cmdobj);
+        } else {
+            addReply(monitor,cmdobj);
+        }
         updateClientMemUsageAndBucket(monitor);
     }
     decrRefCount(cmdobj);

--- a/src/replication.c
+++ b/src/replication.c
@@ -704,7 +704,7 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
     listRewind(monitors, &li);
     while ((ln = listNext(&li))) {
         client *monitor = ln->value;
-        if(monitor->resp > 2) {
+        if (monitor->resp > 2) {
             monitor->flag.pushing = 1;
             addReplyPushLen(monitor,2);
             addReply(monitor,shared.monitorbulk);

--- a/src/replication.c
+++ b/src/replication.c
@@ -706,11 +706,11 @@ void replicationFeedMonitors(client *c, list *monitors, int dictid, robj **argv,
         client *monitor = ln->value;
         if (monitor->resp > 2) {
             monitor->flag.pushing = 1;
-            addReplyPushLen(monitor,2);
-            addReply(monitor,shared.monitorbulk);
-            addReply(monitor,cmdobj);
+            addReplyPushLen(monitor, 2);
+            addReply(monitor, shared.monitorbulk);
+            addReply(monitor, cmdobj);
         } else {
-            addReply(monitor,cmdobj);
+            addReply(monitor, cmdobj);
         }
         updateClientMemUsageAndBucket(monitor);
     }

--- a/src/server.c
+++ b/src/server.c
@@ -2035,6 +2035,7 @@ void createSharedObjects(void) {
     shared.ssubscribebulk = createStringObject("$10\r\nssubscribe\r\n", 17);
     shared.sunsubscribebulk = createStringObject("$12\r\nsunsubscribe\r\n", 19);
     shared.smessagebulk = createStringObject("$8\r\nsmessage\r\n", 14);
+    shared.monitorbulk = createStringObject("$7\r\nmonitor\r\n", 13);
     shared.psubscribebulk = createStringObject("$10\r\npsubscribe\r\n", 17);
     shared.punsubscribebulk = createStringObject("$12\r\npunsubscribe\r\n", 19);
 

--- a/src/server.c
+++ b/src/server.c
@@ -4259,10 +4259,10 @@ int processCommand(client *c) {
         return C_OK;
     }
 
-    /* Prevent a replica from sending commands that access the keyspace.
+    /* Prevent a replica (but not a monitor client) from sending commands that access the keyspace.
      * The main objective here is to prevent abuse of client pause check
      * from which replicas are exempt. */
-    if (c->flag.replica && (is_may_replicate_command || is_write_command || is_read_command)) {
+    if ((c->flag.replica && !c->flag.monitor) && (is_may_replicate_command || is_write_command || is_read_command)) {
         rejectCommandFormat(c, "Replica can't interact with the keyspace");
         return C_OK;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -1437,7 +1437,7 @@ struct sharedObjectsStruct {
         *xgroup, *xclaim, *script, *replconf, *eval, *persist, *set, *pexpireat, *pexpire, *time, *pxat, *absttl,
         *retrycount, *force, *justid, *entriesread, *lastid, *ping, *setid, *keepttl, *load, *createconsumer, *getack,
         *special_asterick, *special_equals, *default_username, *redacted, *ssubscribebulk, *sunsubscribebulk,
-        *smessagebulk, *select[PROTO_SHARED_SELECT_CMDS], *integers[OBJ_SHARED_INTEGERS],
+        *smessagebulk, *monitorbulk, *select[PROTO_SHARED_SELECT_CMDS], *integers[OBJ_SHARED_INTEGERS],
         *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
         *bulkhdr[OBJ_SHARED_BULKHDR_LEN],  /* "$<value>\r\n" */
         *maphdr[OBJ_SHARED_BULKHDR_LEN],   /* "%<value>\r\n" */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -299,6 +299,20 @@ start_server {tags {"introspection"}} {
         set _ $res
     } {*"set" "foo"*"get" "foo"*}
 
+    test {MONITOR should support RESP3 protocol} {
+        set rd [valkey_deferring_client]
+        $rd HELLO 3
+        $rd read ; # Consume the HELLO reply
+
+        $rd monitor
+        $rd read ; # Consume the MONITOR reply
+
+        r set foo bar
+
+        assert_match {monitor*"set"*"foo"*"bar"*} [$rd read]
+        $rd close
+    }
+
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [valkey_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -317,52 +317,20 @@ start_server {tags {"introspection"}} {
         $rd close
     }
 
-    test {MONITOR and CLIENT TRACKING should work on the same connection with RESP3} {
-        set rd1 [valkey_deferring_client]
-        set rd2 [valkey_deferring_client]
+    test {multiple MONITOR commands should result in ERR} {
+        set rd [valkey_deferring_client]
+        $rd HELLO 3
+        $rd read ; # Consume the HELLO reply
 
-        $rd1 HELLO 3
-        $rd1 read ; # Consume the HELLO reply
+        $rd readraw 1 ;
 
-        $rd1 client tracking on
-        $rd1 read ; # Consume the TRACKING reply
+        $rd monitor
+        assert_equal "+OK" [$rd read]
 
-        $rd1 monitor
-        $rd1 read ; # Consume the MONITOR reply
-
-        $rd1 set foo bar
-        assert_equal "OK" [$rd1 read]
-        assert_match {monitor*"set"*"foo"*"bar"*} [$rd1 read]
-
-        # Because we need to verify exact RESP3 response correctness,
-        # we need to instruct valkey client to return raw, unparsed response.
-        $rd1 readraw 1 ;
-
-        $rd1 get foo
-        assert_equal "\$3" [$rd1 read]
-        assert_equal "bar" [$rd1 read]
-
-        assert_equal ">2" [$rd1 read]
-        assert_equal "\$7" [$rd1 read]
-        assert_equal "monitor" [$rd1 read]
-        assert_match {*"get"*"foo"*} [$rd1 read]
-
-        $rd2 set foo baz
-
-        assert_equal ">2" [$rd1 read]
-        assert_equal "\$10" [$rd1 read]
-        assert_equal "invalidate" [$rd1 read]
-        assert_equal "*1" [$rd1 read]
-        assert_equal "\$3" [$rd1 read]
-        assert_equal "foo" [$rd1 read]
-
-        assert_equal ">2" [$rd1 read]
-        assert_equal "\$7" [$rd1 read]
-        assert_equal "monitor" [$rd1 read]
-        assert_match {*"set"*"foo"*"baz"*} [$rd1 read]
-
-        $rd1 close
-        $rd2 close
+        $rd monitor
+        assert_equal "-ERR The connection is already in monitoring mode." [$rd read]
+        
+        $rd close
     }
 
     test {MONITOR can log commands issued by the scripting engine} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -306,7 +306,7 @@ start_server {tags {"introspection"}} {
 
         $rd monitor
         $rd read ; # Consume the MONITOR reply
-        $rd readraw 1 ;
+        $rd readraw 1;
 
         r set foo bar
         assert_equal ">2" [$rd read]
@@ -322,7 +322,7 @@ start_server {tags {"introspection"}} {
         $rd HELLO 3
         $rd read ; # Consume the HELLO reply
 
-        $rd readraw 1 ;
+        $rd readraw 1;
 
         $rd monitor
         assert_equal "+OK" [$rd read]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -334,6 +334,8 @@ start_server {tags {"introspection"}} {
         assert_equal "OK" [$rd1 read]
         assert_match {monitor*"set"*"foo"*"bar"*} [$rd1 read]
 
+        # Because we need to verify exact RESP3 response correctness,
+        # we need to instruct valkey client to return raw, unprased response.
         $rd1 readraw 1 ;
 
         $rd1 get foo

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -335,7 +335,7 @@ start_server {tags {"introspection"}} {
         assert_match {monitor*"set"*"foo"*"bar"*} [$rd1 read]
 
         # Because we need to verify exact RESP3 response correctness,
-        # we need to instruct valkey client to return raw, unprased response.
+        # we need to instruct valkey client to return raw, unparsed response.
         $rd1 readraw 1 ;
 
         $rd1 get foo

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -333,6 +333,26 @@ start_server {tags {"introspection"}} {
         $rd close
     }
 
+    test {MONITOR should came after PONG reply} {
+        set rd [valkey_deferring_client]
+        $rd HELLO 3
+        $rd read ; # Consume the HELLO reply
+
+        $rd monitor
+        $rd read ; # Consume the MONITOR reply
+        $rd readraw 1;
+
+        r ping
+
+        assert_equal "+pong" [$rd read]
+        assert_equal ">2" [$rd read]
+        assert_equal "\$7" [$rd read]
+        assert_equal "monitor" [$rd read]
+        assert_match {*"ping"*} [$rd read]
+
+        $rd close
+    }
+
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [valkey_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -342,9 +342,9 @@ start_server {tags {"introspection"}} {
         $rd read ; # Consume the MONITOR reply
         $rd readraw 1;
 
-        r ping
+        $rd ping
 
-        assert_equal "+pong" [$rd read]
+        assert_equal "+PONG" [$rd read]
         assert_equal ">2" [$rd read]
         assert_equal "\$7" [$rd read]
         assert_equal "monitor" [$rd read]


### PR DESCRIPTION
Change MONITOR in RESP3 mode to report monitored commands using the RESP3 push type, instead of as a stream of simple string replies.

This makes it possible for a client to send commands while it's in monitoring mode. It also makes it possible to use MONITOR with clients like hiredis, that handle push replies by delegating them to a push-callback provided by the user.

Old format, a stream of replies on the form

```
+1733939274.692107 [0 127.0.0.1:51014] "get" "a"
```

New format, after sending HELLO 3 and MONITOR, the connection will receive push messages on the form

```
>2
$7
monitor
+1733939225.708882 [0 127.0.0.1:51014] "get" "a"
```

Additional change: If MONITOR is called again when already in monitoring mode, the command replies with an error instead of no reply. A command with no reply confuses clients. They're expecting a reply to each command.

Closes #1428.