### PR TITLE
Improve readability and efficiency for ZUNION operation

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2793,7 +2793,7 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                 if (isnan(score)) score = 0;
 
                 /* Search for this element in the accumulating dictionary. */
-                de = dictAddRaw(dstzset->dict, zuiSdsFromValue(&zval), &existing);
+                existing = dictFind(dstzset->dict, zuiSdsFromValue(&zval));
                 /* If we don't have it, we need to create a new entry. */
                 if (!existing) {
                     tmp = zuiNewSdsFromValue(&zval);
@@ -2802,8 +2802,8 @@ void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIndex, in
                      * at the end. */
                     totelelen += sdslen(tmp);
                     if (sdslen(tmp) > maxelelen) maxelelen = sdslen(tmp);
-                    /* Update the element with its initial score. */
-                    dictSetKey(dstzset->dict, de, tmp);
+                    /* Insert the element with its initial score. */
+                    de = dictAddRaw(dstzset->dict, tmp, NULL);
                     dictSetDoubleVal(de, score);
                 } else {
                     /* Update the score with the score of the new instance


### PR DESCRIPTION
Currently zunion operation in `t_zset.c` is using `dictAddRaw()` to search for the element in the accumulating dictionary. If the element was not found and got added, it would then set the key to a new key string via `dictSetKey()`, which is counter intuitive and not very effective.

This PR improves the code readability and effectiveness by using `dictFind()` to search for the element in the dictionary, and then uses `dictAddRaw()` and `dictSetDoubleVal()` to create the element in the set, and avoids the need to call `dictSetKey()`. 

Note - this change is consistent with the original implementation of sorted set https://github.com/valkey-io/valkey/blob/d680eb6dbdf2d2030cb96edfb089be1e2a775ac1/src/t_zset.c#L2286. It was later changed to a "not-so-nice" style in commit https://github.com/valkey-io/valkey/commit/68bf45fa1e77c7e2e3f3ab4a7894f9bc1a1da57b