### PR TITLE
refactor: use `argp` library for parsing command line options and arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: test
+        run: |
+          brew install argp-standalone
       - name: make
         # Build with additional upcoming features
         run: make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=yes

--- a/src/Makefile
+++ b/src/Makefile
@@ -181,6 +181,11 @@ else
 	# Homebrew x86/ppc uses /usr/local as HOMEBREW_PREFIX
 	OPENSSL_PREFIX?=/usr/local/opt/openssl
 endif
+	# GNU libc argp library needs to be installed with homebrew:
+	# `brew install argp-standalone`
+	FINAL_LIBS+= -largp
+	FINAL_LDFLAGS+= -L/opt/homebrew/lib
+	FINAL_CFLAGS+= -I/opt/homebrew/include
 else
 ifeq ($(uname_S),AIX)
         # AIX


### PR DESCRIPTION
This commit changes the command line parsing code of `valkey-benchmark` to use the `argp` library (https://www.gnu.org/software/libc/manual/html_node/Argp.html), which is included in libc.

This makes the options and arguments parsing more structured and easy to extend.