### PR TITLE
CMake: fail on warnings

### DIFF
--- a/cmake/Modules/ValkeySetup.cmake
+++ b/cmake/Modules/ValkeySetup.cmake
@@ -93,6 +93,9 @@ macro (valkey_build_and_install_bin target sources ld_flags libs link_name)
         target_link_libraries(${target} execinfo)
     endif ()
 
+    # Enable all warnings + fail on warning
+    target_compile_options(${target} PRIVATE -Werror -Wall)
+
     # Install cli tool and create a redis symbolic link
     valkey_install_bin(${target})
     valkey_create_symlink(${target} ${link_name})

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2040,6 +2040,8 @@ static sds jsonStringOutput(sds out, const char *p, int len, int mode) {
     } else {
         assert(0);
     }
+    /* Silence compiler warning */
+    return NULL;
 }
 
 static sds cliFormatReplyJson(sds out, redisReply *r, int mode) {


### PR DESCRIPTION
When building with `CMake` (especially the targets `valkey-cli`, `valkey-server` and `valkey-benchmark`) it is possible to have a successful build while having warnings. 

This PR fixes this - which is aligned with how the `Makefile` is working today


- Enable `-Wall` + `-Werror` for valkey targets
- Fixed warning in valkey-cli:jsonStringOutput method
