### PR TITLE
Introduce const_sds for const-content sds

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -187,19 +187,19 @@ sds sdsnew(const char *init) {
 }
 
 /* Duplicate an sds string. */
-sds sdsdup(const sds s) {
+sds sdsdup(const_sds s) {
     return sdsnewlen(s, sdslen(s));
 }
 
 /*
  * This method returns the minimum amount of bytes required to store the sds (header + data + NULL terminator).
  */
-static inline size_t sdsminlen(const sds s) {
+static inline size_t sdsminlen(const_sds s) {
     return sdslen(s) + sdsHdrSize(s[-1]) + 1;
 }
 
 /* This method copies the sds `s` into `buf` which is the target character buffer. */
-size_t sdscopytobuffer(unsigned char *buf, size_t buf_len, const sds s, uint8_t *hdr_size) {
+size_t sdscopytobuffer(unsigned char *buf, size_t buf_len, const_sds s, uint8_t *hdr_size) {
     size_t required_keylen = sdsminlen(s);
     if (buf == NULL) {
         return required_keylen;
@@ -432,7 +432,7 @@ sds sdsResize(sds s, size_t size, int would_regrow) {
  * 3) The free buffer at the end if any.
  * 4) The implicit null term.
  */
-size_t sdsAllocSize(sds s) {
+size_t sdsAllocSize(const_sds s) {
     char type = s[-1] & SDS_TYPE_MASK;
     /* SDS_TYPE_5 header doesn't contain the size of the allocation */
     if (type == SDS_TYPE_5) {
@@ -444,7 +444,7 @@ size_t sdsAllocSize(sds s) {
 
 /* Return the pointer of the actual SDS allocation (normally SDS strings
  * are referenced by the start of the string buffer). */
-void *sdsAllocPtr(sds s) {
+void *sdsAllocPtr(const_sds s) {
     return (void *)(s - sdsHdrSize(s[-1]));
 }
 
@@ -559,7 +559,7 @@ sds sdscat(sds s, const char *t) {
  *
  * After the call, the modified sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call. */
-sds sdscatsds(sds s, const sds t) {
+sds sdscatsds(sds s, const_sds t) {
     return sdscatlen(s, t, sdslen(t));
 }
 
@@ -870,7 +870,7 @@ void sdstoupper(sds s) {
  * If two strings share exactly the same prefix, but one of the two has
  * additional characters, the longer string is considered to be greater than
  * the smaller one. */
-int sdscmp(const sds s1, const sds s2) {
+int sdscmp(const_sds s1, const_sds s2) {
     size_t l1, l2, minlen;
     int cmp;
 
@@ -996,7 +996,7 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
  * that is compatible with sdssplitargs(). For this reason, also spaces will be
  * treated as needing an escape.
  */
-int sdsneedsrepr(const sds s) {
+int sdsneedsrepr(const_sds s) {
     size_t len = sdslen(s);
     const char *p = s;
 

--- a/src/sds.h
+++ b/src/sds.h
@@ -39,10 +39,13 @@ extern const char *SDS_NOINIT;
 #include <stdarg.h>
 #include <stdint.h>
 
-typedef char *sds;
+/* Constness:
+ *
+ * - 'const sds' means 'char * const'. It is a const-pointer to non-const content.
+ * - 'const_sds' means 'const char *'. It is a non-const pointer to const content.
+ * - 'const const_sds' means 'const char * const', const pointer and content. */
 
-/* Constness: 'const sds' means 'char * const'. To get 'const char *', use
- * 'const_sds'. To get both, you can use 'const const_sds' */
+typedef char *sds;
 typedef const char *const_sds;
 
 /* Note: sdshdr5 is never used, we just access the flags byte directly.

--- a/src/sds.h
+++ b/src/sds.h
@@ -41,6 +41,10 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds;
 
+/* Constness: 'const sds' means 'char * const'. To get 'const char *', use
+ * 'const_sds'. To get both, you can use 'const const_sds' */
+typedef const char *const_sds;
+
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
  * However is here to document the layout of type 5 SDS strings. */
 struct __attribute__((__packed__)) sdshdr5 {
@@ -83,7 +87,7 @@ struct __attribute__((__packed__)) sdshdr64 {
 #define SDS_HDR(T, s) ((struct sdshdr##T *)((s) - (sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f) >> SDS_TYPE_BITS)
 
-static inline size_t sdslen(const sds s) {
+static inline size_t sdslen(const_sds s) {
     unsigned char flags = s[-1];
     switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: return SDS_TYPE_5_LEN(flags);
@@ -95,7 +99,7 @@ static inline size_t sdslen(const sds s) {
     return 0;
 }
 
-static inline size_t sdsavail(const sds s) {
+static inline size_t sdsavail(const_sds s) {
     unsigned char flags = s[-1];
     switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: {
@@ -151,7 +155,7 @@ static inline void sdsinclen(sds s, size_t inc) {
 }
 
 /* sdsalloc() = sdsavail() + sdslen() */
-static inline size_t sdsalloc(const sds s) {
+static inline size_t sdsalloc(const_sds s) {
     unsigned char flags = s[-1];
     switch (flags & SDS_TYPE_MASK) {
     case SDS_TYPE_5: return SDS_TYPE_5_LEN(flags);
@@ -180,14 +184,14 @@ sds sdsnewlen(const void *init, size_t initlen);
 sds sdstrynewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);
-sds sdsdup(const sds s);
-size_t sdscopytobuffer(unsigned char *buf, size_t buf_len, sds s, uint8_t *hdr_size);
+sds sdsdup(const_sds s);
+size_t sdscopytobuffer(unsigned char *buf, size_t buf_len, const_sds s, uint8_t *hdr_size);
 void sdsfree(sds s);
 void sdsfreeVoid(void *s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);
 sds sdscat(sds s, const char *t);
-sds sdscatsds(sds s, const sds t);
+sds sdscatsds(sds s, const_sds t);
 sds sdscpylen(sds s, const char *t, size_t len);
 sds sdscpy(sds s, const char *t);
 
@@ -204,7 +208,7 @@ void sdssubstr(sds s, size_t start, size_t len);
 void sdsrange(sds s, ssize_t start, ssize_t end);
 void sdsupdatelen(sds s);
 void sdsclear(sds s);
-int sdscmp(const sds s1, const sds s2);
+int sdscmp(const_sds s1, const_sds s2);
 sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count);
 void sdsfreesplitres(sds *tokens, int count);
 void sdstolower(sds s);
@@ -215,14 +219,14 @@ sds *sdssplitargs(const char *line, int *argc);
 sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
 sds sdsjoin(char **argv, int argc, char *sep);
 sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
-int sdsneedsrepr(const sds s);
+int sdsneedsrepr(const_sds s);
 
 /* Callback for sdstemplate. The function gets called by sdstemplate
  * every time a variable needs to be expanded. The variable name is
  * provided as variable, and the callback is expected to return a
  * substitution value. Returning a NULL indicates an error.
  */
-typedef sds (*sdstemplate_callback_t)(const sds variable, void *arg);
+typedef sds (*sdstemplate_callback_t)(const_sds variable, void *arg);
 sds sdstemplate(const char *template, sdstemplate_callback_t cb_func, void *cb_arg);
 
 /* Low level functions exposed to the user API */
@@ -231,8 +235,8 @@ sds sdsMakeRoomForNonGreedy(sds s, size_t addlen);
 void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s, int would_regrow);
 sds sdsResize(sds s, size_t size, int would_regrow);
-size_t sdsAllocSize(sds s);
-void *sdsAllocPtr(sds s);
+size_t sdsAllocSize(const_sds s);
+void *sdsAllocPtr(const_sds s);
 
 /* Export the allocator used by SDS to the program using SDS.
  * Sometimes the program SDS is linked to, may use a different set of

--- a/src/server.c
+++ b/src/server.c
@@ -6696,7 +6696,7 @@ void serverOutOfMemoryHandler(size_t allocation_size) {
 /* Callback for sdstemplate on proc-title-template. See valkey.conf for
  * supported variables.
  */
-static sds serverProcTitleGetVariable(const sds varname, void *arg) {
+static sds serverProcTitleGetVariable(const_sds varname, void *arg) {
     if (!strcmp(varname, "title")) {
         return sdsnew(arg);
     } else if (!strcmp(varname, "listen-addr")) {

--- a/src/unit/test_sds.c
+++ b/src/unit/test_sds.c
@@ -6,7 +6,7 @@
 #include "../sds.h"
 #include "../sdsalloc.h"
 
-static sds sdsTestTemplateCallback(sds varname, void *arg) {
+static sds sdsTestTemplateCallback(const_sds varname, void *arg) {
     UNUSED(arg);
     static const char *_var1 = "variable1";
     static const char *_var2 = "variable2";


### PR DESCRIPTION
`sds` is a typedef of `char *`.

`const sds` means `char * const`, i.e. a const-pointer to non-const content.

More often, you would want `const char *`, i.e. a pointer to const-content. Until now, it's not possible to express that. This PR adds `const_sds` which is a pointer to const-content sds.

To get a const-pointer to const-content sds, you can use `const const_sds`.

In this PR, some uses of `const sds` are replaced by `const_sds`. We can use it more later.

Fixes #1542