### PR TITLE
Skip build-release-packages CI job in forks

### DIFF
--- a/.github/workflows/build-release-packages.yml
+++ b/.github/workflows/build-release-packages.yml
@@ -23,6 +23,7 @@ jobs:
   # This job provides the version metadata from the tag for the other jobs to use.
   release-build-get-meta:
     name: Get metadata to build
+    if: github.repository == 'valkey-io/valkey'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
@@ -66,6 +67,7 @@ jobs:
 
   generate-build-matrix:
     name: Generating build matrix
+    if: github.repository == 'valkey-io/valkey'
     runs-on: ubuntu-latest
     outputs:
       x86_64-build-matrix: ${{ steps.set-matrix.outputs.x86_64-build-matrix }}


### PR DESCRIPTION
The CI job was introduced in #1363, we should skip it in forks.