### PR TITLE
Extend LATENCY LATEST to add sum / cnt stats

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -86,7 +86,6 @@ void latencyAddSample(const char *event, mstime_t latency) {
         ts = zmalloc(sizeof(*ts));
         ts->idx = 0;
         ts->max = 0;
-        ts->min = 0;
         ts->sum = 0;
         ts->cnt = 0;
         memset(ts->samples, 0, sizeof(ts->samples));
@@ -94,7 +93,6 @@ void latencyAddSample(const char *event, mstime_t latency) {
     }
 
     if (latency > ts->max) ts->max = latency;
-    if (latency < ts->min || ts->min == 0) ts->min = latency;
     ts->sum += latency;
     ts->cnt++;
 
@@ -618,12 +616,11 @@ void latencyCommandReplyWithLatestEvents(client *c) {
         struct latencyTimeSeries *ts = dictGetVal(de);
         int last = (ts->idx + LATENCY_TS_LEN - 1) % LATENCY_TS_LEN;
 
-        addReplyArrayLen(c, 7);
+        addReplyArrayLen(c, 6);
         addReplyBulkCString(c, event);
         addReplyLongLong(c, ts->samples[last].time);
         addReplyLongLong(c, ts->samples[last].latency);
         addReplyLongLong(c, ts->max);
-        addReplyLongLong(c, ts->min);
         addReplyLongLong(c, ts->sum);
         addReplyLongLong(c, ts->cnt);
     }

--- a/src/latency.c
+++ b/src/latency.c
@@ -86,11 +86,17 @@ void latencyAddSample(const char *event, mstime_t latency) {
         ts = zmalloc(sizeof(*ts));
         ts->idx = 0;
         ts->max = 0;
+        ts->min = 0;
+        ts->sum = 0;
+        ts->cnt = 0;
         memset(ts->samples, 0, sizeof(ts->samples));
         dictAdd(server.latency_events, zstrdup(event), ts);
     }
 
     if (latency > ts->max) ts->max = latency;
+    if (latency < ts->min || ts->min == 0) ts->min = latency;
+    ts->sum += latency;
+    ts->cnt++;
 
     /* If the previous sample is in the same second, we update our old sample
      * if this latency is > of the old one, or just return. */
@@ -612,11 +618,14 @@ void latencyCommandReplyWithLatestEvents(client *c) {
         struct latencyTimeSeries *ts = dictGetVal(de);
         int last = (ts->idx + LATENCY_TS_LEN - 1) % LATENCY_TS_LEN;
 
-        addReplyArrayLen(c, 4);
+        addReplyArrayLen(c, 7);
         addReplyBulkCString(c, event);
         addReplyLongLong(c, ts->samples[last].time);
         addReplyLongLong(c, ts->samples[last].latency);
         addReplyLongLong(c, ts->max);
+        addReplyLongLong(c, ts->min);
+        addReplyLongLong(c, ts->sum);
+        addReplyLongLong(c, ts->cnt);
     }
     dictReleaseIterator(di);
 }

--- a/src/latency.h
+++ b/src/latency.h
@@ -47,7 +47,6 @@ struct latencySample {
 struct latencyTimeSeries {
     int idx;                                      /* Index of the next sample to store. */
     uint32_t max;                                 /* Max latency observed for this event. */
-    uint32_t min;                                 /* Min latency observed for this event. */
     uint32_t sum;                                 /* Sum latency observed for this event. */
     uint32_t cnt;                                 /* Count observed for this event. */
     struct latencySample samples[LATENCY_TS_LEN]; /* Latest history. */

--- a/src/latency.h
+++ b/src/latency.h
@@ -47,6 +47,9 @@ struct latencySample {
 struct latencyTimeSeries {
     int idx;                                      /* Index of the next sample to store. */
     uint32_t max;                                 /* Max latency observed for this event. */
+    uint32_t min;                                 /* Min latency observed for this event. */
+    uint32_t sum;                                 /* Sum latency observed for this event. */
+    uint32_t cnt;                                 /* Count observed for this event. */
     struct latencySample samples[LATENCY_TS_LEN]; /* Latest history. */
 };
 

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -115,14 +115,13 @@ tags {"needs:debug"} {
 
         # See the previous "Test latency events logging" test for each call.
         foreach event $res {
-            lassign $event eventname time latency max min sum cnt
+            lassign $event eventname time latency max sum cnt
             assert {$eventname eq "command"}
             if {!$::no_latency} {
                 # To avoid timing issues, each event decreases by 50 and
                 # increases by 150 to increase the range.
                 assert_equal $time $last_time
                 assert_range $max 450 650 ;# debug sleep 0.5
-                assert_range $min 250 450 ;# debug sleep 0.3
                 assert_range $sum 1050 1650 ;# debug sleep 0.3 + 0.4 + 0.5
                 assert_equal $cnt 3
             }

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -113,12 +113,18 @@ tags {"needs:debug"} {
             puts $res
         }
 
+        # See the previous "Test latency events logging" test for each call.
         foreach event $res {
-            lassign $event eventname time latency max
+            lassign $event eventname time latency max min sum cnt
             assert {$eventname eq "command"}
             if {!$::no_latency} {
-                assert {$max >= 450 & $max <= 650}
-                assert {$time == $last_time}
+                # To avoid timing issues, each event decreases by 50 and
+                # increases by 150 to increase the range.
+                assert_equal $time $last_time
+                assert_range $max 450 650 ;# debug sleep 0.5
+                assert_range $min 250 450 ;# debug sleep 0.3
+                assert_range $sum 1050 1650 ;# debug sleep 0.3 + 0.4 + 0.5
+                assert_equal $cnt 3
             }
             break
         }


### PR DESCRIPTION
Currently LATENCY LATEST only has the following fields:
- Event name.
- Unix timestamp of the latest latency spike for the event.
- Latest event latency in millisecond.
- All-time maximum latency for this event.

This PR introduced these fields:
- sum: the all-time sum latency for this event (i think it is useful for some events)
- cnt: the event count that trigger the latency, with the sum we can calc the avg