### PR TITLE
Enable module API SendClusterMessage to use light message header type

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -195,11 +195,13 @@ dictType clusterSdsToListType = {
 typedef struct {
     enum {
         ITER_DICT,
-        ITER_LIST
+        ITER_LIST,
+        ITER_NODE,
     } type;
     union {
         dictIterator di;
         listIter li;
+        clusterNode *node;
     };
 } ClusterNodeIterator;
 
@@ -213,6 +215,11 @@ static void clusterNodeIterInitMyShard(ClusterNodeIterator *iter) {
     serverAssert(nodes != NULL);
     iter->type = ITER_LIST;
     listRewind(nodes, &iter->li);
+}
+
+static void clusterNodeIterNode(ClusterNodeIterator *iter, clusterNode *node) {
+    iter->type = ITER_NODE;
+    iter->node = node;
 }
 
 static clusterNode *clusterNodeIterNext(ClusterNodeIterator *iter) {
@@ -229,6 +236,15 @@ static clusterNode *clusterNodeIterNext(ClusterNodeIterator *iter) {
         /* Return the value associated with the node, or NULL if no more nodes */
         return ln ? listNodeValue(ln) : NULL;
     }
+
+    case ITER_NODE: {
+        if (iter->node) {
+            clusterNode *node = iter->node;
+            iter->node = NULL;
+            return node;
+        }
+        return NULL;
+    }
     }
     serverPanic("Unknown iterator type %d", iter->type);
 }
@@ -236,6 +252,8 @@ static clusterNode *clusterNodeIterNext(ClusterNodeIterator *iter) {
 static void clusterNodeIterReset(ClusterNodeIterator *iter) {
     if (iter->type == ITER_DICT) {
         dictResetIterator(&iter->di);
+    } else if (iter->type == ITER_NODE) {
+        iter->node = NULL;
     }
 }
 
@@ -3019,11 +3037,19 @@ static void clusterProcessPublishPacket(clusterMsgDataPublish *publish_data, uin
     }
 }
 
-static void clusterProcessLightPacket(clusterLink *link, uint16_t type) {
+static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {
     clusterMsgLight *hdr = (clusterMsgLight *)link->rcvbuf;
-
+    serverLog(LL_DEBUG, "Processing light packet of type: %s", clusterGetMessageTypeString(type));
     if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
         clusterProcessPublishPacket(&hdr->data.publish.msg, type);
+    } else if (type == CLUSTERMSG_TYPE_MODULE) {
+        uint64_t module_id = hdr->data.module.msg.module_id; /* Endian-safe ID */
+        uint32_t len = ntohl(hdr->data.module.msg.len);
+        uint8_t type = hdr->data.module.msg.type;
+        unsigned char *payload = hdr->data.module.msg.bulk_data;
+        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+    } else {
+        serverAssert(0);
     }
 }
 
@@ -3031,6 +3057,7 @@ static inline int messageTypeSupportsLightHdr(uint16_t type) {
     switch (type) {
     case CLUSTERMSG_TYPE_PUBLISH: return 1;
     case CLUSTERMSG_TYPE_PUBLISHSHARD: return 1;
+    case CLUSTERMSG_TYPE_MODULE: return 1;
     }
     return 0;
 }
@@ -3123,8 +3150,14 @@ int clusterIsValidPacket(clusterLink *link) {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
         explen += sizeof(clusterMsgDataUpdate);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
-        explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
-        explen += sizeof(clusterMsgModule) - 3 + ntohl(hdr->data.module.msg.len);
+        if (is_light) {
+            clusterMsgLight *hdr_light = (clusterMsgLight *)link->rcvbuf;
+            explen = sizeof(clusterMsgLight) - sizeof(union clusterMsgData);
+            explen += sizeof(clusterMsgModule) - 3 + ntohl(hdr_light->data.module.msg.len);
+        } else {
+            explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
+            explen += sizeof(clusterMsgModule) - 3 + ntohl(hdr->data.module.msg.len);
+        }
     } else {
         /* We don't know this type of packet, so we assume it's well formed. */
         explen = totlen;
@@ -3178,7 +3211,7 @@ int clusterProcessPacket(clusterLink *link) {
         }
         clusterNode *sender = link->node;
         sender->data_received = now;
-        clusterProcessLightPacket(link, type);
+        clusterProcessLightPacket(sender, link, type);
         return 1;
     }
 
