### PR TITLE
Avoid importing memory aligned malloc

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -36,6 +36,8 @@
 #include <math.h>
 
 #ifdef HAVE_AVX2
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
 #define __MM_MALLOC_H
 #include <immintrin.h>
 #endif

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -36,6 +36,7 @@
 #include <math.h>
 
 #ifdef HAVE_AVX2
+#define __MM_MALLOC_H
 #include <immintrin.h>
 #endif
 


### PR DESCRIPTION
We deprecate the usage of classic malloc and free, but under certain circumstances they might get imported from intrinsics. The original thought is we should just override malloc and free to use zmalloc and zfree, but I think we should continue to deprecate it to avoid accidental imports of allocations.

Closes https://github.com/valkey-io/valkey/issues/1434.