### PR TITLE
Incr expired_keys if the expiration time is already expired

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1860,7 +1860,8 @@ void deleteExpiredKeyFromOverwriteAndPropagate(client *c, robj *keyobj) {
     robj *aux = server.lazyfree_lazy_expire ? shared.unlink : shared.del;
     rewriteClientCommandVector(c, 2, aux, keyobj);
     signalModifiedKey(c, c->db, keyobj);
-    notifyKeyspaceEvent(NOTIFY_GENERIC, "del", keyobj, c->db->id);
+    notifyKeyspaceEvent(NOTIFY_EXPIRED, "expired", keyobj, c->db->id);
+    server.stat_expiredkeys++;
 }
 
 /* Propagate an implicit key deletion into replicas and the AOF file.

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -142,6 +142,31 @@ start_server {tags {"expire"}} {
         list $e $f
     } {somevalue {}}
 
+    test {EXPIRE / EXPIREAT / PEXPIRE / PEXPIREAT Expiration time is already expired} {
+        set prev_expired [s expired_keys]
+        r del x
+
+        r set x somevalue
+        r expire x -1
+        assert_equal {0} [r exists x]
+        assert_equal {1} [expr {[s expired_keys] - $prev_expired}]
+
+        r set x somevalue
+        r expireat x [expr [clock seconds] - 1]
+        assert_equal {0} [r exists x]
+        assert_equal {2}  [expr {[s expired_keys] - $prev_expired}]
+
+        r set x somevalue
+        r pexpire x -1
+        assert_equal {0} [r exists x]
+        assert_equal {3}  [expr {[s expired_keys] - $prev_expired}]
+
+        r set x somevalue
+        r pexpireat x [expr [clock milliseconds] - 1]
+        assert_equal {0} [r exists x]
+        assert_equal {4}  [expr {[s expired_keys] - $prev_expired}]
+    }
+
     test {TTL returns time to live in seconds} {
         r del x
         r setex x 10 somevalue

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -143,28 +143,28 @@ start_server {tags {"expire"}} {
     } {somevalue {}}
 
     test {EXPIRE / EXPIREAT / PEXPIRE / PEXPIREAT Expiration time is already expired} {
-        set prev_expired [s expired_keys]
-        r del x
+        r flushall
+        r config resetstat
 
         r set x somevalue
         r expire x -1
         assert_equal {0} [r exists x]
-        assert_equal {1} [expr {[s expired_keys] - $prev_expired}]
+        assert_equal {1} [s expired_keys]
 
         r set x somevalue
         r expireat x [expr [clock seconds] - 1]
         assert_equal {0} [r exists x]
-        assert_equal {2}  [expr {[s expired_keys] - $prev_expired}]
+        assert_equal {2}  [s expired_keys]
 
         r set x somevalue
-        r pexpire x -1
+        r pexpire x -1000
         assert_equal {0} [r exists x]
-        assert_equal {3}  [expr {[s expired_keys] - $prev_expired}]
+        assert_equal {3} [s expired_keys]
 
         r set x somevalue
-        r pexpireat x [expr [clock milliseconds] - 1]
+        r pexpireat x [expr [clock milliseconds] - 1000]
         assert_equal {0} [r exists x]
-        assert_equal {4}  [expr {[s expired_keys] - $prev_expired}]
+        assert_equal {4} [s expired_keys]
     }
 
     test {TTL returns time to live in seconds} {

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -425,6 +425,17 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    test "Keyspace notification: expired event (Expiration time is already expired)" {
+        r config set notify-keyspace-events Ex
+        r del foo
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+        r set foo 1
+        r expire foo 0
+        assert_equal "pmessage * __keyevent@${db}__:expired foo" [$rd1 read]
+        $rd1 close
+    }
+
     test "Keyspace notifications: evicted events" {
         r config set notify-keyspace-events Ee
         r config set maxmemory-policy allkeys-lru

--- a/tests/unit/pubsub.tcl
+++ b/tests/unit/pubsub.tcl
@@ -431,7 +431,7 @@ start_server {tags {"pubsub network"}} {
         set rd1 [valkey_deferring_client]
         assert_equal {1} [psubscribe $rd1 *]
         r set foo 1
-        r expire foo 0
+        r expire foo -1
         assert_equal "pmessage * __keyevent@${db}__:expired foo" [$rd1 read]
         $rd1 close
     }


### PR DESCRIPTION
This PR modifies two parts of the `deleteExpiredKeyFromOverwriteAndPropagate` function, which is called when the expiration time has already expired.
* change Keyspace Event notify from `GENERIC-del` to `EXPIRED-expired`. 
Since this delete operation is triggered by EXPIRE, and the flag pass to `dbGenericDeleteWithDictIndex` is `DB_FLAG_KEY_EXPIRED`, which is used to notify module, maybe we should align the behavior and send Keyspace Event notify like `deleteExpiredKeyAndPropagateWithDictIndex` did.
* As i said befoce, this del operation is triggered by EXPIRE, maybe increasing `server.stat_expiredkeys` in this case could more accurately reflect the number of keys deleted due to expiration.