### PR TITLE
Escape unix socket group in unit tests

### DIFF
--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -568,7 +568,8 @@ if {$::verbose} {
 set tempFileId [open $tempFileName w]
 set group [dict get [file attributes $tempFileName] -group]
 if {$group != ""} {
-    start_server [list tags {"repl external:skip"} overrides [list unixsocketgroup $group unixsocketperm 744]] {
+    set escaped_group "\"[string map {"\\" "\\\\"} $group]\""
+    start_server [list tags {"repl external:skip"} overrides [list unixsocketgroup $escaped_group unixsocketperm 744]] {
         test {test unixsocket options are set correctly} {
             set socketpath [lindex [r config get unixsocket] 1]
             set attributes [file attributes $socketpath]


### PR DESCRIPTION
In some cases unix groups could have whitespace and/or `\` in them.
One example is my workstation. It's a MacOS in an Active Directory domain. So my user has group `LD\Domain Users`.
Running `make test` on `unstable` and `8.0` branches fails with:
```
*** FATAL CONFIG FILE ERROR (Version 8.0.2) ***
Reading the configuration file, at line 30
>>> 'unixsocketgroup LD\Domain Users'
wrong number of arguments
```

I'm not sure if we need to fix this in 8.0. But it seems that it should be fixed in unstable.