### PR TITLE
Add `availability_zone` to the HELLO response

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4195,7 +4195,7 @@ void helloCommand(client *c) {
 
     /* Let's switch to the specified RESP mode. */
     if (ver) c->resp = ver;
-    addReplyMapLen(c, 6 + !server.sentinel_mode);
+    addReplyMapLen(c, 6 + !server.sentinel_mode + (sdslen(server.availability_zone) != 0));
 
     addReplyBulkCString(c, "server");
     addReplyBulkCString(c, server.extended_redis_compat ? "redis" : SERVER_NAME);
@@ -4224,6 +4224,11 @@ void helloCommand(client *c) {
 
     addReplyBulkCString(c, "modules");
     addReplyLoadedModules(c);
+
+    if (sdslen(server.availability_zone) != 0) {
+        addReplyBulkCString(c, "availability_zone");
+        addReplyBulkCBuffer(c, server.availability_zone, sdslen(server.availability_zone));
+    }
 }
 
 /* This callback is bound to POST and "Host:" command names. Those are not

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -255,6 +255,14 @@ start_server {tags {"protocol hello"}} {
 
         set reply [r HELLO 2]
         assert_equal [dict get $reply availability_zone] myzone
+
+        r CONFIG SET availability-zone ""
+
+        set reply [r HELLO 3]
+        assert_equal [dict exists $reply availability_zone] 0
+
+        set reply [r HELLO 2]
+        assert_equal [dict exists $reply availability_zone] 0
     }
 }
 

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -232,6 +232,32 @@ start_server {tags {"protocol network"}} {
 
 }
 
+start_server {tags {"protocol hello"}} {
+    test {HELLO without protover} {
+        set reply [r HELLO 3]
+        assert_equal [dict get $reply proto] 3
+
+        set reply [r HELLO]
+        assert_equal [dict get $reply proto] 3
+
+        set reply [r HELLO 2]
+        assert_equal [dict get $reply proto] 2
+
+        set reply [r HELLO]
+        assert_equal [dict get $reply proto] 2
+    }
+
+    test {HELLO and availability-zone} {
+        r CONFIG SET availability-zone myzone
+
+        set reply [r HELLO 3]
+        assert_equal [dict get $reply availability_zone] myzone
+
+        set reply [r HELLO 2]
+        assert_equal [dict get $reply availability_zone] myzone
+    }
+}
+
 start_server {tags {"regression"}} {
     test "Regression for a crash with blocking ops and pipelining" {
         set rd [valkey_deferring_client]

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -154,37 +154,6 @@ start_server {tags {"tracking network logreqres:skip"}} {
         assert_equal [dict get $reply proto] 3
     }
 
-    test {HELLO without protover} {
-        set reply [r HELLO 3]
-        assert_equal [dict get $reply proto] 3
-
-        set reply [r HELLO]
-        assert_equal [dict get $reply proto] 3
-
-        set reply [r HELLO 2]
-        assert_equal [dict get $reply proto] 2
-
-        set reply [r HELLO]
-        assert_equal [dict get $reply proto] 2
-
-        # restore RESP3 for next test
-        r HELLO 3
-    }
-
-    test {HELLO with availability-zone} {
-        r CONFIG SET availability-zone myzone
-
-        set reply [r HELLO 3]
-        assert_equal [dict get $reply availability_zone] myzone
-
-        set reply [r HELLO 2]
-        assert_equal [dict get $reply availability_zone] myzone
-
-        # restore for next test
-        r HELLO 3
-        r CONFIG SET availability-zone ""
-    }
-
     test {RESP3 based basic invalidation} {
         r CLIENT TRACKING off
         r CLIENT TRACKING on

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -171,6 +171,20 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r HELLO 3
     }
 
+    test {HELLO with availability-zone} {
+        r CONFIG SET availability-zone myzone
+
+        set reply [r HELLO 3]
+        assert_equal [dict get $reply availability_zone] myzone
+
+        set reply [r HELLO 2]
+        assert_equal [dict get $reply availability_zone] myzone
+
+        # restore for next test
+        r HELLO 3
+        r CONFIG SET availability-zone ""
+    }
+
     test {RESP3 based basic invalidation} {
         r CLIENT TRACKING off
         r CLIENT TRACKING on


### PR DESCRIPTION
It's inconvenient for client implementations to extract the `availability_zone` information from the `INFO` response. The `INFO` response contains a lot of information that a client implementation typically doesn't need.

This PR adds the availability zone to the `HELLO` response. Clients usually already use the `HELLO` command for protocol negotiation and also get the server `version` and `role` from its response. To keep the `HELLO` response small, the field is only added if availability zone is configured.