### PR TITLE
Synchronously delete data during defrag tests

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -47,6 +47,8 @@ run_solo {defrag} {
             r config set active-defrag-ignore-bytes 2mb
             r config set maxmemory 100mb
             r config set maxmemory-policy allkeys-lru
+            r config set lazyfree-lazy-user-del no
+            r config set lazyfree-lazy-user-flush no
 
             populate 700000 asdf1 150
             populate 100 asdf1 150 0 false 1000


### PR DESCRIPTION
The creation of fragmentation is delayed when we use lazy-free. You can induce some of the active-defrag tests to fail by artificially adding a delay in the lazyfree process, similar to the issues seen in #1433 and issues like https://github.com/valkey-io/valkey/actions/runs/12267010712/job/34226304803#step:7:6538. The solution is to always do sync free during tests.

Might close https://github.com/valkey-io/valkey/issues/1433.