### PR TITLE
Allow clang-format to be triggered in push events

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,7 @@
 name: Clang Format Check
 
 on:
+  push:
   pull_request:
     paths:
       - 'src/**'


### PR DESCRIPTION
Just like spell-check workflow, we should allow to trigger it
in push events, so that the forks repo can notice the format
thing way before submitting the PR.