### PR TITLE
Reduce dual channel testing time

### DIFF
--- a/tests/integration/replication-psync.tcl
+++ b/tests/integration/replication-psync.tcl
@@ -115,6 +115,10 @@ tags {"external:skip"} {
 foreach mdl {no yes} {
     foreach sdl {disabled swapdb} {
         foreach dualchannel {yes no} {
+            # Skip dual channel test with master diskless disabled
+            if {$dualchannel == "yes" && $mdl == "no"} {
+                continue
+            }
             test_psync {no reconnection, just sync} 6 1000000 3600 0 {
             } $mdl $sdl $dualchannel 0
 


### PR DESCRIPTION
- By not waiting `repl-diskless-sync-delay` when we don't have to, we can reduce ~30% of dual channel tests execution time.
- This commit also drops one test which is not required for regular sync (`Sync should continue if not all slaves dropped`).  
- Skip dual channel test with master diskless disabled because it will initiate the same synchronization process as the non-dual channel test, making it redundant.


Before:
```
Execution time of different units:
  171 seconds - integration/dual-channel-replication
  305 seconds - integration/replication-psync

\o/ All tests passed without errors!
```
After:
```
Execution time of different units:
  120 seconds - integration/dual-channel-replication
  236 seconds - integration/replication-psync

\o/ All tests passed without errors!
```

Discused on https://github.com/valkey-io/valkey/pull/1173
