### PR TITLE
In LOLWUT's reply, change "Redis ver." to "Valkey ver."

### DIFF
--- a/src/lolwut.c
+++ b/src/lolwut.c
@@ -44,7 +44,7 @@ void lolwut6Command(client *c);
  * This is what unstable versions of the server will display. */
 void lolwutUnstableCommand(client *c) {
     sds rendered = sdscatprintf(sdsempty(), "%s ver.", server.extended_redis_compat ? "Redis" : "Valkey");
-    rendered = sdscat(rendered, VALKEY_VERSION);
+    rendered = sdscat(rendered, server.extended_redis_compat ? REDIS_VERSION : VALKEY_VERSION);
     rendered = sdscatlen(rendered, "\n", 1);
     addReplyVerbatim(c, rendered, sdslen(rendered), "txt");
     sdsfree(rendered);

--- a/src/lolwut.c
+++ b/src/lolwut.c
@@ -43,7 +43,7 @@ void lolwut6Command(client *c);
 /* The default target for LOLWUT if no matching version was found.
  * This is what unstable versions of the server will display. */
 void lolwutUnstableCommand(client *c) {
-    sds rendered = sdsnew("Valkey ver. ");
+    sds rendered = sdscatprintf(sdsempty(), "%s ver.", server.extended_redis_compat ? "Redis" : "Valkey");
     rendered = sdscat(rendered, VALKEY_VERSION);
     rendered = sdscatlen(rendered, "\n", 1);
     addReplyVerbatim(c, rendered, sdslen(rendered), "txt");

--- a/src/lolwut.c
+++ b/src/lolwut.c
@@ -43,7 +43,7 @@ void lolwut6Command(client *c);
 /* The default target for LOLWUT if no matching version was found.
  * This is what unstable versions of the server will display. */
 void lolwutUnstableCommand(client *c) {
-    sds rendered = sdsnew("Redis ver. ");
+    sds rendered = sdsnew("Valkey ver. ");
     rendered = sdscat(rendered, VALKEY_VERSION);
     rendered = sdscatlen(rendered, "\n", 1);
     addReplyVerbatim(c, rendered, sdslen(rendered), "txt");

--- a/src/lolwut5.c
+++ b/src/lolwut5.c
@@ -161,8 +161,8 @@ void lolwut5Command(client *c) {
     /* Generate some computer art and reply. */
     lwCanvas *canvas = lwDrawSchotter(cols, squares_per_row, squares_per_col);
     sds rendered = renderCanvas(canvas);
-    rendered = sdscat(rendered, "\nGeorg Nees - schotter, plotter on paper, 1968. Redis ver. ");
-    rendered = sdscat(rendered, VALKEY_VERSION);
+    rendered = sdscatprintf(rendered, "\nGeorg Nees - schotter, plotter on paper, 1968. %s ver. ", server.extended_redis_compat ? "Redis" : "Valkey");
+    rendered = sdscat(rendered, server.extended_redis_compat ? REDIS_VERSION : VALKEY_VERSION);
     rendered = sdscatlen(rendered, "\n", 1);
     addReplyVerbatim(c, rendered, sdslen(rendered), "txt");
     sdsfree(rendered);

--- a/src/lolwut6.c
+++ b/src/lolwut6.c
@@ -180,9 +180,10 @@ void lolwut6Command(client *c) {
     lwCanvas *canvas = lwCreateCanvas(cols, rows, 3);
     generateSkyline(canvas);
     sds rendered = renderCanvas(canvas);
-    rendered = sdscat(rendered, "\nDedicated to the 8 bit game developers of past and present.\n"
-                                "Original 8 bit image from Plaguemon by hikikomori. Redis ver. ");
-    rendered = sdscat(rendered, VALKEY_VERSION);
+    rendered = sdscatprintf(rendered, "\nDedicated to the 8 bit game developers of past and present.\n"
+                                      "Original 8 bit image from Plaguemon by hikikomori. %s ver. ",
+                            server.extended_redis_compat ? "Redis" : "Valkey");
+    rendered = sdscat(rendered, server.extended_redis_compat ? REDIS_VERSION : VALKEY_VERSION);
     rendered = sdscatlen(rendered, "\n", 1);
     addReplyVerbatim(c, rendered, sdslen(rendered), "txt");
     sdsfree(rendered);

--- a/src/script.c
+++ b/src/script.c
@@ -548,7 +548,7 @@ void scriptCall(scriptRunCtx *run_ctx, sds *err) {
 
     /* There are commands that are not allowed inside scripts. */
     if (!server.script_disable_deny_script && (cmd->flags & CMD_NOSCRIPT)) {
-        *err = sdsnew("This Redis command is not allowed from script");
+        *err = sdscatprintf(sdsempty(), "This %s command is not allowed from script", server.extended_redis_compat ? "Redis" : "Valkey");
         goto error;
     }
 

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -385,6 +385,8 @@ start_server {tags {"other"}} {
             set info [r info server]
             assert_match "*redis_mode:*" $info
             assert_no_match "*server_mode:*" $info
+            set lolwut_output [r lolwut]
+            assert_match {*Redis ver.*} $lolwut_output
             r config set extended-redis-compatibility no
             set hello [r hello 3]
             assert_equal "valkey" [dict get $hello server]
@@ -392,6 +394,8 @@ start_server {tags {"other"}} {
             set info [r info server]
             assert_no_match "*redis_mode:*" $info
             assert_match "*server_mode:*" $info
+            set lolwut_output [r lolwut]
+            assert_match {*Valkey ver.*} $lolwut_output
         }
     }
 }

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -385,6 +385,10 @@ start_server {tags {"other"}} {
             set info [r info server]
             assert_match "*redis_mode:*" $info
             assert_no_match "*server_mode:*" $info
+            set lolwut_output [r lolwut 5]
+            assert_match {*Redis ver.*} $lolwut_output
+            set lolwut_output [r lolwut 6]
+            assert_match {*Redis ver.*} $lolwut_output
             set lolwut_output [r lolwut]
             assert_match {*Redis ver.*} $lolwut_output
             r config set extended-redis-compatibility no
@@ -395,6 +399,10 @@ start_server {tags {"other"}} {
             assert_no_match "*redis_mode:*" $info
             assert_match "*server_mode:*" $info
             set lolwut_output [r lolwut]
+            assert_match {*Valkey ver.*} $lolwut_output
+            set lolwut_output [r lolwut 5]
+            assert_match {*Valkey ver.*} $lolwut_output
+            set lolwut_output [r lolwut 6]
             assert_match {*Valkey ver.*} $lolwut_output
         }
     }


### PR DESCRIPTION
Make LOLWUT it print the current Valkey version rather than the Redis version. Retain the old behaviour and print the compatible Redis version if the `extended-redis-compat` config is enabled.

Additionally, change "Redis" to "Valkey" in an error message "This Redis command is not allowed from script", also depending on the `extended-redis-compat` config.