### PR TITLE
Test coverage for ECHO for reply schema validation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1220,7 +1220,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable')) &&
+        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'reply-schema')
     steps:
       - name: prep

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -30,6 +30,10 @@ start_server {tags {"other"}} {
         }
     }
 
+    test {Coverage: ECHO} {
+        assert_equal bang [r ECHO bang]
+    }
+
     test {SAVE - make sure there are all the types as values} {
         # Wait for a background saving in progress to terminate
         waitForBgsave r


### PR DESCRIPTION
After #1545 disabled some tests for reply schema validation, we now have another issue that ECHO is not covered.

```
WARNING! The following commands were not hit at all:
  echo
ERROR! at least one command was not hit by the tests
```

(https://github.com/valkey-io/valkey/actions/runs/12728730819/job/35479652660)

This patch adds a test case for ECHO in the unit/other test suite. I haven't checked if there are more commands that aren't covered.