### PR TITLE
Fix a heap-use-after-free bug in cluster bus

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1721,14 +1721,16 @@ void freeClusterNode(clusterNode *n) {
     nodename = sdsnewlen(n->name, CLUSTER_NAMELEN);
     serverAssert(dictDelete(server.cluster->nodes, nodename) == DICT_OK);
     sdsfree(nodename);
-    sdsfree(n->hostname);
-    sdsfree(n->human_nodename);
-    sdsfree(n->announce_client_ipv4);
-    sdsfree(n->announce_client_ipv6);
 
     /* Release links and associated data structures. */
     if (n->link) freeClusterLink(n->link);
     if (n->inbound_link) freeClusterLink(n->inbound_link);
+
+    /* Free these members after links are freed, as freeClusterLink may access them. */
+    sdsfree(n->hostname);
+    sdsfree(n->human_nodename);
+    sdsfree(n->announce_client_ipv4);
+    sdsfree(n->announce_client_ipv6);
     listRelease(n->fail_reports);
     zfree(n->replicas);
     zfree(n);


### PR DESCRIPTION
https://github.com/valkey-io/valkey/issues/1642

A heap-use-after-free is found in cluster bus code.

freeClusterNode free the human_nodename. https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L1725
Then it calls freeClusterLink to free the links. https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L1730
freeClusterLink print human_nodename here, which just got freed by the caller freeClusterNode. https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L1383