### PR TITLE
add paused_actions for INFO Clients

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4613,6 +4613,16 @@ void flushReplicasOutputBuffers(void) {
     }
 }
 
+mstime_t getPausedActionTimeout(uint32_t action) {
+    mstime_t timeout = 0;
+    for (int i = 0; i < NUM_PAUSE_PURPOSES; i++) {
+        pause_event *p = &(server.client_pause_per_purpose[i]);
+        if (p->paused_actions & action && (p->end - server.mstime) > timeout)
+            timeout = p->end - server.mstime;
+    }
+    return timeout;
+}
+
 /* Compute current paused actions and its end time, aggregated for
  * all pause purposes. */
 void updatePausedActions(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -5941,7 +5941,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
                 "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
                 "paused_actions:%s\r\n", paused_actions,
-                "paused_timeout:%lld\r\n", paused_timeout));
+                "paused_timeout_milliseconds:%lld\r\n", paused_timeout));
         info = genValkeyInfoStringACLStats(info);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -5863,6 +5863,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_last_eviction_exceeded_time ? (long long)elapsedUs(server.stat_last_eviction_exceeded_time) : 0;
         long long current_active_defrag_time =
             server.stat_last_active_defrag_time ? (long long)elapsedUs(server.stat_last_active_defrag_time) : 0;
+        char *paused_actions = server.paused_actions & PAUSE_ACTION_CLIENT_ALL ? "all" : server.paused_actions & PAUSE_ACTION_CLIENT_WRITE ? "write" : "none";
 
         if (sections++) info = sdscat(info, "\r\n");
         info = sdscatprintf(
@@ -5930,7 +5931,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "eventloop_duration_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].sum,
                 "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
                 "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
-                "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION)));
+                "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
+                "paused_actions:%s\r\n", paused_actions));
         info = genValkeyInfoStringACLStats(info);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -5863,8 +5863,15 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_last_eviction_exceeded_time ? (long long)elapsedUs(server.stat_last_eviction_exceeded_time) : 0;
         long long current_active_defrag_time =
             server.stat_last_active_defrag_time ? (long long)elapsedUs(server.stat_last_active_defrag_time) : 0;
-        char *paused_actions = server.paused_actions & PAUSE_ACTION_CLIENT_ALL ? "all" : server.paused_actions & PAUSE_ACTION_CLIENT_WRITE ? "write"
-                                                                                                                                           : "none";
+        char *paused_actions = "none";
+        long long paused_timeout = 0;
+        if (server.paused_actions & PAUSE_ACTION_CLIENT_ALL) {
+            paused_actions = "all";
+            paused_timeout = getPausedActionTimeout(PAUSE_ACTION_CLIENT_ALL);
+        } else if (server.paused_actions & PAUSE_ACTION_CLIENT_WRITE) {
+            paused_actions = "write";
+            paused_timeout = getPausedActionTimeout(PAUSE_ACTION_CLIENT_WRITE);
+        }
 
         if (sections++) info = sdscat(info, "\r\n");
         info = sdscatprintf(
@@ -5933,7 +5940,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "eventloop_duration_cmd_sum:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_CMD].sum,
                 "instantaneous_eventloop_cycles_per_sec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_CYCLE),
                 "instantaneous_eventloop_duration_usec:%llu\r\n", getInstantaneousMetric(STATS_METRIC_EL_DURATION),
-                "paused_actions:%s\r\n", paused_actions));
+                "paused_actions:%s\r\n", paused_actions,
+                "paused_timeout:%lld\r\n", paused_timeout));
         info = genValkeyInfoStringACLStats(info);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -5863,7 +5863,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             server.stat_last_eviction_exceeded_time ? (long long)elapsedUs(server.stat_last_eviction_exceeded_time) : 0;
         long long current_active_defrag_time =
             server.stat_last_active_defrag_time ? (long long)elapsedUs(server.stat_last_active_defrag_time) : 0;
-        char *paused_actions = server.paused_actions & PAUSE_ACTION_CLIENT_ALL ? "all" : server.paused_actions & PAUSE_ACTION_CLIENT_WRITE ? "write" : "none";
+        char *paused_actions = server.paused_actions & PAUSE_ACTION_CLIENT_ALL ? "all" : server.paused_actions & PAUSE_ACTION_CLIENT_WRITE ? "write"
+                                                                                                                                           : "none";
 
         if (sections++) info = sdscat(info, "\r\n");
         info = sdscatprintf(

--- a/src/server.h
+++ b/src/server.h
@@ -2701,6 +2701,7 @@ void pauseActions(pause_purpose purpose, mstime_t end, uint32_t actions);
 void unpauseActions(pause_purpose purpose);
 uint32_t isPausedActions(uint32_t action_bitmask);
 uint32_t isPausedActionsWithUpdate(uint32_t action_bitmask);
+mstime_t getPausedActionTimeout(uint32_t action);
 void updatePausedActions(void);
 void unblockPostponedClients(void);
 void processEventsWhileBlocked(void);

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -12,7 +12,7 @@ start_server {tags {"pause network"}} {
 
         r multi
         r client PAUSE 1000 ALL
-        r info stats
+        r info clients
         assert_match "*paused_actions:all*" [r exec]
 
         r client unpause

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,13 +1,17 @@
 start_server {tags {"pause network"}} {
     test "Test check paused_actions in info stats" {
         assert_equal [s paused_actions] "none"
+        assert_equal [s paused_timeout] 0
 
         r client PAUSE 10000 WRITE
         assert_equal [s paused_actions] "write"
+        after 1000
+        set timeout [s paused_timeout]
+        assert {$timeout > 0 && $timeout < 9000}
         r client unpause
 
         r multi
-        r client PAUSE 1000 All
+        r client PAUSE 1000 ALL
         r info stats
         assert_match "*paused_actions:all*" [r exec]
 

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,4 +1,19 @@
 start_server {tags {"pause network"}} {
+    test "Test check paused_actions in info stats" {
+        assert_equal [s paused_actions] "none"
+
+        r client PAUSE 10000 WRITE
+        assert_equal [s paused_actions] "write"
+        r client unpause
+
+        r multi
+        r client PAUSE 1000 All
+        r info stats
+        assert_match "*paused_actions:all*" [r exec]
+
+        r client unpause
+    }
+
     test "Test read commands are not blocked by client pause" {
         r client PAUSE 100000 WRITE
         set rd [valkey_deferring_client]

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -1,12 +1,12 @@
 start_server {tags {"pause network"}} {
     test "Test check paused_actions in info stats" {
         assert_equal [s paused_actions] "none"
-        assert_equal [s paused_timeout] 0
+        assert_equal [s paused_timeout_milliseconds] 0
 
         r client PAUSE 10000 WRITE
         assert_equal [s paused_actions] "write"
         after 1000
-        set timeout [s paused_timeout]
+        set timeout [s paused_timeout_milliseconds]
         assert {$timeout > 0 && $timeout < 9000}
         r client unpause
 


### PR DESCRIPTION
Add `paused_actions` and `paused_timeout_milliseconds` for INFO Clients to inform users about if clients are paused.