### PR TITLE
Remove legacy SERVER_TEST compiler flag from cmake.

### DIFF
--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -7,7 +7,6 @@ get_valkey_server_linker_option(VALKEY_SERVER_LDFLAGS)
 
 # Build unit tests only
 message(STATUS "Building unit tests")
-list(APPEND COMPILE_DEFINITIONS "SERVER_TEST=1")
 if (USE_TLS)
     if (BUILD_TLS_MODULE)
         # TLS as a module


### PR DESCRIPTION
This PR is to cleanup the `SERVER_TEST` compiler flag from cmake compile definitions, as it is no longer required in the new unit test framework (see https://github.com/valkey-io/valkey/issues/428).