### PR TITLE
Free the passed in lua context instead of the global

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -285,7 +285,7 @@ void scriptingInit(int setup) {
 void freeLuaScriptsSync(dict *lua_scripts, list *lua_scripts_lru_list, lua_State *lua) {
     dictRelease(lua_scripts);
     listRelease(lua_scripts_lru_list);
-    lua_gc(lctx.lua, LUA_GCCOLLECT, 0);
+    lua_gc(lua, LUA_GCCOLLECT, 0);
     lua_close(lua);
 
 #if !defined(USE_LIBC)


### PR DESCRIPTION
The fix that Redis gave us for the https://nvd.nist.gov/vuln/detail/CVE-2024-46981 was freeing lctx.lua, and I didn't merge it correctly. We made some changes so that we are able to async free the lua context, so we need to free the passed in context. This was applied correctly on the two released versions (8.0 and 7.2) just not on unstable.