### PR TITLE
Add build folder to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ nodes*.conf
 tests/cluster/tmp/*
 tests/rdma/rdma-test
 tags
+build/
 build-debug/
 build-release/
 cmake-build-debug/


### PR DESCRIPTION
Default cmake build folder in vscode is `"cmake.buildDirectory": "${workspaceFolder}/build"`.  