### PR TITLE
Fix Valkey binary build workflow, version support changes.

### DIFF
--- a/.github/actions/generate-package-build-matrix/action.yml
+++ b/.github/actions/generate-package-build-matrix/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Get targets
       run: |
-        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64") | .target |= sub("ubuntu([0-9]+\\.[0-9]+)"; "ubuntu-\1")]' utils/releasetools/build-config.json)
+        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64")]' utils/releasetools/build-config.json)
         x86_matrix=$(echo "{ \"distro\" : $x86_arch }" | jq -c .)
         echo "X86_MATRIX=$x86_matrix" >> $GITHUB_ENV
 

--- a/.github/actions/generate-package-build-matrix/action.yml
+++ b/.github/actions/generate-package-build-matrix/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Get targets
       run: |
-        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64")]' utils/releasetools/build-config.json)
+        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64") | .target |= sub("(ubuntu)([0-9]+\\.[0-9]+)"; "\(.\1)-\2")]' utils/releasetools/build-config.json)
         x86_matrix=$(echo "{ \"distro\" : $x86_arch }" | jq -c .)
         echo "X86_MATRIX=$x86_matrix" >> $GITHUB_ENV
 

--- a/.github/actions/generate-package-build-matrix/action.yml
+++ b/.github/actions/generate-package-build-matrix/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Get targets
       run: |
-        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64") | .target |= sub("(ubuntu)([0-9]+\\.[0-9]+)"; "\(.\1)-\2")]' utils/releasetools/build-config.json)
+        x86_arch=$(jq -c '[.linux_targets[] | select(.arch=="x86_64") | .target |= sub("ubuntu([0-9]+\\.[0-9]+)"; "ubuntu-\1")]' utils/releasetools/build-config.json)
         x86_matrix=$(echo "{ \"distro\" : $x86_arch }" | jq -c .)
         echo "X86_MATRIX=$x86_matrix" >> $GITHUB_ENV
 

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -36,7 +36,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: "ubuntu-latest"
+    runs-on: ${{matrix.distro.target}}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}

--- a/utils/releasetools/build-config.json
+++ b/utils/releasetools/build-config.json
@@ -1,28 +1,23 @@
 {
     "linux_targets": [
+
         {
           "arch": "x86_64",
-          "target": "ubuntu18.04",
-          "type": "deb",
-          "platform": "bionic"
-        },
-        {
-          "arch": "x86_64",
-          "target": "ubuntu20.04",
+          "target": "ubuntu-20.04",
           "type": "deb",
           "platform": "focal"
         },
         {
           "arch": "x86_64",
-          "target": "ubuntu24.04",
+          "target": "ubuntu-22.04",
           "type": "deb",
-          "platform": "noble"
+          "platform": "jammy"
         },
         {
-          "arch": "arm64",
-          "target": "ubuntu18.04",
+          "arch": "x86_64",
+          "target": "ubuntu-24.04",
           "type": "deb",
-          "platform": "bionic"
+          "platform": "noble"
         },
         {
           "arch": "arm64",
@@ -32,9 +27,9 @@
         },
         {
           "arch": "arm64",
-          "target": "ubuntu24.04",
+          "target": "ubuntu22.04",
           "type": "deb",
-          "platform": "noble"
+          "platform": "jammy"
         }
       ]
 }


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/1269 and https://github.com/valkey-io/valkey/issues/1343
This change makes the binary build on the target ubuntu version.

This PR also deprecated ubuntu18 and valkey will not support:

- X86:
  - Ubuntu 20
  - Ubuntu 22
  - Ubuntu 24
 - ARM:
   - Ubuntu 20
   - Ubuntu 22
   
Removed ARM ubuntu 24 as the action we are using for ARM builds does not support Ubuntu 24.