### PR TITLE
Immediately restart the defrag cycle if we still need to defrag

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1113,8 +1113,7 @@ static void endDefragCycle(bool normal_termination) {
     server.stat_last_active_defrag_time = 0;
     server.active_defrag_cpu_percent = 0;
 
-    /* During the defrag cycle, more fragmentation might have accumulated, so
-     * immediately check if we should start another cycle. */
+    /* Immediately check to see if we should start another defrag cycle. */
     monitorActiveDefrag();
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1112,6 +1112,10 @@ static void endDefragCycle(bool normal_termination) {
     server.stat_total_active_defrag_time += elapsedUs(server.stat_last_active_defrag_time);
     server.stat_last_active_defrag_time = 0;
     server.active_defrag_cpu_percent = 0;
+
+    /* During the defrag cycle, more fragmentation might have accumulated, so
+     * immediately check if we should start another cycle. */
+    monitorActiveDefrag();
 }
 
 


### PR DESCRIPTION
One very subtle change of https://github.com/valkey-io/valkey/pull/1242, is that we now wait for the server cron to start a new defrag cycle. Whereas previously we started it immediately. All of the current tests rely on the behavior of "Active defrag runs until it is done", which was broken because now there is a short period of active defragmentation reports itself off. Running a bunch of tests while this is in a draft, but opening it incase anyone else was taking a look.

Intended to close https://github.com/valkey-io/valkey/issues/1454.

https://github.com/valkey-io/valkey/actions/runs/12524316525/job/34934755959 [Only failure is active-defrag related, but not related to this issue]
https://github.com/valkey-io/valkey/actions/runs/12524547410