### PR TITLE
[feature] sentinel use info sentinel command to run faster

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3382,6 +3382,9 @@ standardConfig static_configs[] = {
     createSpecialConfig("replicaof", "slaveof", IMMUTABLE_CONFIG | MULTI_ARG_CONFIG, setConfigReplicaOfOption, getConfigReplicaOfOption, rewriteConfigReplicaOfOption, NULL),
     createSpecialConfig("latency-tracking-info-percentiles", NULL, MODIFIABLE_CONFIG | MULTI_ARG_CONFIG, setConfigLatencyTrackingInfoPercentilesOutputOption, getConfigLatencyTrackingInfoPercentilesOutputOption, rewriteConfigLatencyTrackingInfoPercentilesOutputOption, NULL),
 
+    /* Capabalities */
+    createBoolConfig("info-simple-for-sentinel", NULL, IMMUTABLE_CONFIG, server.info_simple_for_sentinel, 1, NULL, NULL),
+
     /* NULL Terminator, this is dropped when we convert to the runtime array. */
     {NULL},
 };

--- a/src/server.c
+++ b/src/server.c
@@ -5571,6 +5571,42 @@ void totalNumberOfStatefulKeys(unsigned long *blocking_keys,
     if (watched_keys) *watched_keys = wkeys;
 }
 
+static sds genValKeyReplicasInfo(sds info) {
+    if (listLength(server.replicas)) {
+        int replica_id = 0;
+        listNode *ln;
+        listIter li;
+
+        listRewind(server.replicas, &li);
+        while ((ln = listNext(&li))) {
+            client *replica = listNodeValue(ln);
+            char ip[NET_IP_STR_LEN], *replica_ip = replica->repl_data->replica_addr;
+            int port;
+            long lag = 0;
+
+            if (!replica_ip) {
+                if (connAddrPeerName(replica->conn, ip, sizeof(ip), &port) == -1) continue;
+                replica_ip = ip;
+            }
+            const char *state = replstateToString(replica->repl_data->repl_state);
+            if (state[0] == '\0') continue;
+            if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE) lag = time(NULL) - replica->repl_data->repl_ack_time;
+
+            info = sdscatprintf(info,
+                                "slave%d:ip=%s,port=%d,state=%s,"
+                                "offset=%lld,lag=%ld,type=%s\r\n",
+                                replica_id, replica_ip, replica->repl_data->replica_listening_port, state,
+                                replica->repl_data->repl_ack_off, lag,
+                                replica->flag.repl_rdb_channel                                ? "rdb-channel"
+                                : replica->repl_data->repl_state == REPLICA_STATE_BG_RDB_LOAD ? "main-channel"
+                                                                                              : "replica");
+            replica_id++;
+        }
+    }
+
+    return info;
+}
+
 /* Create the string returned by the INFO command. This is decoupled
  * by the INFO command itself as we need to report the same information
  * on memory corruption problems. */
@@ -5580,6 +5616,29 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
     int j;
     int sections = 0;
     if (everything) all_sections = 1;
+
+    if (dictFind(section_dict, "sentinel") != NULL) {
+        info = sdscatprintf(info, FMTARGS(
+                                      "run_id:%s\r\n", server.runid,
+                                      "role:%s\r\n", server.primary_host == NULL ? "master" : "slave"));
+        info = genValKeyReplicasInfo(info);
+        if (server.primary_host) {
+            long long replica_repl_offset = 1;
+            if (server.primary) {
+                replica_repl_offset = server.primary->repl_data->reploff;
+            } else if (server.cached_primary) {
+                replica_repl_offset = server.cached_primary->repl_data->reploff;
+            }
+
+            info = sdscatprintf(info, FMTARGS(
+                                          "master_host:%s\r\n", server.primary_host,
+                                          "master_port:%d\r\n", server.primary_port,
+                                          "master_link_status:%s\r\n", (server.repl_state == REPL_STATE_CONNECTED) ? "up" : "down",
+                                          "slave_priority:%d\r\n", server.replica_priority,
+                                          "slave_repl_offset:%lld\r\n", replica_repl_offset,
+                                          "replica_announced:%d\r\n", server.replica_announced));
+        }
+    }
 
     /* Server */
     if (all_sections || (dictFind(section_dict, "server") != NULL)) {
@@ -5645,7 +5704,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "executable:%s\r\n", server.executable ? server.executable : "",
                 "config_file:%s\r\n", server.configfile ? server.configfile : "",
                 "io_threads_active:%i\r\n", server.active_io_threads_num > 1,
-                "availability_zone:%s\r\n", server.availability_zone));
+                "availability_zone:%s\r\n", server.availability_zone,
+                "info_simple_for_sentinel:%i\r\n", server.info_simple_for_sentinel));
 
         /* Conditional properties */
         if (isShutdownInitiated()) {
@@ -6028,37 +6088,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             info = sdscatprintf(info, "min_slaves_good_slaves:%d\r\n", server.repl_good_replicas_count);
         }
 
