### PR TITLE
Add approximate usec percentage per command

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5430,7 +5430,24 @@ const char *getSafeInfoString(const char *s, size_t len, char **tmp) {
     return memmapchars(new, len, unsafe_info_chars, unsafe_info_chars_substs, sizeof(unsafe_info_chars) - 1);
 }
 
-sds genValkeyInfoStringCommandStats(sds info, hashtable *commands) {
+long long getTotalCommandUsec(hashtable *commands) {
+    hashtableIterator iter;
+    void *next;
+    long long total_usec = 0;
+    hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
+    while (hashtableNext(&iter, &next)) {
+        struct serverCommand *cmd = next;
+        total_usec += cmd->microseconds;
+        if (cmd->subcommands_ht) {
+            total_usec += getTotalCommandUsec(cmd->subcommands_ht);
+        }
+    }
+    hashtableResetIterator(&iter);
+
+    return total_usec;
+}
+
+sds genValkeyInfoStringCommandStats(sds info, hashtable *commands, long long total_usec) {
     hashtableIterator iter;
     void *next;
     hashtableInitIterator(&iter, commands, HASHTABLE_ITER_SAFE);
@@ -5439,15 +5456,16 @@ sds genValkeyInfoStringCommandStats(sds info, hashtable *commands) {
         char *tmpsafe;
         if (c->calls || c->failed_calls || c->rejected_calls) {
             info = sdscatprintf(info,
-                                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f"
+                                "cmdstat_%s:calls=%lld,usec=%lld,usec_per_call=%.2f,approx_usec_perc=%lld"
                                 ",rejected_calls=%lld,failed_calls=%lld\r\n",
                                 getSafeInfoString(c->fullname, sdslen(c->fullname), &tmpsafe), c->calls,
                                 c->microseconds, (c->calls == 0) ? 0 : ((float)c->microseconds / c->calls),
+                                (c->microseconds == 0) ? 0 : (c->microseconds * 100 / total_usec),
                                 c->rejected_calls, c->failed_calls);
             if (tmpsafe != NULL) zfree(tmpsafe);
         }
         if (c->subcommands_ht) {
-            info = genValkeyInfoStringCommandStats(info, c->subcommands_ht);
+            info = genValkeyInfoStringCommandStats(info, c->subcommands_ht, total_usec);
         }
     }
     hashtableResetIterator(&iter);
@@ -6114,7 +6132,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
     if (all_sections || (dictFind(section_dict, "commandstats") != NULL)) {
         if (sections++) info = sdscat(info, "\r\n");
         info = sdscatprintf(info, "# Commandstats\r\n");
-        info = genValkeyInfoStringCommandStats(info, server.commands);
+        long long total_command_usec = getTotalCommandUsec(server.commands);
+        info = genValkeyInfoStringCommandStats(info, server.commands, total_command_usec);
     }
 
     /* Error statistics */


### PR DESCRIPTION
## Background
https://github.com/valkey-io/valkey/issues/1619

## Changes
- Add a function for calculating total command usec time
- With total usec, caculate approximate usec percentage
  - Don't need to use floating point-level accuracy because it's just hint for identifying occupied commands.

## Sample screenshot

<img width="789" alt="Screenshot 2025-01-27 at 12 27 24 PM" src="https://github.com/user-attachments/assets/53a8dad8-1471-4125-85a2-f60a010a16d0" />

### Concern
A recursive function is used when calculating the total command time, but there may be a better way. Please give me feedback.
