### PR TITLE
Fix timing issue in pause test

### DIFF
--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -7,7 +7,7 @@ start_server {tags {"pause network"}} {
         assert_equal [s paused_actions] "write"
         after 1000
         set timeout [s paused_timeout_milliseconds]
-        assert {$timeout > 0 && $timeout < 9000}
+        assert {$timeout > 0 && $timeout <= 9000}
         r client unpause
 
         r multi


### PR DESCRIPTION
The wait might execute exactly in 1000ms, which means there are still 9000ms left of the timeout, so we need to do less than or equal to in the comparison.

https://github.com/valkey-io/valkey/actions/runs/13000845302/job/36259020129