### PR TITLE
Skip CLI tests with reply schema validation

### DIFF
--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -6,7 +6,7 @@ if {$::singledb} {
     set ::dbnum 9
 }
 
-start_server {tags {"cli"}} {
+start_server {tags {"cli logreqres:skip"}} {
     proc open_cli {{opts ""} {infile ""}} {
         if { $opts == "" } {
             set opts "-n $::dbnum"


### PR DESCRIPTION
The commands used in valkey-cli tests are not important the reply schema validation. Skip them to avoid the problem if tests hanging. This has failed lately in the daily job:

```
[TIMEOUT]: clients state report follows.
sock55fedcc19be0 => (IN PROGRESS) valkey-cli pubsub mode with single standard channel subscription
Killing still running Valkey server 33357
```

These test cases use a special valkey-cli command `:get pubsub` command, which is an internal command to valkey-cli rather than a Valkey server command. This command hangs when compiled with with logreqres enabled. Easy solution is to skip the tests in this setup.

The test cases were introduced in #1432.