### PR TITLE
Only (re-)send MEET packet once every handshake timeout period

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4044,8 +4044,10 @@ void clusterSendPing(clusterLink *link, int type) {
     clusterMsg *hdr = &msgblock->msg;
 
     if (!link->inbound) {
-        if (type == CLUSTERMSG_TYPE_PING)       link->node->ping_sent = mstime();
-        else if (type == CLUSTERMSG_TYPE_MEET)  link->node->meet_sent = mstime();
+        if (type == CLUSTERMSG_TYPE_PING)
+            link->node->ping_sent = mstime();
+        else if (type == CLUSTERMSG_TYPE_MEET)
+            link->node->meet_sent = mstime();
     }
 
     /* Populate the gossip fields */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3229,10 +3229,15 @@ int clusterProcessPacket(clusterLink *link) {
                      * to this is the flag that indicates extensions are supported, as
                      * we want to send extensions right away in the return PONG in order
                      * to reduce the amount of time needed to stabilize the shard ID. */
-                    clusterNode *node;
-
-                    node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
-                    serverAssert(nodeIp2String(node->ip, link, hdr->myip) == C_OK);
+                    clusterNode *node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
+                    if (nodeIp2String(node->ip, link, hdr->myip) != C_OK) {
+                        /* We cannot get the IP info from the link, it probably means the connection is closed. */
+                        serverLog(LL_NOTICE, "Closing link even though we received a MEET packet on it, "
+                                  "because the connection has an error");
+                        freeClusterLink(link);
+                        freeClusterNode(node);
+                        return 0;
+                    }
                     getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
                     node->cport = ntohs(hdr->cport);
                     if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3223,12 +3223,12 @@ int clusterProcessPacket(clusterLink *link) {
             if (!sender) {
                 if (!link->node) {
                     /* Add this node if it is new for us and the msg type is MEET.
-                    * In this stage we don't try to add the node with the right
-                    * flags, replicaof pointer, and so forth, as this details will be
-                    * resolved when we'll receive PONGs from the node. The exception
-                    * to this is the flag that indicates extensions are supported, as
-                    * we want to send extensions right away in the return PONG in order
-                    * to reduce the amount of time needed to stabilize the shard ID. */
+                     * In this stage we don't try to add the node with the right
+                     * flags, replicaof pointer, and so forth, as this details will be
+                     * resolved when we'll receive PONGs from the node. The exception
+                     * to this is the flag that indicates extensions are supported, as
+                     * we want to send extensions right away in the return PONG in order
+                     * to reduce the amount of time needed to stabilize the shard ID. */
                     clusterNode *node;
 
                     node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3233,7 +3233,7 @@ int clusterProcessPacket(clusterLink *link) {
                     if (nodeIp2String(node->ip, link, hdr->myip) != C_OK) {
                         /* We cannot get the IP info from the link, it probably means the connection is closed. */
                         serverLog(LL_NOTICE, "Closing link even though we received a MEET packet on it, "
-                                  "because the connection has an error");
+                                             "because the connection has an error");
                         freeClusterLink(link);
                         freeClusterNode(node);
                         return 0;

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -340,6 +340,7 @@ struct _clusterNode {
     mstime_t ping_sent;                     /* Unix time we sent latest ping */
     mstime_t pong_received;                 /* Unix time we received the pong */
     mstime_t data_received;                 /* Unix time we received any data */
+    mstime_t meet_sent;                     /* Unix time we sent latest meet packet */
     mstime_t fail_time;                     /* Unix time when FAIL flag was set */
     mstime_t repl_offset_time;              /* Unix time we received offset for this node */
     mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -183,9 +183,8 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
                 fail "Node 0 never exited handshake state"
             }
 
-            # At this point Node 0 knows Node 1 & 2 through the gossip, but they don't know Node 0.
+            # At this point Node 0 knows Node 2 through the gossip, but Node 1 & 2 don't know Node 0.
             wait_for_condition 50 100 {
-                [cluster_get_node_by_id 0 $node1_id] != {} &&
                 [cluster_get_node_by_id 0 $node2_id] != {} &&
                 [cluster_get_node_by_id 1 $node0_id] eq {} &&
                 [cluster_get_node_by_id 2 $node0_id] eq {}

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -70,7 +70,7 @@ tags {tls:skip external:skip cluster} {
                 [CI 0 cluster_stats_messages_meet_received] >= 4 &&
                 [CI 1 cluster_stats_messages_meet_sent] == [CI 0 cluster_stats_messages_meet_received]
             } else {
-                fail "1 cluster_state:[CI 1 cluster_state], 0 cluster_state: [CI 0 cluster_state]"
+                fail "Unexpected cluster state: node 1 cluster_state:[CI 1 cluster_state], node 0 cluster_state: [CI 0 cluster_state]"
             }
         }
     } ;# stop servers

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -178,7 +178,7 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
 
             # Wait for Node 0's handshake to timeout
             wait_for_condition 50 100 {
-                [cluster_get_first_node_in_handshake 1] eq {}
+                [cluster_get_first_node_in_handshake 0] eq {}
             } else {
                 fail "Node 0 never exited handshake state"
             }


### PR DESCRIPTION
Add `meet_sent` field in `clusterNode` indicating the last time we sent a MEET packet. Use this field to only (re-)send a MEET packet once every handshake timeout period when detecting a node without an inbound link.

When receiving multiple MEET packets on the same link while the node is in handshake state, instead of dropping the packet, we now simply prevent the creation of a new node. This way we still process the MEET packet's gossip and reply with a PONG as any other packets.

Improve some logging messages to include `human_nodename`. Add `nodeExceedsHandshakeTimeout()` function.

This is a follow-up to this previous PR: https://github.com/valkey-io/valkey/pull/1307
And a partial fix to the crash described in: https://github.com/valkey-io/valkey/pull/1436