### PR TITLE
Fix wrong file name in build-release-packages.yml

### DIFF
--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - '.github/workflows/build-release-packages.yml'
       - '.github/workflows/call-build-linux-arm-packages.yml'
-      - '.github/workflows/call-build-linux-x86_64-packages.yml'
+      - '.github/workflows/call-build-linux-x86-packages.yml'
       - 'utils/releasetools/build-config.json'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Introduced in #1363, the file name does not match.