@@ -4326,22 +4359,50 @@ void clusterSendUpdate(clusterLink *link, clusterNode *node) {
  *
  * If link is NULL, then the message is broadcasted to the whole cluster. */
 void clusterSendModule(clusterLink *link, uint64_t module_id, uint8_t type, const char *payload, uint32_t len) {
-    uint32_t msglen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
-    msglen += sizeof(clusterMsgModule) - 3 + len;
-    clusterMsgSendBlock *msgblock = createClusterMsgSendBlock(CLUSTERMSG_TYPE_MODULE, msglen);
+    clusterMsgSendBlock *msgblock = NULL, *msgblock_light = NULL;
+    ClusterNodeIterator iter;
 
-    clusterMsg *hdr = getMessageFromSendBlock(msgblock);
-    hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
-    hdr->data.module.msg.type = type;
-    hdr->data.module.msg.len = htonl(len);
-    memcpy(hdr->data.module.msg.bulk_data, payload, len);
-
-    if (link)
-        clusterSendMessage(link, msgblock);
-    else
-        clusterBroadcastMessage(msgblock);
-
-    clusterMsgSendBlockDecrRefCount(msgblock);
+    if (link) {
+        clusterNodeIterNode(&iter, link->node);
+    } else {
+        /* Broadcast to all the nodes. */
+        clusterNodeIterInitAllNodes(&iter);
+    }
+    clusterNode *node;
+    while ((node = clusterNodeIterNext(&iter)) != NULL) {
+        if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
+        if (nodeSupportsLightMsgHdr(node)) {
+            if (msgblock_light == NULL) {
+                uint32_t msglen_light = sizeof(clusterMsgLight) - sizeof(union clusterMsgData);
+                msglen_light += sizeof(clusterMsgModule) - 3 + len;
+                int msgtype_light = CLUSTERMSG_TYPE_MODULE;
+                msgtype_light |= CLUSTERMSG_LIGHT;
+                msgblock_light = createClusterMsgSendBlock(msgtype_light, msglen_light);
+                clusterMsgLight *hdr = getLightMessageFromSendBlock(msgblock_light);
+                hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
+                hdr->data.module.msg.type = type;
+                hdr->data.module.msg.len = htonl(len);
+                memcpy(hdr->data.module.msg.bulk_data, payload, len);
+            }
+            clusterSendMessage(node->link, msgblock_light);
+        } else {
+            if (msgblock == NULL) {
+                uint32_t msglen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
+                msglen += sizeof(clusterMsgModule) - 3 + len;
+                int msgtype = CLUSTERMSG_TYPE_MODULE;
+                msgblock = createClusterMsgSendBlock(msgtype, msglen);
+                clusterMsg *hdr = getMessageFromSendBlock(msgblock);
+                hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
+                hdr->data.module.msg.type = type;
+                hdr->data.module.msg.len = htonl(len);
+                memcpy(hdr->data.module.msg.bulk_data, payload, len);
+            }
+            clusterSendMessage(node->link, msgblock);
+        }
+    }
+    clusterNodeIterReset(&iter);
+    if (msgblock != NULL) clusterMsgSendBlockDecrRefCount(msgblock);
+    if (msgblock_light != NULL) clusterMsgSendBlockDecrRefCount(msgblock_light);
 }
 
 /* This function gets a cluster node ID string as target, the same way the nodes

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4400,8 +4400,7 @@ static clusterMsgSendBlock *createModuleMsgBlock(int64_t module_id, uint8_t type
  *
  * If link is NULL, then the message is broadcasted to the whole cluster. */
 void clusterSendModule(clusterLink *link, uint64_t module_id, uint8_t type, const char *payload, uint32_t len) {
-    clusterMsgSendBlock *msgblock[CLUSTERMSG_HDR_NUM];
-    memset(msgblock, 0, sizeof(msgblock));
+    clusterMsgSendBlock *msgblock[CLUSTERMSG_HDR_NUM] = {0};
     ClusterNodeIterator iter;
 
     if (link) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1006,7 +1006,7 @@ void clusterUpdateMyselfFlags(void) {
     int nofailover = server.cluster_replica_no_failover ? CLUSTER_NODE_NOFAILOVER : 0;
     myself->flags &= ~CLUSTER_NODE_NOFAILOVER;
     myself->flags |= nofailover;
-    myself->flags |= CLUSTER_NODE_LIGHT_HDR_SUPPORTED;
+    myself->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED | CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
     if (myself->flags != oldflags) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
     }
@@ -3228,10 +3228,16 @@ int clusterProcessPacket(clusterLink *link) {
 
     /* Checks if the node supports light message hdr */
     if (sender) {
-        if (flags & CLUSTER_NODE_LIGHT_HDR_SUPPORTED) {
-            sender->flags |= CLUSTER_NODE_LIGHT_HDR_SUPPORTED;
+        if (flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED) {
+            sender->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED;
         } else {
-            sender->flags &= ~CLUSTER_NODE_LIGHT_HDR_SUPPORTED;
+            sender->flags &= ~CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED;
+        }
+
+        if (flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED) {
+            sender->flags |= CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
+        } else {
+            sender->flags &= ~CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
         }
     }
 
@@ -4371,7 +4377,7 @@ void clusterSendModule(clusterLink *link, uint64_t module_id, uint8_t type, cons
     clusterNode *node;
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
-        if (nodeSupportsLightMsgHdr(node)) {
+        if (nodeSupportsLightMsgHdrForModule(node)) {
             if (msgblock_light == NULL) {
                 uint32_t msglen_light = sizeof(clusterMsgLight) - sizeof(union clusterMsgData);
                 msglen_light += sizeof(clusterMsgModule) - 3 + len;
@@ -4452,7 +4458,7 @@ void clusterPropagatePublish(robj *channel, robj *message, int sharded) {
     clusterNode *node;
     while ((node = clusterNodeIterNext(&iter)) != NULL) {
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
-        if (nodeSupportsLightMsgHdr(node)) {
+        if (nodeSupportsLightMsgHdrForPubSub(node)) {
             clusterSendMessage(node->link, msgblock_light);
         } else {
             if (msgblock == NULL) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3037,17 +3037,24 @@ static void clusterProcessPublishPacket(clusterMsgDataPublish *publish_data, uin
     }
 }
 
+static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNode *sender) {
+        if (!sender) return; /* Protect the module from unknown nodes. */
+        /* We need to route this message back to the right module subscribed
+         * for the right message type. */
+        uint64_t module_id = module_data->module_id; /* Endian-safe ID */
+        uint32_t len = ntohl(module_data->len);
+        uint8_t type = module_data->type;
+        unsigned char *payload = module_data->bulk_data;
+        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+}
+
 static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {
     clusterMsgLight *hdr = (clusterMsgLight *)link->rcvbuf;
     serverLog(LL_DEBUG, "Processing light packet of type: %s", clusterGetMessageTypeString(type));
     if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
         clusterProcessPublishPacket(&hdr->data.publish.msg, type);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
-        uint64_t module_id = hdr->data.module.msg.module_id; /* Endian-safe ID */
-        uint32_t len = ntohl(hdr->data.module.msg.len);
-        uint8_t type = hdr->data.module.msg.type;
-        unsigned char *payload = hdr->data.module.msg.bulk_data;
-        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+        clusterProcessModulePacket(&hdr->data.module.msg, sender);
     } else {
         serverAssert(0);
     }
@@ -3740,14 +3747,7 @@ int clusterProcessPacket(clusterLink *link) {
          * config accordingly. */
         clusterUpdateSlotsConfigWith(n, reportedConfigEpoch, hdr->data.update.nodecfg.slots);
     } else if (type == CLUSTERMSG_TYPE_MODULE) {
-        if (!sender) return 1; /* Protect the module from unknown nodes. */
-        /* We need to route this message back to the right module subscribed
-         * for the right message type. */
-        uint64_t module_id = hdr->data.module.msg.module_id; /* Endian-safe ID */
-        uint32_t len = ntohl(hdr->data.module.msg.len);
-        uint8_t type = hdr->data.module.msg.type;
-        unsigned char *payload = hdr->data.module.msg.bulk_data;
-        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+        clusterProcessModulePacket(&hdr->data.module.msg, sender);
     } else {
         serverLog(LL_WARNING, "Received unknown packet type: %d", type);
     }
@@ -4361,6 +4361,41 @@ void clusterSendUpdate(clusterLink *link, clusterNode *node) {
     clusterMsgSendBlockDecrRefCount(msgblock);
 }
 
+/* Create a MODULE message block.
+ *
+ * If is_light is 1, then build a message block with `clusterMsgLight` struct else `clusterMsg`. */
+static clusterMsgSendBlock *createModuleMsgBlock(int64_t module_id, uint8_t type, const char *payload, uint32_t len, int is_light) {
+    uint32_t msglen;
+    int msgtype;
+    clusterMsgSendBlock *msgblock;
+    clusterMsgModule *module_data;
+
+    if (is_light) {
+        msglen = sizeof(clusterMsgLight) - sizeof(union clusterMsgData);
+        msgtype = CLUSTERMSG_TYPE_MODULE | CLUSTERMSG_LIGHT;
+    } else {
+        msglen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
+        msgtype = CLUSTERMSG_TYPE_MODULE;
+    }
+    msglen += sizeof(clusterMsgModule) - 3 + len;
+    msgblock = createClusterMsgSendBlock(msgtype, msglen);
+
+    if (is_light) {
+        clusterMsgLight *hdr = getLightMessageFromSendBlock(msgblock);
+        module_data = &hdr->data.module.msg;
+    } else {
+        clusterMsg *hdr = getMessageFromSendBlock(msgblock);
+        module_data = &hdr->data.module.msg;
+    }
+
+    module_data->module_id = module_id;  /* Already endian adjusted */
+    module_data->type = type;
+    module_data->len = htonl(len);
+    memcpy(module_data->bulk_data, payload, len);
+
+    return msgblock;
+}
+
 /* Send a MODULE message.
  *
  * If link is NULL, then the message is broadcasted to the whole cluster. */
@@ -4379,29 +4414,12 @@ void clusterSendModule(clusterLink *link, uint64_t module_id, uint8_t type, cons
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_HANDSHAKE)) continue;
         if (nodeSupportsLightMsgHdrForModule(node)) {
             if (msgblock_light == NULL) {
-                uint32_t msglen_light = sizeof(clusterMsgLight) - sizeof(union clusterMsgData);
-                msglen_light += sizeof(clusterMsgModule) - 3 + len;
-                int msgtype_light = CLUSTERMSG_TYPE_MODULE;
-                msgtype_light |= CLUSTERMSG_LIGHT;
-                msgblock_light = createClusterMsgSendBlock(msgtype_light, msglen_light);
-                clusterMsgLight *hdr = getLightMessageFromSendBlock(msgblock_light);
-                hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
-                hdr->data.module.msg.type = type;
-                hdr->data.module.msg.len = htonl(len);
-                memcpy(hdr->data.module.msg.bulk_data, payload, len);
+                msgblock_light = createModuleMsgBlock(module_id, type, payload, len, 1);
             }
             clusterSendMessage(node->link, msgblock_light);
         } else {
             if (msgblock == NULL) {
-                uint32_t msglen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
-                msglen += sizeof(clusterMsgModule) - 3 + len;
-                int msgtype = CLUSTERMSG_TYPE_MODULE;
-                msgblock = createClusterMsgSendBlock(msgtype, msglen);
-                clusterMsg *hdr = getMessageFromSendBlock(msgblock);
-                hdr->data.module.msg.module_id = module_id; /* Already endian adjusted. */
-                hdr->data.module.msg.type = type;
-                hdr->data.module.msg.len = htonl(len);
-                memcpy(hdr->data.module.msg.bulk_data, payload, len);
+                msgblock = createModuleMsgBlock(module_id, type, payload, len, 0);
             }
             clusterSendMessage(node->link, msgblock);
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3038,14 +3038,14 @@ static void clusterProcessPublishPacket(clusterMsgDataPublish *publish_data, uin
 }
 
 static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNode *sender) {
-        if (!sender) return; /* Protect the module from unknown nodes. */
-        /* We need to route this message back to the right module subscribed
-         * for the right message type. */
-        uint64_t module_id = module_data->module_id; /* Endian-safe ID */
-        uint32_t len = ntohl(module_data->len);
-        uint8_t type = module_data->type;
-        unsigned char *payload = module_data->bulk_data;
-        moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+    if (!sender) return; /* Protect the module from unknown nodes. */
+    /* We need to route this message back to the right module subscribed
+     * for the right message type. */
+    uint64_t module_id = module_data->module_id; /* Endian-safe ID */
+    uint32_t len = ntohl(module_data->len);
+    uint8_t type = module_data->type;
+    unsigned char *payload = module_data->bulk_data;
+    moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
 }
 
 static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {
@@ -4388,7 +4388,7 @@ static clusterMsgSendBlock *createModuleMsgBlock(int64_t module_id, uint8_t type
         module_data = &hdr->data.module.msg;
     }
 
-    module_data->module_id = module_id;  /* Already endian adjusted */
+    module_data->module_id = module_id; /* Already endian adjusted */
     module_data->type = type;
     module_data->len = htonl(len);
     memcpy(module_data->bulk_data, payload, len);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -106,6 +106,14 @@ typedef struct clusterNodeFailReport {
 /* We check for the modifier bit to determine if the message is sent using light header.*/
 #define IS_LIGHT_MESSAGE(type) ((type) & CLUSTERMSG_LIGHT)
 
+/* Types of header supported over the cluster bus. */
+typedef enum {
+    CLUSTERMSG_HDR_NORMAL = 0, /* This corresponds to `clusterMsg` struct. */
+    CLUSTERMSG_HDR_LIGHT,      /* This corresponds to `clusterMsgLight` struct. */
+    CLUSTERMSG_HDR_NUM,        /* Overall count of header type supported. */
+} clusterMsgHdrType;
+
+
 /* Initially we don't know our "name", but we'll find it once we connect
  * to the first node, using the getsockname() function. Then we'll use this
  * address for all the next messages. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -53,7 +53,8 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_MIGRATE_TO (1 << 8)            /* Primary eligible for replica migration. */
 #define CLUSTER_NODE_NOFAILOVER (1 << 9)            /* Replica will not try to failover. */
 #define CLUSTER_NODE_EXTENSIONS_SUPPORTED (1 << 10) /* This node supports extensions. */
-#define CLUSTER_NODE_LIGHT_HDR_SUPPORTED (1 << 11)  /* This node supports light pubsub message header. */
+#define CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED (1 << 11)  /* This node supports light message header for publish type. */
+#define CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED (1 << 12)  /* This node supports light message header for module type. */
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \
     "\000\000\000\000\000\000\000\000\000\000\000\000"
@@ -67,7 +68,8 @@ typedef struct clusterLink {
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
-#define nodeSupportsLightMsgHdr(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_SUPPORTED)
+#define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
+#define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
 
 /* This structure represent elements of node->fail_reports. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -42,18 +42,18 @@ typedef struct clusterLink {
 } clusterLink;
 
 /* Cluster node flags and macros. */
-#define CLUSTER_NODE_PRIMARY (1 << 0)               /* The node is a primary */
-#define CLUSTER_NODE_REPLICA (1 << 1)               /* The node is a replica */
-#define CLUSTER_NODE_PFAIL (1 << 2)                 /* Failure? Need acknowledge */
-#define CLUSTER_NODE_FAIL (1 << 3)                  /* The node is believed to be malfunctioning */
-#define CLUSTER_NODE_MYSELF (1 << 4)                /* This node is myself */
-#define CLUSTER_NODE_HANDSHAKE (1 << 5)             /* We have still to exchange the first ping */
-#define CLUSTER_NODE_NOADDR (1 << 6)                /* We don't know the address of this node */
-#define CLUSTER_NODE_MEET (1 << 7)                  /* Send a MEET message to this node */
-#define CLUSTER_NODE_MIGRATE_TO (1 << 8)            /* Primary eligible for replica migration. */
-#define CLUSTER_NODE_NOFAILOVER (1 << 9)            /* Replica will not try to failover. */
-#define CLUSTER_NODE_EXTENSIONS_SUPPORTED (1 << 10) /* This node supports extensions. */
-#define CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED (1 << 11)  /* This node supports light message header for publish type. */
+#define CLUSTER_NODE_PRIMARY (1 << 0)                      /* The node is a primary */
+#define CLUSTER_NODE_REPLICA (1 << 1)                      /* The node is a replica */
+#define CLUSTER_NODE_PFAIL (1 << 2)                        /* Failure? Need acknowledge */
+#define CLUSTER_NODE_FAIL (1 << 3)                         /* The node is believed to be malfunctioning */
+#define CLUSTER_NODE_MYSELF (1 << 4)                       /* This node is myself */
+#define CLUSTER_NODE_HANDSHAKE (1 << 5)                    /* We have still to exchange the first ping */
+#define CLUSTER_NODE_NOADDR (1 << 6)                       /* We don't know the address of this node */
+#define CLUSTER_NODE_MEET (1 << 7)                         /* Send a MEET message to this node */
+#define CLUSTER_NODE_MIGRATE_TO (1 << 8)                   /* Primary eligible for replica migration. */
+#define CLUSTER_NODE_NOFAILOVER (1 << 9)                   /* Replica will not try to failover. */
+#define CLUSTER_NODE_EXTENSIONS_SUPPORTED (1 << 10)        /* This node supports extensions. */
+#define CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED (1 << 11) /* This node supports light message header for publish type. */
 #define CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED (1 << 12)  /* This node supports light message header for module type. */
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -113,7 +113,6 @@ typedef enum {
     CLUSTERMSG_HDR_NUM,        /* Overall count of header type supported. */
 } clusterMsgHdrType;
 
-
 /* Initially we don't know our "name", but we'll find it once we connect
  * to the first node, using the getsockname() function. Then we'll use this
  * address for all the next messages. */

--- a/src/module.c
+++ b/src/module.c
@@ -8982,6 +8982,8 @@ void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
 /* Send a message to all the nodes in the cluster if `target` is NULL, otherwise
  * at the specified target, which is a VALKEYMODULE_NODE_ID_LEN bytes node ID, as
  * returned by the receiver callback or by the nodes iteration functions.
+ * This API  uses lesser overhead if the target server support the light message header type (~30B)
+ * or else it uses the regular message overhead (~2KB).
  *
  * The function returns VALKEYMODULE_OK if the message was successfully sent,
  * otherwise if the node is not connected or such node ID does not map to any

--- a/src/module.c
+++ b/src/module.c
@@ -8982,8 +8982,9 @@ void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
 /* Send a message to all the nodes in the cluster if `target` is NULL, otherwise
  * at the specified target, which is a VALKEYMODULE_NODE_ID_LEN bytes node ID, as
  * returned by the receiver callback or by the nodes iteration functions.
- * This API  uses lesser overhead if the target server support the light message header type (~30B)
- * or else it uses the regular message overhead (~2KB).
+ *
+ * In Valkey 8.1 and later, the cluster protocol overhead for this message is
+ * ~30B, to compare with earlier versions where it's ~2KB.
  *
  * The function returns VALKEYMODULE_OK if the message was successfully sent,
  * otherwise if the node is not connected or such node ID does not map to any

--- a/tests/assets/minimal-cluster.conf
+++ b/tests/assets/minimal-cluster.conf
@@ -1,0 +1,8 @@
+# Minimal configuration for testing.
+always-show-logo yes
+daemonize no
+pidfile /var/run/valkey.pid
+loglevel verbose
+enable-debug-command yes
+cluster-enabled yes
+enable-module-command yes

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -34,39 +34,16 @@ int test_cluster_shards(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     return VALKEYMODULE_OK;
 }
 
-#define MSGTYPE_PING 1
-#define MSGTYPE_PONG 2
+#define MSGTYPE_DING 1
+#define MSGTYPE_DONG 2
 
 /* test.pingall */
-int PingallCommand_ValkeyCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
 
-    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_PING, "Hey", 3);
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_DING, "Hey", 3);
     return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
-}
-
-/* Callback for message MSGTYPE_PING */
-void PingReceiver(ValkeyModuleCtx *ctx,
-                  const char *sender_id,
-                  uint8_t type,
-                  const unsigned char *payload,
-                  uint32_t len) {
-    ValkeyModule_Log(ctx, "notice", "PING (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN,
-                     sender_id, (int)len, payload);
-    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_PONG, "Ohi!", 4);
-    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, "INCR", "c", "pings_received");
-    ValkeyModule_FreeCallReply(reply);
-}
-
-/* Callback for message MSGTYPE_PONG */
-void PongReceiver(ValkeyModuleCtx *ctx,
-                  const char *sender_id,
-                  uint8_t type,
-                  const unsigned char *payload,
-                  uint32_t len) {
-    ValkeyModule_Log(ctx, "notice", "PONG (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN,
-                     sender_id, (int)len, payload);
 }
 
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
@@ -76,7 +53,7 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_Init(ctx, "cluster", 1, VALKEYMODULE_APIVER_1)== VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    if (ValkeyModule_CreateCommand(ctx, "test.pingall", PingallCommand_ValkeyCommand, "readonly", 0, 0, 0) ==
+    if (ValkeyModule_CreateCommand(ctx, "test.pingall", PingallCommand, "readonly", 0, 0, 0) ==
         VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -34,12 +34,54 @@ int test_cluster_shards(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     return VALKEYMODULE_OK;
 }
 
+#define MSGTYPE_PING 1
+#define MSGTYPE_PONG 2
+
+/* test.pingall */
+int PingallCommand_ValkeyCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_PING, "Hey", 3);
+    return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+/* Callback for message MSGTYPE_PING */
+void PingReceiver(ValkeyModuleCtx *ctx,
+                  const char *sender_id,
+                  uint8_t type,
+                  const unsigned char *payload,
+                  uint32_t len) {
+    ValkeyModule_Log(ctx, "notice", "PING (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN,
+                     sender_id, (int)len, payload);
+    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_PONG, "Ohi!", 4);
+    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, "INCR", "c", "pings_received");
+    ValkeyModule_FreeCallReply(reply);
+}
+
+/* Callback for message MSGTYPE_PONG */
+void PongReceiver(ValkeyModuleCtx *ctx,
+                  const char *sender_id,
+                  uint8_t type,
+                  const unsigned char *payload,
+                  uint32_t len) {
+    ValkeyModule_Log(ctx, "notice", "PONG (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN,
+                     sender_id, (int)len, payload);
+}
+
+
+
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
 
     if (ValkeyModule_Init(ctx, "cluster", 1, VALKEYMODULE_APIVER_1)== VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "test.pingall", PingallCommand_ValkeyCommand, "readonly", 0, 0, 0) ==
+        VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
 
     if (ValkeyModule_CreateCommand(ctx, "test.cluster_slots", test_cluster_slots, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -69,8 +69,6 @@ void PongReceiver(ValkeyModuleCtx *ctx,
                      sender_id, (int)len, payload);
 }
 
-
-
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
@@ -81,7 +79,6 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_CreateCommand(ctx, "test.pingall", PingallCommand_ValkeyCommand, "readonly", 0, 0, 0) ==
         VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
-
 
     if (ValkeyModule_CreateCommand(ctx, "test.cluster_slots", test_cluster_slots, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -14,23 +14,12 @@ start_cluster 3 0 [list config_lines $modules] {
 
     test "Cluster module send message API - VM_SendClusterMessage" {
         assert_equal OK [$node1 test.pingall]
+        assert_equal 2 [CI 0 cluster_stats_messages_module_sent]
         wait_for_condition 50 100 {
-            [CI 0 cluster_stats_messages_module_sent] eq 2
-        } else {
-            puts [$node1 CLUSTER INFO]
-            puts [$node2 CLUSTER INFO]
-            puts [$node3 CLUSTER INFO]
-            fail "node 1 didn't send cluster module message to all nodes"
-        }
-        wait_for_condition 50 1000 {
-            [CI 1 cluster_stats_messages_module_received] eq 1
-        } else {
-            fail "node 2 didn't receive cluster module message"
-        }
-        wait_for_condition 50 1000 {
+            [CI 1 cluster_stats_messages_module_received] eq 1 &&
             [CI 2 cluster_stats_messages_module_received] eq 1
         } else {
-            fail "node 3 didn't receive cluster module message"
+            fail "node 2 or node 3 didn't receive cluster module message"
         }
     }
 }

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -5,6 +5,36 @@ source tests/support/cli.tcl
 # cluster creation is complicated with TLS, and the current tests don't really need that coverage
 tags {tls:skip external:skip cluster modules} {
 
+set testmodule [file normalize tests/modules/cluster.so]
+set modules [list loadmodule $testmodule]
+start_cluster 3 0 [list config_lines $modules] {
+    set node1 [srv 0 client]
+    set node2 [srv -1 client]
+    set node3 [srv -2 client]
+
+    test "Cluster module send message API - VM_SendClusterMessage" {
+        assert_equal OK [$node1 test.pingall]
+        wait_for_condition 50 100 {
+            [CI 0 cluster_stats_messages_module_sent] eq 2
+        } else {
+            puts [$node1 CLUSTER INFO]
+            puts [$node2 CLUSTER INFO]
+            puts [$node3 CLUSTER INFO]
+            fail "node 1 didn't send cluster module message to all nodes"
+        }
+        wait_for_condition 50 1000 {
+            [CI 1 cluster_stats_messages_module_received] eq 1
+        } else {
+            fail "node 2 didn't receive cluster module message"
+        }
+        wait_for_condition 50 1000 {
+            [CI 2 cluster_stats_messages_module_received] eq 1
+        } else {
+            fail "node 3 didn't receive cluster module message"
+        }
+    }
+}
+
 set testmodule_nokey [file normalize tests/modules/blockonbackground.so]
 set testmodule_blockedclient [file normalize tests/modules/blockedclient.so]
 set testmodule [file normalize tests/modules/blockonkeys.so]

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -5,7 +5,7 @@
 # To disable `SELECT` command to be ran on the server.
 set ::singledb 1
 
-tags {external:skip cluster modules} {
+tags {external:skip needs:other-server cluster modules} {
 
 # To run this test use the `--other-server-path` parameter and pass in a compatible server path supporting
 # SendClusterMessage module API. 

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -1,0 +1,61 @@
+# Test cross version compatibility of cluster.
+#
+# Use minimal.conf to make sure we don't use any configs not supported on the old version.
+
+# To disable `SELECT` command to be ran on the server.
+set ::singledb 1
+
+tags {external:skip cluster modules} {
+
+# To run this test use the `--other-server-path` parameter and pass in a compatible server path supporting
+# SendClusterMessage module API. 
+#
+# ./runtest-moduleapi --single unit/moduleapi/cross-version-cluster --other-server-path tests/tmp/valkey-8-0/valkey-server
+#
+# Test cross version compatibility of cluster module send message API.
+start_server {config "minimal-cluster.conf" start-other-server 1} {
+    set testmodule [file normalize tests/modules/cluster.so]
+    r MODULE LOAD $testmodule
+    set other_node_name [r CLUSTER MYID]
+
+    start_server {config "minimal-cluster.conf"} {
+        r MODULE LOAD $testmodule
+
+        test "set up cluster" {
+            r CLUSTER MEET [srv -1 host] [srv -1 port] 
+
+            # Link establishment requires few PING-PONG between two nodes
+            wait_for_condition 50 100 {
+                [string match {*handshake*} [r CLUSTER NODES]] eq 0 &&
+                [string match {*handshake*} [r -1 CLUSTER NODES]] eq 0
+            } else {
+                puts [r CLUSTER NODES]
+                puts [r -1 CLUSTER NODES]
+                fail "Cluster meet stuck in handshake state"
+            }
+        }
+
+        test "Send cluster message via module from latest to other server" {
+            assert_equal OK [r test.pingall]
+            assert_match "*cluster_stats_messages_module_sent:1*" [r CLUSTER INFO]
+            wait_for_condition 50 100 {
+                [string match {*cluster_stats_messages_module_received:1*} [r -1 CLUSTER INFO]]
+            } else {
+                fail "Node didn't receive the message"
+            }
+        }
+
+        test "Send cluster message via module from other server to latest" {
+            r CONFIG resetstat
+            r -1 CONFIG resetstat
+            assert_equal OK [r -1 test.pingall]
+            assert_match "*cluster_stats_messages_module_sent:1*" [r -1 CLUSTER INFO]
+            wait_for_condition 50 100 {
+                [string match {*cluster_stats_messages_module_received:1*} [r CLUSTER INFO]]
+            } else {
+                fail "Node didn't receive the message"
+            }
+        }
+    }
+}
+}

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -7,58 +7,57 @@ set old_singledb $::singledb
 set ::singledb 1
 
 tags {external:skip needs:other-server cluster modules} {
-
-# To run this test use the `--other-server-path` parameter and pass in a compatible server path supporting
-# SendClusterMessage module API. 
-#
-# ./runtest-moduleapi --single unit/moduleapi/cross-version-cluster --other-server-path tests/tmp/valkey-8-0/valkey-server
-#
-# Test cross version compatibility of cluster module send message API.
-start_server {config "minimal-cluster.conf" start-other-server 1} {
-    set testmodule [file normalize tests/modules/cluster.so]
-    r MODULE LOAD $testmodule
-    set other_node_name [r CLUSTER MYID]
-
-    start_server {config "minimal-cluster.conf"} {
+    # To run this test use the `--other-server-path` parameter and pass in a compatible server path supporting
+    # SendClusterMessage module API.
+    #
+    # ./runtest-moduleapi --single unit/moduleapi/cross-version-cluster --other-server-path tests/tmp/valkey-8-0/valkey-server
+    #
+    # Test cross version compatibility of cluster module send message API.
+    start_server {config "minimal-cluster.conf" start-other-server 1} {
+        set testmodule [file normalize tests/modules/cluster.so]
         r MODULE LOAD $testmodule
+        set other_node_name [r CLUSTER MYID]
 
-        test "set up cluster" {
-            r CLUSTER MEET [srv -1 host] [srv -1 port] 
+        start_server {config "minimal-cluster.conf"} {
+            r MODULE LOAD $testmodule
 
-            # Link establishment requires few PING-PONG between two nodes
-            wait_for_condition 50 100 {
-                [string match {*handshake*} [r CLUSTER NODES]] eq 0 &&
-                [string match {*handshake*} [r -1 CLUSTER NODES]] eq 0
-            } else {
-                puts [r CLUSTER NODES]
-                puts [r -1 CLUSTER NODES]
-                fail "Cluster meet stuck in handshake state"
+            test "set up cluster" {
+                r CLUSTER MEET [srv -1 host] [srv -1 port]
+
+                # Link establishment requires few PING-PONG between two nodes
+                wait_for_condition 50 100 {
+                    [string match {*handshake*} [r CLUSTER NODES]] eq 0 &&
+                    [string match {*handshake*} [r -1 CLUSTER NODES]] eq 0
+                } else {
+                    puts [r CLUSTER NODES]
+                    puts [r -1 CLUSTER NODES]
+                    fail "Cluster meet stuck in handshake state"
+                }
             }
-        }
 
-        test "Send cluster message via module from latest to other server" {
-            assert_equal OK [r test.pingall]
-            assert_match "*cluster_stats_messages_module_sent:1*" [r CLUSTER INFO]
-            wait_for_condition 50 100 {
-                [string match {*cluster_stats_messages_module_received:1*} [r -1 CLUSTER INFO]]
-            } else {
-                fail "Node didn't receive the message"
+            test "Send cluster message via module from latest to other server" {
+                assert_equal OK [r test.pingall]
+                assert_match "*cluster_stats_messages_module_sent:1*" [r CLUSTER INFO]
+                wait_for_condition 50 100 {
+                    [string match {*cluster_stats_messages_module_received:1*} [r -1 CLUSTER INFO]]
+                } else {
+                    fail "Node didn't receive the message"
+                }
             }
-        }
 
-        test "Send cluster message via module from other server to latest" {
-            r CONFIG resetstat
-            r -1 CONFIG resetstat
-            assert_equal OK [r -1 test.pingall]
-            assert_match "*cluster_stats_messages_module_sent:1*" [r -1 CLUSTER INFO]
-            wait_for_condition 50 100 {
-                [string match {*cluster_stats_messages_module_received:1*} [r CLUSTER INFO]]
-            } else {
-                fail "Node didn't receive the message"
+            test "Send cluster message via module from other server to latest" {
+                r CONFIG resetstat
+                r -1 CONFIG resetstat
+                assert_equal OK [r -1 test.pingall]
+                assert_match "*cluster_stats_messages_module_sent:1*" [r -1 CLUSTER INFO]
+                wait_for_condition 50 100 {
+                    [string match {*cluster_stats_messages_module_received:1*} [r CLUSTER INFO]]
+                } else {
+                    fail "Node didn't receive the message"
+                }
             }
         }
     }
-}
 }
 
 set ::singledb $old_singledb

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -2,7 +2,8 @@
 #
 # Use minimal.conf to make sure we don't use any configs not supported on the old version.
 
-# To disable `SELECT` command to be ran on the server.
+# make sure the test infra won't use SELECT
+set old_singledb $::singledb
 set ::singledb 1
 
 tags {external:skip needs:other-server cluster modules} {
@@ -59,3 +60,5 @@ start_server {config "minimal-cluster.conf" start-other-server 1} {
     }
 }
 }
+
+set ::singledb $old_singledb


### PR DESCRIPTION
This change uses the light message header for cluster module message type to be sent to a target node or broadcast across the cluster. The light message header was introduced in Valkey 8 to reduce network in/out over clusterbus and have been already used for pub/sub message transfer. It's only used if the target node supports the light message header (~30B) otherwise it falls back to using the regular header (~2KB). The module API `VM_SendClusterMessage` remains as is. 