### PR TITLE
Print the number of lua scripts if any when doing check-rdb

### DIFF
--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -285,12 +285,13 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             }
 
             if (!strcasecmp(auxkey->ptr, "lua")) {
-                /* We do not print the lua aux field in here, otherwise a large number of lua
-                 * scripts will pollute the output. */
+                /* In older version before 7.0, we may save lua scripts in a replication RDB,
+                 * although it is not an actually aux field, we will still print it in here since
+                 * it's easy to filter using external grep. Use a counter so that at the end we
+                 * can print its number, if any. */
                 rdbstate.lua_scripts++;
-            } else {
-                rdbCheckInfo("AUX FIELD %s = '%s'", (char *)auxkey->ptr, (char *)auxval->ptr);
             }
+            rdbCheckInfo("AUX FIELD %s = '%s'", (char *)auxkey->ptr, (char *)auxval->ptr);
             decrRefCount(auxkey);
             decrRefCount(auxval);
             continue; /* Read type again. */


### PR DESCRIPTION
In old versions, if we are saving the replication info on disk, we will
save the lua scripts in the RDB see f11a7585a8498689e8fd1afbcab4fdc2ba38c38f.

Currently check-rdb prints all the aux fields, this including lua scripts.
Although we no longer save lua scripts to RDB file, we may use the new
check-rdb tool to check the old RDB files, and the printing of lua scripts
will pollute the output. If it is an RDB file that abuses lua eval scripts,
it will print a lot of content. 

Although it is not an actually aux field, we will still print it since
it's easy to filter using external grep.

At the end, if there is a lua script, we will print an info to show the
number of lua scripts.