### PR TITLE
Handle imports with deprecated APIs

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -36,13 +36,17 @@
 #include <math.h>
 
 #ifdef HAVE_AVX2
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if defined(__GNUC__) && __GNUC__ >= 7
 /* Some of the functions in <immintrin.h> can include calls to malloc,
  * which get flagged as deprecated. We don't use these functions so
  * we'll suppress the warning. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include <immintrin.h>
+#if defined(__GNUC__) && __GNUC__ >= 12
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 /* The HyperLogLog implementation is based on the following ideas:

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -36,7 +36,13 @@
 #include <math.h>
 
 #ifdef HAVE_AVX2
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+/* Some of the functions in <immintrin.h> can include calls to malloc,
+ * which get flagged as deprecated. We don't use these functions so
+ * we'll suppress the warning. */
 #include <immintrin.h>
+#pragma GCC diagnostic pop
 #endif
 
 /* The HyperLogLog implementation is based on the following ideas:

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -41,7 +41,7 @@
  * which get flagged as deprecated. We don't use these functions so
  * we'll suppress the warning. */
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 #include <immintrin.h>
 #if defined(__GNUC__) && __GNUC__ >= 12


### PR DESCRIPTION
We deprecate malloc and free to prevent accidental usage inside our codebase. Some change in clang might include a library that makes a call to malloc that we don't use, which triggered the flag.

Results: https://github.com/valkey-io/valkey/actions/runs/12324132483