### PR TITLE
Actually run code coverage on ubuntu 22

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   coverity:
     if: github.repository == 'valkey-io/valkey'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download and extract the Coverity Build Tool


### PR DESCRIPTION
This commit, https://github.com/valkey-io/valkey/pull/1504, moved the wrong worker to ubuntu 22. We wanted to move codecov and not coverity. 