### PR TITLE
Add a hint about the current file for TCL debugging

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -309,7 +309,7 @@ proc spawn_server {config_file stdout stderr args} {
     }
 
     # Tell the test server about this new instance.
-    send_data_packet $::test_server_fd server-spawned $pid
+    send_data_packet $::test_server_fd server-spawned "$pid - $::curfile"
     return $pid
 }
 


### PR DESCRIPTION
There are some tests like https://github.com/valkey-io/valkey/actions/runs/12403569355/job/34627292621 that fail and give no useful information since they are outside of a test context. Now we will at least get the file we are located in.

We can sort of reverse engineer where we are in the test by seeing which tests have finished in a file.

```
[TIMEOUT]: clients state report follows.
sock6 => (SPAWNED SERVER) pid:30375 - tests/unit/info.tcl
Killing still running Valkey server 30375 - tests/unit/info.tcl
```