### PR TITLE
Hex encode the data in dump test

### DIFF
--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -125,16 +125,16 @@ start_server {tags {"dump"}} {
     } {} {needs:repl}
 
     test {RESTORE key with future RDB version, strict version check} {
-        #              str len    RDB 222 CRC64 checksum
-        #               |   |      |       |
+        #              str len  "bar"      RDB 222 CRC64 checksum
+        #               |   |     |         |       |
         set bar_dump "\x00\x03\x62\x61\x72\xde\x00\x0fYUza\xd3\xec\xe0"
         assert_error {ERR DUMP payload version or checksum are wrong} {r restore foo 0 $bar_dump replace}
     }
 
     test {RESTORE key with future RDB version, relaxed version check} {
-        #              str len    RDB 222 CRC64 checksum
-        #               |   |      |       |
         r config set rdb-version-check relaxed 
+        #               |type|len|           |  RDB  |      CRC64        |
+        #               |str | 3 |   "bar"   |  222  |     checksum      |
         r restore foo 0 "\x00\x03\x62\x61\x72\xde\x00\x0fYUza\xd3\xec\xe0" replace
         r config set rdb-version-check strict
         assert_equal {bar} [r get foo]

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -127,20 +127,18 @@ start_server {tags {"dump"}} {
     test {RESTORE key with future RDB version, strict version check} {
         #              str len    RDB 222 CRC64 checksum
         #               |   |      |       |
-        set bar_dump "\x00\x03bar\xde\x00\x0fYUza\xd3\xec\xe0"
-       assert_error {ERR DUMP payload version or checksum are wrong} {r restore foo 0 $bar_dump replace}
+        set bar_dump "\x00\x03\x62\x61\x72\xde\x00\x0fYUza\xd3\xec\xe0"
+        assert_error {ERR DUMP payload version or checksum are wrong} {r restore foo 0 $bar_dump replace}
     }
 
     test {RESTORE key with future RDB version, relaxed version check} {
         #              str len    RDB 222 CRC64 checksum
         #               |   |      |       |
-        set bar_dump "\x00\x03bar\xde\x00\x0fYUza\xd3\xec\xe0"
-        r config set rdb-version-check relaxed
-        catch {r restore foo 0 $bar_dump replace} e
+        r config set rdb-version-check relaxed 
+        r restore foo 0 "\x00\x03\x62\x61\x72\xde\x00\x0fYUza\xd3\xec\xe0" replace
         r config set rdb-version-check strict
         assert_equal {bar} [r get foo]
-        set e
-    } {OK}
+    }
 
     test {DUMP of non existing key returns nil} {
         r dump nonexisting_key


### PR DESCRIPTION
Addresses the failure here: https://github.com/valkey-io/valkey/actions/runs/13000845302/job/36259016156#step:5:7272.

This change does three things:
1. For some reason TCL 8.5 (which is used on macos) is handling `\x03ba` as `\0xba`, according to https://www.tcl-lang.org/man/tcl8.5/TclCmd/Tcl.htm#M27 so we encode "bar" using hex escapes too.
2. Fix a spacing issue. 
3. Make it so that if the restore fails, it immediately errors. 