### PR TITLE
Update info.tcl test to revert client output limits sooner

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -409,7 +409,7 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             r config set client-output-buffer-limit $org_outbuf_limit
             set info [r info stats]
             assert_equal [getInfoProperty $info client_output_buffer_limit_disconnections] {1}
-        } {OK} {logreqres:skip} ;# same as obuf-limits.tcl, skip logreqres
+        } {} {logreqres:skip} ;# same as obuf-limits.tcl, skip logreqres
 
         test {clients: pubsub clients} {
             set info [r info clients]

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -406,9 +406,9 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             r config set client-output-buffer-limit "normal 10 0 0"
             r set key [string repeat a 100000] ;# to trigger output buffer limit check this needs to be big
             catch {r get key}
+            r config set client-output-buffer-limit $org_outbuf_limit
             set info [r info stats]
             assert_equal [getInfoProperty $info client_output_buffer_limit_disconnections] {1}
-            r config set client-output-buffer-limit $org_outbuf_limit
         } {OK} {logreqres:skip} ;# same as obuf-limits.tcl, skip logreqres
 
         test {clients: pubsub clients} {


### PR DESCRIPTION
We set the client output buffer limits to 10 bytes, and then execute `info stats` which produces more than 10 bytes of output, which can cause that command to throw an error.

I'm not sure why it wasn't consistently erroring before, might have been some change related to the ubuntu upgrade though.

Issues related to ubuntu-tls are hopefully resolved now: https://github.com/madolson/valkey/actions/runs/12423520830. 