### PR TITLE
Loop optimization: move maxlen check outside to reduce unnecessary checks

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2183,7 +2183,7 @@ int hashtableLongestBucketChain(hashtable *ht) {
             int chainlen = 0;
             bucket *b = &ht->tables[table][i];
             while (b->chained) {
-                ++chainlen
+                ++chainlen;
                 b = getChildBucket(b);
             }
             if (chainlen > maxlen) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2183,10 +2183,11 @@ int hashtableLongestBucketChain(hashtable *ht) {
             int chainlen = 0;
             bucket *b = &ht->tables[table][i];
             while (b->chained) {
-                if (++chainlen > maxlen) {
-                    maxlen = chainlen;
-                }
+                ++chainlen
                 b = getChildBucket(b);
+            }
+            if (chainlen > maxlen) {
+                maxlen = chainlen;
             }
         }
     }


### PR DESCRIPTION
A trival pr, move maxlen check outside to reduce unnecessary ecks