### PR TITLE
Fix cluster info sent stats for message with light header

### DIFF
--- a/tests/unit/cluster/pubsub.tcl
+++ b/tests/unit/cluster/pubsub.tcl
@@ -41,14 +41,10 @@ start_cluster 3 0 {tags {external:skip cluster}} {
         R 0 PUBLISH hello world
         assert_equal 2 [CI 0 cluster_stats_messages_publish_sent]
         wait_for_condition 50 100 {
-            [CI 1 cluster_stats_messages_publish_received] eq 1
-        } else {
-            fail "node 2 didn't receive clusterbus publish packet"
-        }
-        wait_for_condition 50 100 {
+            [CI 1 cluster_stats_messages_publish_received] eq 1 &&
             [CI 2 cluster_stats_messages_publish_received] eq 1
         } else {
-            fail "node 3 didn't receive clusterbus publish packet"
+            fail "node 2 or node 3 didn't receive clusterbus publish packet"
         }
     }
 }

--- a/tests/unit/cluster/pubsub.tcl
+++ b/tests/unit/cluster/pubsub.tcl
@@ -34,5 +34,21 @@ test "Test publishing to master" {
 test "Test publishing to slave" {
     test_cluster_publish 5 10
 }
-
 } ;# start_cluster
+
+start_cluster 3 0 {tags {external:skip cluster}} {
+    test "Test cluster info stats for publish" {
+        R 0 PUBLISH hello world
+        assert_equal 2 [CI 0 cluster_stats_messages_publish_sent]
+        wait_for_condition 50 100 {
+            [CI 1 cluster_stats_messages_publish_received] eq 1
+        } else {
+            fail "node 2 didn't receive clusterbus publish packet"
+        }
+        wait_for_condition 50 100 {
+            [CI 2 cluster_stats_messages_publish_received] eq 1
+        } else {
+            fail "node 3 didn't receive clusterbus publish packet"
+        }
+    }
+}


### PR DESCRIPTION
This issue only impacted two message type (CLUSTERMSG_TYPE_PUBLISH / CLUSTERMSG_TYPE_PUBLISHSHARD) as those were the only message type uses light message header where the `CLUSTER INFO` stats had missing information of sent/received messages of that type.

Before
```
cluster_state:ok
cluster_slots_assigned:16384
cluster_slots_ok:16384
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_known_nodes:3
cluster_size:3
cluster_current_epoch:2
cluster_my_epoch:0
cluster_stats_messages_ping_sent:20
cluster_stats_messages_pong_sent:22
cluster_stats_messages_meet_sent:2
cluster_stats_messages_sent:44
cluster_stats_messages_ping_received:22
cluster_stats_messages_pong_received:22
cluster_stats_messages_received:44
total_cluster_links_buffer_limit_exceeded:0
```


After
```
cluster_state:ok
cluster_slots_assigned:16384
cluster_slots_ok:16384
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_known_nodes:3
cluster_size:3
cluster_current_epoch:2
cluster_my_epoch:1
cluster_stats_messages_ping_sent:20
cluster_stats_messages_pong_sent:23
cluster_stats_messages_meet_sent:2
**cluster_stats_messages_publish_sent:2**
cluster_stats_messages_sent:47
cluster_stats_messages_ping_received:23
cluster_stats_messages_pong_received:22
cluster_stats_messages_received:45
total_cluster_links_buffer_limit_exceeded:0
```