### PR TITLE
Fix storing the wrong PID in active servers

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -421,7 +421,8 @@ proc read_from_test_client fd {
     } elseif {$status eq {server-spawning}} {
         set ::active_clients_task($fd) "(SPAWNING SERVER) $data"
     } elseif {$status eq {server-spawned}} {
-        lappend ::active_servers $data
+        set pid [string trim [lindex [split $data "-"] 0]]
+        lappend ::active_servers $pid
         set ::active_clients_task($fd) "(SPAWNED SERVER) pid:$data"
     } elseif {$status eq {server-killing}} {
         set ::active_clients_task($fd) "(KILLING SERVER) pid:$data"


### PR DESCRIPTION
In https://github.com/valkey-io/valkey/pull/1459, I missed that the data was also used to keep track of the PID files so if the testing framework crashed it would no longer be able to cleanup the extra servers. So now we properly extract the PID and store it so we can clean up PIDs.