### PR TITLE
Fix Protocol desync regression test

### DIFF
--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -69,7 +69,7 @@ start_server {tags {"protocol network"}} {
     }
 
     set c 0
-    foreach seq [list "\x00" "*\x00" "$\x00"] {
+    foreach seq [list "\x00" "*\x00" "$\x00" "*1\r\n$\x00"] {
         incr c
         test "Protocol desync regression test #$c" {
             if {$::tls} {
@@ -88,6 +88,8 @@ start_server {tags {"protocol network"}} {
                     puts -nonewline $s $payload
                     flush $s
                 }]} {
+                    set retval [gets $s]
+                    puts "got error response from client: $retval"
                     puts "exception after writing $payload_size bytes"
                     assert_morethan $payload_size $PROTO_INLINE_MAX_SIZE
                     break

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -79,6 +79,8 @@ start_server {tags {"protocol network"}} {
             }
             fconfigure $s -blocking 0
             puts -nonewline $s $seq
+            # PROTO_INLINE_MAX_SIZE is hardcoded in Valkey code to 64K. doing the same here 
+            # since we would like to validate it is enforced. 
             set PROTO_INLINE_MAX_SIZE [expr 1024 * 64]
             set payload [string repeat A 1024]"\n"
             set payload_size 0

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -88,7 +88,6 @@ start_server {tags {"protocol network"}} {
                     puts -nonewline $s $payload
                     flush $s
                 }]} {
-                    puts "exception after writing $payload_size bytes"
                     assert_morethan $payload_size $PROTO_INLINE_MAX_SIZE
                     break
                 }

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -94,7 +94,7 @@ start_server {tags {"protocol network"}} {
                 }
             }
            
-            wait_for_condition 5 10 {
+            wait_for_condition 50 100 {
                 [string match {*Protocol error*} [gets $s]]
             } else {
                 fail "expected connection to be closed on protocol error after sending $payload_size bytes"


### PR DESCRIPTION
The desync regression test was created as a regression test for the following bug:
in case we embed NULL termination inside inline/multi-bulk message we will not be able to perform strchr in order to 
identify the newline(\n)/carriage-return(\r) in the client query buffer. this can influence (for example) replica reading primary stream and keep filling it's query buffer endlessly consuming more and more memory. 

In order to handle the above risk, a check was added to verify the inline bulk and multi-bulk size are not exceeding the 64K bytes in the query-buffer. A test was placed in order to verify this.

This PR introduce the following fixes to the desync regression test:
1. fix the sent payload to flush 1024 bytes block of 'A's  instead of 'payload' which was sent by mistake.
2. Make sure that the connection is correctly terminated on protocol error by the server after exceeding the 64K and not over 64K.
3. add another test intrinsic which will also verify the nested bulk with embedded null termination (was not verified before)

fixes https://github.com/valkey-io/valkey/issues/1583


NOTE: Although it is possible to change the use of strchr to a more "safe" utility (eg memchr) which will not pause scan at first occurrence of '\0', we still like to protect against over excessive usage of the query buffer and also preserve the current behavior(?). We will look into improving this though in a followup issue.