### PR TITLE
Fix LUA garbage collector (CVE-2024-46981)

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -285,6 +285,7 @@ void scriptingInit(int setup) {
 void freeLuaScriptsSync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua) {
     dictRelease(lua_scripts);
     listRelease(lua_scripts_lru_list);
+    lua_gc(lctx.lua, LUA_GCCOLLECT, 0);
     lua_close(lua);
 
 #if !defined(USE_LIBC)


### PR DESCRIPTION
Reset GC state before closing the lua VM to prevent user data to be wrongly freed while still might be used on destructor callbacks.

Created and publish by Redis in their OSS branch.