### PR TITLE
Lower latenct-monitor-threashold in expire-cycle test case

### DIFF
--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -143,11 +143,7 @@ tags {"needs:debug"} {
 } ;# tag
 
     test {LATENCY of expire events are correctly collected} {
-<<<<<<< Updated upstream
-        r config set latency-monitor-threshold 5
-=======
-        r config set latency-monitor-threshold 2
->>>>>>> Stashed changes
+        r config set latency-monitor-threshold 1
         r config set lazyfree-lazy-expire no
         r flushdb
         if {$::valgrind} {set count 100000} else {set count 1000000}

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -143,7 +143,11 @@ tags {"needs:debug"} {
 } ;# tag
 
     test {LATENCY of expire events are correctly collected} {
-        r config set latency-monitor-threshold 20
+<<<<<<< Updated upstream
+        r config set latency-monitor-threshold 5
+=======
+        r config set latency-monitor-threshold 2
+>>>>>>> Stashed changes
         r config set lazyfree-lazy-expire no
         r flushdb
         if {$::valgrind} {set count 100000} else {set count 1000000}


### PR DESCRIPTION
The test case checks for expire-cycle in LATENCY LATEST, but with the new hash table, the expiry-cycle is too fast to be logged by latency monitor. Lower the latency monitor threshold to make it more likely to be logged.

Fixes #1580