### PR TITLE
Cleanup aof temp files in sigShutdownHandler before exiting

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -922,7 +922,7 @@ void killAppendOnlyChild(void) {
     if (kill(server.child_pid, SIGUSR1) != -1) {
         while (waitpid(-1, &statloc, 0) != server.child_pid);
     }
-    aofRemoveTempFile(server.child_pid);
+    aofRemoveTempFile(server.child_pid, 0);
     resetChildState();
     server.aof_rewrite_time_start = -1;
 }
@@ -2470,14 +2470,37 @@ void bgrewriteaofCommand(client *c) {
     }
 }
 
-void aofRemoveTempFile(pid_t childpid) {
+/* Note that we may call this function in signal handle 'sigShutdownHandler',
+ * so we need guarantee all functions we call are async-signal-safe.
+ * If we call this function from signal handle, we won't call bg_unlink that
+ * is not async-signal-safe. */
+void aofRemoveTempFile(pid_t childpid, int from_signal) {
     char tmpfile[256];
+    char tmpfile2[256];
+    char pid[32];
 
-    snprintf(tmpfile, 256, "temp-rewriteaof-bg-%d.aof", (int)childpid);
-    bg_unlink(tmpfile);
+    /* Generate temp aof file name using aync-signal safe functions. */
+    ll2string(pid, sizeof(pid), childpid);
+    valkey_strlcpy(tmpfile, "temp-rewriteaof-bg-", sizeof(tmpfile));
+    valkey_strlcat(tmpfile, pid, sizeof(tmpfile));
+    valkey_strlcat(tmpfile, ".aof", sizeof(tmpfile));
+    valkey_strlcpy(tmpfile2, "temp-rewriteaof-", sizeof(tmpfile2));
+    valkey_strlcat(tmpfile2, pid, sizeof(tmpfile2));
+    valkey_strlcat(tmpfile2, ".aof", sizeof(tmpfile2));
 
-    snprintf(tmpfile, 256, "temp-rewriteaof-%d.aof", (int)childpid);
-    bg_unlink(tmpfile);
+    if (from_signal) {
+        /* bg_unlink is not async-signal-safe, but in this case we don't really
+         * need to close the fd, it'll be released when the process exists. */
+        int fd = open(tmpfile, O_RDONLY | O_NONBLOCK);
+        int fd2 = open(tmpfile2, O_RDONLY | O_NONBLOCK);
+        UNUSED(fd);
+        UNUSED(fd2);
+        unlink(tmpfile);
+        unlink(tmpfile2);
+    } else {
+        bg_unlink(tmpfile);
+        bg_unlink(tmpfile2);
+    }
 }
 
 /* Get size of an AOF file.
@@ -2675,7 +2698,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
     }
 
 cleanup:
-    aofRemoveTempFile(server.child_pid);
+    aofRemoveTempFile(server.child_pid, 0);
     /* Clear AOF buffer and delete temp incr aof for next rewrite. */
     if (server.aof_state == AOF_WAIT_REWRITE) {
         sdsfree(server.aof_buf);

--- a/src/aof.c
+++ b/src/aof.c
@@ -2479,7 +2479,7 @@ void aofRemoveTempFile(pid_t childpid, int from_signal) {
     char tmpfile2[256];
     char pid[32];
 
-    /* Generate temp aof file name using aync-signal safe functions. */
+    /* Generate temp aof file name using async-signal safe functions. */
     ll2string(pid, sizeof(pid), childpid);
     valkey_strlcpy(tmpfile, "temp-rewriteaof-bg-", sizeof(tmpfile));
     valkey_strlcat(tmpfile, pid, sizeof(tmpfile));

--- a/src/aof.c
+++ b/src/aof.c
@@ -2470,7 +2470,7 @@ void bgrewriteaofCommand(client *c) {
     }
 }
 
-/* Note that we may call this function in signal handle 'sigShutdownHandler',
+/* Note that we may call this function in signal handler 'sigShutdownHandler',
  * so we need guarantee all functions we call are async-signal-safe.
  * If we call this function from signal handle, we won't call bg_unlink that
  * is not async-signal-safe. */

--- a/src/server.h
+++ b/src/server.h
@@ -3148,7 +3148,7 @@ int bg_unlink(const char *filename);
 /* AOF persistence */
 void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
-void aofRemoveTempFile(pid_t childpid);
+void aofRemoveTempFile(pid_t childpid, int from_signal);
 int rewriteAppendOnlyFileBackground(void);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -67,7 +67,7 @@ start_server {tags {"shutdown external:skip"} overrides {save {900 1}}} {
         wait_for_condition 50 10 {
             ![file exists $temp_rdb]
         } else {
-            fail "Can't trigger rdb save on shutdown"
+            fail "Can't delete rdb temp file on shutdown"
         }
     }
 }


### PR DESCRIPTION
I think this code previously only meant to handle save in shutdown,
which means we may a do foreground save in shutdown. It also implicitly
handles the backgroud save, for example the child process will also
get the chance to call getpid() and clean up the temp RDB file.

However, we did not handle AOFRW, so we also leave temp files in here.
Noted that we can not use the same aofRemoveTempFile(getpid()) trick
for AOF. Since we rename the temp file (temp-rewriteaof-bg-pid.aof) to
the base aof file only in backgroundRewriteDoneHandler, and in this time,
there is no child process, so the cleanup job must be done by the parent
process.

The following sequences have been tested (not just signal handlers):
1. Long foreground save + shutdown
2. Long backgroud save + shutdown
3. Long backgroud save + long lua script + shutdown
4. Long bgrewriteaof + shutdown
5. Long bgrewriteaof + long lua script + shutdown
6. Short bgrewriteaof + long done handler + shutdown

All temporary files will be removed in the local tests.