-        if (listLength(server.replicas)) {
-            int replica_id = 0;
-            listNode *ln;
-            listIter li;
-
-            listRewind(server.replicas, &li);
-            while ((ln = listNext(&li))) {
-                client *replica = listNodeValue(ln);
-                char ip[NET_IP_STR_LEN], *replica_ip = replica->repl_data->replica_addr;
-                int port;
-                long lag = 0;
-
-                if (!replica_ip) {
-                    if (connAddrPeerName(replica->conn, ip, sizeof(ip), &port) == -1) continue;
-                    replica_ip = ip;
-                }
-                const char *state = replstateToString(replica->repl_data->repl_state);
-                if (state[0] == '\0') continue;
-                if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE) lag = time(NULL) - replica->repl_data->repl_ack_time;
-
-                info = sdscatprintf(info,
-                                    "slave%d:ip=%s,port=%d,state=%s,"
-                                    "offset=%lld,lag=%ld,type=%s\r\n",
-                                    replica_id, replica_ip, replica->repl_data->replica_listening_port, state,
-                                    replica->repl_data->repl_ack_off, lag,
-                                    replica->flag.repl_rdb_channel                                ? "rdb-channel"
-                                    : replica->repl_data->repl_state == REPLICA_STATE_BG_RDB_LOAD ? "main-channel"
-                                                                                                  : "replica");
-                replica_id++;
-            }
-        }
+        info = genValKeyReplicasInfo(info);
         info = sdscatprintf(
             info,
             FMTARGS(
@@ -6591,8 +6621,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;
@@ -7037,7 +7067,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
     }
     if (server.sentinel_mode) sentinelCheckConfigFile();
 
-        /* Do system checks */
+    /* Do system checks */
 #ifdef __linux__
     linuxMemoryWarnings();
     sds err_msg = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -5638,6 +5638,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                                           "slave_repl_offset:%lld\r\n", replica_repl_offset,
                                           "replica_announced:%d\r\n", server.replica_announced));
         }
+        if (server.repl_state != REPL_STATE_CONNECTED) {
+            info = sdscatprintf(info, "master_link_down_since_seconds:%jd\r\n",
+                                server.repl_down_since ? (intmax_t)(server.unixtime - server.repl_down_since) : -1);
+        }
     }
 
     /* Server */

--- a/src/server.h
+++ b/src/server.h
@@ -2144,6 +2144,9 @@ struct valkeyServer {
     /* Local environment */
     char *locale_collate;
     char *debug_context; /* A free-form string that has no impact on server except being included in a crash report. */
+
+    /* capabilities */
+    int info_simple_for_sentinel; /* server support simple info for sentinel. */
 };
 
 #define MAX_KEYS_BUFFER 256

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -708,6 +708,7 @@ start_server {tags {"introspection"}} {
             rdma-rx-size
             rdma-bind
             rdma-port
+            info-simple-for-sentinel
         }
 
         if {!$::tls} {


### PR DESCRIPTION
In sentinel cluster, sentinels will send info command to collect valkey-server state;
but in large cluster, the info command response is heavy and slow, so we need some 
simple info response for sentinel.

### changes in this pr:
#### valkey-server:
  * add info-simple-for-sentinel flag,  to distinguish the valkey-server is support simple info;
  * info command add sentinel subcommand, to cover sentinel used info

#### sentinel:
  * sentinelValkeyInstance struct add info_simple flag;
  * sentinelSendPeriodicCommands will check info_simple to send diff comamnd;
  * reconnect valkey instacne, reset info_simple flag;
  * handle info response from server to parse info_simple flag

### performence test:
  * info comamnd:
   ```valkey-benchmark -q -n 1000000 info```
  info: 65841.45 requests per second, p50=0.703 msec
  * info sentinel:
```valkey-benchmark -q -n 1000000 info sentinel```
info sentinel: 236910.67 requests per second, p50=0.111 msec