### PR TITLE
[Backport] Fix cluster info sent stats for message with light header (#1563)

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3773,7 +3773,7 @@ void clusterSendMessage(clusterLink *link, clusterMsgSendBlock *msgblock) {
     server.stat_cluster_links_memory += sizeof(listNode);
 
     /* Populate sent messages stats. */
-    uint16_t type = ntohs(msgblock->msg.type);
+    uint16_t type = ntohs(msgblock->msg.type) & ~CLUSTERMSG_MODIFIER_MASK;
     if (type < CLUSTERMSG_TYPE_COUNT) server.cluster->stats_bus_messages_sent[type]++;
 }
 

--- a/tests/unit/cluster/pubsub.tcl
+++ b/tests/unit/cluster/pubsub.tcl
@@ -34,5 +34,17 @@ test "Test publishing to master" {
 test "Test publishing to slave" {
     test_cluster_publish 5 10
 }
-
 } ;# start_cluster
+
+start_cluster 3 0 {tags {external:skip cluster}} {
+    test "Test cluster info stats for publish" {
+        R 0 PUBLISH hello world
+        assert_equal 2 [CI 0 cluster_stats_messages_publish_sent]
+        wait_for_condition 50 100 {
+            [CI 1 cluster_stats_messages_publish_received] eq 1 &&
+            [CI 2 cluster_stats_messages_publish_received] eq 1
+        } else {
+            fail "node 2 or node 3 didn't receive clusterbus publish packet"
+        }
+    }
+}


### PR DESCRIPTION
This issue affected only two message types (CLUSTERMSG_TYPE_PUBLISH and CLUSTERMSG_TYPE_PUBLISHSHARD) because they used a light message header, which caused the CLUSTER INFO stats to miss sent/received message information for those types.

---------

Cherry pick to 8.0 branch