### PR TITLE
add parameter for initiating bgrewriteaof on exceeding maximum AOF size

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1011,16 +1011,22 @@ int startAppendOnly(void) {
  * the first call is short, there is a end-of-space condition, so the next
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
- * there is an actual error condition we'll get it at the next try. */
-ssize_t aofWrite(int fd, const char *buf, size_t len) {
-    ssize_t nwritten = 0, totwritten = 0;
+ * there is an actual error condition we'll get it at the next try.
+ * We also check for aof-max-size limit here returning "no space" on exceed. */
+ssize_t aofWrite(int fd, const char *buf, size_t len, off_t aof_current_size, unsigned long long aof_max_size) {
+    ssize_t nwritten = 0, totwritten = 0, nonewritten = -1;
+
+    if (aof_max_size && (unsigned long long)aof_current_size >= aof_max_size) {
+        errno = ENOSPC;
+        return nonewritten;
+    }
 
     while (len) {
         nwritten = write(fd, buf, len);
 
         if (nwritten < 0) {
             if (errno == EINTR) continue;
-            return totwritten ? totwritten : -1;
+            return totwritten ? totwritten : nonewritten;
         }
 
         len -= nwritten;
@@ -1120,7 +1126,7 @@ void flushAppendOnlyFile(int force) {
     }
 
     latencyStartMonitor(latency);
-    nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf));
+    nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf), server.aof_current_size, server.aof_max_size);
     latencyEndMonitor(latency);
     /* We want to capture different events for delayed writes:
      * when the delay happens with a pending fsync, or with a saving child

--- a/src/aof.c
+++ b/src/aof.c
@@ -1012,12 +1012,13 @@ int startAppendOnly(void) {
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
  * there is an actual error condition we'll get it at the next try.
- * We also check for aof-max-size limit here returning "no space" on exceed. */
-ssize_t aofWrite(int fd, const char *buf, size_t len, off_t aof_current_size, unsigned long long aof_max_size) {
-    ssize_t nwritten = 0, totwritten = 0, nonewritten = -1;
+ * We also check for aof-max-size limit here returning custom error on exceed. */
+ssize_t aofWrite(int fd, const char *buf, size_t len, off_t aof_current_size, size_t aof_max_size) {
+    ssize_t nwritten = 0, totwritten = 0;
+    const ssize_t nonewritten = -1;
 
-    if (aof_max_size && (unsigned long long)aof_current_size >= aof_max_size) {
-        errno = ENOSPC;
+    if (aof_max_size && aof_current_size >= 0 && (size_t)aof_current_size >= aof_max_size) {
+        errno = EFBIG;
         return nonewritten;
     }
 
@@ -1162,7 +1163,7 @@ void flushAppendOnlyFile(int force) {
         /* Log the AOF write error and record the error code. */
         if (nwritten == -1) {
             if (can_log) {
-                serverLog(LL_WARNING, "Error writing to the AOF file: %s", strerror(errno));
+                serverLog(LL_WARNING, "Error writing to the AOF file: %s", getAofWriteErrStr(errno));
             }
             server.aof_last_write_errno = errno;
         } else {

--- a/src/aof.c
+++ b/src/aof.c
@@ -917,7 +917,7 @@ void aof_background_fsync_and_close(int fd) {
 void killAppendOnlyChild(void) {
     int statloc;
     /* No AOFRW child? return. */
-    if (server.child_type != CHILD_TYPE_AOF) return;
+    if (!isAofRewriteInProgress()) return;
     /* Kill AOFRW child, wait for child exit. */
     serverLog(LL_NOTICE, "Killing running AOF rewrite child: %ld", (long)server.child_pid);
     if (kill(server.child_pid, SIGUSR1) != -1) {
@@ -964,7 +964,7 @@ int startAppendOnly(void) {
     serverAssert(server.aof_state == AOF_OFF);
 
     server.aof_state = AOF_WAIT_REWRITE;
-    if (hasActiveChildProcess() && server.child_type != CHILD_TYPE_AOF) {
+    if (hasActiveChildProcess() && !isAofRewriteInProgress()) {
         server.aof_rewrite_scheduled = 1;
         serverLog(LL_NOTICE, "AOF was enabled but there is already another background operation. An AOF background was "
                              "scheduled to start when possible.");
@@ -976,7 +976,7 @@ int startAppendOnly(void) {
         /* If there is a pending AOF rewrite, we need to switch it off and
          * start a new one: the old one cannot be reused because it is not
          * accumulating the AOF buffer. */
-        if (server.child_type == CHILD_TYPE_AOF) {
+        if (isAofRewriteInProgress()) {
             serverLog(LL_NOTICE, "AOF was enabled but there is already an AOF rewriting in background. Stopping "
                                  "background AOF and starting a rewrite now.");
             killAppendOnlyChild();
@@ -1012,14 +1012,20 @@ int startAppendOnly(void) {
  * is likely to fail. However apparently in modern systems this is no longer
  * true, and in general it looks just more resilient to retry the write. If
  * there is an actual error condition we'll get it at the next try.
- * We also check for aof-max-size limit here returning custom error on exceed. */
-ssize_t aofWrite(int fd, const char *buf, size_t len, off_t aof_current_size, size_t aof_max_size) {
+ * We also run bgrewriteaof on aof-max-size exceeding here. */
+ssize_t aofWrite(int fd, const char *buf, size_t len) {
     ssize_t nwritten = 0, totwritten = 0;
-    const ssize_t nonewritten = -1;
 
-    if (aof_max_size && aof_current_size >= 0 && (size_t)aof_current_size >= aof_max_size) {
-        errno = EFBIG;
-        return nonewritten;
+    if (!isAofRewriteInProgress() &&
+        server.aof_max_size &&
+        server.aof_current_size >= server.aof_max_size &&
+        server.aof_rewrite_base_size < server.aof_max_size) {
+        /* 1. no need to start already initiated rewrite
+           2. aof-max-size == 0 turns off this
+           3. size should be large enough
+           4. last rewrite success should be less than aof-max-size - or we might end up with eternal rewrites
+        */
+        rewriteAppendOnlyFileBackground();
     }
 
     while (len) {
@@ -1027,7 +1033,7 @@ ssize_t aofWrite(int fd, const char *buf, size_t len, off_t aof_current_size, si
 
         if (nwritten < 0) {
             if (errno == EINTR) continue;
-            return totwritten ? totwritten : nonewritten;
+            return totwritten ? totwritten : -1;
         }
 
         len -= nwritten;
@@ -1127,7 +1133,7 @@ void flushAppendOnlyFile(int force) {
     }
 
     latencyStartMonitor(latency);
-    nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf), server.aof_current_size, server.aof_max_size);
+    nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf));
     latencyEndMonitor(latency);
     /* We want to capture different events for delayed writes:
      * when the delay happens with a pending fsync, or with a saving child
@@ -1163,7 +1169,7 @@ void flushAppendOnlyFile(int force) {
         /* Log the AOF write error and record the error code. */
         if (nwritten == -1) {
             if (can_log) {
-                serverLog(LL_WARNING, "Error writing to the AOF file: %s", getAofWriteErrStr(errno));
+                serverLog(LL_WARNING, "Error writing to the AOF file: %s", strerror(errno));
             }
             server.aof_last_write_errno = errno;
         } else {
@@ -1356,7 +1362,7 @@ void feedAppendOnlyFile(int dictid, robj **argv, int argc) {
     /* Append to the AOF buffer. This will be flushed on disk just before
      * of re-entering the event loop, so before the client will get a
      * positive reply about the operation performed. */
-    if (server.aof_state == AOF_ON || (server.aof_state == AOF_WAIT_REWRITE && server.child_type == CHILD_TYPE_AOF)) {
+    if (server.aof_state == AOF_ON || (server.aof_state == AOF_WAIT_REWRITE && isAofRewriteInProgress())) {
         server.aof_buf = sdscatlen(server.aof_buf, buf, sdslen(buf));
     }
 
@@ -2467,7 +2473,7 @@ int rewriteAppendOnlyFileBackground(void) {
 }
 
 void bgrewriteaofCommand(client *c) {
-    if (server.child_type == CHILD_TYPE_AOF) {
+    if (isAofRewriteInProgress()) {
         addReplyError(c, "Background append only file rewriting already in progress");
     } else if (hasActiveChildProcess() || server.in_exec) {
         server.aof_rewrite_scheduled = 1;

--- a/src/config.c
+++ b/src/config.c
@@ -3348,6 +3348,7 @@ standardConfig static_configs[] = {
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),
     createULongLongConfig("cluster-link-sendbuf-limit", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.cluster_link_msg_queue_limit_bytes, 0, MEMORY_CONFIG, NULL, NULL),
+    createULongLongConfig("aof-max-size", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.aof_max_size, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Size_t configs */
     createSizeTConfig("hash-max-listpack-entries", "hash-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_entries, 512, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.c
+++ b/src/config.c
@@ -3348,7 +3348,6 @@ standardConfig static_configs[] = {
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),
     createULongLongConfig("cluster-link-sendbuf-limit", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.cluster_link_msg_queue_limit_bytes, 0, MEMORY_CONFIG, NULL, NULL),
-    createULongLongConfig("aof-max-size", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.aof_max_size, 0, INTEGER_CONFIG, NULL, NULL),
 
     /* Size_t configs */
     createSizeTConfig("hash-max-listpack-entries", "hash-max-ziplist-entries", MODIFIABLE_CONFIG, 0, LONG_MAX, server.hash_max_listpack_entries, 512, INTEGER_CONFIG, NULL, NULL),
@@ -3368,6 +3367,7 @@ standardConfig static_configs[] = {
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
+    createOffTConfig("aof-max-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_max_size, 0, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
 
     /* Tls configs */

--- a/src/script.c
+++ b/src/script.c
@@ -179,7 +179,7 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx,
                                         "Writable scripts are blocked. Use 'no-writes' flag for read only scripts. "
                                         "AOF error: %s",
                                         server.extended_redis_compat ? "Redis" : SERVER_TITLE,
-                                        strerror(server.aof_last_write_errno));
+                                        getAofWriteErrStr(server.aof_last_write_errno));
                 return C_ERR;
             }
 

--- a/src/script.c
+++ b/src/script.c
@@ -179,7 +179,7 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx,
                                         "Writable scripts are blocked. Use 'no-writes' flag for read only scripts. "
                                         "AOF error: %s",
                                         server.extended_redis_compat ? "Redis" : SERVER_TITLE,
-                                        getAofWriteErrStr(server.aof_last_write_errno));
+                                        strerror(server.aof_last_write_errno));
                 return C_ERR;
             }
 

--- a/src/server.c
+++ b/src/server.c
@@ -5990,10 +5990,17 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "module_fork_last_cow_size:%zu\r\n", server.stat_module_cow_bytes));
 
         if (server.aof_enabled) {
+            char aof_current_size_hdsk[64];
+            char aof_max_size_hdsk[64];
+            bytesToHuman(aof_current_size_hdsk, sizeof(aof_current_size_hdsk), (unsigned long long)server.aof_current_size);
+            bytesToHuman(aof_max_size_hdsk, sizeof(aof_max_size_hdsk), server.aof_max_size);
             info = sdscatprintf(
                 info,
                 FMTARGS(
                     "aof_current_size:%lld\r\n", (long long)server.aof_current_size,
+                    "aof_current_size_human:%s\r\n", aof_current_size_hdsk,
+                    "aof_max_size:%lld\r\n", server.aof_max_size,
+                    "aof_max_size_human:%s\r\n", aof_max_size_hdsk,
                     "aof_base_size:%lld\r\n", (long long)server.aof_rewrite_base_size,
                     "aof_pending_rewrite:%d\r\n", server.aof_rewrite_scheduled,
                     "aof_buffer_length:%zu\r\n", sdslen(server.aof_buf),
@@ -7309,6 +7316,14 @@ __attribute__((weak)) int main(int argc, char **argv) {
                   "WARNING: You specified a maxmemory value that is less than 1MB (current value is %llu bytes). Are "
                   "you sure this is what you really want?",
                   server.maxmemory);
+    }
+
+    /* Warning the user about suspicious aof-max-size setting. */
+    if (server.aof_max_size > 0 && server.aof_max_size < 1024 * 1024) {
+        serverLog(LL_WARNING,
+                  "WARNING: You specified a aof-max-size value that is less than 1MB (current value is %llu bytes). Are "
+                  "you sure this is what you really want?",
+                  server.aof_max_size);
     }
 
     serverSetCpuAffinity(server.server_cpulist);

--- a/src/server.c
+++ b/src/server.c
@@ -4769,13 +4769,17 @@ int writeCommandsDeniedByDiskError(void) {
     return DISK_ERROR_TYPE_NONE;
 }
 
+char *getAofWriteErrStr(int error_code) {
+    return (error_code == EFBIG) ? "Reached aof-max-size" : strerror(error_code);
+}
+
 sds writeCommandsGetDiskErrorMessage(int error_code) {
     sds ret = NULL;
     if (error_code == DISK_ERROR_TYPE_RDB) {
         ret = sdsdup(shared.bgsaveerr->ptr);
     } else {
         ret = sdscatfmt(sdsempty(), "-MISCONF Errors writing to the AOF file: %s\r\n",
-                        strerror(server.aof_last_write_errno));
+                        getAofWriteErrStr(server.aof_last_write_errno));
     }
     return ret;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -1392,7 +1392,7 @@ void checkChildrenDone(void) {
         } else if (pid == server.child_pid) {
             if (server.child_type == CHILD_TYPE_RDB) {
                 backgroundSaveDoneHandler(exitcode, bysignal);
-            } else if (server.child_type == CHILD_TYPE_AOF) {
+            } else if (isAofRewriteInProgress()) {
                 backgroundRewriteDoneHandler(exitcode, bysignal);
             } else if (server.child_type == CHILD_TYPE_MODULE) {
                 ModuleForkDoneHandler(exitcode, bysignal);
@@ -2624,6 +2624,10 @@ int createSocketAcceptHandler(connListener *sfd, aeFileProc *accept_handler) {
         }
     }
     return C_OK;
+}
+
+int isAofRewriteInProgress(void) {
+    return server.child_type == CHILD_TYPE_AOF;
 }
 
 /* Initialize a set of file descriptors to listen to the specified 'port'
@@ -4656,7 +4660,7 @@ int finishShutdown(void) {
 
     /* Kill the AOF saving child as the AOF we already have may be longer
      * but contains the full dataset anyway. */
-    if (server.child_type == CHILD_TYPE_AOF) {
+    if (isAofRewriteInProgress()) {
         /* If we have AOF enabled but haven't written the AOF yet, don't
          * shutdown or else the dataset will be lost. */
         if (server.aof_state == AOF_WAIT_REWRITE) {
@@ -4769,17 +4773,13 @@ int writeCommandsDeniedByDiskError(void) {
     return DISK_ERROR_TYPE_NONE;
 }
 
-char *getAofWriteErrStr(int error_code) {
-    return (error_code == EFBIG) ? "Reached aof-max-size" : strerror(error_code);
-}
-
 sds writeCommandsGetDiskErrorMessage(int error_code) {
     sds ret = NULL;
     if (error_code == DISK_ERROR_TYPE_RDB) {
         ret = sdsdup(shared.bgsaveerr->ptr);
     } else {
         ret = sdscatfmt(sdsempty(), "-MISCONF Errors writing to the AOF file: %s\r\n",
-                        getAofWriteErrStr(server.aof_last_write_errno));
+                        strerror(server.aof_last_write_errno));
     }
     return ret;
 }
@@ -5981,10 +5981,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
                 "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
                 "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
-                "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
+                "aof_rewrite_in_progress:%d\r\n", isAofRewriteInProgress(),
                 "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,
                 "aof_last_rewrite_time_sec:%jd\r\n", (intmax_t)server.aof_rewrite_time_last,
-                "aof_current_rewrite_time_sec:%jd\r\n", (intmax_t)((server.child_type != CHILD_TYPE_AOF) ? -1 : time(NULL) - server.aof_rewrite_time_start),
+                "aof_current_rewrite_time_sec:%jd\r\n", (intmax_t)((!isAofRewriteInProgress()) ? -1 : time(NULL) - server.aof_rewrite_time_start),
                 "aof_last_bgrewrite_status:%s\r\n", (server.aof_lastbgrewrite_status == C_OK ? "ok" : "err"),
                 "aof_rewrites:%lld\r\n", server.stat_aof_rewrites,
                 "aof_rewrites_consecutive_failures:%lld\r\n", server.stat_aofrw_consecutive_failures,
@@ -5997,13 +5997,13 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             char aof_current_size_hdsk[64];
             char aof_max_size_hdsk[64];
             bytesToHuman(aof_current_size_hdsk, sizeof(aof_current_size_hdsk), (unsigned long long)server.aof_current_size);
-            bytesToHuman(aof_max_size_hdsk, sizeof(aof_max_size_hdsk), server.aof_max_size);
+            bytesToHuman(aof_max_size_hdsk, sizeof(aof_max_size_hdsk), (unsigned long long)server.aof_max_size);
             info = sdscatprintf(
                 info,
                 FMTARGS(
                     "aof_current_size:%lld\r\n", (long long)server.aof_current_size,
                     "aof_current_size_human:%s\r\n", aof_current_size_hdsk,
-                    "aof_max_size:%lld\r\n", server.aof_max_size,
+                    "aof_max_size:%lld\r\n", (long long)server.aof_max_size,
                     "aof_max_size_human:%s\r\n", aof_max_size_hdsk,
                     "aof_base_size:%lld\r\n", (long long)server.aof_rewrite_base_size,
                     "aof_pending_rewrite:%d\r\n", server.aof_rewrite_scheduled,
@@ -7325,9 +7325,9 @@ __attribute__((weak)) int main(int argc, char **argv) {
     /* Warning the user about suspicious aof-max-size setting. */
     if (server.aof_max_size > 0 && server.aof_max_size < 1024 * 1024) {
         serverLog(LL_WARNING,
-                  "WARNING: You specified a aof-max-size value that is less than 1MB (current value is %llu bytes). Are "
+                  "WARNING: You specified a aof-max-size value that is less than 1MB (current value is %lld bytes). Are "
                   "you sure this is what you really want?",
-                  server.aof_max_size);
+                  (long long)server.aof_max_size);
     }
 
     serverSetCpuAffinity(server.server_cpulist);

--- a/src/server.h
+++ b/src/server.h
@@ -1857,6 +1857,7 @@ struct valkeyServer {
     off_t aof_rewrite_min_size;         /* the AOF file is at least N bytes. */
     off_t aof_rewrite_base_size;        /* AOF size on latest startup or rewrite. */
     off_t aof_current_size;             /* AOF current size (Including BASE + INCRs). */
+    unsigned long long aof_max_size;    /* Max number of disk bytes to use for AOF */
     off_t aof_last_incr_size;           /* The size of the latest incr AOF. */
     off_t aof_last_incr_fsync_offset;   /* AOF offset which is already requested to be synced to disk.
                                          * Compare with the aof_last_incr_size. */

--- a/src/server.h
+++ b/src/server.h
@@ -3032,6 +3032,7 @@ int allPersistenceDisabled(void);
 #define DISK_ERROR_TYPE_RDB 2  /* Don't accept writes: RDB errors. */
 #define DISK_ERROR_TYPE_NONE 0 /* No problems, we can accept writes. */
 int writeCommandsDeniedByDiskError(void);
+char *getAofWriteErrStr(int);
 sds writeCommandsGetDiskErrorMessage(int);
 
 /* RDB persistence */

--- a/src/server.h
+++ b/src/server.h
@@ -1857,7 +1857,7 @@ struct valkeyServer {
     off_t aof_rewrite_min_size;         /* the AOF file is at least N bytes. */
     off_t aof_rewrite_base_size;        /* AOF size on latest startup or rewrite. */
     off_t aof_current_size;             /* AOF current size (Including BASE + INCRs). */
-    unsigned long long aof_max_size;    /* Max number of disk bytes to use for AOF */
+    off_t aof_max_size;                 /* Max number of disk bytes to use for AOF */
     off_t aof_last_incr_size;           /* The size of the latest incr AOF. */
     off_t aof_last_incr_fsync_offset;   /* AOF offset which is already requested to be synced to disk.
                                          * Compare with the aof_last_incr_size. */
@@ -3032,7 +3032,6 @@ int allPersistenceDisabled(void);
 #define DISK_ERROR_TYPE_RDB 2  /* Don't accept writes: RDB errors. */
 #define DISK_ERROR_TYPE_NONE 0 /* No problems, we can accept writes. */
 int writeCommandsDeniedByDiskError(void);
-char *getAofWriteErrStr(int);
 sds writeCommandsGetDiskErrorMessage(int);
 
 /* RDB persistence */
@@ -3045,6 +3044,7 @@ void flushAppendOnlyFile(int force);
 void feedAppendOnlyFile(int dictid, robj **argv, int argc);
 void aofRemoveTempFile(pid_t childpid, int from_signal);
 int rewriteAppendOnlyFileBackground(void);
+int isAofRewriteInProgress(void);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -16,9 +16,9 @@ start_server {tags {"external:skip"}} {
     set master_host [srv 0 host]
     set master_port [srv 0 port]
 
-    test "Low aof-max-size stops writing AOF with ENOSPC" {
+    test "Low aof-max-size stops writing AOF with EFBIG" {
         setup
-        wait_for_log_messages 0 {"*Error writing to the AOF file: No space left on device*"} 0 100 10
+        wait_for_log_messages 0 {"*Error writing to the AOF file: Reached aof-max-size*"} 0 100 10
         cleanup
     }
 
@@ -29,7 +29,7 @@ start_server {tags {"external:skip"}} {
         set len1 [getInfoProperty $info1 aof_buffer_length]
 
         catch {r set somelongerkey somelongrvalue} err
-        assert {$err eq "MISCONF Errors writing to the AOF file: No space left on device"}
+        assert {$err eq "MISCONF Errors writing to the AOF file: Reached aof-max-size"}
         assert_equal [r get somelongerkey] ""
 
         set info2 [r info]

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -1,0 +1,61 @@
+start_server {tags {"aof-max-size" "external:skip"}} {
+    r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
+    r config set appendonly yes ; # enable AOF
+
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    test "Low aof-max-size stops writing AOF with ENOSPC" {
+        r set k v
+        r config set aof-max-size 1
+
+        r set k2 v2
+        wait_for_log_messages 0 {"*Error writing to the AOF file: No space left on device*"} 0 100 10
+    }
+
+    test "New write attempts fail and doesn't insrease AOF buffer anymore" {
+        set info1 [r info]
+        set buf1 [getInfoProperty $info1 mem_aof_buffer]
+        set len1 [getInfoProperty $info1 aof_buffer_length]
+
+        catch {r set somelongerkey somelongervalue} err
+        assert {$err eq "MISCONF Errors writing to the AOF file: No space left on device"}
+        assert_equal [r get somelongerkey] ""
+
+        set info2 [r info]
+        set buf2 [getInfoProperty $info2 mem_aof_buffer]
+        set len2 [getInfoProperty $info2 aof_buffer_length]
+        assert_equal $buf1 $buf2
+        assert_equal $len1 $len2
+    }
+
+    test "Increasing aof-max-size fixes AOF write error" {
+        r config set aof-max-size 1000
+        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} 0 100 10
+
+        assert_equal [r set k3 v3] "OK"
+        assert_equal [r get k3] "v3"
+    }
+
+    test "Meeting aof-max-size does not prevent AOF rewrite" {
+        set loglines [count_log_lines 0] ; # want to check new line, not from previous test
+        
+        # start write load
+        set load_handle0 [start_write_load $master_host $master_port 10]
+        wait_for_condition 50 100 {
+            [r dbsize] > 0
+        } else {
+            fail "No write load detected."
+        }
+
+        waitForBgrewriteaof r
+        r bgrewriteaof
+        wait_for_log_messages 0 {"*Background AOF rewrite finished successfully*"} $loglines 100 10
+        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} $loglines 100 10
+
+        # stop write load
+        stop_write_load $load_handle0
+        wait_load_handlers_disconnected
+    }
+}

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -1,25 +1,34 @@
-start_server {tags {"aof-max-size" "external:skip"}} {
+proc setup {{size 1}} {
+    r set k v
+    r config set aof-max-size $size
+    r set k2 v2
+}
+
+proc cleanup {} {
+    r config set aof-max-size 0
+    r flushall
+}
+
+start_server {tags {"external:skip"}} {
     r config set auto-aof-rewrite-percentage 0 ; # disable auto-rewrite
     r config set appendonly yes ; # enable AOF
 
-    set master [srv 0 client]
     set master_host [srv 0 host]
     set master_port [srv 0 port]
 
     test "Low aof-max-size stops writing AOF with ENOSPC" {
-        r set k v
-        r config set aof-max-size 1
-
-        r set k2 v2
+        setup
         wait_for_log_messages 0 {"*Error writing to the AOF file: No space left on device*"} 0 100 10
+        cleanup
     }
 
-    test "New write attempts fail and doesn't insrease AOF buffer anymore" {
+    test "New write attempts when limited with aof-max-size fail and doesn't insrease AOF buffer anymore" {
+        setup
         set info1 [r info]
         set buf1 [getInfoProperty $info1 mem_aof_buffer]
         set len1 [getInfoProperty $info1 aof_buffer_length]
 
-        catch {r set somelongerkey somelongervalue} err
+        catch {r set somelongerkey somelongrvalue} err
         assert {$err eq "MISCONF Errors writing to the AOF file: No space left on device"}
         assert_equal [r get somelongerkey] ""
 
@@ -28,34 +37,28 @@ start_server {tags {"aof-max-size" "external:skip"}} {
         set len2 [getInfoProperty $info2 aof_buffer_length]
         assert_equal $buf1 $buf2
         assert_equal $len1 $len2
+        cleanup
     }
 
     test "Increasing aof-max-size fixes AOF write error" {
+        setup
+        set loglines [count_log_lines 0] ; # want to check new line, not from previous test
         r config set aof-max-size 1000
-        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} 0 100 10
+        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} $loglines 100 10
 
         assert_equal [r set k3 v3] "OK"
         assert_equal [r get k3] "v3"
+        cleanup
     }
 
     test "Meeting aof-max-size does not prevent AOF rewrite" {
+        setup 200
         set loglines [count_log_lines 0] ; # want to check new line, not from previous test
-        
-        # start write load
-        set load_handle0 [start_write_load $master_host $master_port 10]
-        wait_for_condition 50 100 {
-            [r dbsize] > 0
-        } else {
-            fail "No write load detected."
-        }
 
         waitForBgrewriteaof r
         r bgrewriteaof
         wait_for_log_messages 0 {"*Background AOF rewrite finished successfully*"} $loglines 100 10
         wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} $loglines 100 10
-
-        # stop write load
-        stop_write_load $load_handle0
-        wait_load_handlers_disconnected
+        cleanup
     }
 }

--- a/tests/unit/aof-max-size.tcl
+++ b/tests/unit/aof-max-size.tcl
@@ -16,49 +16,11 @@ start_server {tags {"external:skip"}} {
     set master_host [srv 0 host]
     set master_port [srv 0 port]
 
-    test "Low aof-max-size stops writing AOF with EFBIG" {
+    test "Low aof-max-size starts AOF rewrite" {
         setup
-        wait_for_log_messages 0 {"*Error writing to the AOF file: Reached aof-max-size*"} 0 100 10
-        cleanup
-    }
-
-    test "New write attempts when limited with aof-max-size fail and doesn't insrease AOF buffer anymore" {
-        setup
-        set info1 [r info]
-        set buf1 [getInfoProperty $info1 mem_aof_buffer]
-        set len1 [getInfoProperty $info1 aof_buffer_length]
-
-        catch {r set somelongerkey somelongrvalue} err
-        assert {$err eq "MISCONF Errors writing to the AOF file: Reached aof-max-size"}
-        assert_equal [r get somelongerkey] ""
-
-        set info2 [r info]
-        set buf2 [getInfoProperty $info2 mem_aof_buffer]
-        set len2 [getInfoProperty $info2 aof_buffer_length]
-        assert_equal $buf1 $buf2
-        assert_equal $len1 $len2
-        cleanup
-    }
-
-    test "Increasing aof-max-size fixes AOF write error" {
-        setup
-        set loglines [count_log_lines 0] ; # want to check new line, not from previous test
-        r config set aof-max-size 1000
-        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} $loglines 100 10
-
-        assert_equal [r set k3 v3] "OK"
-        assert_equal [r get k3] "v3"
-        cleanup
-    }
-
-    test "Meeting aof-max-size does not prevent AOF rewrite" {
-        setup 200
-        set loglines [count_log_lines 0] ; # want to check new line, not from previous test
-
-        waitForBgrewriteaof r
-        r bgrewriteaof
-        wait_for_log_messages 0 {"*Background AOF rewrite finished successfully*"} $loglines 100 10
-        wait_for_log_messages 0 {"*AOF write error looks solved. The server can write again.*"} $loglines 100 10
+        wait_for_log_messages 0 {"*Background append only file rewriting started*"} 0 100 10
+        r set k3 v3
         cleanup
     }
 }
+

--- a/valkey.conf
+++ b/valkey.conf
@@ -1696,6 +1696,9 @@ aof-use-rdb-preamble yes
 # the AOF format in a way that may not be compatible with existing AOF parsers.
 aof-timestamp-enabled no
 
+# Maximum size for AOF files on disk in bytes. Ignored, if set to 0.
+aof-max-size 0 
+
 ################################ SHUTDOWN #####################################
 
 # Maximum time to wait for replicas when shutting down, in seconds.


### PR DESCRIPTION
there are some scenarios of filling up the whole disk besides any chosen AOF rewrite strategy - the simplest is this:
- we have auto-aof-rewrite-percentage 100,
- and last automatic rewrite compacted AOF to 51% of disk,
-> we'll never try again.

we can lower auto-percentage, but in some cases it's not what we want to. I suggest that we add soft upper limit in this PR:
- if no AOF rewrite is running currently,
- and limit is set in config,
- and AOF exceed the limit,
- and last rewrite compacted AOF to somewhat smaller than limit (otherwise we might end up with useless attempts of uninterrupted rewrites)
-> bgrewriteaof is initiated.

this doesn't completely solves the problem, but gives some additional possibilities for some users to improve the situation initially described in #540 (noticed that solution from the issue seems to be inappropriate for some cases)