### PR TITLE
Fix: restore replica output bytes stat update

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2231,6 +2231,8 @@ int postWriteToClient(client *c) {
     server.stat_total_writes_processed++;
     if (getClientType(c) != CLIENT_TYPE_REPLICA) {
         _postWriteToClient(c);
+    } else {
+        server.stat_net_repl_output_bytes += c->nwritten > 0 ? c->nwritten : 0;
     }
 
     if (c->write_flags & WRITE_FLAGS_WRITE_ERROR) {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -194,6 +194,30 @@ start_server {tags {"repl external:skip"}} {
             }          
             assert_match {*calls=1,*,rejected_calls=0,failed_calls=1*} [cmdrstat blpop $B]
         }
+        
+        test {Replica output bytes metric} {
+            # reset stats 
+            $A config resetstat
+            
+            set info [$A info stats]
+            set replica_bytes_output [getInfoProperty $info "total_net_repl_output_bytes"]
+            assert_equal $replica_bytes_output 0
+            
+            # sent set command to primary
+            $A set key value
+            
+            # wait for command propagation
+            wait_for_condition 50 100 {
+                [$B get key] eq {value}
+            } else {
+                fail "Replica did not receive the command"
+            }
+            
+            # get the new stats
+            set info [$A info stats]
+            set replica_bytes_output [getInfoProperty $info "total_net_repl_output_bytes"]
+            assert {$replica_bytes_output > 0}
+        }
     }
 }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -216,7 +216,7 @@ start_server {tags {"repl external:skip"}} {
             # get the new stats
             set info [$A info stats]
             set replica_bytes_output [getInfoProperty $info "total_net_repl_output_bytes"]
-            assert {$replica_bytes_output > 0}
+            assert_morethan $replica_bytes_output 0
         }
     }
 }


### PR DESCRIPTION
This PR fixes the missing stat update for `total_net_repl_output_bytes` that was removed during the refactoring in PR #758. The metric was not being updated when writing to replica connections.

Changes:
- Restored the stat update in postWriteToClient for replica connections
- Added integration test to verify the metric is properly updated