### PR TITLE
Move coverity back to ubuntu 22 until test failures are fixed

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   coverity:
     if: github.repository == 'valkey-io/valkey'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download and extract the Coverity Build Tool


### PR DESCRIPTION
The issues in https://github.com/valkey-io/valkey/issues/1453 seem to have only shown up since we moved to ubuntu 24, as part of the rolling `ubunut-latest` migration from 22->24.