### PR TITLE
Add support for MustObeyClient Module API

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3719,6 +3719,14 @@ ValkeyModuleString *VM_GetClientUserNameById(ValkeyModuleCtx *ctx, uint64_t id) 
     return str;
 }
 
+/* Returns 1 if commands are arriving from the primary client or AOF client
+ * and should never be rejected.
+ * Returns 0 otherwise (and also if ctx or if the client is NULL). */
+int VM_MustObeyClient(ValkeyModuleCtx *ctx) {
+    if (!ctx || !ctx->client) return 0;
+    return mustObeyClient(ctx->client);
+}
+
 /* This is a helper for VM_GetClientInfoById() and other functions: given
  * a client, it populates the client info structure with the appropriate
  * fields depending on the version provided. If the version is not valid
@@ -13839,6 +13847,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ChannelAtPosWithFlags);
     REGISTER_API(GetClientId);
     REGISTER_API(GetClientUserNameById);
+    REGISTER_API(MustObeyClient);
     REGISTER_API(GetContextFlags);
     REGISTER_API(AvoidReplicaTraffic);
     REGISTER_API(PoolAlloc);

--- a/src/module.c
+++ b/src/module.c
@@ -3721,6 +3721,8 @@ ValkeyModuleString *VM_GetClientUserNameById(ValkeyModuleCtx *ctx, uint64_t id) 
 
 /* Returns 1 if commands are arriving from the primary client or AOF client
  * and should never be rejected.
+ * This check can be used in places such as skipping validation of commands
+ * on replicas (to not diverge from primary) or from AOF files.
  * Returns 0 otherwise (and also if ctx or if the client is NULL). */
 int VM_MustObeyClient(ValkeyModuleCtx *ctx) {
     if (!ctx || !ctx->client) return 0;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int (*ValkeyModule_MustObeyClient) (ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;                                                             
+VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;                                                                        
+VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;                                                             
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;                                                                        
+VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;                                                                        
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int (*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_MustObeyClient) (ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,6 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;                                                                        
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1317,7 +1317,7 @@ VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(ValkeyModuleCtx *ctx
 VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(ValkeyModuleCtx *ctx,
                                                                            uint64_t id)VALKEYMODULE_ATTR;
-VALKEYMODULE_API int *(*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_MustObeyClient)(ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id) VALKEYMODULE_ATTR;
 VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(ValkeyModuleCtx *ctx,
                                                                        uint64_t id)VALKEYMODULE_ATTR;
@@ -1943,6 +1943,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(ChannelAtPosWithFlags);
     VALKEYMODULE_GET_API(GetClientId);
     VALKEYMODULE_GET_API(GetClientUserNameById);
+    VALKEYMODULE_GET_API(MustObeyClient);
     VALKEYMODULE_GET_API(GetContextFlags);
     VALKEYMODULE_GET_API(AvoidReplicaTraffic);
     VALKEYMODULE_GET_API(PoolAlloc);

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -406,9 +406,9 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
             return VALKEYMODULE_ERR;
 
     if (ValkeyModule_CreateCommand(ctx,"propagate-test.obeyed",
-        propagateTestObeyed,
-        "",1,1,1) == VALKEYMODULE_ERR)
-    return VALKEYMODULE_ERR;
+                propagateTestObeyed,
+                "",1,1,1) == VALKEYMODULE_ERR)
+            return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/propagate.c
+++ b/tests/modules/propagate.c
@@ -310,11 +310,26 @@ int propagateTestNestedCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, 
     return VALKEYMODULE_OK;
 }
 
+/* Counter to track "propagate-test.incr" commands which were obeyed (due to being replicated or processed from AOF). */
+static long long obeyed_cmds = 0;
+
+/* Handles the "propagate-test.obeyed" command to return the `obeyed_cmds` count. */
+int propagateTestObeyed(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    ValkeyModule_ReplyWithLongLong(ctx, obeyed_cmds);
+    return VALKEYMODULE_OK;
+}
+
 int propagateTestIncr(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
 {
     VALKEYMODULE_NOT_USED(argc);
     ValkeyModuleCallReply *reply;
 
+    /* Track the number of commands which are "obeyed". */
+    if (ValkeyModule_MustObeyClient(ctx)) {
+        obeyed_cmds += 1;
+    }
     /* This test propagates the module command, not the INCR it executes. */
     reply = ValkeyModule_Call(ctx, "INCR", "s", argv[1]);
     ValkeyModule_ReplyWithCallReply(ctx,reply);
@@ -389,6 +404,11 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
                 propagateTestIncr,
                 "write",1,1,1) == VALKEYMODULE_ERR)
             return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx,"propagate-test.obeyed",
+        propagateTestObeyed,
+        "",1,1,1) == VALKEYMODULE_ERR)
+    return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;
 }

--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -583,6 +583,7 @@ tags "modules" {
                     after 110
 
                     set repl [attach_to_replication_stream]
+                    assert_equal [$replica propagate-test.obeyed] 0
                     $master propagate-test.incr k1
 
                     assert_replication_stream $repl {
@@ -598,6 +599,10 @@ tags "modules" {
                     assert_equal [$master ttl k1] -1
                     assert_equal [$replica get k1] 1
                     assert_equal [$replica ttl k1] -1
+                    # Validate that replicated commands were "obeyed" from primary.
+                    assert_equal [$replica propagate-test.obeyed] 1
+                    $master propagate-test.incr k1
+                    assert_equal [$replica propagate-test.obeyed] 2
                 }
 
                 test {module notification on set} {


### PR DESCRIPTION
This PR adds support for MustObeyClient Module API.

The purpose of this API is for Modules to handle commands / callbacks knowing whether commands are arriving from the primary client or AOF client and should never be rejected.

A use case is that Modules can have validation logic in command handlers which only should be executed on primary nodes. Replica nodes must obey commands replicated.