### PR TITLE
Explicitly check C_ERR condition to improve readability in clusterSaveConfig

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -868,7 +868,7 @@ int clusterSaveConfig(int do_fsync) {
 
 cleanup:
     if (fd != -1) close(fd);
-    if (retval) unlink(tmpfilename);
+    if (retval == C_ERR) unlink(tmpfilename);
     sdsfree(tmpfilename);
     sdsfree(ci);
     return retval;


### PR DESCRIPTION
It's not obvious to see it at first, modify it to use C_ERR.