### PR TITLE
Fix JSON description of SET command

### DIFF
--- a/src/commands/set.json
+++ b/src/commands/set.json
@@ -111,14 +111,7 @@
                         "type": "string",
                         "token": "IFEQ",
                         "since": "8.1.0",
-                        "summary": "Sets the key's value only if the current value matches the specified comparison value.",
-                        "arguments": [
-                            {
-                                "name": "comparison-value",
-                                "type": "string",
-                                "summary": "The value to compare with the current key's value before setting."
-                            }
-                        ]
+                        "summary": "Sets the key's value only if the current value matches the specified comparison value."
                     }
                 ]
             },


### PR DESCRIPTION
In the `arguments` section, the `arguments` key is only used for arguments of type `block` or `oneof`.

Consequently, the `arguments` given for `IFEQ` are ignored by the server. However, they lead to strange results when rendering the command's page for the web documentation.

Fix this by removing `arguments` for `IFEQ`.