### PR TITLE
Fix flakly half-finish importing cluster test

### DIFF
--- a/tests/unit/cluster/half-migrated-slot.tcl
+++ b/tests/unit/cluster/half-migrated-slot.tcl
@@ -84,6 +84,7 @@ test "Move key back" {
 test "Half-finish importing" {
     # Now we half finish 'importing' node
     assert_equal {OK} [$nodeto(link) cluster setslot 609 node $nodeto(id)]
+    assert_equal {OK} [$nodefrom(link) cluster setslot 609 node $nodeto(id)]
     fix_cluster $nodefrom(addr)
     assert_equal "xyz" [$cluster get aga]
 }

--- a/tests/unit/cluster/half-migrated-slot.tcl
+++ b/tests/unit/cluster/half-migrated-slot.tcl
@@ -81,11 +81,11 @@ test "Move key back" {
     assert_equal "xyz" [$cluster get aga]
 }
 
+reset_cluster
+
 test "Half-finish importing" {
     # Now we half finish 'importing' node
     assert_equal {OK} [$nodeto(link) cluster setslot 609 node $nodeto(id)]
-    assert_equal {OK} [$nodefrom(link) cluster setslot 609 node $nodeto(id)]
-    fix_cluster $nodefrom(addr)
     assert_equal "xyz" [$cluster get aga]
 }
 


### PR DESCRIPTION
With this, the source node is also informed that the slot ownership has been changed.
100 iterations passed for this test, which were flakily failing before.

Fixes #1526.