### PR TITLE
Opaque robj: add get/set methods and remove all robj->ptr refs

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1450,7 +1450,7 @@ void ACLInit(void) {
  *  ENOENT: if the specified user does not exist at all.
  */
 int ACLCheckUserCredentials(robj *username, robj *password) {
-    user *u = ACLGetUserByName(username->ptr, sdslen(username->ptr));
+    user *u = ACLGetUserByName(objectGetVal(username), sdslen(objectGetVal(username)));
     if (u == NULL) {
         errno = ENOENT;
         return C_ERR;
@@ -1470,7 +1470,7 @@ int ACLCheckUserCredentials(robj *username, robj *password) {
     listIter li;
     listNode *ln;
     listRewind(u->passwords, &li);
-    sds hashed = ACLHashPassword(password->ptr, sdslen(password->ptr));
+    sds hashed = ACLHashPassword(objectGetVal(password), sdslen(objectGetVal(password)));
     while ((ln = listNext(&li))) {
         sds thispass = listNodeValue(ln);
         if (!time_independent_strcmp(hashed, thispass, HASH_PASSWORD_LEN)) {
@@ -1493,7 +1493,7 @@ void addAuthErrReply(client *c, robj *err) {
         addReplyError(c, "-WRONGPASS invalid username-password pair or user is disabled.");
         return;
     }
-    addReplyError(c, err->ptr);
+    addReplyError(c, objectGetVal(err));
 }
 
 /* This is like ACLCheckUserCredentials(), however if the user/pass
@@ -1504,11 +1504,11 @@ void addAuthErrReply(client *c, robj *err) {
 int checkPasswordBasedAuth(client *c, robj *username, robj *password) {
     if (ACLCheckUserCredentials(username, password) == C_OK) {
         c->flag.authenticated = 1;
-        c->user = ACLGetUserByName(username->ptr, sdslen(username->ptr));
+        c->user = ACLGetUserByName(objectGetVal(username), sdslen(objectGetVal(username)));
         moduleNotifyUserChanged(c);
         return AUTH_OK;
     } else {
-        addACLLogEntry(c, ACL_DENIED_AUTH, (c->flag.multi) ? ACL_LOG_CTX_MULTI : ACL_LOG_CTX_TOPLEVEL, 0, username->ptr,
+        addACLLogEntry(c, ACL_DENIED_AUTH, (c->flag.multi) ? ACL_LOG_CTX_MULTI : ACL_LOG_CTX_TOPLEVEL, 0, objectGetVal(username),
                        NULL);
         return AUTH_ERR;
     }
@@ -1711,7 +1711,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
             while (1) {
                 if (selector->allowed_firstargs[id][subid] == NULL) return ACL_DENIED_CMD;
                 int idx = cmd->parent ? 2 : 1;
-                if (!strcasecmp(argv[idx]->ptr, selector->allowed_firstargs[id][subid]))
+                if (!strcasecmp(objectGetVal(argv[idx]), selector->allowed_firstargs[id][subid]))
                     break; /* First argument match found. Stop here. */
                 subid++;
             }
@@ -1730,7 +1730,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
         keyReference *resultidx = result->keys;
         for (int j = 0; j < result->numkeys; j++) {
             int idx = resultidx[j].pos;
-            ret = ACLSelectorCheckKey(selector, argv[idx]->ptr, sdslen(argv[idx]->ptr), resultidx[j].flags);
+            ret = ACLSelectorCheckKey(selector, objectGetVal(argv[idx]), sdslen(objectGetVal(argv[idx])), resultidx[j].flags);
             if (ret != ACL_OK) {
                 if (keyidxptr) *keyidxptr = resultidx[j].pos;
                 return ret;
@@ -1751,7 +1751,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
             if (!(channelref[j].flags & channel_flags)) continue;
             int is_pattern = channelref[j].flags & CMD_CHANNEL_PATTERN;
             int ret =
-                ACLCheckChannelAgainstList(selector->channels, argv[idx]->ptr, sdslen(argv[idx]->ptr), is_pattern);
+                ACLCheckChannelAgainstList(selector->channels, objectGetVal(argv[idx]), sdslen(objectGetVal(argv[idx])), is_pattern);
             if (ret != ACL_OK) {
                 if (keyidxptr) *keyidxptr = channelref[j].pos;
                 getKeysFreeResult(&channels);
@@ -1964,7 +1964,7 @@ int ACLShouldKillPubsubClient(client *c, list *upcoming) {
         dictEntry *de;
         while (!kill && ((de = dictNext(di)) != NULL)) {
             o = dictGetKey(de);
-            int res = ACLCheckChannelAgainstList(upcoming, o->ptr, sdslen(o->ptr), 1);
+            int res = ACLCheckChannelAgainstList(upcoming, objectGetVal(o), sdslen(objectGetVal(o)), 1);
             kill = (res == ACL_DENIED_CHANNEL);
         }
         dictReleaseIterator(di);
@@ -1976,7 +1976,7 @@ int ACLShouldKillPubsubClient(client *c, list *upcoming) {
 
             while (!kill && ((de = dictNext(di)) != NULL)) {
                 o = dictGetKey(de);
-                int res = ACLCheckChannelAgainstList(upcoming, o->ptr, sdslen(o->ptr), 0);
+                int res = ACLCheckChannelAgainstList(upcoming, objectGetVal(o), sdslen(objectGetVal(o)), 0);
                 kill = (res == ACL_DENIED_CHANNEL);
             }
             dictReleaseIterator(di);
@@ -1986,7 +1986,7 @@ int ACLShouldKillPubsubClient(client *c, list *upcoming) {
             di = dictGetIterator(c->pubsub_data->pubsubshard_channels);
             while (!kill && ((de = dictNext(di)) != NULL)) {
                 o = dictGetKey(de);
-                int res = ACLCheckChannelAgainstList(upcoming, o->ptr, sdslen(o->ptr), 0);
+                int res = ACLCheckChannelAgainstList(upcoming, objectGetVal(o), sdslen(objectGetVal(o)), 0);
                 kill = (res == ACL_DENIED_CHANNEL);
             }
             dictReleaseIterator(di);
@@ -2485,7 +2485,7 @@ int ACLSaveToFile(const char *filename) {
         user = sdscatsds(user, u->name);
         user = sdscatlen(user, " ", 1);
         robj *descr = ACLDescribeUser(u);
-        user = sdscatsds(user, descr->ptr);
+        user = sdscatsds(user, objectGetVal(descr));
         decrRefCount(descr);
         acl = sdscatsds(acl, user);
         acl = sdscatlen(acl, "\n", 1);
@@ -2677,9 +2677,9 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     } else {
         switch (reason) {
         case ACL_DENIED_CMD: le->object = sdsdup(c->cmd->fullname); break;
-        case ACL_DENIED_KEY: le->object = sdsdup(c->argv[argpos]->ptr); break;
-        case ACL_DENIED_CHANNEL: le->object = sdsdup(c->argv[argpos]->ptr); break;
-        case ACL_DENIED_AUTH: le->object = sdsdup(c->argv[0]->ptr); break;
+        case ACL_DENIED_KEY: le->object = sdsdup(objectGetVal(c->argv[argpos])); break;
+        case ACL_DENIED_CHANNEL: le->object = sdsdup(objectGetVal(c->argv[argpos])); break;
+        case ACL_DENIED_AUTH: le->object = sdsdup(objectGetVal(c->argv[0])); break;
         default: le->object = sdsempty();
         }
     }
@@ -2843,7 +2843,7 @@ int aclAddReplySelectorDescription(client *c, aclSelector *s) {
  * ACL LOG [<count> | RESET]
  */
 void aclCommand(client *c) {
-    char *sub = c->argv[1]->ptr;
+    char *sub = objectGetVal(c->argv[1]);
     if (!strcasecmp(sub, "setuser") && c->argc >= 3) {
         /* Initially redact all of the arguments to not leak any information
          * about the user. */
@@ -2851,7 +2851,7 @@ void aclCommand(client *c) {
             redactClientCommandArgument(c, j);
         }
 
-        sds username = c->argv[2]->ptr;
+        sds username = objectGetVal(c->argv[2]);
         /* Check username validity. */
         if (ACLStringHasSpaces(username, sdslen(username))) {
             addReplyError(c, "Usernames can't contain spaces or null characters");
@@ -2861,7 +2861,7 @@ void aclCommand(client *c) {
         user *u = ACLGetUserByName(username, sdslen(username));
 
         sds *temp_argv = zmalloc(c->argc * sizeof(sds));
-        for (int i = 3; i < c->argc; i++) temp_argv[i - 3] = c->argv[i]->ptr;
+        for (int i = 3; i < c->argc; i++) temp_argv[i - 3] = objectGetVal(c->argv[i]);
 
         sds error = ACLStringSetUser(u, username, temp_argv, c->argc - 3);
         zfree(temp_argv);
@@ -2878,7 +2878,7 @@ void aclCommand(client *c) {
 
         int deleted = 0;
         for (int j = 2; j < c->argc; j++) {
-            sds username = c->argv[j]->ptr;
+            sds username = objectGetVal(c->argv[j]);
             if (!strcmp(username, "default")) {
                 addReplyError(c, "The 'default' user cannot be removed");
                 return;
@@ -2886,7 +2886,7 @@ void aclCommand(client *c) {
         }
 
         for (int j = 2; j < c->argc; j++) {
-            sds username = c->argv[j]->ptr;
+            sds username = objectGetVal(c->argv[j]);
             user *u;
             if (raxRemove(Users, (unsigned char *)username, sdslen(username), (void **)&u)) {
                 ACLFreeUserAndKillClients(u);
@@ -2898,7 +2898,7 @@ void aclCommand(client *c) {
         /* Redact the username to not leak any information about the user. */
         redactClientCommandArgument(c, 2);
 
-        user *u = ACLGetUserByName(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        user *u = ACLGetUserByName(objectGetVal(c->argv[2]), sdslen(objectGetVal(c->argv[2])));
         if (u == NULL) {
             addReplyNull(c);
             return;
@@ -2959,7 +2959,7 @@ void aclCommand(client *c) {
                 config = sdscatsds(config, u->name);
                 config = sdscatlen(config, " ", 1);
                 robj *descr = ACLDescribeUser(u);
-                config = sdscatsds(config, descr->ptr);
+                config = sdscatsds(config, objectGetVal(descr));
                 decrRefCount(descr);
                 addReplyBulkSds(c, config);
             }
@@ -2998,9 +2998,9 @@ void aclCommand(client *c) {
         for (j = 0; ACLCommandCategories[j].flag != 0; j++) addReplyBulkCString(c, ACLCommandCategories[j].name);
         setDeferredArrayLen(c, dl, j);
     } else if (!strcasecmp(sub, "cat") && c->argc == 3) {
-        uint64_t cflag = ACLGetCommandCategoryFlagByName(c->argv[2]->ptr);
+        uint64_t cflag = ACLGetCommandCategoryFlagByName(objectGetVal(c->argv[2]));
         if (cflag == 0) {
-            addReplyErrorFormat(c, "Unknown category '%.128s'", (char *)c->argv[2]->ptr);
+            addReplyErrorFormat(c, "Unknown category '%.128s'", (char *)objectGetVal(c->argv[2]));
             return;
         }
         int arraylen = 0;
@@ -3033,7 +3033,7 @@ void aclCommand(client *c) {
          * the number of entries the user wants to display, or alternatively
          * the "RESET" command in order to flush the old entries. */
         if (c->argc == 3) {
-            if (!strcasecmp(c->argv[2]->ptr, "reset")) {
+            if (!strcasecmp(objectGetVal(c->argv[2]), "reset")) {
                 listSetFreeMethod(ACLLog, ACLFreeLogEntry);
                 listEmpty(ACLLog);
                 listSetFreeMethod(ACLLog, NULL);
@@ -3099,14 +3099,14 @@ void aclCommand(client *c) {
         }
     } else if (!strcasecmp(sub, "dryrun") && c->argc >= 4) {
         struct serverCommand *cmd;
-        user *u = ACLGetUserByName(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        user *u = ACLGetUserByName(objectGetVal(c->argv[2]), sdslen(objectGetVal(c->argv[2])));
         if (u == NULL) {
-            addReplyErrorFormat(c, "User '%s' not found", (char *)c->argv[2]->ptr);
+            addReplyErrorFormat(c, "User '%s' not found", (char *)objectGetVal(c->argv[2]));
             return;
         }
 
         if ((cmd = lookupCommand(c->argv + 3, c->argc - 3)) == NULL) {
-            addReplyErrorFormat(c, "Command '%s' not found", (char *)c->argv[3]->ptr);
+            addReplyErrorFormat(c, "Command '%s' not found", (char *)objectGetVal(c->argv[3]));
             return;
         }
 
@@ -3118,7 +3118,7 @@ void aclCommand(client *c) {
         int idx;
         int result = ACLCheckAllUserCommandPerm(u, cmd, c->argv + 3, c->argc - 3, &idx);
         if (result != ACL_OK) {
-            sds err = getAclErrorMessage(result, u, cmd, c->argv[idx + 3]->ptr, 1);
+            sds err = getAclErrorMessage(result, u, cmd, objectGetVal(c->argv[idx + 3]), 1);
             addReplyBulkSds(c, err);
             return;
         }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1058,12 +1058,12 @@ void bitfieldGeneric(client *c, int flags) {
     uint64_t highest_write_offset = 0;
 
     for (j = 2; j < c->argc; j++) {
-        int remargs = c->argc - j - 1;  /* Remaining args other than current. */
+        int remargs = c->argc - j - 1;           /* Remaining args other than current. */
         char *subcmd = objectGetVal(c->argv[j]); /* Current command name. */
-        int opcode;                     /* Current operation code. */
-        long long i64 = 0;              /* Signed SET value. */
-        int sign = 0;                   /* Signed or unsigned type? */
-        int bits = 0;                   /* Bitfield width in bits. */
+        int opcode;                              /* Current operation code. */
+        long long i64 = 0;                       /* Signed SET value. */
+        int sign = 0;                            /* Signed or unsigned type? */
+        int bits = 0;                            /* Bitfield width in bits. */
 
         if (!strcasecmp(subcmd, "get") && remargs >= 2)
             opcode = BITFIELDOP_GET;

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -491,7 +491,7 @@ robj *lookupStringForBitCommand(client *c, uint64_t maxbit, int *dirty) {
     } else {
         o = dbUnshareStringValue(c->db, c->argv[1], o);
         size_t oldlen = sdslen(objectGetVal(o));
-        o->ptr = sdsgrowzero(objectGetVal(o), byte + 1);
+        objectSetVal(o, sdsgrowzero(objectGetVal(o), byte + 1));
         if (dirty && oldlen != sdslen(objectGetVal(o))) *dirty = 1;
     }
     return o;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4250,8 +4250,8 @@ clusterMsgSendBlock *clusterCreatePublishMsgBlock(robj *channel, robj *message, 
 
     channel = getDecodedObject(channel);
     message = getDecodedObject(message);
-    channel_len = sdslen(channel->ptr);
-    message_len = sdslen(message->ptr);
+    channel_len = sdslen(objectGetVal(channel));
+    message_len = sdslen(objectGetVal(message));
     size_t msglen;
 
     if (is_light) {
@@ -4274,8 +4274,8 @@ clusterMsgSendBlock *clusterCreatePublishMsgBlock(robj *channel, robj *message, 
     }
     hdr_data_msg->channel_len = htonl(channel_len);
     hdr_data_msg->message_len = htonl(message_len);
-    memcpy(hdr_data_msg->bulk_data, channel->ptr, sdslen(channel->ptr));
-    memcpy(hdr_data_msg->bulk_data + sdslen(channel->ptr), message->ptr, sdslen(message->ptr));
+    memcpy(hdr_data_msg->bulk_data, objectGetVal(channel), sdslen(objectGetVal(channel)));
+    memcpy(hdr_data_msg->bulk_data + sdslen(objectGetVal(channel)), objectGetVal(message), sdslen(objectGetVal(message)));
 
     decrRefCount(channel);
     decrRefCount(message);
@@ -6428,7 +6428,7 @@ int clusterNodeIsPrimary(clusterNode *n) {
 }
 
 int handleDebugClusterCommand(client *c) {
-    if (strcasecmp(c->argv[1]->ptr, "CLUSTERLINK") || strcasecmp(c->argv[2]->ptr, "KILL") || c->argc != 5) {
+    if (strcasecmp(objectGetVal(c->argv[1]), "CLUSTERLINK") || strcasecmp(objectGetVal(c->argv[2]), "KILL") || c->argc != 5) {
         return 0;
     }
 
@@ -6438,9 +6438,9 @@ int handleDebugClusterCommand(client *c) {
     }
 
     /* Find the node. */
-    clusterNode *n = clusterLookupNode(c->argv[4]->ptr, sdslen(c->argv[4]->ptr));
+    clusterNode *n = clusterLookupNode(objectGetVal(c->argv[4]), sdslen(objectGetVal(c->argv[4])));
     if (!n) {
-        addReplyErrorFormat(c, "Unknown node %s", (char *)c->argv[4]->ptr);
+        addReplyErrorFormat(c, "Unknown node %s", (char *)objectGetVal(c->argv[4]));
         return 1;
     }
     if (n == server.cluster->myself) {
@@ -6449,15 +6449,15 @@ int handleDebugClusterCommand(client *c) {
     }
 
     /* Terminate the link based on the direction or all. */
-    if (!strcasecmp(c->argv[3]->ptr, "from")) {
+    if (!strcasecmp(objectGetVal(c->argv[3]), "from")) {
         if (n->inbound_link) freeClusterLink(n->inbound_link);
-    } else if (!strcasecmp(c->argv[3]->ptr, "to")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "to")) {
         if (n->link) freeClusterLink(n->link);
-    } else if (!strcasecmp(c->argv[3]->ptr, "all")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "all")) {
         if (n->link) freeClusterLink(n->link);
         if (n->inbound_link) freeClusterLink(n->inbound_link);
     } else {
-        addReplyErrorFormat(c, "Unknown direction %s", (char *)c->argv[3]->ptr);
+        addReplyErrorFormat(c, "Unknown direction %s", (char *)objectGetVal(c->argv[3]));
     }
     addReply(c, shared.ok);
 
@@ -6548,15 +6548,15 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
 
     if ((slot = getSlotOrReply(c, c->argv[2])) == -1) return 0;
 
-    if (!strcasecmp(c->argv[3]->ptr, "migrating") && c->argc >= 5) {
+    if (!strcasecmp(objectGetVal(c->argv[3]), "migrating") && c->argc >= 5) {
         /* CLUSTER SETSLOT <SLOT> MIGRATING <NODE> */
         if (nodeIsPrimary(myself) && server.cluster->slots[slot] != myself) {
             addReplyErrorFormat(c, "I'm not the owner of hash slot %u", slot);
             return 0;
         }
-        n = clusterLookupNode(c->argv[4]->ptr, sdslen(c->argv[4]->ptr));
+        n = clusterLookupNode(objectGetVal(c->argv[4]), sdslen(objectGetVal(c->argv[4])));
         if (n == NULL) {
-            addReplyErrorFormat(c, "I don't know about node %s", (char *)c->argv[4]->ptr);
+            addReplyErrorFormat(c, "I don't know about node %s", (char *)objectGetVal(c->argv[4]));
             return 0;
         }
         if (nodeIsReplica(n)) {
@@ -6564,15 +6564,15 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
             return 0;
         }
         if (c->argc > 5) optarg_pos = 5;
-    } else if (!strcasecmp(c->argv[3]->ptr, "importing") && c->argc >= 5) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "importing") && c->argc >= 5) {
         /* CLUSTER SETSLOT <SLOT> IMPORTING <NODE> */
         if (server.cluster->slots[slot] == myself) {
             addReplyErrorFormat(c, "I'm already the owner of hash slot %u", slot);
             return 0;
         }
-        n = clusterLookupNode(c->argv[4]->ptr, sdslen(c->argv[4]->ptr));
+        n = clusterLookupNode(objectGetVal(c->argv[4]), sdslen(objectGetVal(c->argv[4])));
         if (n == NULL) {
-            addReplyErrorFormat(c, "I don't know about node %s", (char *)c->argv[4]->ptr);
+            addReplyErrorFormat(c, "I don't know about node %s", (char *)objectGetVal(c->argv[4]));
             return 0;
         }
         if (nodeIsReplica(n)) {
@@ -6580,14 +6580,14 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
             return 0;
         }
         if (c->argc > 5) optarg_pos = 5;
-    } else if (!strcasecmp(c->argv[3]->ptr, "stable") && c->argc >= 4) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "stable") && c->argc >= 4) {
         /* CLUSTER SETSLOT <SLOT> STABLE */
         if (c->argc > 4) optarg_pos = 4;
-    } else if (!strcasecmp(c->argv[3]->ptr, "node") && c->argc >= 5) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "node") && c->argc >= 5) {
         /* CLUSTER SETSLOT <SLOT> NODE <NODE ID> */
-        n = clusterLookupNode(c->argv[4]->ptr, sdslen(c->argv[4]->ptr));
+        n = clusterLookupNode(objectGetVal(c->argv[4]), sdslen(objectGetVal(c->argv[4])));
         if (!n) {
-            addReplyErrorFormat(c, "Unknown node %s", (char *)c->argv[4]->ptr);
+            addReplyErrorFormat(c, "Unknown node %s", (char *)objectGetVal(c->argv[4]));
             return 0;
         }
         if (nodeIsReplica(n)) {
@@ -6613,7 +6613,7 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
 
     /* Process optional arguments */
     for (int i = optarg_pos; i < c->argc; i++) {
-        if (!strcasecmp(c->argv[i]->ptr, "timeout")) {
+        if (!strcasecmp(objectGetVal(c->argv[i]), "timeout")) {
             if (i + 1 >= c->argc) {
                 addReplyError(c, "Missing timeout value");
                 return 0;
@@ -6711,18 +6711,18 @@ void clusterCommandSetSlot(client *c) {
 
     /* Slot states have been updated on the compatible replicas (if any).
      * Now execute the command on the primary. */
-    if (!strcasecmp(c->argv[3]->ptr, "migrating")) {
+    if (!strcasecmp(objectGetVal(c->argv[3]), "migrating")) {
         serverLog(LL_NOTICE, "Migrating slot %d to node %.40s (%s)", slot, n->name, n->human_nodename);
         server.cluster->migrating_slots_to[slot] = n;
-    } else if (!strcasecmp(c->argv[3]->ptr, "importing")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "importing")) {
         serverLog(LL_NOTICE, "Importing slot %d from node %.40s (%s)", slot, n->name, n->human_nodename);
         server.cluster->importing_slots_from[slot] = n;
-    } else if (!strcasecmp(c->argv[3]->ptr, "stable")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "stable")) {
         /* CLUSTER SETSLOT <SLOT> STABLE */
         serverLog(LL_NOTICE, "Marking slot %d stable", slot);
         server.cluster->importing_slots_from[slot] = NULL;
         server.cluster->migrating_slots_to[slot] = NULL;
-    } else if (!strcasecmp(c->argv[3]->ptr, "node")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[3]), "node")) {
         /* CLUSTER SETSLOT <SLOT> NODE <NODE ID> */
         serverLog(LL_NOTICE, "Assigning slot %d to node %.40s (%s) in shard %.40s", slot, n->name, n->human_nodename,
                   n->shard_id);
@@ -6800,35 +6800,35 @@ void clusterCommandSetSlot(client *c) {
 }
 
 int clusterCommandSpecial(client *c) {
-    if (!strcasecmp(c->argv[1]->ptr, "meet") && (c->argc == 4 || c->argc == 5)) {
+    if (!strcasecmp(objectGetVal(c->argv[1]), "meet") && (c->argc == 4 || c->argc == 5)) {
         /* CLUSTER MEET <ip> <port> [cport] */
         long long port, cport;
 
         if (getLongLongFromObject(c->argv[3], &port) != C_OK) {
-            addReplyErrorFormat(c, "Invalid base port specified: %s", (char *)c->argv[3]->ptr);
+            addReplyErrorFormat(c, "Invalid base port specified: %s", (char *)objectGetVal(c->argv[3]));
             return 1;
         }
 
         if (c->argc == 5) {
             if (getLongLongFromObject(c->argv[4], &cport) != C_OK) {
-                addReplyErrorFormat(c, "Invalid bus port specified: %s", (char *)c->argv[4]->ptr);
+                addReplyErrorFormat(c, "Invalid bus port specified: %s", (char *)objectGetVal(c->argv[4]));
                 return 1;
             }
         } else {
             cport = port + CLUSTER_PORT_INCR;
         }
 
-        if (clusterStartHandshake(c->argv[2]->ptr, port, cport) == 0 && errno == EINVAL) {
-            addReplyErrorFormat(c, "Invalid node address specified: %s:%s", (char *)c->argv[2]->ptr,
-                                (char *)c->argv[3]->ptr);
+        if (clusterStartHandshake(objectGetVal(c->argv[2]), port, cport) == 0 && errno == EINVAL) {
+            addReplyErrorFormat(c, "Invalid node address specified: %s:%s", (char *)objectGetVal(c->argv[2]),
+                                (char *)objectGetVal(c->argv[3]));
         } else {
             sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
-            serverLog(LL_NOTICE, "Cluster meet %s:%lld (user request from '%s').", (char *)c->argv[2]->ptr, port,
+            serverLog(LL_NOTICE, "Cluster meet %s:%lld (user request from '%s').", (char *)objectGetVal(c->argv[2]), port,
                       client);
             sdsfree(client);
             addReply(c, shared.ok);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "flushslots") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "flushslots") && c->argc == 2) {
         /* CLUSTER FLUSHSLOTS */
         if (kvstoreSize(server.db[0].keys) != 0) {
             addReplyError(c, "DB must be empty to perform CLUSTER FLUSHSLOTS.");
@@ -6837,12 +6837,12 @@ int clusterCommandSpecial(client *c) {
         clusterDelNodeSlots(myself);
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
         addReply(c, shared.ok);
-    } else if ((!strcasecmp(c->argv[1]->ptr, "addslots") || !strcasecmp(c->argv[1]->ptr, "delslots")) && c->argc >= 3) {
+    } else if ((!strcasecmp(objectGetVal(c->argv[1]), "addslots") || !strcasecmp(objectGetVal(c->argv[1]), "delslots")) && c->argc >= 3) {
         /* CLUSTER ADDSLOTS <slot> [slot] ... */
         /* CLUSTER DELSLOTS <slot> [slot] ... */
         int j, slot;
         unsigned char *slots = zmalloc(CLUSTER_SLOTS);
-        int del = !strcasecmp(c->argv[1]->ptr, "delslots");
+        int del = !strcasecmp(objectGetVal(c->argv[1]), "delslots");
 
         memset(slots, 0, CLUSTER_SLOTS);
         /* Check that all the arguments are parseable.*/
@@ -6864,7 +6864,7 @@ int clusterCommandSpecial(client *c) {
         zfree(slots);
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
         addReply(c, shared.ok);
-    } else if ((!strcasecmp(c->argv[1]->ptr, "addslotsrange") || !strcasecmp(c->argv[1]->ptr, "delslotsrange")) &&
+    } else if ((!strcasecmp(objectGetVal(c->argv[1]), "addslotsrange") || !strcasecmp(objectGetVal(c->argv[1]), "delslotsrange")) &&
                c->argc >= 4) {
         if (c->argc % 2 == 1) {
             addReplyErrorArity(c);
@@ -6874,7 +6874,7 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER DELSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...] */
         int j, startslot, endslot;
         unsigned char *slots = zmalloc(CLUSTER_SLOTS);
-        int del = !strcasecmp(c->argv[1]->ptr, "delslotsrange");
+        int del = !strcasecmp(objectGetVal(c->argv[1]), "delslotsrange");
 
         memset(slots, 0, CLUSTER_SLOTS);
         /* Check that all the arguments are parseable and that all the
@@ -6903,35 +6903,35 @@ int clusterCommandSpecial(client *c) {
         zfree(slots);
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "setslot") && c->argc >= 4) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "setslot") && c->argc >= 4) {
         /* SETSLOT 10 MIGRATING <node ID> */
         /* SETSLOT 10 IMPORTING <node ID> */
         /* SETSLOT 10 STABLE */
         /* SETSLOT 10 NODE <node ID> */
         clusterCommandSetSlot(c);
-    } else if (!strcasecmp(c->argv[1]->ptr, "bumpepoch") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "bumpepoch") && c->argc == 2) {
         /* CLUSTER BUMPEPOCH */
         int retval = clusterBumpConfigEpochWithoutConsensus();
         sds reply = sdscatprintf(sdsempty(), "+%s %llu\r\n", (retval == C_OK) ? "BUMPED" : "STILL",
                                  (unsigned long long)myself->configEpoch);
         addReplySds(c, reply);
-    } else if (!strcasecmp(c->argv[1]->ptr, "saveconfig") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "saveconfig") && c->argc == 2) {
         int retval = clusterSaveConfig(1);
 
         if (retval == C_OK)
             addReply(c, shared.ok);
         else
             addReplyErrorFormat(c, "error saving the cluster node config: %s", strerror(errno));
-    } else if (!strcasecmp(c->argv[1]->ptr, "forget") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "forget") && c->argc == 3) {
         /* CLUSTER FORGET <NODE ID> */
-        clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        clusterNode *n = clusterLookupNode(objectGetVal(c->argv[2]), sdslen(objectGetVal(c->argv[2])));
         if (!n) {
-            if (clusterBlacklistExists((char *)c->argv[2]->ptr))
+            if (clusterBlacklistExists((char *)objectGetVal(c->argv[2])))
                 /* Already forgotten. The deletion may have been gossipped by
                  * another node, so we pretend it succeeded. */
                 addReply(c, shared.ok);
             else
-                addReplyErrorFormat(c, "Unknown node %s", (char *)c->argv[2]->ptr);
+                addReplyErrorFormat(c, "Unknown node %s", (char *)objectGetVal(c->argv[2]));
             return 1;
         } else if (n == myself) {
             addReplyError(c, "I tried hard but I can't forget myself...");
@@ -6941,18 +6941,18 @@ int clusterCommandSpecial(client *c) {
             return 1;
         }
         sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
-        serverLog(LL_NOTICE, "Cluster forget %s (user request from '%s').", (char *)c->argv[2]->ptr, client);
+        serverLog(LL_NOTICE, "Cluster forget %s (user request from '%s').", (char *)objectGetVal(c->argv[2]), client);
         sdsfree(client);
         clusterBlacklistAddNode(n);
         clusterDelNode(n);
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "replicate") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "replicate") && c->argc == 3) {
         /* CLUSTER REPLICATE <NODE ID> */
         /* Lookup the specified node in our table. */
-        clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        clusterNode *n = clusterLookupNode(objectGetVal(c->argv[2]), sdslen(objectGetVal(c->argv[2])));
         if (!n) {
-            addReplyErrorFormat(c, "Unknown node %s", (char *)c->argv[2]->ptr);
+            addReplyErrorFormat(c, "Unknown node %s", (char *)objectGetVal(c->argv[2]));
             return 1;
         }
 
@@ -6991,24 +6991,24 @@ int clusterCommandSpecial(client *c) {
         clusterSetPrimary(n, 1, 1);
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "count-failure-reports") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "count-failure-reports") && c->argc == 3) {
         /* CLUSTER COUNT-FAILURE-REPORTS <NODE ID> */
-        clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
+        clusterNode *n = clusterLookupNode(objectGetVal(c->argv[2]), sdslen(objectGetVal(c->argv[2])));
 
         if (!n) {
-            addReplyErrorFormat(c, "Unknown node %s", (char *)c->argv[2]->ptr);
+            addReplyErrorFormat(c, "Unknown node %s", (char *)objectGetVal(c->argv[2]));
             return 1;
         } else {
             addReplyLongLong(c, clusterNodeFailureReportsCount(n));
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "failover") && (c->argc == 2 || c->argc == 3)) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "failover") && (c->argc == 2 || c->argc == 3)) {
         /* CLUSTER FAILOVER [FORCE|TAKEOVER] */
         int force = 0, takeover = 0;
 
         if (c->argc == 3) {
-            if (!strcasecmp(c->argv[2]->ptr, "force")) {
+            if (!strcasecmp(objectGetVal(c->argv[2]), "force")) {
                 force = 1;
-            } else if (!strcasecmp(c->argv[2]->ptr, "takeover")) {
+            } else if (!strcasecmp(objectGetVal(c->argv[2]), "takeover")) {
                 takeover = 1;
                 force = 1; /* Takeover also implies force. */
             } else {
@@ -7056,7 +7056,7 @@ int clusterCommandSpecial(client *c) {
         }
         sdsfree(client);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "set-config-epoch") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "set-config-epoch") && c->argc == 3) {
         /* CLUSTER SET-CONFIG-EPOCH <epoch>
          *
          * The user is allowed to set the config epoch only when a node is
@@ -7087,15 +7087,15 @@ int clusterCommandSpecial(client *c) {
             clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
             addReply(c, shared.ok);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "reset") && (c->argc == 2 || c->argc == 3)) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "reset") && (c->argc == 2 || c->argc == 3)) {
         /* CLUSTER RESET [SOFT|HARD] */
         int hard = 0;
 
         /* Parse soft/hard argument. Default is soft. */
         if (c->argc == 3) {
-            if (!strcasecmp(c->argv[2]->ptr, "hard")) {
+            if (!strcasecmp(objectGetVal(c->argv[2]), "hard")) {
                 hard = 1;
-            } else if (!strcasecmp(c->argv[2]->ptr, "soft")) {
+            } else if (!strcasecmp(objectGetVal(c->argv[2]), "soft")) {
                 hard = 0;
             } else {
                 addReplyErrorObject(c, shared.syntaxerr);
@@ -7115,7 +7115,7 @@ int clusterCommandSpecial(client *c) {
         sdsfree(client);
         clusterReset(hard);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "links") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "links") && c->argc == 2) {
         /* CLUSTER LINKS */
         addReplyClusterLinksDescription(c);
     } else {

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -276,7 +276,7 @@ void clusterSlotStatsCommand(client *c) {
     }
 
     /* Parse additional arguments. */
-    if (c->argc == 5 && !strcasecmp(c->argv[2]->ptr, "slotsrange")) {
+    if (c->argc == 5 && !strcasecmp(objectGetVal(c->argv[2]), "slotsrange")) {
         /* CLUSTER SLOT-STATS SLOTSRANGE start-slot end-slot */
         int startslot, endslot;
         if ((startslot = getSlotOrReply(c, c->argv[3])) == -1 ||
@@ -292,17 +292,17 @@ void clusterSlotStatsCommand(client *c) {
         int assigned_slots_count = markSlotsAssignedToMyShard(assigned_slots, startslot, endslot);
         addReplySlotsRange(c, assigned_slots, startslot, endslot, assigned_slots_count);
 
-    } else if (c->argc >= 4 && !strcasecmp(c->argv[2]->ptr, "orderby")) {
+    } else if (c->argc >= 4 && !strcasecmp(objectGetVal(c->argv[2]), "orderby")) {
         /* CLUSTER SLOT-STATS ORDERBY metric [LIMIT limit] [ASC | DESC] */
         int desc = 1;
         slotStatType order_by = INVALID;
-        if (!strcasecmp(c->argv[3]->ptr, "key-count")) {
+        if (!strcasecmp(objectGetVal(c->argv[3]), "key-count")) {
             order_by = KEY_COUNT;
-        } else if (!strcasecmp(c->argv[3]->ptr, "cpu-usec") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(objectGetVal(c->argv[3]), "cpu-usec") && server.cluster_slot_stats_enabled) {
             order_by = CPU_USEC;
-        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-in") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(objectGetVal(c->argv[3]), "network-bytes-in") && server.cluster_slot_stats_enabled) {
             order_by = NETWORK_BYTES_IN;
-        } else if (!strcasecmp(c->argv[3]->ptr, "network-bytes-out") && server.cluster_slot_stats_enabled) {
+        } else if (!strcasecmp(objectGetVal(c->argv[3]), "network-bytes-out") && server.cluster_slot_stats_enabled) {
             order_by = NETWORK_BYTES_OUT;
         } else {
             addReplyError(c, "Unrecognized sort metric for ORDERBY.");
@@ -313,7 +313,7 @@ void clusterSlotStatsCommand(client *c) {
         long limit = CLUSTER_SLOTS;
         while (i < c->argc) {
             int moreargs = c->argc > i + 1;
-            if (!strcasecmp(c->argv[i]->ptr, "limit") && moreargs) {
+            if (!strcasecmp(objectGetVal(c->argv[i]), "limit") && moreargs) {
                 if (getRangeLongFromObjectOrReply(
                         c, c->argv[i + 1], 1, CLUSTER_SLOTS, &limit,
                         "Limit has to lie in between 1 and 16384 (maximum number of slots).") != C_OK) {
@@ -321,10 +321,10 @@ void clusterSlotStatsCommand(client *c) {
                 }
                 i++;
                 limit_counter++;
-            } else if (!strcasecmp(c->argv[i]->ptr, "asc")) {
+            } else if (!strcasecmp(objectGetVal(c->argv[i]), "asc")) {
                 desc = 0;
                 asc_desc_counter++;
-            } else if (!strcasecmp(c->argv[i]->ptr, "desc")) {
+            } else if (!strcasecmp(objectGetVal(c->argv[i]), "desc")) {
                 desc = 1;
                 asc_desc_counter++;
             } else {

--- a/src/config.c
+++ b/src/config.c
@@ -810,11 +810,11 @@ void configSetCommand(client *c) {
 
     /* Find all relevant configs */
     for (i = 0; i < config_count; i++) {
-        standardConfig *config = lookupConfig(c->argv[2 + i * 2]->ptr);
+        standardConfig *config = lookupConfig(objectGetVal(c->argv[2 + i * 2]));
         /* Fail if we couldn't find this config */
         if (!config) {
             if (!invalid_args) {
-                invalid_arg_name = c->argv[2 + i * 2]->ptr;
+                invalid_arg_name = objectGetVal(c->argv[2 + i * 2]);
                 invalid_args = 1;
             }
             continue;
@@ -835,7 +835,7 @@ void configSetCommand(client *c) {
             (config->flags & PROTECTED_CONFIG && !allowProtectedAction(server.enable_protected_configs, c))) {
             /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
             errstr = (config->flags & IMMUTABLE_CONFIG) ? "can't set immutable config" : "can't set protected config";
-            err_arg_name = c->argv[2 + i * 2]->ptr;
+            err_arg_name = objectGetVal(c->argv[2 + i * 2]);
             invalid_args = 1;
             continue;
         }
@@ -852,14 +852,14 @@ void configSetCommand(client *c) {
             if (set_configs[j] == config) {
                 /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
                 errstr = "duplicate parameter";
-                err_arg_name = c->argv[2 + i * 2]->ptr;
+                err_arg_name = objectGetVal(c->argv[2 + i * 2]);
                 invalid_args = 1;
                 break;
             }
         }
         set_configs[i] = config;
         config_names[i] = config->name;
-        new_values[i] = c->argv[2 + i * 2 + 1]->ptr;
+        new_values[i] = objectGetVal(c->argv[2 + i * 2 + 1]);
     }
 
     if (invalid_args) goto err;
@@ -954,7 +954,7 @@ void configGetCommand(client *c) {
     dict *matches = dictCreate(&externalStringType);
     for (i = 0; i < c->argc - 2; i++) {
         robj *o = c->argv[2 + i];
-        sds name = o->ptr;
+        sds name = objectGetVal(o);
 
         /* If the string doesn't contain glob patterns, just directly
          * look up the key in the dictionary. */
@@ -1425,7 +1425,7 @@ void rewriteConfigUserOption(struct rewriteConfigState *state) {
         line = sdscatsds(line, u->name);
         line = sdscatlen(line, " ", 1);
         robj *descr = ACLDescribeUser(u);
-        line = sdscatsds(line, descr->ptr);
+        line = sdscatsds(line, objectGetVal(descr));
         decrRefCount(descr);
         rewriteConfigRewriteLine(state, "user", line, 1);
     }

--- a/src/db.c
+++ b/src/db.c
@@ -99,8 +99,8 @@ void updateLFU(robj *val) {
  * expired on replicas even if the primary is lagging expiring our key via DELs
  * in the replication link. */
 robj *lookupKey(serverDb *db, robj *key, int flags) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
-    robj *val = dbFindWithDictIndex(db, key->ptr, dict_index);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+    robj *val = dbFindWithDictIndex(db, objectGetVal(key), dict_index);
     if (val) {
         /* Forcing deletion of expired keys on a replica makes the replica
          * inconsistent with the primary. We forbid it on readonly replicas, but
@@ -211,21 +211,21 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  * If the update_if_existing argument is false, the program is aborted
  * if the key already exists, otherwise, it can fall back to dbOverwrite. */
 static void dbAddInternal(serverDb *db, robj *key, robj **valref, int update_if_existing) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     void **oldref = NULL;
     if (update_if_existing) {
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
+        oldref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
         if (oldref != NULL) {
             dbSetValue(db, key, valref, 1, oldref);
             return;
         }
     } else {
-        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, key->ptr) == NULL);
+        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key)) == NULL);
     }
 
     /* Not existing. Convert val to valkey object and insert. */
     robj *val = *valref;
-    val = objectSetKeyAndExpire(val, key->ptr, -1);
+    val = objectSetKeyAndExpire(val, objectGetVal(key), -1);
     initObjectLRUOrLFU(val);
     kvstoreHashtableAdd(db->keys, dict_index, val);
     signalKeyAsReady(db, key, val->type);
@@ -323,8 +323,8 @@ int dbAddRDBLoad(serverDb *db, sds key, robj **valref) {
 static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, void **oldref) {
     robj *val = *valref;
     if (oldref == NULL) {
-        int dict_index = getKVStoreIndexForKey(key->ptr);
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
+        int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+        oldref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
     }
     serverAssertWithInfo(NULL, key, oldref != NULL);
     robj *old = *oldref;
@@ -351,10 +351,10 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
          * encoding with the content of val. */
         int tmp_type = old->type;
         int tmp_encoding = old->encoding;
-        void *tmp_ptr = old->ptr;
+        void *tmp_ptr = objectGetVal(old);
         old->type = val->type;
         old->encoding = val->encoding;
-        old->ptr = val->ptr;
+        old->ptr = objectGetVal(val);
         val->type = tmp_type;
         val->encoding = tmp_encoding;
         val->ptr = tmp_ptr;
@@ -365,12 +365,12 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         /* Replace the old value at its location in the key space. */
         val->lru = old->lru;
         long long expire = objectGetExpire(old);
-        new = objectSetKeyAndExpire(val, key->ptr, expire);
+        new = objectSetKeyAndExpire(val, objectGetVal(key), expire);
         *oldref = new;
         /* Replace the old value at its location in the expire space. */
         if (expire >= 0) {
-            int dict_index = getKVStoreIndexForKey(key->ptr);
-            void **expireref = kvstoreHashtableFindRef(db->expires, dict_index, key->ptr);
+            int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+            void **expireref = kvstoreHashtableFindRef(db->expires, dict_index, objectGetVal(key));
             serverAssert(expireref != NULL);
             *expireref = new;
         }
@@ -467,7 +467,7 @@ robj *dbRandomKey(serverDb *db) {
 
 int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, int dict_index) {
     hashtablePosition pos;
-    void **ref = kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, key->ptr, &pos);
+    void **ref = kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, objectGetVal(key), &pos);
     if (ref != NULL) {
         robj *val = *ref;
         /* VM_StringDMA may call dbUnshareStringValue which may free val, so we
@@ -486,10 +486,10 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
          * (The expires table has no destructor callback.) */
         kvstoreHashtableTwoPhasePopDelete(db->keys, dict_index, &pos);
         if (objectGetExpire(val) != -1) {
-            int deleted = kvstoreHashtableDelete(db->expires, dict_index, key->ptr);
+            int deleted = kvstoreHashtableDelete(db->expires, dict_index, objectGetVal(key));
             serverAssert(deleted);
         } else {
-            debugServerAssert(0 == kvstoreHashtableDelete(db->expires, dict_index, key->ptr));
+            debugServerAssert(0 == kvstoreHashtableDelete(db->expires, dict_index, objectGetVal(key)));
         }
 
         if (async) {
@@ -506,7 +506,7 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
 
 /* Helper for sync and async delete. */
 int dbGenericDelete(serverDb *db, robj *key, int async, int flags) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     return dbGenericDeleteWithDictIndex(db, key, async, flags, dict_index);
 }
 
@@ -558,7 +558,7 @@ robj *dbUnshareStringValue(serverDb *db, robj *key, robj *o) {
     serverAssert(o->type == OBJ_STRING);
     if (o->refcount != 1 || o->encoding != OBJ_ENCODING_RAW) {
         robj *decoded = getDecodedObject(o);
-        o = createRawStringObject(decoded->ptr, sdslen(decoded->ptr));
+        o = createRawStringObject(objectGetVal(decoded), sdslen(objectGetVal(decoded)));
         decrRefCount(decoded);
         dbReplaceValue(db, key, &o);
     }
@@ -747,9 +747,9 @@ void signalFlushedDb(int dbid, int async) {
  * C_ERR is returned and the function sends an error to the client. */
 int getFlushCommandFlags(client *c, int *flags) {
     /* Parse the optional ASYNC option. */
-    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr, "sync")) {
+    if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "sync")) {
         *flags = EMPTYDB_NO_FLAGS;
-    } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr, "async")) {
+    } else if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "async")) {
         *flags = EMPTYDB_ASYNC;
     } else if (c->argc == 1) {
         *flags = server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS;
@@ -884,7 +884,7 @@ void randomkeyCommand(client *c) {
 }
 
 void keysCommand(client *c) {
-    sds pattern = c->argv[1]->ptr;
+    sds pattern = objectGetVal(c->argv[1]);
     int plen = sdslen(pattern), allkeys, pslot = -1;
     unsigned long numkeys = 0;
     void *replylen = addReplyDeferredLen(c);
@@ -936,7 +936,7 @@ int objectTypeCompare(robj *o, long long target) {
             return 1;
     }
     /* module type compare */
-    long long mt = (long long)VALKEYMODULE_TYPE_SIGN(((moduleValue *)o->ptr)->type->id);
+    long long mt = (long long)VALKEYMODULE_TYPE_SIGN(((moduleValue *)objectGetVal(o))->type->id);
     if (target != -mt)
         return 0;
     else
@@ -1037,7 +1037,7 @@ void hashtableScanCallback(void *privdata, void *entry) {
  * returns C_OK. Otherwise return C_ERR and send an error to the
  * client. */
 int parseScanCursorOrReply(client *c, robj *o, unsigned long long *cursor) {
-    if (!string2ull(o->ptr, cursor)) {
+    if (!string2ull(objectGetVal(o), cursor)) {
         addReplyError(c, "invalid cursor");
         return C_ERR;
     }
@@ -1069,7 +1069,7 @@ char *getObjectTypeName(robj *o) {
     serverAssert(o->type >= 0 && o->type < OBJ_TYPE_MAX);
 
     if (o->type == OBJ_MODULE) {
-        moduleValue *mv = o->ptr;
+        moduleValue *mv = objectGetVal(o);
         return mv->type->name;
     } else {
         return obj_type_name[o->type];
@@ -1106,7 +1106,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     /* Step 1: Parse options. */
     while (i < c->argc) {
         j = c->argc - i;
-        if (!strcasecmp(c->argv[i]->ptr, "count") && j >= 2) {
+        if (!strcasecmp(objectGetVal(c->argv[i]), "count") && j >= 2) {
             if (getLongFromObjectOrReply(c, c->argv[i + 1], &count, NULL) != C_OK) {
                 return;
             }
@@ -1117,8 +1117,8 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             }
 
             i += 2;
-        } else if (!strcasecmp(c->argv[i]->ptr, "match") && j >= 2) {
-            pat = c->argv[i + 1]->ptr;
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "match") && j >= 2) {
+            pat = objectGetVal(c->argv[i + 1]);
             patlen = sdslen(pat);
 
             /* The pattern always matches if it is exactly "*", so it is
@@ -1126,23 +1126,23 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
             use_pattern = !(patlen == 1 && pat[0] == '*');
 
             i += 2;
-        } else if (!strcasecmp(c->argv[i]->ptr, "type") && o == NULL && j >= 2) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "type") && o == NULL && j >= 2) {
             /* SCAN for a particular type only applies to the db dict */
-            typename = c->argv[i + 1]->ptr;
+            typename = objectGetVal(c->argv[i + 1]);
             type = getObjectTypeByName(typename);
             if (type == LLONG_MAX) {
                 addReplyErrorFormat(c, "unknown type name '%s'", typename);
                 return;
             }
             i += 2;
-        } else if (!strcasecmp(c->argv[i]->ptr, "novalues")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "novalues")) {
             if (!o || o->type != OBJ_HASH) {
                 addReplyError(c, "NOVALUES option can only be used in HSCAN");
                 return;
             }
             only_keys = 1;
             i++;
-        } else if (!strcasecmp(c->argv[i]->ptr, "noscores")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "noscores")) {
             if (!o || o->type != OBJ_ZSET) {
                 addReplyError(c, "NOSCORES option can only be used in ZSCAN");
                 return;
@@ -1169,13 +1169,13 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
     if (o == NULL) {
         shallow_copied_list_items = 1;
     } else if (o->type == OBJ_SET && o->encoding == OBJ_ENCODING_HASHTABLE) {
-        ht = o->ptr;
+        ht = objectGetVal(o);
         shallow_copied_list_items = 1;
     } else if (o->type == OBJ_HASH && o->encoding == OBJ_ENCODING_HASHTABLE) {
-        ht = o->ptr;
+        ht = objectGetVal(o);
         shallow_copied_list_items = 1;
     } else if (o->type == OBJ_ZSET && o->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = o->ptr;
+        zset *zs = objectGetVal(o);
         ht = zs->ht;
         /* scanning ZSET allocates temporary strings even though it's a dict */
         shallow_copied_list_items = 0;
@@ -1253,7 +1253,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         setTypeReleaseIterator(si);
         cursor = 0;
     } else if ((o->type == OBJ_HASH || o->type == OBJ_ZSET) && o->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *p = lpFirst(o->ptr);
+        unsigned char *p = lpFirst(objectGetVal(o));
         unsigned char *str;
         int64_t len;
         unsigned char intbuf[LP_INTBUF_SIZE];
@@ -1261,10 +1261,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
         while (p) {
             str = lpGet(p, &len, intbuf);
             /* point to the value */
-            p = lpNext(o->ptr, p);
+            p = lpNext(objectGetVal(o), p);
             if (use_pattern && !stringmatchlen(pat, sdslen(pat), (char *)str, len, 0)) {
                 /* jump to the next key/val pair */
-                p = lpNext(o->ptr, p);
+                p = lpNext(objectGetVal(o), p);
                 continue;
             }
             /* add key object */
@@ -1274,7 +1274,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
                 str = lpGet(p, &len, intbuf);
                 listAddNodeTail(keys, sdsnewlen(str, len));
             }
-            p = lpNext(o->ptr, p);
+            p = lpNext(objectGetVal(o), p);
         }
         cursor = 0;
     } else {
@@ -1321,15 +1321,15 @@ void shutdownCommand(client *c) {
     int flags = SHUTDOWN_NOFLAGS;
     int abort = 0;
     for (int i = 1; i < c->argc; i++) {
-        if (!strcasecmp(c->argv[i]->ptr, "nosave")) {
+        if (!strcasecmp(objectGetVal(c->argv[i]), "nosave")) {
             flags |= SHUTDOWN_NOSAVE;
-        } else if (!strcasecmp(c->argv[i]->ptr, "save")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "save")) {
             flags |= SHUTDOWN_SAVE;
-        } else if (!strcasecmp(c->argv[i]->ptr, "now")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "now")) {
             flags |= SHUTDOWN_NOW;
-        } else if (!strcasecmp(c->argv[i]->ptr, "force")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "force")) {
             flags |= SHUTDOWN_FORCE;
-        } else if (!strcasecmp(c->argv[i]->ptr, "abort")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[i]), "abort")) {
             abort = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
@@ -1383,7 +1383,7 @@ void renameGenericCommand(client *c, int nx) {
 
     /* When source and dest key is the same, no operation is performed,
      * if the key exists, however we still return an error on unexisting key. */
-    if (sdscmp(c->argv[1]->ptr, c->argv[2]->ptr) == 0) samekey = 1;
+    if (sdscmp(objectGetVal(c->argv[1]), objectGetVal(c->argv[2])) == 0) samekey = 1;
 
     if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.nokeyerr)) == NULL) return;
 
@@ -1500,9 +1500,9 @@ void copyCommand(client *c) {
     dbid = c->db->id;
     for (j = 3; j < c->argc; j++) {
         int additional = c->argc - j - 1;
-        if (!strcasecmp(c->argv[j]->ptr, "replace")) {
+        if (!strcasecmp(objectGetVal(c->argv[j]), "replace")) {
             replace = 1;
-        } else if (!strcasecmp(c->argv[j]->ptr, "db") && additional >= 1) {
+        } else if (!strcasecmp(objectGetVal(c->argv[j]), "db") && additional >= 1) {
             if (getIntFromObjectOrReply(c, c->argv[j + 1], &dbid, NULL) != C_OK) return;
 
             if (selectDb(c, dbid) == C_ERR) {
@@ -1528,7 +1528,7 @@ void copyCommand(client *c) {
      * it is probably an error. */
     robj *key = c->argv[1];
     robj *newkey = c->argv[2];
-    if (src == dst && (sdscmp(key->ptr, newkey->ptr) == 0)) {
+    if (src == dst && (sdscmp(objectGetVal(key), objectGetVal(newkey)) == 0)) {
         addReplyErrorObject(c, shared.sameobjecterr);
         return;
     }
@@ -1592,7 +1592,7 @@ void scanDatabaseForReadyKeys(serverDb *db) {
     dictIterator *di = dictGetSafeIterator(db->blocking_keys);
     while ((de = dictNext(di)) != NULL) {
         robj *key = dictGetKey(de);
-        robj *value = dbFind(db, key->ptr);
+        robj *value = dbFind(db, objectGetVal(key));
         if (value) {
             signalKeyAsReady(db, key, value->type);
         }
@@ -1611,14 +1611,14 @@ void scanDatabaseForDeletedKeys(serverDb *emptied, serverDb *replaced_with) {
         int existed = 0, exists = 0;
         int original_type = -1, curr_type = -1;
 
-        robj *value = dbFind(emptied, key->ptr);
+        robj *value = dbFind(emptied, objectGetVal(key));
         if (value) {
             original_type = value->type;
             existed = 1;
         }
 
         if (replaced_with) {
-            value = dbFind(replaced_with, key->ptr);
+            value = dbFind(replaced_with, objectGetVal(key));
             if (value) {
                 curr_type = value->type;
                 exists = 1;
@@ -1756,9 +1756,9 @@ void swapdbCommand(client *c) {
  *----------------------------------------------------------------------------*/
 
 int removeExpire(serverDb *db, robj *key) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     void *popped;
-    if (kvstoreHashtablePop(db->expires, dict_index, key->ptr, &popped)) {
+    if (kvstoreHashtablePop(db->expires, dict_index, objectGetVal(key), &popped)) {
         robj *val = popped;
         robj *newval = objectSetExpire(val, -1);
         serverAssert(newval == val);
@@ -1779,8 +1779,8 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
     /* Reuse the object from the main dict in the expire dict. When setting
      * expire in an robj, it's potentially reallocated. We need to updates the
      * pointer(s) to it. */
-    int dict_index = getKVStoreIndexForKey(key->ptr);
-    void **valref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+    void **valref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
     serverAssertWithInfo(NULL, key, valref != NULL);
     val = *valref;
     long long old_when = objectGetExpire(val);
@@ -1810,7 +1810,7 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
 long long getExpireWithDictIndex(serverDb *db, robj *key, int dict_index) {
     robj *val;
 
-    if ((val = dbFindExpiresWithDictIndex(db, key->ptr, dict_index)) == NULL) return -1;
+    if ((val = dbFindExpiresWithDictIndex(db, objectGetVal(key), dict_index)) == NULL) return -1;
 
     return objectGetExpire(val);
 }
@@ -1818,7 +1818,7 @@ long long getExpireWithDictIndex(serverDb *db, robj *key, int dict_index) {
 /* Return the expire time of the specified key, or -1 if no expire
  * is associated with this key (i.e. the key is non volatile) */
 long long getExpire(serverDb *db, robj *key) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     return getExpireWithDictIndex(db, key, dict_index);
 }
 
@@ -1836,7 +1836,7 @@ void deleteExpiredKeyAndPropagateWithDictIndex(serverDb *db, robj *keyobj, int d
 
 /* Delete the specified expired key and propagate expire. */
 void deleteExpiredKeyAndPropagate(serverDb *db, robj *keyobj) {
-    int dict_index = getKVStoreIndexForKey(keyobj->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(keyobj));
     deleteExpiredKeyAndPropagateWithDictIndex(db, keyobj, dict_index);
 }
 
@@ -1933,7 +1933,7 @@ static int keyIsExpiredWithDictIndex(serverDb *db, robj *key, int dict_index) {
 
 /* Check if the key is expired. */
 int keyIsExpired(serverDb *db, robj *key) {
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     return keyIsExpiredWithDictIndex(db, key, dict_index);
 }
 
@@ -1995,7 +1995,7 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
     /* The key needs to be converted from static to heap before deleted */
     int static_key = key->refcount == OBJ_STATIC_REFCOUNT;
     if (static_key) {
-        key = createStringObject(key->ptr, sdslen(key->ptr));
+        key = createStringObject(objectGetVal(key), sdslen(objectGetVal(key)));
     }
     /* Delete the key */
     deleteExpiredKeyAndPropagateWithDictIndex(db, key, dict_index);
@@ -2041,7 +2041,7 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
  * or returns KEY_DELETED if the key is expired and deleted. */
 static keyStatus expireIfNeeded(serverDb *db, robj *key, robj *val, int flags) {
     if (val != NULL && !objectIsExpired(val)) return KEY_VALID; /* shortcut */
-    int dict_index = getKVStoreIndexForKey(key->ptr);
+    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
     return expireIfNeededWithDictIndex(db, key, val, flags, dict_index);
 }
 
@@ -2191,7 +2191,7 @@ int getKeysUsingKeySpecs(struct serverCommand *cmd, robj **argv, int argc, int s
             int end_index = spec->bs.keyword.startfrom > 0 ? argc - 1 : 1;
             for (i = start_index; i != end_index; i = start_index <= end_index ? i + 1 : i - 1) {
                 if (i >= argc || i < 1) break;
-                if (!strcasecmp((char *)argv[i]->ptr, spec->bs.keyword.keyword)) {
+                if (!strcasecmp((char *)objectGetVal(argv[i]), spec->bs.keyword.keyword)) {
                     first = i + 1;
                     break;
                 }
@@ -2222,7 +2222,7 @@ int getKeysUsingKeySpecs(struct serverCommand *cmd, robj **argv, int argc, int s
             long long numkeys;
             if (spec->fk.keynum.keynumidx >= argc) goto invalid_spec;
 
-            sds keynum_str = argv[first + spec->fk.keynum.keynumidx]->ptr;
+            sds keynum_str = objectGetVal(argv[first + spec->fk.keynum.keynumidx]);
             if (!string2ll(keynum_str, sdslen(keynum_str), &numkeys) || numkeys < 0) {
                 /* Unable to parse the numkeys argument or it was invalid */
                 goto invalid_spec;
@@ -2511,7 +2511,7 @@ int genericGetKeys(int storeKeyOfs,
     int i, num;
     keyReference *keys;
 
-    num = atoi(argv[keyCountOfs]->ptr);
+    num = atoi(objectGetVal(argv[keyCountOfs]));
     /* Sanity check. Don't return any key if the command is going to
      * reply with syntax error. (no input keys). */
     if (num < 1 || num > (argc - firstKeyOfs) / keyStep) {
@@ -2636,10 +2636,10 @@ int sortGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult 
 
     for (i = 2; i < argc; i++) {
         for (j = 0; skiplist[j].name != NULL; j++) {
-            if (!strcasecmp(argv[i]->ptr, skiplist[j].name)) {
+            if (!strcasecmp(objectGetVal(argv[i]), skiplist[j].name)) {
                 i += skiplist[j].skip;
                 break;
-            } else if (!strcasecmp(argv[i]->ptr, "store") && i + 1 < argc) {
+            } else if (!strcasecmp(objectGetVal(argv[i]), "store") && i + 1 < argc) {
                 /* Note: we don't increment "num" here and continue the loop
                  * to be sure to process the *last* "STORE" option if multiple
                  * ones are provided. This is same behavior as SORT. */
@@ -2671,8 +2671,8 @@ int migrateGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResu
     } skip_keywords[] = {{"copy", 0}, {"replace", 0}, {"auth", 1}, {"auth2", 2}, {NULL, 0}};
     if (argc > 6) {
         for (i = 6; i < argc; i++) {
-            if (!strcasecmp(argv[i]->ptr, "keys")) {
-                if (sdslen(argv[3]->ptr) > 0) {
+            if (!strcasecmp(objectGetVal(argv[i]), "keys")) {
+                if (sdslen(objectGetVal(argv[3])) > 0) {
                     /* This is a syntax error. So ignore the keys and leave
                      * the syntax error to be handled by migrateCommand. */
                     num = 0;
@@ -2683,7 +2683,7 @@ int migrateGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResu
                 break;
             }
             for (j = 0; skip_keywords[j].name != NULL; j++) {
-                if (!strcasecmp(argv[i]->ptr, skip_keywords[j].name)) {
+                if (!strcasecmp(objectGetVal(argv[i]), skip_keywords[j].name)) {
                     i += skip_keywords[j].skip;
                     break;
                 }
@@ -2714,7 +2714,7 @@ int georadiusGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysRe
     /* Check for the presence of the stored key in the command */
     int stored_key = -1;
     for (i = 5; i < argc; i++) {
-        char *arg = argv[i]->ptr;
+        char *arg = objectGetVal(argv[i]);
         /* For the case when user specifies both "store" and "storedist" options, the
          * second key specified would override the first key. This behavior is kept
          * the same as in georadiusCommand method.
@@ -2758,7 +2758,7 @@ int xreadGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult
      * name of the stream key. */
     int streams_pos = -1;
     for (i = 1; i < argc; i++) {
-        char *arg = argv[i]->ptr;
+        char *arg = objectGetVal(argv[i]);
         if (!strcasecmp(arg, "block")) {
             i++; /* Skip option argument. */
         } else if (!strcasecmp(arg, "count")) {
@@ -2804,7 +2804,7 @@ int setGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *
     result->numkeys = 1;
 
     for (int i = 3; i < argc; i++) {
-        char *arg = argv[i]->ptr;
+        char *arg = objectGetVal(argv[i]);
         if ((arg[0] == 'g' || arg[0] == 'G') && (arg[1] == 'e' || arg[1] == 'E') && (arg[2] == 't' || arg[2] == 'T') &&
             arg[3] == '\0') {
             keys[0].flags = CMD_KEY_RW | CMD_KEY_ACCESS | CMD_KEY_UPDATE;
@@ -2829,7 +2829,7 @@ int bitfieldGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysRes
 
     for (int i = 2; i < argc; i++) {
         int remargs = argc - i - 1; /* Remaining args other than current. */
-        char *arg = argv[i]->ptr;
+        char *arg = objectGetVal(argv[i]);
         if (!strcasecmp(arg, "get") && remargs >= 2) {
             i += 2;
         } else if ((!strcasecmp(arg, "set") || !strcasecmp(arg, "incrby")) && remargs >= 3) {

--- a/src/db.c
+++ b/src/db.c
@@ -354,10 +354,10 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         void *tmp_ptr = objectGetVal(old);
         old->type = val->type;
         old->encoding = val->encoding;
-        old->ptr = objectGetVal(val);
+        objectSetVal(old, objectGetVal(val));
         val->type = tmp_type;
         val->encoding = tmp_encoding;
-        val->ptr = tmp_ptr;
+        objectSetVal(val, tmp_ptr);
         /* Set new to old to keep the old object. Set old to val to be freed below. */
         new = old;
         old = val;

--- a/src/debug.c
+++ b/src/debug.c
@@ -104,7 +104,7 @@ void xorDigest(unsigned char *digest, const void *ptr, size_t len) {
 
 void xorStringObjectDigest(unsigned char *digest, robj *o) {
     o = getDecodedObject(o);
-    xorDigest(digest, o->ptr, sdslen(o->ptr));
+    xorDigest(digest, objectGetVal(o), sdslen(objectGetVal(o)));
     decrRefCount(o);
 }
 
@@ -133,7 +133,7 @@ void mixDigest(unsigned char *digest, const void *ptr, size_t len) {
 
 void mixStringObjectDigest(unsigned char *digest, robj *o) {
     o = getDecodedObject(o);
-    mixDigest(digest, o->ptr, sdslen(o->ptr));
+    mixDigest(digest, objectGetVal(o), sdslen(objectGetVal(o)));
     decrRefCount(o);
 }
 
@@ -175,7 +175,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
         unsigned char eledigest[20];
 
         if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            unsigned char *zl = o->ptr;
+            unsigned char *zl = objectGetVal(o);
             unsigned char *eptr, *sptr;
             unsigned char *vstr;
             unsigned int vlen;
@@ -205,7 +205,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
                 zzlNext(zl, &eptr, &sptr);
             }
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = o->ptr;
+            zset *zs = objectGetVal(o);
             hashtableIterator iter;
             hashtableInitIterator(&iter, zs->ht, 0);
 
@@ -242,7 +242,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
         hashTypeResetIterator(&hi);
     } else if (o->type == OBJ_STREAM) {
         streamIterator si;
-        streamIteratorStart(&si, o->ptr, NULL, NULL, 0);
+        streamIteratorStart(&si, objectGetVal(o), NULL, NULL, 0);
         streamID id;
         int64_t numfields;
 
@@ -262,7 +262,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
         streamIteratorStop(&si);
     } else if (o->type == OBJ_MODULE) {
         ValkeyModuleDigest md = {{0}, {0}, keyobj, db->id};
-        moduleValue *mv = o->ptr;
+        moduleValue *mv = objectGetVal(o);
         moduleType *mt = mv->type;
         moduleInitDigestContext(&md);
         if (mt->digest) {
@@ -390,7 +390,7 @@ void mallctl_string(client *c, robj **argv, int argc) {
 #endif
 
 void debugCommand(client *c) {
-    if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr, "help")) {
+    if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "help")) {
         const char *help[] = {
             "AOF-FLUSH-SLEEP <microsec>",
             "    Server will sleep before flushing the AOF, this is used for testing.",
@@ -510,45 +510,45 @@ void debugCommand(client *c) {
             "    Enable or disable the main dict and expire dict resizing.",
             NULL};
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
-    } else if (!strcasecmp(c->argv[1]->ptr, "segfault")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "segfault")) {
         /* Compiler gives warnings about writing to a random address
          * e.g "*((char*)-1) = 'x';". As a workaround, we map a read-only area
          * and try to write there to trigger segmentation fault. */
         char *p = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE | MAP_ANON, -1, 0);
         *p = 'x';
-    } else if (!strcasecmp(c->argv[1]->ptr, "panic")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "panic")) {
         serverPanic("DEBUG PANIC called at Unix time %lld", (long long)time(NULL));
-    } else if (!strcasecmp(c->argv[1]->ptr, "restart") || !strcasecmp(c->argv[1]->ptr, "crash-and-recover")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "restart") || !strcasecmp(objectGetVal(c->argv[1]), "crash-and-recover")) {
         long long delay = 0;
         if (c->argc >= 3) {
             if (getLongLongFromObjectOrReply(c, c->argv[2], &delay, NULL) != C_OK) return;
             if (delay < 0) delay = 0;
         }
-        int flags = !strcasecmp(c->argv[1]->ptr, "restart")
+        int flags = !strcasecmp(objectGetVal(c->argv[1]), "restart")
                         ? (RESTART_SERVER_GRACEFULLY | RESTART_SERVER_CONFIG_REWRITE)
                         : RESTART_SERVER_NONE;
         restartServer(c, flags, delay);
         addReplyError(c, "failed to restart the server. Check server logs.");
-    } else if (!strcasecmp(c->argv[1]->ptr, "oom")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "oom")) {
         void *ptr = zmalloc(SIZE_MAX / 2); /* Should trigger an out of memory. */
         zfree(ptr);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "assert")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "assert")) {
         serverAssertWithInfo(c, c->argv[0], 1 == 2);
-    } else if (!strcasecmp(c->argv[1]->ptr, "log") && c->argc == 3) {
-        serverLog(LL_WARNING, "DEBUG LOG: %s", (char *)c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "log") && c->argc == 3) {
+        serverLog(LL_WARNING, "DEBUG LOG: %s", (char *)objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "leak") && c->argc == 3) {
-        sdsdup(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "leak") && c->argc == 3) {
+        sdsdup(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "reload")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "reload")) {
         int flush = 1, save = 1;
         int flags = RDBFLAGS_NONE;
 
         /* Parse the additional options that modify the RELOAD
          * behavior. */
         for (int j = 2; j < c->argc; j++) {
-            char *opt = c->argv[j]->ptr;
+            char *opt = objectGetVal(c->argv[j]);
             if (!strcasecmp(opt, "MERGE")) {
                 flags |= RDBFLAGS_ALLOW_DUP;
             } else if (!strcasecmp(opt, "NOFLUSH")) {
@@ -587,7 +587,7 @@ void debugCommand(client *c) {
         }
         serverLog(LL_NOTICE, "DB reloaded by DEBUG RELOAD");
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "loadaof")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "loadaof")) {
         if (server.aof_state != AOF_OFF) flushAppendOnlyFile(1);
         emptyData(-1, EMPTYDB_NO_FLAGS, NULL);
         protectClient(c);
@@ -603,25 +603,25 @@ void debugCommand(client *c) {
         server.dirty = 0; /* Prevent AOF / replication */
         serverLog(LL_NOTICE, "Append Only File loaded by DEBUG LOADAOF");
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "drop-cluster-packet-filter") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "drop-cluster-packet-filter") && c->argc == 3) {
         long packet_type;
         if (getLongFromObjectOrReply(c, c->argv[2], &packet_type, NULL) != C_OK) return;
         server.cluster_drop_packet_filter = packet_type;
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "close-cluster-link-on-packet-drop") && c->argc == 3) {
-        server.debug_cluster_close_link_on_packet_drop = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "close-cluster-link-on-packet-drop") && c->argc == 3) {
+        server.debug_cluster_close_link_on_packet_drop = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "disable-cluster-random-ping") && c->argc == 3) {
-        server.debug_cluster_disable_random_ping = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "disable-cluster-random-ping") && c->argc == 3) {
+        server.debug_cluster_disable_random_ping = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "object") && (c->argc == 3 || c->argc == 4)) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "object") && (c->argc == 3 || c->argc == 4)) {
         robj *val;
         char *strenc;
 
         int fast = 0;
-        if (c->argc == 4 && !strcasecmp(c->argv[3]->ptr, "fast")) fast = 1;
+        if (c->argc == 4 && !strcasecmp(objectGetVal(c->argv[3]), "fast")) fast = 1;
 
-        if ((val = dbFind(c->db, c->argv[2]->ptr)) == NULL) {
+        if ((val = dbFind(c->db, objectGetVal(c->argv[2]))) == NULL) {
             addReplyErrorObject(c, shared.nokeyerr);
             return;
         }
@@ -631,7 +631,7 @@ void debugCommand(client *c) {
         if (val->encoding == OBJ_ENCODING_QUICKLIST) {
             char *nextra = extra;
             int remaining = sizeof(extra);
-            quicklist *ql = val->ptr;
+            quicklist *ql = objectGetVal(val);
             /* Add number of quicklist nodes */
             int used = snprintf(nextra, remaining, " ql_nodes:%lu", ql->len);
             nextra += used;
@@ -671,11 +671,11 @@ void debugCommand(client *c) {
         s = sdscatprintf(s, "%s", extra);
         addReplyStatusLength(c, s, sdslen(s));
         sdsfree(s);
-    } else if (!strcasecmp(c->argv[1]->ptr, "sdslen") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "sdslen") && c->argc == 3) {
         robj *val;
         sds key;
 
-        if ((val = dbFind(c->db, c->argv[2]->ptr)) == NULL) {
+        if ((val = dbFind(c->db, objectGetVal(c->argv[2]))) == NULL) {
             addReplyErrorObject(c, shared.nokeyerr);
             return;
         }
@@ -688,10 +688,10 @@ void debugCommand(client *c) {
                                  "key_sds_len:%lld, key_sds_avail:%lld, key_zmalloc: %lld, "
                                  "val_sds_len:%lld, val_sds_avail:%lld, val_zmalloc: %lld",
                                  (long long)sdslen(key), (long long)sdsavail(key), (long long)sdsAllocSize(key),
-                                 (long long)sdslen(val->ptr), (long long)sdsavail(val->ptr),
+                                 (long long)sdslen(objectGetVal(val)), (long long)sdsavail(objectGetVal(val)),
                                  (long long)getStringObjectSdsUsedMemory(val));
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "listpack") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "listpack") && c->argc == 3) {
         robj *o;
 
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.nokeyerr)) == NULL) return;
@@ -699,23 +699,23 @@ void debugCommand(client *c) {
         if (o->encoding != OBJ_ENCODING_LISTPACK) {
             addReplyError(c, "Not a listpack encoded object.");
         } else {
-            lpRepr(o->ptr);
+            lpRepr(objectGetVal(o));
             addReplyStatus(c, "Listpack structure printed on stdout");
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "quicklist") && (c->argc == 3 || c->argc == 4)) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "quicklist") && (c->argc == 3 || c->argc == 4)) {
         robj *o;
 
         if ((o = objectCommandLookupOrReply(c, c->argv[2], shared.nokeyerr)) == NULL) return;
 
         int full = 0;
-        if (c->argc == 4) full = atoi(c->argv[3]->ptr);
+        if (c->argc == 4) full = atoi(objectGetVal(c->argv[3]));
         if (o->encoding != OBJ_ENCODING_QUICKLIST) {
             addReplyError(c, "Not a quicklist encoded object.");
         } else {
-            quicklistRepr(o->ptr, full);
+            quicklistRepr(objectGetVal(o), full);
             addReplyStatus(c, "Quicklist structure printed on stdout");
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "populate") && c->argc >= 3 && c->argc <= 5) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "populate") && c->argc >= 3 && c->argc <= 5) {
         long keys, j;
         robj *key, *val;
         char buf[128];
@@ -735,7 +735,7 @@ void debugCommand(client *c) {
         if (c->argc == 5 && getPositiveLongFromObjectOrReply(c, c->argv[4], &valsize, NULL) != C_OK) return;
 
         for (j = 0; j < keys; j++) {
-            snprintf(buf, sizeof(buf), "%s:%lu", (c->argc == 3) ? "key" : (char *)c->argv[3]->ptr, j);
+            snprintf(buf, sizeof(buf), "%s:%lu", (c->argc == 3) ? "key" : (char *)objectGetVal(c->argv[3]), j);
             key = createStringObject(buf, strlen(buf));
             if (lookupKeyWrite(c->db, key) != NULL) {
                 decrRefCount(key);
@@ -747,14 +747,14 @@ void debugCommand(client *c) {
             else {
                 int buflen = strlen(buf);
                 val = createStringObject(NULL, valsize);
-                memcpy(val->ptr, buf, valsize <= buflen ? valsize : buflen);
+                memcpy(objectGetVal(val), buf, valsize <= buflen ? valsize : buflen);
             }
             dbAdd(c->db, key, &val);
             signalModifiedKey(c, c->db, key);
             decrRefCount(key);
         }
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "digest") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "digest") && c->argc == 2) {
         /* DEBUG DIGEST (form without keys specified) */
         unsigned char digest[20];
         sds d = sdsempty();
@@ -763,7 +763,7 @@ void debugCommand(client *c) {
         for (int i = 0; i < 20; i++) d = sdscatprintf(d, "%02x", digest[i]);
         addReplyStatus(c, d);
         sdsfree(d);
-    } else if (!strcasecmp(c->argv[1]->ptr, "digest-value") && c->argc >= 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "digest-value") && c->argc >= 2) {
         /* DEBUG DIGEST-VALUE key key key ... key. */
         addReplyArrayLen(c, c->argc - 2);
         for (int j = 2; j < c->argc; j++) {
@@ -772,7 +772,7 @@ void debugCommand(client *c) {
 
             /* We don't use lookupKey because a debug command should
              * work on logically expired keys */
-            robj *o = dbFind(c->db, c->argv[j]->ptr);
+            robj *o = dbFind(c->db, objectGetVal(c->argv[j]));
             if (o) xorObjectDigest(c->db, c->argv[j], digest, o);
 
             sds d = sdsempty();
@@ -780,10 +780,10 @@ void debugCommand(client *c) {
             addReplyStatus(c, d);
             sdsfree(d);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "protocol") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "protocol") && c->argc == 3) {
         /* DEBUG PROTOCOL [string|integer|double|bignum|null|array|set|map|
          *                 attrib|push|verbatim|true|false] */
-        char *name = c->argv[2]->ptr;
+        char *name = objectGetVal(c->argv[2]);
         if (!strcasecmp(name, "string")) {
             addReplyBulkCString(c, "Hello World");
         } else if (!strcasecmp(name, "integer")) {
@@ -842,8 +842,8 @@ void debugCommand(client *c) {
             addReplyError(c, "Wrong protocol type name. Please use one of the following: "
                              "string|integer|double|bignum|null|array|set|map|attrib|push|verbatim|true|false");
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "sleep") && c->argc == 3) {
-        double dtime = valkey_strtod(c->argv[2]->ptr, NULL);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "sleep") && c->argc == 3) {
+        double dtime = valkey_strtod(objectGetVal(c->argv[2]), NULL);
         long long utime = dtime * 1000000;
         struct timespec tv;
 
@@ -851,34 +851,34 @@ void debugCommand(client *c) {
         tv.tv_nsec = (utime % 1000000) * 1000;
         nanosleep(&tv, NULL);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "set-active-expire") && c->argc == 3) {
-        server.active_expire_enabled = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "set-active-expire") && c->argc == 3) {
+        server.active_expire_enabled = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "quicklist-packed-threshold") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "quicklist-packed-threshold") && c->argc == 3) {
         int memerr;
-        unsigned long long sz = memtoull((const char *)c->argv[2]->ptr, &memerr);
+        unsigned long long sz = memtoull((const char *)objectGetVal(c->argv[2]), &memerr);
         if (memerr || !quicklistSetPackedThreshold(sz)) {
             addReplyError(c, "argument must be a memory value bigger than 1 and smaller than 4gb");
         } else {
             addReply(c, shared.ok);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "set-skip-checksum-validation") && c->argc == 3) {
-        server.skip_checksum_validation = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "set-skip-checksum-validation") && c->argc == 3) {
+        server.skip_checksum_validation = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "aof-flush-sleep") && c->argc == 3) {
-        server.aof_flush_sleep = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "aof-flush-sleep") && c->argc == 3) {
+        server.aof_flush_sleep = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "replicate") && c->argc >= 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "replicate") && c->argc >= 3) {
         replicationFeedReplicas(-1, c->argv + 2, c->argc - 2);
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "error") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "error") && c->argc == 3) {
         sds errstr = sdsnewlen("-", 1);
 
-        errstr = sdscatsds(errstr, c->argv[2]->ptr);
+        errstr = sdscatsds(errstr, objectGetVal(c->argv[2]));
         errstr = sdsmapchars(errstr, "\n\r", "  ", 2); /* no newlines in errors. */
         errstr = sdscatlen(errstr, "\r\n", 2);
         addReplySds(c, errstr);
-    } else if (!strcasecmp(c->argv[1]->ptr, "structsize") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "structsize") && c->argc == 2) {
         sds sizes = sdsempty();
         sizes = sdscatprintf(sizes, "bits:%d ", (sizeof(void *) == 8) ? 64 : 32);
         sizes = sdscatprintf(sizes, "robj:%d ", (int)sizeof(robj));
@@ -889,7 +889,7 @@ void debugCommand(client *c) {
         sizes = sdscatprintf(sizes, "sdshdr32:%d ", (int)sizeof(struct sdshdr32));
         sizes = sdscatprintf(sizes, "sdshdr64:%d ", (int)sizeof(struct sdshdr64));
         addReplyBulkSds(c, sizes);
-    } else if (!strcasecmp(c->argv[1]->ptr, "htstats") && c->argc >= 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "htstats") && c->argc >= 3) {
         long dbid;
         sds stats = sdsempty();
         char buf[4096];
@@ -904,7 +904,7 @@ void debugCommand(client *c) {
             addReplyError(c, "Out of range database");
             return;
         }
-        if (c->argc >= 4 && !strcasecmp(c->argv[3]->ptr, "full")) full = 1;
+        if (c->argc >= 4 && !strcasecmp(objectGetVal(c->argv[3]), "full")) full = 1;
 
         stats = sdscatprintf(stats, "[Dictionary HT]\n");
         kvstoreGetStats(server.db[dbid].keys, buf, sizeof(buf), full);
@@ -916,9 +916,9 @@ void debugCommand(client *c) {
 
         addReplyVerbatim(c, stats, sdslen(stats), "txt");
         sdsfree(stats);
-    } else if (!strcasecmp(c->argv[1]->ptr, "htstats-key") && c->argc >= 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "htstats-key") && c->argc >= 3) {
         int full = 0;
-        if (c->argc >= 4 && !strcasecmp(c->argv[3]->ptr, "full")) full = 1;
+        if (c->argc >= 4 && !strcasecmp(objectGetVal(c->argv[3]), "full")) full = 1;
 
         robj *o = objectCommandLookupOrReply(c, c->argv[2], shared.nokeyerr);
         if (o == NULL) return;
@@ -927,10 +927,10 @@ void debugCommand(client *c) {
         hashtable *ht = NULL;
         switch (o->encoding) {
         case OBJ_ENCODING_SKIPLIST: {
-            zset *zs = o->ptr;
+            zset *zs = objectGetVal(o);
             ht = zs->ht;
         } break;
-        case OBJ_ENCODING_HASHTABLE: ht = o->ptr; break;
+        case OBJ_ENCODING_HASHTABLE: ht = objectGetVal(o); break;
         }
 
         if (ht != NULL) {
@@ -941,23 +941,23 @@ void debugCommand(client *c) {
             addReplyError(c, "The value stored at the specified key is not "
                              "represented using an hash table");
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "change-repl-id") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "change-repl-id") && c->argc == 2) {
         serverLog(LL_NOTICE, "Changing replication IDs after receiving DEBUG change-repl-id");
         changeReplicationId();
         clearReplicationId2();
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "stringmatch-test") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "stringmatch-test") && c->argc == 2) {
         stringmatchlen_fuzz_test();
         addReplyStatus(c, "Apparently the server did not crash: test passed");
-    } else if (!strcasecmp(c->argv[1]->ptr, "set-disable-deny-scripts") && c->argc == 3) {
-        server.script_disable_deny_script = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "set-disable-deny-scripts") && c->argc == 3) {
+        server.script_disable_deny_script = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "config-rewrite-force-all") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "config-rewrite-force-all") && c->argc == 2) {
         if (rewriteConfig(server.configfile, 1) == -1)
             addReplyErrorFormat(c, "CONFIG-REWRITE-FORCE-ALL failed: %s", strerror(errno));
         else
             addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "client-eviction") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "client-eviction") && c->argc == 2) {
         if (!server.client_mem_usage_buckets) {
             addReplyError(c, "maxmemory-clients is disabled.");
             return;
@@ -988,33 +988,33 @@ void debugCommand(client *c) {
         mallctl_string(c, c->argv + 2, c->argc - 2);
         return;
 #endif
-    } else if (!strcasecmp(c->argv[1]->ptr, "pause-cron") && c->argc == 3) {
-        server.pause_cron = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-cron") && c->argc == 3) {
+        server.pause_cron = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "replybuffer") && c->argc == 4) {
-        if (!strcasecmp(c->argv[2]->ptr, "peak-reset-time")) {
-            if (!strcasecmp(c->argv[3]->ptr, "never")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "replybuffer") && c->argc == 4) {
+        if (!strcasecmp(objectGetVal(c->argv[2]), "peak-reset-time")) {
+            if (!strcasecmp(objectGetVal(c->argv[3]), "never")) {
                 server.reply_buffer_peak_reset_time = -1;
-            } else if (!strcasecmp(c->argv[3]->ptr, "reset")) {
+            } else if (!strcasecmp(objectGetVal(c->argv[3]), "reset")) {
                 server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
             } else {
                 if (getLongFromObjectOrReply(c, c->argv[3], &server.reply_buffer_peak_reset_time, NULL) != C_OK) return;
             }
-        } else if (!strcasecmp(c->argv[2]->ptr, "resizing")) {
-            server.reply_buffer_resizing_enabled = atoi(c->argv[3]->ptr);
+        } else if (!strcasecmp(objectGetVal(c->argv[2]), "resizing")) {
+            server.reply_buffer_resizing_enabled = atoi(objectGetVal(c->argv[3]));
         } else {
             addReplySubcommandSyntaxError(c);
             return;
         }
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "pause-after-fork") && c->argc == 3) {
-        server.debug_pause_after_fork = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "pause-after-fork") && c->argc == 3) {
+        server.debug_pause_after_fork = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "delay-rdb-client-free-seconds") && c->argc == 3) {
-        server.wait_before_rdb_client_free = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "delay-rdb-client-free-seconds") && c->argc == 3) {
+        server.wait_before_rdb_client_free = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
-    } else if (!strcasecmp(c->argv[1]->ptr, "dict-resizing") && c->argc == 3) {
-        server.dict_resizing = atoi(c->argv[2]->ptr);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "dict-resizing") && c->argc == 3) {
+        server.dict_resizing = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
     } else if (!handleDebugClusterCommand(c)) {
         addReplySubcommandSyntaxError(c);
@@ -1046,7 +1046,7 @@ __attribute__((noinline, weak)) void _serverAssert(const char *estr, const char 
 /* Returns the argv argument in binary representation, limited to length 128. */
 sds getArgvReprString(robj *argv) {
     robj *decoded = getDecodedObject(argv);
-    sds repr = sdscatrepr(sdsempty(), decoded->ptr, min(sdslen(decoded->ptr), 128));
+    sds repr = sdscatrepr(sdsempty(), objectGetVal(decoded), min(sdslen(objectGetVal(decoded)), 128));
     decrRefCount(decoded);
     return repr;
 }
@@ -1072,13 +1072,13 @@ void _serverAssertPrintClientInfo(const client *c) {
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {
         if (shouldRedactArg(c, j)) {
-            serverLog(LL_WARNING, "client->argv[%d]: %zu bytes", j, sdslen((sds)c->argv[j]->ptr));
+            serverLog(LL_WARNING, "client->argv[%d]: %zu bytes", j, sdslen((sds)objectGetVal(c->argv[j])));
             continue;
         }
         sds repr = getArgvReprString(c->argv[j]);
         serverLog(LL_WARNING, "client->argv[%d] = %s (refcount: %d)", j, repr, c->argv[j]->refcount);
         sdsfree(repr);
-        if (!strcasecmp(c->argv[j]->ptr, "auth") || !strcasecmp(c->argv[j]->ptr, "auth2")) {
+        if (!strcasecmp(objectGetVal(c->argv[j]), "auth") || !strcasecmp(objectGetVal(c->argv[j]), "auth2")) {
             break;
         }
     }
@@ -1891,13 +1891,13 @@ void logCurrentClient(client *cc, const char *title) {
     serverLog(LL_WARNING | LL_RAW, "argc: %d\n", cc->argc);
     for (j = 0; j < cc->argc; j++) {
         if (shouldRedactArg(cc, j)) {
-            serverLog(LL_WARNING | LL_RAW, "argv[%d]: %zu bytes\n", j, sdslen((sds)cc->argv[j]->ptr));
+            serverLog(LL_WARNING | LL_RAW, "argv[%d]: %zu bytes\n", j, sdslen((sds)objectGetVal(cc->argv[j])));
             continue;
         }
         sds repr = getArgvReprString(cc->argv[j]);
         serverLog(LL_WARNING | LL_RAW, "argv[%d]: %s\n", j, repr);
         sdsfree(repr);
-        if (!strcasecmp(cc->argv[j]->ptr, "auth") || !strcasecmp(cc->argv[j]->ptr, "auth2")) {
+        if (!strcasecmp(objectGetVal(cc->argv[j]), "auth") || !strcasecmp(objectGetVal(cc->argv[j]), "auth2")) {
             break;
         }
     }
@@ -1907,9 +1907,9 @@ void logCurrentClient(client *cc, const char *title) {
         robj *val, *key;
 
         key = getDecodedObject(cc->argv[1]);
-        val = dbFind(cc->db, key->ptr);
+        val = dbFind(cc->db, objectGetVal(key));
         if (val) {
-            serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)key->ptr);
+            serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)objectGetVal(key));
             serverLogObjectDebugInfo(val);
         }
         decrRefCount(key);

--- a/src/expire.c
+++ b/src/expire.c
@@ -478,13 +478,13 @@ void rememberReplicaKeyWithExpire(serverDb *db, robj *key) {
     }
     if (db->id > 63) return;
 
-    dictEntry *de = dictAddOrFind(replicaKeysWithExpire, key->ptr);
+    dictEntry *de = dictAddOrFind(replicaKeysWithExpire, objectGetVal(key));
     /* If the entry was just created, set it to a copy of the SDS string
      * representing the key: we don't want to need to take those keys
      * in sync with the main DB. The keys will be removed by expireReplicaKeys()
      * as it scans to find keys to remove. */
-    if (dictGetKey(de) == key->ptr) {
-        dictSetKey(replicaKeysWithExpire, de, sdsdup(key->ptr));
+    if (dictGetKey(de) == objectGetVal(key)) {
+        dictSetKey(replicaKeysWithExpire, de, sdsdup(objectGetVal(key)));
         dictSetUnsignedIntegerVal(de, 0);
     }
 
@@ -544,7 +544,7 @@ int parseExtendedExpireArgumentsOrReply(client *c, int *flags) {
 
     int j = 3;
     while (j < c->argc) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         if (!strcasecmp(opt, "nx")) {
             *flags |= EXPIRE_NX;
             nx = 1;

--- a/src/geo.c
+++ b/src/geo.c
@@ -115,7 +115,7 @@ int extractLongLatOrReply(client *c, robj **argv, double *xy) {
 int longLatFromMember(robj *zobj, robj *member, double *xy) {
     double score = 0;
 
-    if (zsetScore(zobj, member->ptr, &score) == C_ERR) return C_ERR;
+    if (zsetScore(zobj, objectGetVal(member), &score) == C_ERR) return C_ERR;
     if (!decodeGeohash(score, xy)) return C_ERR;
     return C_OK;
 }
@@ -127,7 +127,7 @@ int longLatFromMember(robj *zobj, robj *member, double *xy) {
  * If the unit is not valid, an error is reported to the client, and a value
  * less than zero is returned. */
 double extractUnitOrReply(client *c, robj *unit) {
-    char *u = unit->ptr;
+    char *u = objectGetVal(unit);
 
     if (!strcasecmp(u, "m")) {
         return 1;
@@ -255,7 +255,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
     zrangespec range = {.min = min, .max = max, .minex = 0, .maxex = 1};
     size_t origincount = ga->used;
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr = NULL;
         unsigned int vlen = 0;
@@ -286,7 +286,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             zzlNext(zl, &eptr, &sptr);
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
 
@@ -435,7 +435,7 @@ void geoaddCommand(client *c) {
     /* Parse options. At the end 'longidx' is set to the argument position
      * of the longitude of the first element. */
     while (longidx < c->argc) {
-        char *opt = c->argv[longidx]->ptr;
+        char *opt = objectGetVal(c->argv[longidx]);
         if (!strcasecmp(opt, "nx"))
             nx = 1;
         else if (!strcasecmp(opt, "xx"))
@@ -561,7 +561,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     if (c->argc > base_args) {
         int remaining = c->argc - base_args;
         for (int i = 0; i < remaining; i++) {
-            char *arg = c->argv[base_args + i]->ptr;
+            char *arg = objectGetVal(c->argv[base_args + i]);
             if (!strcasecmp(arg, "withdist")) {
                 withdist = 1;
             } else if (!strcasecmp(arg, "withhash")) {
@@ -640,12 +640,12 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
     if ((flags & GEOSEARCH) && !(frommember || fromloc)) {
         addReplyErrorFormat(c, "exactly one of FROMMEMBER or FROMLONLAT can be specified for %s",
-                            (char *)c->argv[0]->ptr);
+                            (char *)objectGetVal(c->argv[0]));
         return;
     }
 
     if ((flags & GEOSEARCH) && !(byradius || bybox)) {
-        addReplyErrorFormat(c, "exactly one of BYRADIUS and BYBOX can be specified for %s", (char *)c->argv[0]->ptr);
+        addReplyErrorFormat(c, "exactly one of BYRADIUS and BYBOX can be specified for %s", (char *)objectGetVal(c->argv[0]));
         return;
     }
 
@@ -761,7 +761,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
         if (returned_items) {
             zobj = createZsetObject();
-            zs = zobj->ptr;
+            zs = objectGetVal(zobj);
         }
 
         for (i = 0; i < returned_items; i++) {
@@ -839,7 +839,7 @@ void geohashCommand(client *c) {
     addReplyArrayLen(c, c->argc - 2);
     for (j = 2; j < c->argc; j++) {
         double score;
-        if (!zobj || zsetScore(zobj, c->argv[j]->ptr, &score) == C_ERR) {
+        if (!zobj || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
             addReplyNull(c);
         } else {
             /* The internal format we use for geocoding is a bit different
@@ -900,7 +900,7 @@ void geoposCommand(client *c) {
     addReplyArrayLen(c, c->argc - 2);
     for (j = 2; j < c->argc; j++) {
         double score;
-        if (!zobj || zsetScore(zobj, c->argv[j]->ptr, &score) == C_ERR) {
+        if (!zobj || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
             addReplyNullArray(c);
         } else {
             /* Decode... */
@@ -940,7 +940,7 @@ void geodistCommand(client *c) {
 
     /* Get the scores. We need both otherwise NULL is returned. */
     double score1, score2, xyxy[4];
-    if (zsetScore(zobj, c->argv[2]->ptr, &score1) == C_ERR || zsetScore(zobj, c->argv[3]->ptr, &score2) == C_ERR) {
+    if (zsetScore(zobj, objectGetVal(c->argv[2]), &score1) == C_ERR || zsetScore(zobj, objectGetVal(c->argv[3]), &score2) == C_ERR) {
         addReplyNull(c);
         return;
     }

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -593,7 +593,7 @@ void hllDenseRegHisto(uint8_t *registers, int *reghisto) {
  * The function returns C_OK if the sparse representation was valid,
  * otherwise C_ERR is returned if the representation was corrupted. */
 int hllSparseToDense(robj *o) {
-    sds sparse = o->ptr, dense;
+    sds sparse = objectGetVal(o), dense;
     struct hllhdr *hdr, *oldhdr = (struct hllhdr *)sparse;
     int idx = 0, runlen, regval;
     uint8_t *p = (uint8_t *)sparse, *end = p + sdslen(sparse);
@@ -642,7 +642,7 @@ int hllSparseToDense(robj *o) {
     }
 
     /* Free the old representation and set the new one. */
-    sdsfree(o->ptr);
+    sdsfree(objectGetVal(o));
     o->ptr = dense;
     return C_OK;
 }
@@ -681,19 +681,19 @@ int hllSparseSet(robj *o, long index, uint8_t count) {
      * If the available size of hyperloglog sds string is not enough for the increment
      * we need, we promote the hyperloglog to dense representation in 'step 3'.
      */
-    if (sdsalloc(o->ptr) < server.hll_sparse_max_bytes && sdsavail(o->ptr) < 3) {
-        size_t newlen = sdslen(o->ptr) + 3;
+    if (sdsalloc(objectGetVal(o)) < server.hll_sparse_max_bytes && sdsavail(objectGetVal(o)) < 3) {
+        size_t newlen = sdslen(objectGetVal(o)) + 3;
         newlen +=
             min(newlen,
                 300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300 to it when it exceeds 300 */
         if (newlen > server.hll_sparse_max_bytes) newlen = server.hll_sparse_max_bytes;
-        o->ptr = sdsResize(o->ptr, newlen, 1);
+        o->ptr = sdsResize(objectGetVal(o), newlen, 1);
     }
 
     /* Step 1: we need to locate the opcode we need to modify to check
      * if a value update is actually needed. */
-    sparse = p = ((uint8_t *)o->ptr) + HLL_HDR_SIZE;
-    end = p + sdslen(o->ptr) - HLL_HDR_SIZE;
+    sparse = p = ((uint8_t *)objectGetVal(o)) + HLL_HDR_SIZE;
+    end = p + sdslen(objectGetVal(o)) - HLL_HDR_SIZE;
 
     first = 0;
     prev = NULL; /* Points to previous opcode at the end of the loop. */
@@ -850,10 +850,10 @@ int hllSparseSet(robj *o, long index, uint8_t count) {
     int oldlen = is_xzero ? 2 : 1;
     int deltalen = seqlen - oldlen;
 
-    if (deltalen > 0 && sdslen(o->ptr) + deltalen > server.hll_sparse_max_bytes) goto promote;
-    serverAssert(sdslen(o->ptr) + deltalen <= sdsalloc(o->ptr));
+    if (deltalen > 0 && sdslen(objectGetVal(o)) + deltalen > server.hll_sparse_max_bytes) goto promote;
+    serverAssert(sdslen(objectGetVal(o)) + deltalen <= sdsalloc(objectGetVal(o)));
     if (deltalen && next) memmove(next + deltalen, next, end - next);
-    sdsIncrLen(o->ptr, deltalen);
+    sdsIncrLen(objectGetVal(o), deltalen);
     memcpy(p, seq, seqlen);
     end += deltalen;
 
@@ -883,7 +883,7 @@ updated:
                 if (len <= HLL_SPARSE_VAL_MAX_LEN) {
                     HLL_SPARSE_VAL_SET(p + 1, v1, len);
                     memmove(p, p + 1, end - p);
-                    sdsIncrLen(o->ptr, -1);
+                    sdsIncrLen(objectGetVal(o), -1);
                     end--;
                     /* After a merge we reiterate without incrementing 'p'
                      * in order to try to merge the just merged value with
@@ -896,13 +896,13 @@ updated:
     }
 
     /* Invalidate the cached cardinality. */
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
     HLL_INVALIDATE_CACHE(hdr);
     return 1;
 
 promote:                                         /* Promote to dense representation. */
     if (hllSparseToDense(o) == C_ERR) return -1; /* Corrupted HLL. */
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
 
     /* We need to call hllDenseAdd() to perform the operation after the
      * conversion. However the result must be 1, since if we need to
@@ -1070,7 +1070,7 @@ uint64_t hllCount(struct hllhdr *hdr, int *invalid) {
 
 /* Call hllDenseAdd() or hllSparseAdd() according to the HLL encoding. */
 int hllAdd(robj *o, unsigned char *ele, size_t elesize) {
-    struct hllhdr *hdr = o->ptr;
+    struct hllhdr *hdr = objectGetVal(o);
     switch (hdr->encoding) {
     case HLL_DENSE: return hllDenseAdd(hdr->registers, ele, elesize);
     case HLL_SPARSE: return hllSparseAdd(o, ele, elesize);
@@ -1217,13 +1217,13 @@ void hllMergeDense(uint8_t *reg_raw, const uint8_t *reg_dense) {
  * If the HyperLogLog is sparse and is found to be invalid, C_ERR
  * is returned, otherwise the function always succeeds. */
 int hllMerge(uint8_t *max, robj *hll) {
-    struct hllhdr *hdr = hll->ptr;
+    struct hllhdr *hdr = objectGetVal(hll);
     int i;
 
     if (hdr->encoding == HLL_DENSE) {
         hllMergeDense(max, hdr->registers);
     } else {
-        uint8_t *p = hll->ptr, *end = p + sdslen(hll->ptr);
+        uint8_t *p = objectGetVal(hll), *end = p + sdslen(objectGetVal(hll));
         long runlen, regval;
 
         p += HLL_HDR_SIZE;
@@ -1396,7 +1396,7 @@ robj *createHLLObject(void) {
 
     /* Create the actual object. */
     o = createObject(OBJ_STRING, s);
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
     memcpy(hdr->magic, "HYLL", 4);
     hdr->encoding = HLL_SPARSE;
     return o;
@@ -1413,7 +1413,7 @@ int isHLLObjectOrReply(client *c, robj *o) {
 
     if (!sdsEncodedObject(o)) goto invalid;
     if (stringObjectLen(o) < sizeof(*hdr)) goto invalid;
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
 
     /* Magic should be "HYLL". */
     if (hdr->magic[0] != 'H' || hdr->magic[1] != 'Y' || hdr->magic[2] != 'L' || hdr->magic[3] != 'L') goto invalid;
@@ -1451,13 +1451,13 @@ void pfaddCommand(client *c) {
     }
     /* Perform the low level ADD operation for every element. */
     for (j = 2; j < c->argc; j++) {
-        int retval = hllAdd(o, (unsigned char *)c->argv[j]->ptr, sdslen(c->argv[j]->ptr));
+        int retval = hllAdd(o, (unsigned char *)objectGetVal(c->argv[j]), sdslen(objectGetVal(c->argv[j])));
         switch (retval) {
         case 1: updated++; break;
         case -1: addReplyError(c, invalid_hll_err); return;
         }
     }
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
     if (updated) {
         HLL_INVALIDATE_CACHE(hdr);
         signalModifiedKey(c, c->db, c->argv[1]);
@@ -1526,7 +1526,7 @@ void pfcountCommand(client *c) {
         o = dbUnshareStringValue(c->db, c->argv[1], o);
 
         /* Check if the cached cardinality is valid. */
-        hdr = o->ptr;
+        hdr = objectGetVal(o);
         if (HLL_VALID_CACHE(hdr)) {
             /* Just return the cached value. */
             card = (uint64_t)hdr->card[0];
@@ -1582,7 +1582,7 @@ void pfmergeCommand(client *c) {
 
         /* If at least one involved HLL is dense, use the dense representation
          * as target ASAP to save time and avoid the conversion step. */
-        hdr = o->ptr;
+        hdr = objectGetVal(o);
         if (hdr->encoding == HLL_DENSE) use_dense = 1;
 
         /* Merge with this HLL with our 'max' HLL by setting max[i]
@@ -1618,19 +1618,19 @@ void pfmergeCommand(client *c) {
     /* Write the resulting HLL to the destination HLL registers and
      * invalidate the cached value. */
     if (use_dense) {
-        hdr = o->ptr;
+        hdr = objectGetVal(o);
         hllDenseCompress(hdr->registers, max);
     } else {
         for (j = 0; j < HLL_REGISTERS; j++) {
             if (max[j] == 0) continue;
-            hdr = o->ptr;
+            hdr = objectGetVal(o);
             switch (hdr->encoding) {
             case HLL_DENSE: hllDenseSet(hdr->registers, j, max[j]); break;
             case HLL_SPARSE: hllSparseSet(o, j, max[j]); break;
             }
         }
     }
-    hdr = o->ptr; /* o->ptr may be different now, as a side effect of
+    hdr = objectGetVal(o); /* o->ptr may be different now, as a side effect of
                      last hllSparseSet() call. */
     HLL_INVALIDATE_CACHE(hdr);
 
@@ -1705,7 +1705,7 @@ void pfselftestCommand(client *c) {
         /* Make sure that for small cardinalities we use sparse
          * encoding. */
         if (j == checkpoint && j < server.hll_sparse_max_bytes / 2) {
-            hdr2 = o->ptr;
+            hdr2 = objectGetVal(o);
             if (hdr2->encoding != HLL_SPARSE) {
                 addReplyError(c, "TESTFAILED sparse encoding not used");
                 goto cleanup;
@@ -1713,7 +1713,7 @@ void pfselftestCommand(client *c) {
         }
 
         /* Check that dense and sparse representations agree. */
-        if (j == checkpoint && hllCount(hdr, NULL) != hllCount(o->ptr, NULL)) {
+        if (j == checkpoint && hllCount(hdr, NULL) != hllCount(objectGetVal(o), NULL)) {
             addReplyError(c, "TESTFAILED dense/sparse disagree");
             goto cleanup;
         }
@@ -1756,7 +1756,7 @@ cleanup:
  * PFDEBUG SIMD (ON|OFF)
  */
 void pfdebugCommand(client *c) {
-    char *cmd = c->argv[1]->ptr;
+    char *cmd = objectGetVal(c->argv[1]);
     struct hllhdr *hdr;
     robj *o;
     int j;
@@ -1764,11 +1764,11 @@ void pfdebugCommand(client *c) {
     if (!strcasecmp(cmd, "simd")) {
         if (c->argc != 3) goto arityerr;
 
-        if (!strcasecmp(c->argv[2]->ptr, "on")) {
+        if (!strcasecmp(objectGetVal(c->argv[2]), "on")) {
 #ifdef HAVE_AVX2
             simd_enabled = 1;
 #endif
-        } else if (!strcasecmp(c->argv[2]->ptr, "off")) {
+        } else if (!strcasecmp(objectGetVal(c->argv[2]), "off")) {
 #ifdef HAVE_AVX2
             simd_enabled = 0;
 #endif
@@ -1792,7 +1792,7 @@ void pfdebugCommand(client *c) {
     }
     if (isHLLObjectOrReply(c, o) != C_OK) return;
     o = dbUnshareStringValue(c->db, c->argv[2], o);
-    hdr = o->ptr;
+    hdr = objectGetVal(o);
 
     /* PFDEBUG GETREG <key> */
     if (!strcasecmp(cmd, "getreg")) {
@@ -1806,7 +1806,7 @@ void pfdebugCommand(client *c) {
             server.dirty++; /* Force propagation on encoding change. */
         }
 
-        hdr = o->ptr;
+        hdr = objectGetVal(o);
         addReplyArrayLen(c, HLL_REGISTERS);
         for (j = 0; j < HLL_REGISTERS; j++) {
             uint8_t val;
@@ -1819,7 +1819,7 @@ void pfdebugCommand(client *c) {
     else if (!strcasecmp(cmd, "decode")) {
         if (c->argc != 3) goto arityerr;
 
-        uint8_t *p = o->ptr, *end = p + sdslen(o->ptr);
+        uint8_t *p = objectGetVal(o), *end = p + sdslen(objectGetVal(o));
         sds decoded = sdsempty();
 
         if (hdr->encoding != HLL_SPARSE) {

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -643,7 +643,7 @@ int hllSparseToDense(robj *o) {
 
     /* Free the old representation and set the new one. */
     sdsfree(objectGetVal(o));
-    o->ptr = dense;
+    objectSetVal(o, dense);
     return C_OK;
 }
 
@@ -687,7 +687,7 @@ int hllSparseSet(robj *o, long index, uint8_t count) {
             min(newlen,
                 300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300 to it when it exceeds 300 */
         if (newlen > server.hll_sparse_max_bytes) newlen = server.hll_sparse_max_bytes;
-        o->ptr = sdsResize(objectGetVal(o), newlen, 1);
+        objectSetVal(o, sdsResize(objectGetVal(o), newlen, 1));
     }
 
     /* Step 1: we need to locate the opcode we need to modify to check

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -506,7 +506,7 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
 
     /* We offload only the free of the ptr that may be allocated by the I/O thread.
      * The object itself was allocated by the main thread and will be freed by the main thread. */
-    IOJobQueue_push(jq, sdsfreeVoid, obj->ptr);
+    IOJobQueue_push(jq, sdsfreeVoid, objectGetVal(obj));
     obj->ptr = NULL;
     decrRefCount(obj);
 

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -507,7 +507,7 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
     /* We offload only the free of the ptr that may be allocated by the I/O thread.
      * The object itself was allocated by the main thread and will be freed by the main thread. */
     IOJobQueue_push(jq, sdsfreeVoid, objectGetVal(obj));
-    obj->ptr = NULL;
+    objectSetVal(obj, NULL);
     decrRefCount(obj);
 
     server.stat_io_freed_objects++;

--- a/src/latency.c
+++ b/src/latency.c
@@ -551,7 +551,7 @@ void latencySpecificCommandsFillCDF(client *c) {
     void *replylen = addReplyDeferredLen(c);
     int command_with_data = 0;
     for (int j = 2; j < c->argc; j++) {
-        struct serverCommand *cmd = lookupCommandBySds(c->argv[j]->ptr);
+        struct serverCommand *cmd = lookupCommandBySds(objectGetVal(c->argv[j]));
         /* If the command does not exist we skip the reply */
         if (cmd == NULL) {
             continue;
@@ -677,21 +677,21 @@ sds latencyCommandGenSparkeline(char *event, struct latencyTimeSeries *ts) {
 void latencyCommand(client *c) {
     struct latencyTimeSeries *ts;
 
-    if (!strcasecmp(c->argv[1]->ptr, "history") && c->argc == 3) {
+    if (!strcasecmp(objectGetVal(c->argv[1]), "history") && c->argc == 3) {
         /* LATENCY HISTORY <event> */
-        ts = dictFetchValue(server.latency_events, c->argv[2]->ptr);
+        ts = dictFetchValue(server.latency_events, objectGetVal(c->argv[2]));
         if (ts == NULL) {
             addReplyArrayLen(c, 0);
         } else {
             latencyCommandReplyWithSamples(c, ts);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "graph") && c->argc == 3) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "graph") && c->argc == 3) {
         /* LATENCY GRAPH <event> */
         sds graph;
         dictEntry *de;
         char *event;
 
-        de = dictFind(server.latency_events, c->argv[2]->ptr);
+        de = dictFind(server.latency_events, objectGetVal(c->argv[2]));
         if (de == NULL) goto nodataerr;
         ts = dictGetVal(de);
         event = dictGetKey(de);
@@ -699,26 +699,26 @@ void latencyCommand(client *c) {
         graph = latencyCommandGenSparkeline(event, ts);
         addReplyVerbatim(c, graph, sdslen(graph), "txt");
         sdsfree(graph);
-    } else if (!strcasecmp(c->argv[1]->ptr, "latest") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "latest") && c->argc == 2) {
         /* LATENCY LATEST */
         latencyCommandReplyWithLatestEvents(c);
-    } else if (!strcasecmp(c->argv[1]->ptr, "doctor") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "doctor") && c->argc == 2) {
         /* LATENCY DOCTOR */
         sds report = createLatencyReport();
 
         addReplyVerbatim(c, report, sdslen(report), "txt");
         sdsfree(report);
-    } else if (!strcasecmp(c->argv[1]->ptr, "reset") && c->argc >= 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "reset") && c->argc >= 2) {
         /* LATENCY RESET */
         if (c->argc == 2) {
             addReplyLongLong(c, latencyResetEvent(NULL));
         } else {
             int j, resets = 0;
 
-            for (j = 2; j < c->argc; j++) resets += latencyResetEvent(c->argv[j]->ptr);
+            for (j = 2; j < c->argc; j++) resets += latencyResetEvent(objectGetVal(c->argv[j]));
             addReplyLongLong(c, resets);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "histogram") && c->argc >= 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "histogram") && c->argc >= 2) {
         /* LATENCY HISTOGRAM*/
         if (c->argc == 2) {
             int command_with_data = 0;
@@ -728,7 +728,7 @@ void latencyCommand(client *c) {
         } else {
             latencySpecificCommandsFillCDF(c);
         }
-    } else if (!strcasecmp(c->argv[1]->ptr, "help") && c->argc == 2) {
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "help") && c->argc == 2) {
         const char *help[] = {
             "DOCTOR",
             "    Return a human readable latency analysis report.",
@@ -755,7 +755,7 @@ void latencyCommand(client *c) {
 nodataerr:
     /* Common error when the user asks for an event we have no latency
      * information about. */
-    addReplyErrorFormat(c, "No samples available for event '%s'", (char *)c->argv[2]->ptr);
+    addReplyErrorFormat(c, "No samples available for event '%s'", (char *)objectGetVal(c->argv[2]));
 }
 
 void durationAddSample(int type, monotime duration) {

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -115,20 +115,20 @@ void lazyfreeResetStats(void) {
  * representing the list. */
 size_t lazyfreeGetFreeEffort(robj *key, robj *obj, int dbid) {
     if (obj->type == OBJ_LIST && obj->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklist *ql = obj->ptr;
+        quicklist *ql = objectGetVal(obj);
         return ql->len;
     } else if (obj->type == OBJ_SET && obj->encoding == OBJ_ENCODING_HASHTABLE) {
-        hashtable *ht = obj->ptr;
+        hashtable *ht = objectGetVal(obj);
         return hashtableSize(ht);
     } else if (obj->type == OBJ_ZSET && obj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = obj->ptr;
+        zset *zs = objectGetVal(obj);
         return zs->zsl->length;
     } else if (obj->type == OBJ_HASH && obj->encoding == OBJ_ENCODING_HASHTABLE) {
-        hashtable *ht = obj->ptr;
+        hashtable *ht = objectGetVal(obj);
         return hashtableSize(ht);
     } else if (obj->type == OBJ_STREAM) {
         size_t effort = 0;
-        stream *s = obj->ptr;
+        stream *s = objectGetVal(obj);
 
         /* Make a best effort estimate to maintain constant runtime. Every macro
          * node in the Stream is one allocation. */

--- a/src/lolwut.c
+++ b/src/lolwut.c
@@ -55,7 +55,7 @@ void lolwutCommand(client *c) {
     char *v = VALKEY_VERSION;
     char verstr[64];
 
-    if (c->argc >= 3 && !strcasecmp(c->argv[1]->ptr, "version")) {
+    if (c->argc >= 3 && !strcasecmp(objectGetVal(c->argv[1]), "version")) {
         long ver;
         if (getLongFromObjectOrReply(c, c->argv[2], &ver, NULL) != C_OK) return;
         snprintf(verstr, sizeof(verstr), "%u.0.0", (unsigned int)ver);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -130,7 +130,7 @@ static void prefetchValue(KeyPrefetchInfo *info) {
     if (hashtableIncrementalFindGetResult(&info->hashtab_state, &entry)) {
         robj *val = entry;
         if (val->encoding == OBJ_ENCODING_RAW && val->type == OBJ_STRING) {
-            valkey_prefetch(val->ptr);
+            valkey_prefetch(objectGetVal(val));
         }
     }
 
@@ -187,14 +187,14 @@ static void prefetchCommands(void) {
         if (!c || c->argc <= 1) continue;
         for (int j = 1; j < c->argc; j++) {
             if (c->argv[j]->encoding == OBJ_ENCODING_RAW) {
-                valkey_prefetch(c->argv[j]->ptr);
+                valkey_prefetch(objectGetVal(c->argv[j]));
             }
         }
     }
 
     /* Get the keys ptrs - we do it here after the key obj was prefetched. */
     for (size_t i = 0; i < batch->key_count; i++) {
-        batch->keys[i] = ((robj *)batch->keys[i])->ptr;
+        batch->keys[i] = objectGetVal(batch->keys[i]);
     }
 
     /* Prefetch hashtable keys for all commands. Prefetching is beneficial only if there are more than one key. */

--- a/src/notify.c
+++ b/src/notify.c
@@ -125,7 +125,7 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
         len = ll2string(buf, sizeof(buf), dbid);
         chan = sdscatlen(chan, buf, len);
         chan = sdscatlen(chan, "__:", 3);
-        chan = sdscatsds(chan, key->ptr);
+        chan = sdscatsds(chan, objectGetVal(key));
         chanobj = createObject(OBJ_STRING, chan);
         pubsubPublishMessage(chanobj, eventobj, 0);
         decrRefCount(chanobj);
@@ -137,7 +137,7 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
         if (len == -1) len = ll2string(buf, sizeof(buf), dbid);
         chan = sdscatlen(chan, buf, len);
         chan = sdscatlen(chan, "__:", 3);
-        chan = sdscatsds(chan, eventobj->ptr);
+        chan = sdscatsds(chan, objectGetVal(eventobj));
         chanobj = createObject(OBJ_STRING, chan);
         pubsubPublishMessage(chanobj, key, 0);
         decrRefCount(chanobj);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -523,10 +523,10 @@ ssize_t rdbSaveStringObject(rio *rdb, robj *obj) {
     /* Avoid to decode the object, then encode it again, if the
      * object is already integer encoded. */
     if (obj->encoding == OBJ_ENCODING_INT) {
-        return rdbSaveLongLongAsStringObject(rdb, (long)obj->ptr);
+        return rdbSaveLongLongAsStringObject(rdb, (long)objectGetVal(obj));
     } else {
         serverAssertWithInfo(NULL, obj, sdsEncodedObject(obj));
-        return rdbSaveRawString(rdb, obj->ptr, sdslen(obj->ptr));
+        return rdbSaveRawString(rdb, objectGetVal(obj), sdslen(objectGetVal(obj)));
     }
 }
 
@@ -585,7 +585,7 @@ void *rdbGenericLoadStringObject(rio *rdb, int flags, size_t *lenptr) {
                       "rdbGenericLoadStringObject failed allocating %llu bytes", len);
             return NULL;
         }
-        if (len && rioRead(rdb, o->ptr, len) == 0) {
+        if (len && rioRead(rdb, objectGetVal(o), len) == 0) {
             decrRefCount(o);
             return NULL;
         }
@@ -843,7 +843,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_LIST) {
         /* Save a list value */
         if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-            quicklist *ql = o->ptr;
+            quicklist *ql = objectGetVal(o);
             quicklistNode *node = ql->head;
 
             if ((n = rdbSaveLen(rdb, ql->len)) == -1) return -1;
@@ -865,7 +865,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
                 node = node->next;
             }
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            unsigned char *lp = o->ptr;
+            unsigned char *lp = objectGetVal(o);
 
             /* Save list listpack as a fake quicklist that only has a single node. */
             if ((n = rdbSaveLen(rdb, 1)) == -1) return -1;
@@ -880,7 +880,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_SET) {
         /* Save a set value */
         if (o->encoding == OBJ_ENCODING_HASHTABLE) {
-            hashtable *set = o->ptr;
+            hashtable *set = objectGetVal(o);
 
             if ((n = rdbSaveLen(rdb, hashtableSize(set))) == -1) {
                 return -1;
@@ -900,13 +900,13 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
             }
             hashtableResetIterator(&iterator);
         } else if (o->encoding == OBJ_ENCODING_INTSET) {
-            size_t l = intsetBlobLen((intset *)o->ptr);
+            size_t l = intsetBlobLen((intset *)objectGetVal(o));
 
-            if ((n = rdbSaveRawString(rdb, o->ptr, l)) == -1) return -1;
+            if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
         } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            size_t l = lpBytes((unsigned char *)o->ptr);
-            if ((n = rdbSaveRawString(rdb, o->ptr, l)) == -1) return -1;
+            size_t l = lpBytes((unsigned char *)objectGetVal(o));
+            if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
         } else {
             serverPanic("Unknown set encoding");
@@ -914,12 +914,12 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_ZSET) {
         /* Save a sorted set value */
         if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            size_t l = lpBytes((unsigned char *)o->ptr);
+            size_t l = lpBytes((unsigned char *)objectGetVal(o));
 
-            if ((n = rdbSaveRawString(rdb, o->ptr, l)) == -1) return -1;
+            if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = o->ptr;
+            zset *zs = objectGetVal(o);
             zskiplist *zsl = zs->zsl;
 
             if ((n = rdbSaveLen(rdb, zsl->length)) == -1) return -1;
@@ -947,12 +947,12 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_HASH) {
         /* Save a hash value */
         if (o->encoding == OBJ_ENCODING_LISTPACK) {
-            size_t l = lpBytes((unsigned char *)o->ptr);
+            size_t l = lpBytes((unsigned char *)objectGetVal(o));
 
-            if ((n = rdbSaveRawString(rdb, o->ptr, l)) == -1) return -1;
+            if ((n = rdbSaveRawString(rdb, objectGetVal(o), l)) == -1) return -1;
             nwritten += n;
         } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
-            hashtable *ht = o->ptr;
+            hashtable *ht = objectGetVal(o);
 
             if ((n = rdbSaveLen(rdb, hashtableSize(ht))) == -1) {
                 return -1;
@@ -983,7 +983,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
         }
     } else if (o->type == OBJ_STREAM) {
         /* Store how many listpacks we have inside the radix tree. */
-        stream *s = o->ptr;
+        stream *s = objectGetVal(o);
         rax *rax = s->rax;
         if ((n = rdbSaveLen(rdb, raxSize(rax))) == -1) return -1;
         nwritten += n;
@@ -1094,7 +1094,7 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid) {
     } else if (o->type == OBJ_MODULE) {
         /* Save a module-specific value. */
         ValkeyModuleIO io;
-        moduleValue *mv = o->ptr;
+        moduleValue *mv = objectGetVal(o);
         moduleType *mt = mv->type;
 
         /* Write the "module" identifier as prefix, so that we'll be able
@@ -1895,8 +1895,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 return NULL;
             }
             dec = getDecodedObject(ele);
-            size_t len = sdslen(dec->ptr);
-            quicklistPushTail(o->ptr, dec->ptr, len);
+            size_t len = sdslen(objectGetVal(dec));
+            quicklistPushTail(objectGetVal(o), objectGetVal(dec), len);
             decrRefCount(dec);
             decrRefCount(ele);
         }
@@ -1914,7 +1914,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             o = createSetObject();
             /* It's faster to expand the dict to the right size asap in order
              * to avoid rehashing */
-            if (!hashtableTryExpand(o->ptr, len)) {
+            if (!hashtableTryExpand(objectGetVal(o), len)) {
                 rdbReportCorruptRDB("OOM in hashtableTryExpand %llu", (unsigned long long)len);
                 decrRefCount(o);
                 return NULL;
@@ -1941,7 +1941,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 /* Fetch integer value from element. */
                 if (isSdsRepresentableAsLongLong(sdsele, &llval) == C_OK) {
                     uint8_t success;
-                    o->ptr = intsetAdd(o->ptr, llval, &success);
+                    o->ptr = intsetAdd(objectGetVal(o), llval, &success);
                     if (!success) {
                         rdbReportCorruptRDB("Duplicate set members detected");
                         decrRefCount(o);
@@ -1966,15 +1966,15 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
              * to a listpack encoded set. */
             if (o->encoding == OBJ_ENCODING_LISTPACK) {
                 if (setTypeSize(o) < server.set_max_listpack_entries && elelen <= server.set_max_listpack_value &&
-                    lpSafeToAdd(o->ptr, elelen)) {
-                    unsigned char *p = lpFirst(o->ptr);
-                    if (p && lpFind(o->ptr, p, (unsigned char *)sdsele, elelen, 0)) {
+                    lpSafeToAdd(objectGetVal(o), elelen)) {
+                    unsigned char *p = lpFirst(objectGetVal(o));
+                    if (p && lpFind(objectGetVal(o), p, (unsigned char *)sdsele, elelen, 0)) {
                         rdbReportCorruptRDB("Duplicate set members detected");
                         decrRefCount(o);
                         sdsfree(sdsele);
                         return NULL;
                     }
-                    o->ptr = lpAppend(o->ptr, (unsigned char *)sdsele, elelen);
+                    o->ptr = lpAppend(objectGetVal(o), (unsigned char *)sdsele, elelen);
                 } else if (setTypeConvertAndExpand(o, OBJ_ENCODING_HASHTABLE, len, 0) != C_OK) {
                     rdbReportCorruptRDB("OOM in hashtableTryExpand %llu", (unsigned long long)len);
                     sdsfree(sdsele);
@@ -1986,7 +1986,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             /* This will also be called when the set was just converted
              * to a regular hash table encoded set. */
             if (o->encoding == OBJ_ENCODING_HASHTABLE) {
-                if (!hashtableAdd((hashtable *)o->ptr, sdsele)) {
+                if (!hashtableAdd((hashtable *)objectGetVal(o), sdsele)) {
                     rdbReportCorruptRDB("Duplicate set members detected");
                     decrRefCount(o);
                     sdsfree(sdsele);
@@ -2006,7 +2006,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
         if (zsetlen == 0) goto emptykey;
 
         o = createZsetObject();
-        zs = o->ptr;
+        zs = objectGetVal(o);
 
         if (!hashtableTryExpand(zs->ht, zsetlen)) {
             rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)zsetlen);
@@ -2118,11 +2118,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
 
             /* Convert to hash table if size threshold is exceeded */
             if (sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value ||
-                !lpSafeToAdd(o->ptr, sdslen(field) + sdslen(value))) {
+                !lpSafeToAdd(objectGetVal(o), sdslen(field) + sdslen(value))) {
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
                 hashTypeEntry *entry = hashTypeCreateEntry(field, value);
                 sdsfree(field);
-                if (!hashtableAdd((hashtable *)o->ptr, entry)) {
+                if (!hashtableAdd((hashtable *)objectGetVal(o), entry)) {
                     rdbReportCorruptRDB("Duplicate hash fields detected");
                     if (dupSearchDict) dictRelease(dupSearchDict);
                     freeHashTypeEntry(entry);
@@ -2133,8 +2133,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             }
 
             /* Add pair to listpack */
-            o->ptr = lpAppend(o->ptr, (unsigned char *)field, sdslen(field));
-            o->ptr = lpAppend(o->ptr, (unsigned char *)value, sdslen(value));
+            o->ptr = lpAppend(objectGetVal(o), (unsigned char *)field, sdslen(field));
+            o->ptr = lpAppend(objectGetVal(o), (unsigned char *)value, sdslen(value));
 
             sdsfree(field);
             sdsfree(value);
@@ -2148,7 +2148,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
         }
 
         if (o->encoding == OBJ_ENCODING_HASHTABLE) {
-            if (!hashtableTryExpand(o->ptr, len)) {
+            if (!hashtableTryExpand(objectGetVal(o), len)) {
                 rdbReportCorruptRDB("OOM in hashtableTryExpand %llu", (unsigned long long)len);
                 decrRefCount(o);
                 return NULL;
@@ -2172,7 +2172,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             /* Add pair to hash table */
             hashTypeEntry *entry = hashTypeCreateEntry(field, value);
             sdsfree(field);
-            if (!hashtableAdd((hashtable *)o->ptr, entry)) {
+            if (!hashtableAdd((hashtable *)objectGetVal(o), entry)) {
                 rdbReportCorruptRDB("Duplicate hash fields detected");
                 freeHashTypeEntry(entry);
                 decrRefCount(o);
@@ -2213,7 +2213,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             }
 
             if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
-                quicklistAppendPlainNode(o->ptr, data, encoded_len);
+                quicklistAppendPlainNode(objectGetVal(o), data, encoded_len);
                 continue;
             }
 
@@ -2244,11 +2244,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 zfree(lp);
                 continue;
             } else {
-                quicklistAppendListpack(o->ptr, lp);
+                quicklistAppendListpack(objectGetVal(o), lp);
             }
         }
 
-        if (quicklistCount(o->ptr) == 0) {
+        if (quicklistCount(objectGetVal(o)) == 0) {
             decrRefCount(o);
             goto emptykey;
         }
@@ -2285,7 +2285,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
              * when loading dumps created by Redis OSS 2.4 gets deprecated. */
             {
                 unsigned char *lp = lpNew(0);
-                unsigned char *zi = zipmapRewind(o->ptr);
+                unsigned char *zi = zipmapRewind(objectGetVal(o));
                 unsigned char *fstr, *vstr;
                 unsigned int flen, vlen;
                 unsigned int maxlen = 0;
@@ -2313,7 +2313,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 }
 
                 dictRelease(dupSearchDict);
-                zfree(o->ptr);
+                zfree(objectGetVal(o));
                 o->ptr = lp;
                 o->type = OBJ_HASH;
                 o->encoding = OBJ_ENCODING_LISTPACK;
@@ -2360,7 +2360,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             }
             o->type = OBJ_SET;
             o->encoding = OBJ_ENCODING_INTSET;
-            if (intsetLen(o->ptr) > server.set_max_intset_entries) setTypeConvert(o, OBJ_ENCODING_HASHTABLE);
+            if (intsetLen(objectGetVal(o)) > server.set_max_intset_entries) setTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             break;
         case RDB_TYPE_SET_LISTPACK:
             if (deep_integrity_validation) server.stat_dump_payload_sanitizations++;
@@ -2393,7 +2393,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 return NULL;
             }
 
-            zfree(o->ptr);
+            zfree(objectGetVal(o));
             o->type = OBJ_ZSET;
             o->ptr = lp;
             o->encoding = OBJ_ENCODING_LISTPACK;
@@ -2405,7 +2405,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             if (zsetLength(o) > server.zset_max_listpack_entries)
                 zsetConvert(o, OBJ_ENCODING_SKIPLIST);
             else
-                o->ptr = lpShrinkToFit(o->ptr);
+                o->ptr = lpShrinkToFit(objectGetVal(o));
             break;
         }
         case RDB_TYPE_ZSET_LISTPACK:
@@ -2437,7 +2437,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 return NULL;
             }
 
-            zfree(o->ptr);
+            zfree(objectGetVal(o));
             o->ptr = lp;
             o->type = OBJ_HASH;
             o->encoding = OBJ_ENCODING_LISTPACK;
@@ -2449,7 +2449,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             if (hashTypeLength(o) > server.hash_max_listpack_entries)
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
             else
-                o->ptr = lpShrinkToFit(o->ptr);
+                o->ptr = lpShrinkToFit(objectGetVal(o));
             break;
         }
         case RDB_TYPE_HASH_LISTPACK:
@@ -2478,7 +2478,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
     } else if (rdbtype == RDB_TYPE_STREAM_LISTPACKS || rdbtype == RDB_TYPE_STREAM_LISTPACKS_2 ||
                rdbtype == RDB_TYPE_STREAM_LISTPACKS_3) {
         o = createStreamObject();
-        stream *s = o->ptr;
+        stream *s = objectGetVal(o);
         uint64_t listpacks = rdbLoadLen(rdb, NULL);
         if (listpacks == RDB_LENERR) {
             rdbReportReadError("Stream listpacks len loading failed.");
@@ -3120,48 +3120,48 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 goto eoferr;
             }
 
-            if (((char *)auxkey->ptr)[0] == '%') {
+            if (((char *)objectGetVal(auxkey))[0] == '%') {
                 /* All the fields with a name staring with '%' are considered
                  * information fields and are logged at startup with a log
                  * level of NOTICE. */
-                serverLog(LL_NOTICE, "RDB '%s': %s", (char *)auxkey->ptr, (char *)auxval->ptr);
-            } else if (!strcasecmp(auxkey->ptr, "repl-stream-db")) {
-                if (rsi) rsi->repl_stream_db = atoi(auxval->ptr);
-            } else if (!strcasecmp(auxkey->ptr, "repl-id")) {
-                if (rsi && sdslen(auxval->ptr) == CONFIG_RUN_ID_SIZE) {
-                    memcpy(rsi->repl_id, auxval->ptr, CONFIG_RUN_ID_SIZE + 1);
+                serverLog(LL_NOTICE, "RDB '%s': %s", (char *)objectGetVal(auxkey), (char *)objectGetVal(auxval));
+            } else if (!strcasecmp(objectGetVal(auxkey), "repl-stream-db")) {
+                if (rsi) rsi->repl_stream_db = atoi(objectGetVal(auxval));
+            } else if (!strcasecmp(objectGetVal(auxkey), "repl-id")) {
+                if (rsi && sdslen(objectGetVal(auxval)) == CONFIG_RUN_ID_SIZE) {
+                    memcpy(rsi->repl_id, objectGetVal(auxval), CONFIG_RUN_ID_SIZE + 1);
                     rsi->repl_id_is_set = 1;
                 }
-            } else if (!strcasecmp(auxkey->ptr, "repl-offset")) {
-                if (rsi) rsi->repl_offset = strtoll(auxval->ptr, NULL, 10);
-            } else if (!strcasecmp(auxkey->ptr, "lua")) {
+            } else if (!strcasecmp(objectGetVal(auxkey), "repl-offset")) {
+                if (rsi) rsi->repl_offset = strtoll(objectGetVal(auxval), NULL, 10);
+            } else if (!strcasecmp(objectGetVal(auxkey), "lua")) {
                 /* Won't load the script back in memory anymore. */
-            } else if (!strcasecmp(auxkey->ptr, "redis-ver")) {
-                serverLog(LL_NOTICE, "Loading RDB produced by Redis version %s", (char *)auxval->ptr);
-            } else if (!strcasecmp(auxkey->ptr, "valkey-ver")) {
-                serverLog(LL_NOTICE, "Loading RDB produced by Valkey version %s", (char *)auxval->ptr);
-            } else if (!strcasecmp(auxkey->ptr, "ctime")) {
-                time_t age = time(NULL) - strtol(auxval->ptr, NULL, 10);
+            } else if (!strcasecmp(objectGetVal(auxkey), "redis-ver")) {
+                serverLog(LL_NOTICE, "Loading RDB produced by Redis version %s", (char *)objectGetVal(auxval));
+            } else if (!strcasecmp(objectGetVal(auxkey), "valkey-ver")) {
+                serverLog(LL_NOTICE, "Loading RDB produced by Valkey version %s", (char *)objectGetVal(auxval));
+            } else if (!strcasecmp(objectGetVal(auxkey), "ctime")) {
+                time_t age = time(NULL) - strtol(objectGetVal(auxval), NULL, 10);
                 if (age < 0) age = 0;
                 serverLog(LL_NOTICE, "RDB age %ld seconds", (unsigned long)age);
-            } else if (!strcasecmp(auxkey->ptr, "used-mem")) {
-                long long usedmem = strtoll(auxval->ptr, NULL, 10);
+            } else if (!strcasecmp(objectGetVal(auxkey), "used-mem")) {
+                long long usedmem = strtoll(objectGetVal(auxval), NULL, 10);
                 serverLog(LL_NOTICE, "RDB memory usage when created %.2f Mb", (double)usedmem / (1024 * 1024));
                 server.loading_rdb_used_mem = usedmem;
-            } else if (!strcasecmp(auxkey->ptr, "aof-preamble")) {
-                long long haspreamble = strtoll(auxval->ptr, NULL, 10);
+            } else if (!strcasecmp(objectGetVal(auxkey), "aof-preamble")) {
+                long long haspreamble = strtoll(objectGetVal(auxval), NULL, 10);
                 if (haspreamble) serverLog(LL_NOTICE, "RDB has an AOF tail");
-            } else if (!strcasecmp(auxkey->ptr, "aof-base")) {
-                long long isbase = strtoll(auxval->ptr, NULL, 10);
+            } else if (!strcasecmp(objectGetVal(auxkey), "aof-base")) {
+                long long isbase = strtoll(objectGetVal(auxval), NULL, 10);
                 if (isbase) serverLog(LL_NOTICE, "RDB is base AOF");
-            } else if (!strcasecmp(auxkey->ptr, "redis-bits")) {
+            } else if (!strcasecmp(objectGetVal(auxkey), "redis-bits")) {
                 /* Just ignored. */
-            } else if (!strcasecmp(auxkey->ptr, "slot-info")) {
+            } else if (!strcasecmp(objectGetVal(auxkey), "slot-info")) {
                 int slot_id;
                 unsigned long slot_size, expires_slot_size;
                 /* Try to parse the slot information. In case the number of parsed arguments is smaller than expected
                  * we'll fail the RDB load. */
-                if (sscanf(auxval->ptr, "%i,%lu,%lu", &slot_id, &slot_size, &expires_slot_size) < 3) {
+                if (sscanf(objectGetVal(auxval), "%i,%lu,%lu", &slot_id, &slot_size, &expires_slot_size) < 3) {
                     decrRefCount(auxkey);
                     decrRefCount(auxval);
                     goto eoferr;
@@ -3178,11 +3178,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 /* Check if this is a dynamic aux field */
                 int handled = 0;
                 if (rdbAuxFields != NULL) {
-                    dictEntry *de = dictFind(rdbAuxFields, auxkey->ptr);
+                    dictEntry *de = dictFind(rdbAuxFields, objectGetVal(auxkey));
                     if (de != NULL) {
                         handled = 1;
                         rdbAuxFieldCodec *codec = (rdbAuxFieldCodec *)dictGetVal(de);
-                        if (codec->decoder(rdbflags, auxval->ptr) == C_ERR) {
+                        if (codec->decoder(rdbflags, objectGetVal(auxval)) == C_ERR) {
                             decrRefCount(auxkey);
                             decrRefCount(auxval);
                             goto eoferr;
@@ -3193,7 +3193,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 if (!handled) {
                     /* We ignore fields we don't understand, as by AUX field
                      * contract. */
-                    serverLog(LL_DEBUG, "Unrecognized RDB AUX field: '%s'", (char *)auxkey->ptr);
+                    serverLog(LL_DEBUG, "Unrecognized RDB AUX field: '%s'", (char *)objectGetVal(auxkey));
                 }
             }
 
@@ -3718,9 +3718,9 @@ void bgsaveCommand(client *c) {
     /* The SCHEDULE option changes the behavior of BGSAVE when an AOF rewrite
      * is in progress. Instead of returning an error a BGSAVE gets scheduled. */
     if (c->argc > 1) {
-        if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr, "schedule")) {
+        if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "schedule")) {
             schedule = 1;
-        } else if (c->argc == 2 && !strcasecmp(c->argv[1]->ptr, "cancel")) {
+        } else if (c->argc == 2 && !strcasecmp(objectGetVal(c->argv[1]), "cancel")) {
             /* Terminates an in progress BGSAVE */
             if (server.child_type == CHILD_TYPE_RDB) {
                 /* There is an ongoing bgsave */

--- a/src/script.c
+++ b/src/script.c
@@ -344,7 +344,7 @@ static int scriptVerifyACL(client *c, sds *err) {
     int acl_retval = ACLCheckAllPerm(c, &acl_errpos);
     if (acl_retval != ACL_OK) {
         addACLLogEntry(c, acl_retval, ACL_LOG_CTX_LUA, acl_errpos, NULL, NULL);
-        sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, c->argv[acl_errpos]->ptr, 0);
+        sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, objectGetVal(c->argv[acl_errpos]), 0);
         *err = sdscatsds(sdsnew("ACL failure in script: "), msg);
         sdsfree(msg);
         return C_ERR;
@@ -376,7 +376,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
     int deny_write_type = writeCommandsDeniedByDiskError();
 
     if (server.primary_host && server.repl_replica_ro && !mustObeyClient(run_ctx->original_client)) {
-        *err = sdsdup(shared.roreplicaerr->ptr);
+        *err = sdsdup(objectGetVal(shared.roreplicaerr));
         return C_ERR;
     }
 
@@ -390,7 +390,7 @@ static int scriptVerifyWriteCommandAllow(scriptRunCtx *run_ctx, char **err) {
      * for Eval scripts that didn't declare flags, see the other check in
      * scriptPrepareForRun */
     if (!checkGoodReplicasStatus()) {
-        *err = sdsdup(shared.noreplicaserr->ptr);
+        *err = sdsdup(objectGetVal(shared.noreplicaserr));
         return C_ERR;
     }
 
@@ -413,7 +413,7 @@ static int scriptVerifyOOM(scriptRunCtx *run_ctx, char **err) {
         !(run_ctx->flags & SCRIPT_WRITE_DIRTY) &&    /* Script had no side effects so far. */
         server.pre_command_oom_state &&              /* Detected OOM when script start. */
         (run_ctx->c->cmd->flags & CMD_DENYOOM)) {
-        *err = sdsdup(shared.oomerr->ptr);
+        *err = sdsdup(objectGetVal(shared.oomerr));
         return C_ERR;
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -419,12 +419,12 @@ void *dictSdsDup(const void *key) {
 
 int dictObjKeyCompare(const void *key1, const void *key2) {
     const robj *o1 = key1, *o2 = key2;
-    return dictSdsKeyCompare(o1->ptr, o2->ptr);
+    return dictSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
 }
 
 uint64_t dictObjHash(const void *key) {
     const robj *o = key;
-    return dictGenHashFunction(o->ptr, sdslen((sds)o->ptr));
+    return dictGenHashFunction(objectGetVal(o), sdslen((sds)objectGetVal(o)));
 }
 
 uint64_t dictSdsHash(const void *key) {
@@ -473,7 +473,7 @@ int dictEncObjKeyCompare(const void *key1, const void *key2) {
     robj *o1 = (robj *)key1, *o2 = (robj *)key2;
     int cmp;
 
-    if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT) return o1->ptr == o2->ptr;
+    if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT) return objectGetVal(o1) == objectGetVal(o2);
 
     /* Due to OBJ_STATIC_REFCOUNT, we avoid calling getDecodedObject() without
      * good reasons, because it would incrRefCount() the object, which
@@ -481,7 +481,7 @@ int dictEncObjKeyCompare(const void *key1, const void *key2) {
      * objects as well. */
     if (o1->refcount != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
-    cmp = dictSdsKeyCompare(o1->ptr, o2->ptr);
+    cmp = dictSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
     if (o1->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
     return cmp;
@@ -491,12 +491,12 @@ uint64_t dictEncObjHash(const void *key) {
     robj *o = (robj *)key;
 
     if (sdsEncodedObject(o)) {
-        return dictGenHashFunction(o->ptr, sdslen((sds)o->ptr));
+        return dictGenHashFunction(objectGetVal(o), sdslen((sds)objectGetVal(o)));
     } else if (o->encoding == OBJ_ENCODING_INT) {
         char buf[32];
         int len;
 
-        len = ll2string(buf, 32, (long)o->ptr);
+        len = ll2string(buf, 32, (long)objectGetVal(o));
         return dictGenHashFunction((unsigned char *)buf, len);
     } else {
         serverPanic("Unknown string encoding");
@@ -582,13 +582,13 @@ void hashtableObjectPrefetchValue(const void *entry) {
     const robj *obj = entry;
     if (obj->encoding != OBJ_ENCODING_EMBSTR &&
         obj->encoding != OBJ_ENCODING_INT) {
-        valkey_prefetch(obj->ptr);
+        valkey_prefetch(objectGetVal(obj));
     }
 }
 
 int hashtableObjKeyCompare(const void *key1, const void *key2) {
     const robj *o1 = key1, *o2 = key2;
-    return hashtableSdsKeyCompare(o1->ptr, o2->ptr);
+    return hashtableSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
 }
 
 void hashtableObjectDestructor(void *val) {
@@ -3300,7 +3300,7 @@ struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_
  */
 struct serverCommand *lookupCommandLogic(hashtable *commands, robj **argv, int argc, int strict) {
     void *entry = NULL;
-    int found_command = hashtableFind(commands, argv[0]->ptr, &entry);
+    int found_command = hashtableFind(commands, objectGetVal(argv[0]), &entry);
     struct serverCommand *base_cmd = entry;
     int has_subcommands = found_command && base_cmd->subcommands_ht;
     if (argc == 1 || !has_subcommands) {
@@ -3310,7 +3310,7 @@ struct serverCommand *lookupCommandLogic(hashtable *commands, robj **argv, int a
     } else { /* argc > 1 && has_subcommands */
         if (strict && argc != 2) return NULL;
         /* Note: Currently we support just one level of subcommands */
-        return lookupSubcommand(base_cmd, argv[1]->ptr);
+        return lookupSubcommand(base_cmd, objectGetVal(argv[1]));
     }
 }
 
@@ -3858,7 +3858,7 @@ void rejectCommand(client *c, robj *reply) {
     c->duration = 0;
     if (c->cmd) c->cmd->rejected_calls++;
     if (c->cmd && c->cmd->proc == execCommand) {
-        execCommandAbort(c, reply->ptr);
+        execCommandAbort(c, objectGetVal(reply));
     } else {
         /* using addReplyError* rather than addReply so that the error can be logged. */
         addReplyErrorObject(c, reply);
@@ -3911,22 +3911,22 @@ void afterCommand(client *c) {
 int commandCheckExistence(client *c, sds *err) {
     if (c->cmd) return 1;
     if (!err) return 0;
-    if (isContainerCommandBySds(c->argv[0]->ptr) && c->argc >= 2) {
+    if (isContainerCommandBySds(objectGetVal(c->argv[0])) && c->argc >= 2) {
         /* If we can't find the command but argv[0] by itself is a command
          * it means we're dealing with an invalid subcommand. Print Help. */
-        sds cmd = sdsnew((char *)c->argv[0]->ptr);
+        sds cmd = sdsnew((char *)objectGetVal(c->argv[0]));
         sdstoupper(cmd);
         *err = sdsnew(NULL);
-        *err = sdscatprintf(*err, "unknown subcommand '%.128s'. Try %s HELP.", (char *)c->argv[1]->ptr, cmd);
+        *err = sdscatprintf(*err, "unknown subcommand '%.128s'. Try %s HELP.", (char *)objectGetVal(c->argv[1]), cmd);
         sdsfree(cmd);
     } else {
         sds args = sdsempty();
         int i;
         for (i = 1; i < c->argc && sdslen(args) < 128; i++)
-            args = sdscatprintf(args, "'%.*s' ", 128 - (int)sdslen(args), (char *)c->argv[i]->ptr);
+            args = sdscatprintf(args, "'%.*s' ", 128 - (int)sdslen(args), (char *)objectGetVal(c->argv[i]));
         *err = sdsnew(NULL);
         *err =
-            sdscatprintf(*err, "unknown command '%.128s', with args beginning with: %s", (char *)c->argv[0]->ptr, args);
+            sdscatprintf(*err, "unknown command '%.128s', with args beginning with: %s", (char *)objectGetVal(c->argv[0]), args);
         sdsfree(args);
     }
     /* Make sure there are no newlines in the string, otherwise invalid protocol
@@ -4009,7 +4009,7 @@ int processCommand(client *c) {
         struct serverCommand *cmd = c->io_parsed_cmd ? c->io_parsed_cmd : lookupCommand(c->argv, c->argc);
         if (!cmd) {
             /* Handle possible security attacks. */
-            if (!strcasecmp(c->argv[0]->ptr, "host:") || !strcasecmp(c->argv[0]->ptr, "post")) {
+            if (!strcasecmp(objectGetVal(c->argv[0]), "host:") || !strcasecmp(objectGetVal(c->argv[0]), "post")) {
                 securityWarningCommand(c);
                 return C_ERR;
             }
@@ -4079,7 +4079,7 @@ int processCommand(client *c) {
     if (acl_retval != ACL_OK) {
         addACLLogEntry(c, acl_retval, (c->flag.multi) ? ACL_LOG_CTX_MULTI : ACL_LOG_CTX_TOPLEVEL, acl_errpos, NULL,
                        NULL);
-        sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, c->argv[acl_errpos]->ptr, 0);
+        sds msg = getAclErrorMessage(acl_retval, c->user, c->cmd, objectGetVal(c->argv[acl_errpos]), 0);
         rejectCommandFormat(c, "-NOPERM %s", msg);
         sdsfree(msg);
         return C_OK;
@@ -4629,7 +4629,7 @@ int writeCommandsDeniedByDiskError(void) {
 sds writeCommandsGetDiskErrorMessage(int error_code) {
     sds ret = NULL;
     if (error_code == DISK_ERROR_TYPE_RDB) {
-        ret = sdsdup(shared.bgsaveerr->ptr);
+        ret = sdsdup(objectGetVal(shared.bgsaveerr));
     } else {
         ret = sdscatfmt(sdsempty(), "-MISCONF Errors writing to the AOF file: %s\r\n",
                         strerror(server.aof_last_write_errno));
@@ -5239,9 +5239,9 @@ void commandListCommand(client *c) {
     commandListFilter filter = {0};
     for (; i < c->argc; i++) {
         int moreargs = (c->argc - 1) - i; /* Number of additional arguments. */
-        char *opt = c->argv[i]->ptr;
+        char *opt = objectGetVal(c->argv[i]);
         if (!strcasecmp(opt, "filterby") && moreargs == 2) {
-            char *filtertype = c->argv[i + 1]->ptr;
+            char *filtertype = objectGetVal(c->argv[i + 1]);
             if (!strcasecmp(filtertype, "module")) {
                 filter.type = COMMAND_LIST_FILTER_MODULE;
             } else if (!strcasecmp(filtertype, "aclcat")) {
@@ -5253,7 +5253,7 @@ void commandListCommand(client *c) {
                 return;
             }
             got_filter = 1;
-            filter.arg = c->argv[i + 2]->ptr;
+            filter.arg = objectGetVal(c->argv[i + 2]);
             i += 2;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
@@ -5290,7 +5290,7 @@ void commandInfoCommand(client *c) {
     } else {
         addReplyArrayLen(c, c->argc - 2);
         for (i = 2; i < c->argc; i++) {
-            addReplyCommandInfo(c, lookupCommandBySds(c->argv[i]->ptr));
+            addReplyCommandInfo(c, lookupCommandBySds(objectGetVal(c->argv[i])));
         }
     }
 }
@@ -5315,7 +5315,7 @@ void commandDocsCommand(client *c) {
         int numcmds = 0;
         void *replylen = addReplyDeferredLen(c);
         for (i = 2; i < c->argc; i++) {
-            struct serverCommand *cmd = lookupCommandBySds(c->argv[i]->ptr);
+            struct serverCommand *cmd = lookupCommandBySds(objectGetVal(c->argv[i]));
             if (!cmd) continue;
             addReplyBulkCBuffer(c, cmd->fullname, sdslen(cmd->fullname));
             addReplyCommandDocs(c, cmd);
@@ -5538,15 +5538,15 @@ dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, i
     dict *section_dict = dictCreate(&stringSetDictType);
     dictExpand(section_dict, min(argc, 16));
     for (int i = 0; i < argc; i++) {
-        if (!strcasecmp(argv[i]->ptr, "default")) {
+        if (!strcasecmp(objectGetVal(argv[i]), "default")) {
             addInfoSectionsToDict(section_dict, defaults);
-        } else if (!strcasecmp(argv[i]->ptr, "all")) {
+        } else if (!strcasecmp(objectGetVal(argv[i]), "all")) {
             if (out_all) *out_all = 1;
-        } else if (!strcasecmp(argv[i]->ptr, "everything")) {
+        } else if (!strcasecmp(objectGetVal(argv[i]), "everything")) {
             if (out_everything) *out_everything = 1;
             if (out_all) *out_all = 1;
         } else {
-            sds section = sdsnew(argv[i]->ptr);
+            sds section = sdsnew(objectGetVal(argv[i]));
             if (dictAdd(section_dict, section, NULL) != DICT_OK) sdsfree(section);
         }
     }

--- a/src/server.h
+++ b/src/server.h
@@ -2897,6 +2897,7 @@ void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long expire);
 robj *objectSetKeyAndExpire(robj *val, sds key, long long expire);
 robj *objectSetExpire(robj *val, long long expire);
+void *objectGetVal(const robj *o);
 sds objectGetKey(const robj *val);
 long long objectGetExpire(const robj *val);
 

--- a/src/server.h
+++ b/src/server.h
@@ -2895,6 +2895,7 @@ void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 
 /* Objects with key attached, AKA valkey (val+key) objects */
 robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long expire);
+void objectSetVal(robj *o, void *val);
 robj *objectSetKeyAndExpire(robj *val, sds key, long long expire);
 robj *objectSetExpire(robj *val, long long expire);
 void *objectGetVal(const robj *o);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -296,7 +296,7 @@ int hashTypeSet(robj *o, sds field, sds value, int flags) {
             zl = lpAppend(zl, (unsigned char *)field, sdslen(field));
             zl = lpAppend(zl, (unsigned char *)value, sdslen(value));
         }
-        o->ptr = zl;
+        objectSetVal(o, zl);
 
         /* Check if the listpack needs to be converted to a hash table */
         if (hashTypeLength(o) > server.hash_max_listpack_entries) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
@@ -348,7 +348,7 @@ int hashTypeDelete(robj *o, sds field) {
             if (fptr != NULL) {
                 /* Delete both field and value. */
                 zl = lpDeleteRangeWithEntry(zl, &fptr, 2);
-                o->ptr = zl;
+                objectSetVal(o, zl);
                 deleted = 1;
             }
         }
@@ -535,7 +535,7 @@ void hashTypeConvertListpack(robj *o, int enc) {
         hashTypeResetIterator(&hi);
         zfree(objectGetVal(o));
         o->encoding = OBJ_ENCODING_HASHTABLE;
-        o->ptr = ht;
+        objectSetVal(o, ht);
     } else {
         serverPanic("Unknown hash encoding");
     }

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -48,23 +48,23 @@ static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end,
     if (argv) {
         for (int i = start; i <= end; i++) {
             if (!sdsEncodedObject(argv[i])) continue;
-            add_bytes += sdslen(argv[i]->ptr);
+            add_bytes += sdslen(objectGetVal(argv[i]));
         }
         add_length = end - start + 1;
     }
 
-    if (quicklistNodeExceedsLimit(server.list_max_listpack_size, lpBytes(o->ptr) + add_bytes,
-                                  lpLength(o->ptr) + add_length)) {
+    if (quicklistNodeExceedsLimit(server.list_max_listpack_size, lpBytes(objectGetVal(o)) + add_bytes,
+                                  lpLength(objectGetVal(o)) + add_length)) {
         /* Invoke callback before conversion. */
         if (fn) fn(data);
 
         quicklist *ql = quicklistNew(server.list_max_listpack_size, server.list_compress_depth);
 
         /* Append listpack to quicklist if it's not empty, otherwise release it. */
-        if (lpLength(o->ptr))
-            quicklistAppendListpack(ql, o->ptr);
+        if (lpLength(objectGetVal(o)))
+            quicklistAppendListpack(ql, objectGetVal(o));
         else
-            lpFree(o->ptr);
+            lpFree(objectGetVal(o));
         o->ptr = ql;
         o->encoding = OBJ_ENCODING_QUICKLIST;
     }
@@ -84,7 +84,7 @@ static void listTypeTryConvertQuicklist(robj *o, int shrinking, beforeConvertCB 
 
     size_t sz_limit;
     unsigned int count_limit;
-    quicklist *ql = o->ptr;
+    quicklist *ql = objectGetVal(o);
 
     /* A quicklist can be converted to listpack only if it has only one packed node. */
     if (ql->len != 1 || ql->head->container != QUICKLIST_NODE_CONTAINER_PACKED) return;
@@ -158,18 +158,18 @@ void listTypePush(robj *subject, robj *value, int where) {
         int pos = (where == LIST_HEAD) ? QUICKLIST_HEAD : QUICKLIST_TAIL;
         if (value->encoding == OBJ_ENCODING_INT) {
             char buf[32];
-            ll2string(buf, 32, (long)value->ptr);
-            quicklistPush(subject->ptr, buf, strlen(buf), pos);
+            ll2string(buf, 32, (long)objectGetVal(value));
+            quicklistPush(objectGetVal(subject), buf, strlen(buf), pos);
         } else {
-            quicklistPush(subject->ptr, value->ptr, sdslen(value->ptr), pos);
+            quicklistPush(objectGetVal(subject), objectGetVal(value), sdslen(objectGetVal(value)), pos);
         }
     } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
         if (value->encoding == OBJ_ENCODING_INT) {
-            subject->ptr = (where == LIST_HEAD) ? lpPrependInteger(subject->ptr, (long)value->ptr)
-                                                : lpAppendInteger(subject->ptr, (long)value->ptr);
+            subject->ptr = (where == LIST_HEAD) ? lpPrependInteger(objectGetVal(subject), (long)objectGetVal(value))
+                                                : lpAppendInteger(objectGetVal(subject), (long)objectGetVal(value));
         } else {
-            subject->ptr = (where == LIST_HEAD) ? lpPrepend(subject->ptr, value->ptr, sdslen(value->ptr))
-                                                : lpAppend(subject->ptr, value->ptr, sdslen(value->ptr));
+            subject->ptr = (where == LIST_HEAD) ? lpPrepend(objectGetVal(subject), objectGetVal(value), sdslen(objectGetVal(value)))
+                                                : lpAppend(objectGetVal(subject), objectGetVal(value), sdslen(objectGetVal(value)));
         }
     } else {
         serverPanic("Unknown list encoding");
@@ -186,7 +186,7 @@ robj *listTypePop(robj *subject, int where) {
     if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
         long long vlong;
         int ql_where = where == LIST_HEAD ? QUICKLIST_HEAD : QUICKLIST_TAIL;
-        if (quicklistPopCustom(subject->ptr, ql_where, (unsigned char **)&value, NULL, &vlong, listPopSaver)) {
+        if (quicklistPopCustom(objectGetVal(subject), ql_where, (unsigned char **)&value, NULL, &vlong, listPopSaver)) {
             if (!value) value = createStringObjectFromLongLong(vlong);
         }
     } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
@@ -195,11 +195,11 @@ robj *listTypePop(robj *subject, int where) {
         int64_t vlen;
         unsigned char intbuf[LP_INTBUF_SIZE];
 
-        p = (where == LIST_HEAD) ? lpFirst(subject->ptr) : lpLast(subject->ptr);
+        p = (where == LIST_HEAD) ? lpFirst(objectGetVal(subject)) : lpLast(objectGetVal(subject));
         if (p) {
             vstr = lpGet(p, &vlen, intbuf);
             value = createStringObject((char *)vstr, vlen);
-            subject->ptr = lpDelete(subject->ptr, p, NULL);
+            subject->ptr = lpDelete(objectGetVal(subject), p, NULL);
         }
     } else {
         serverPanic("Unknown list encoding");
@@ -209,9 +209,9 @@ robj *listTypePop(robj *subject, int where) {
 
 unsigned long listTypeLength(const robj *subject) {
     if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
-        return quicklistCount(subject->ptr);
+        return quicklistCount(objectGetVal(subject));
     } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
-        return lpLength(subject->ptr);
+        return lpLength(objectGetVal(subject));
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -228,9 +228,9 @@ listTypeIterator *listTypeInitIterator(robj *subject, long index, unsigned char 
      * LIST_TAIL means start at HEAD and move *towards* tail. */
     if (li->encoding == OBJ_ENCODING_QUICKLIST) {
         int iter_direction = direction == LIST_HEAD ? AL_START_TAIL : AL_START_HEAD;
-        li->iter = quicklistGetIteratorAtIdx(li->subject->ptr, iter_direction, index);
+        li->iter = quicklistGetIteratorAtIdx(objectGetVal(li->subject), iter_direction, index);
     } else if (li->encoding == OBJ_ENCODING_LISTPACK) {
-        li->lpi = lpSeek(subject->ptr, index);
+        li->lpi = lpSeek(objectGetVal(subject), index);
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -246,7 +246,7 @@ void listTypeSetIteratorDirection(listTypeIterator *li, listTypeEntry *entry, un
         int dir = direction == LIST_HEAD ? AL_START_TAIL : AL_START_HEAD;
         quicklistSetDirection(li->iter, dir);
     } else if (li->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *lp = li->subject->ptr;
+        unsigned char *lp = objectGetVal(li->subject);
         /* Note that the iterator for listpack always points to the next of the current entry,
          * so we need to update position of the iterator depending on the direction. */
         li->lpi = (direction == LIST_TAIL) ? lpNext(lp, entry->lpe) : lpPrev(lp, entry->lpe);
@@ -275,7 +275,7 @@ int listTypeNext(listTypeIterator *li, listTypeEntry *entry) {
         entry->lpe = li->lpi;
         if (entry->lpe != NULL) {
             li->lpi =
-                (li->direction == LIST_TAIL) ? lpNext(li->subject->ptr, li->lpi) : lpPrev(li->subject->ptr, li->lpi);
+                (li->direction == LIST_TAIL) ? lpNext(objectGetVal(li->subject), li->lpi) : lpPrev(objectGetVal(li->subject), li->lpi);
             return 1;
         }
     } else {
@@ -323,7 +323,7 @@ robj *listTypeGet(listTypeEntry *entry) {
 void listTypeInsert(listTypeEntry *entry, robj *value, int where) {
     robj *subject = entry->li->subject;
     value = getDecodedObject(value);
-    sds str = value->ptr;
+    sds str = objectGetVal(value);
     size_t len = sdslen(str);
 
     if (entry->li->encoding == OBJ_ENCODING_QUICKLIST) {
@@ -334,7 +334,7 @@ void listTypeInsert(listTypeEntry *entry, robj *value, int where) {
         }
     } else if (entry->li->encoding == OBJ_ENCODING_LISTPACK) {
         int lpw = (where == LIST_TAIL) ? LP_AFTER : LP_BEFORE;
-        subject->ptr = lpInsertString(subject->ptr, (unsigned char *)str, len, entry->lpe, lpw, &entry->lpe);
+        subject->ptr = lpInsertString(objectGetVal(subject), (unsigned char *)str, len, entry->lpe, lpw, &entry->lpe);
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -345,13 +345,13 @@ void listTypeInsert(listTypeEntry *entry, robj *value, int where) {
 void listTypeReplace(listTypeEntry *entry, robj *value) {
     robj *subject = entry->li->subject;
     value = getDecodedObject(value);
-    sds str = value->ptr;
+    sds str = objectGetVal(value);
     size_t len = sdslen(str);
 
     if (entry->li->encoding == OBJ_ENCODING_QUICKLIST) {
         quicklistReplaceEntry(entry->li->iter, &entry->entry, str, len);
     } else if (entry->li->encoding == OBJ_ENCODING_LISTPACK) {
-        subject->ptr = lpReplace(subject->ptr, &entry->lpe, (unsigned char *)str, len);
+        subject->ptr = lpReplace(objectGetVal(subject), &entry->lpe, (unsigned char *)str, len);
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -365,17 +365,17 @@ void listTypeReplace(listTypeEntry *entry, robj *value) {
  * Returns 0 if replace failed and no changes happened. */
 int listTypeReplaceAtIndex(robj *o, int index, robj *value) {
     value = getDecodedObject(value);
-    sds vstr = value->ptr;
+    sds vstr = objectGetVal(value);
     size_t vlen = sdslen(vstr);
     int replaced = 0;
 
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklist *ql = o->ptr;
+        quicklist *ql = objectGetVal(o);
         replaced = quicklistReplaceAtIndex(ql, index, vstr, vlen);
     } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *p = lpSeek(o->ptr, index);
+        unsigned char *p = lpSeek(objectGetVal(o), index);
         if (p) {
-            o->ptr = lpReplace(o->ptr, &p, (unsigned char *)vstr, vlen);
+            o->ptr = lpReplace(objectGetVal(o), &p, (unsigned char *)vstr, vlen);
             replaced = 1;
         }
     } else {
@@ -390,9 +390,9 @@ int listTypeReplaceAtIndex(robj *o, int index, robj *value) {
 int listTypeEqual(listTypeEntry *entry, robj *o) {
     serverAssertWithInfo(NULL, o, sdsEncodedObject(o));
     if (entry->li->encoding == OBJ_ENCODING_QUICKLIST) {
-        return quicklistCompare(&entry->entry, o->ptr, sdslen(o->ptr));
+        return quicklistCompare(&entry->entry, objectGetVal(o), sdslen(objectGetVal(o)));
     } else if (entry->li->encoding == OBJ_ENCODING_LISTPACK) {
-        return lpCompare(entry->lpe, o->ptr, sdslen(o->ptr));
+        return lpCompare(entry->lpe, objectGetVal(o), sdslen(objectGetVal(o)));
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -404,18 +404,18 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry) {
         quicklistDelEntry(iter->iter, &entry->entry);
     } else if (entry->li->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *p = entry->lpe;
-        iter->subject->ptr = lpDelete(iter->subject->ptr, p, &p);
+        iter->subject->ptr = lpDelete(objectGetVal(iter->subject), p, &p);
 
         /* Update position of the iterator depending on the direction */
         if (iter->direction == LIST_TAIL)
             iter->lpi = p;
         else {
             if (p) {
-                iter->lpi = lpPrev(iter->subject->ptr, p);
+                iter->lpi = lpPrev(objectGetVal(iter->subject), p);
             } else {
                 /* We deleted the last element, so we need to set the
                  * iterator to the last element. */
-                iter->lpi = lpLast(iter->subject->ptr);
+                iter->lpi = lpLast(objectGetVal(iter->subject));
             }
         }
     } else {
@@ -434,8 +434,8 @@ robj *listTypeDup(robj *o) {
     serverAssert(o->type == OBJ_LIST);
 
     switch (o->encoding) {
-    case OBJ_ENCODING_LISTPACK: lobj = createObject(OBJ_LIST, lpDup(o->ptr)); break;
-    case OBJ_ENCODING_QUICKLIST: lobj = createObject(OBJ_LIST, quicklistDup(o->ptr)); break;
+    case OBJ_ENCODING_LISTPACK: lobj = createObject(OBJ_LIST, lpDup(objectGetVal(o))); break;
+    case OBJ_ENCODING_QUICKLIST: lobj = createObject(OBJ_LIST, quicklistDup(objectGetVal(o))); break;
     default: serverPanic("Unknown list encoding"); break;
     }
     lobj->encoding = o->encoding;
@@ -445,9 +445,9 @@ robj *listTypeDup(robj *o) {
 /* Delete a range of elements from the list. */
 void listTypeDelRange(robj *subject, long start, long count) {
     if (subject->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklistDelRange(subject->ptr, start, count);
+        quicklistDelRange(objectGetVal(subject), start, count);
     } else if (subject->encoding == OBJ_ENCODING_LISTPACK) {
-        subject->ptr = lpDeleteRange(subject->ptr, start, count);
+        subject->ptr = lpDeleteRange(objectGetVal(subject), start, count);
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -515,9 +515,9 @@ void linsertCommand(client *c) {
     listTypeEntry entry;
     int inserted = 0;
 
-    if (strcasecmp(c->argv[2]->ptr, "after") == 0) {
+    if (strcasecmp(objectGetVal(c->argv[2]), "after") == 0) {
         where = LIST_TAIL;
-    } else if (strcasecmp(c->argv[2]->ptr, "before") == 0) {
+    } else if (strcasecmp(objectGetVal(c->argv[2]), "before") == 0) {
         where = LIST_HEAD;
     } else {
         addReplyErrorObject(c, shared.syntaxerr);
@@ -656,7 +656,7 @@ void addListQuicklistRangeReply(client *c, robj *o, int from, int rangelen, int 
     addWritePreparedReplyArrayLen(wpc, rangelen);
 
     int direction = reverse ? AL_START_TAIL : AL_START_HEAD;
-    quicklistIter *iter = quicklistGetIteratorAtIdx(o->ptr, direction, from);
+    quicklistIter *iter = quicklistGetIteratorAtIdx(objectGetVal(o), direction, from);
     while (rangelen--) {
         quicklistEntry qe;
         serverAssert(quicklistNext(iter, &qe)); /* fail on corrupt data */
@@ -677,7 +677,7 @@ void addListListpackRangeReply(client *c, robj *o, int from, int rangelen, int r
     if (!wpc) return;
     /* Return the result in form of a multi-bulk reply */
     addWritePreparedReplyArrayLen(wpc, rangelen);
-    unsigned char *p = lpSeek(o->ptr, from);
+    unsigned char *p = lpSeek(objectGetVal(o), from);
     unsigned char *vstr;
     unsigned int vlen;
     long long lval;
@@ -690,7 +690,7 @@ void addListListpackRangeReply(client *c, robj *o, int from, int rangelen, int r
         } else {
             addWritePreparedReplyBulkLongLong(wpc, lval);
         }
-        p = reverse ? lpPrev(o->ptr, p) : lpNext(o->ptr, p);
+        p = reverse ? lpPrev(objectGetVal(o), p) : lpNext(objectGetVal(o), p);
     }
 }
 
@@ -891,11 +891,11 @@ void ltrimCommand(client *c) {
 
     /* Remove list elements to perform the trim */
     if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklistDelRange(o->ptr, 0, ltrim);
-        quicklistDelRange(o->ptr, -rtrim, rtrim);
+        quicklistDelRange(objectGetVal(o), 0, ltrim);
+        quicklistDelRange(objectGetVal(o), -rtrim, rtrim);
     } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        o->ptr = lpDeleteRange(o->ptr, 0, ltrim);
-        o->ptr = lpDeleteRange(o->ptr, -rtrim, rtrim);
+        o->ptr = lpDeleteRange(objectGetVal(o), 0, ltrim);
+        o->ptr = lpDeleteRange(objectGetVal(o), -rtrim, rtrim);
     } else {
         serverPanic("Unknown list encoding");
     }
@@ -937,7 +937,7 @@ void lposCommand(client *c) {
 
     /* Parse the optional arguments. */
     for (int j = 3; j < c->argc; j++) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         int moreargs = (c->argc - 1) - j;
 
         if (!strcasecmp(opt, "RANK") && moreargs) {
@@ -1079,9 +1079,9 @@ void lmoveHandlePush(client *c, robj *dstkey, robj *dstobj, robj *value, int whe
 }
 
 int getListPositionFromObjectOrReply(client *c, robj *arg, int *position) {
-    if (strcasecmp(arg->ptr, "right") == 0) {
+    if (strcasecmp(objectGetVal(arg), "right") == 0) {
         *position = LIST_TAIL;
-    } else if (strcasecmp(arg->ptr, "left") == 0) {
+    } else if (strcasecmp(objectGetVal(arg), "left") == 0) {
         *position = LIST_HEAD;
     } else {
         addReplyErrorObject(c, shared.syntaxerr);
@@ -1298,7 +1298,7 @@ void lmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
 
     /* Parse the optional arguments. */
     for (j = where_idx + 1; j < c->argc; j++) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         int moreargs = (c->argc - 1) - j;
 
         if (count == -1 && !strcasecmp(opt, "COUNT") && moreargs) {

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -539,7 +539,7 @@ void setrangeCommand(client *c) {
     }
 
     if (sdslen(value) > 0) {
-        o->ptr = sdsgrowzero(objectGetVal(o), offset + sdslen(value));
+        objectSetVal(o, sdsgrowzero(objectGetVal(o), offset + sdslen(value)));
         memcpy((char *)objectGetVal(o) + offset, value, sdslen(value));
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
@@ -669,7 +669,7 @@ void incrDecrCommand(client *c, long long incr) {
     if (o && o->refcount == 1 && o->encoding == OBJ_ENCODING_INT &&
         value >= LONG_MIN && value <= LONG_MAX) {
         new = o;
-        o->ptr = (void *)((long)value);
+        objectSetVal(o, (void *)((long)value));
     } else {
         new = createStringObjectFromLongLongForValue(value);
         if (o) {
@@ -767,7 +767,7 @@ void appendCommand(client *c) {
 
         /* Append the value */
         o = dbUnshareStringValue(c->db, c->argv[1], o);
-        o->ptr = sdscatlen(objectGetVal(o), objectGetVal(append), sdslen(objectGetVal(append)));
+        objectSetVal(o, sdscatlen(objectGetVal(o), objectGetVal(append), sdslen(objectGetVal(append))));
         totlen = sdslen(objectGetVal(o));
     }
     signalModifiedKey(c, c->db, c->argv[1]);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -180,7 +180,7 @@ void setGenericCommand(client *c,
         int j;
         robj **argv = zmalloc((c->argc - 1) * sizeof(robj *));
         for (j = 0; j < c->argc; j++) {
-            char *a = c->argv[j]->ptr;
+            char *a = objectGetVal(c->argv[j]);
             /* Skip GET which may be repeated multiple times. */
             if (j >= 3 && (a[0] == 'g' || a[0] == 'G') && (a[1] == 'e' || a[1] == 'E') &&
                 (a[2] == 't' || a[2] == 'T') && a[3] == '\0')
@@ -252,7 +252,7 @@ static int getExpireMillisecondsOrReply(client *c, robj *expire, int flags, int 
 int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj **expire, robj **compare_val, int command_type) {
     int j = command_type == COMMAND_GET ? 2 : 3;
     for (; j < c->argc; j++) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         robj *next = (j == c->argc - 1) ? NULL : c->argv[j + 1];
 
         /* clang-format off */
@@ -492,7 +492,7 @@ void getsetCommand(client *c) {
 void setrangeCommand(client *c) {
     robj *o;
     long offset;
-    sds value = c->argv[3]->ptr;
+    sds value = objectGetVal(c->argv[3]);
 
     if (getLongFromObjectOrReply(c, c->argv[2], &offset, NULL) != C_OK)
         return;
@@ -539,14 +539,14 @@ void setrangeCommand(client *c) {
     }
 
     if (sdslen(value) > 0) {
-        o->ptr = sdsgrowzero(o->ptr, offset + sdslen(value));
-        memcpy((char *)o->ptr + offset, value, sdslen(value));
+        o->ptr = sdsgrowzero(objectGetVal(o), offset + sdslen(value));
+        memcpy((char *)objectGetVal(o) + offset, value, sdslen(value));
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_STRING,
                             "setrange", c->argv[1], c->db->id);
         server.dirty++;
     }
-    addReplyLongLong(c, sdslen(o->ptr));
+    addReplyLongLong(c, sdslen(objectGetVal(o)));
 }
 
 void getrangeCommand(client *c) {
@@ -564,9 +564,9 @@ void getrangeCommand(client *c) {
 
     if (o->encoding == OBJ_ENCODING_INT) {
         str = llbuf;
-        strlen = ll2string(llbuf, sizeof(llbuf), (long)o->ptr);
+        strlen = ll2string(llbuf, sizeof(llbuf), (long)objectGetVal(o));
     } else {
-        str = o->ptr;
+        str = objectGetVal(o);
         strlen = sdslen(str);
     }
 
@@ -762,13 +762,13 @@ void appendCommand(client *c) {
 
         /* "append" is an argument, so always an sds */
         append = c->argv[2];
-        if (checkStringLength(c, stringObjectLen(o), sdslen(append->ptr)) != C_OK)
+        if (checkStringLength(c, stringObjectLen(o), sdslen(objectGetVal(append))) != C_OK)
             return;
 
         /* Append the value */
         o = dbUnshareStringValue(c->db, c->argv[1], o);
-        o->ptr = sdscatlen(o->ptr, append->ptr, sdslen(append->ptr));
-        totlen = sdslen(o->ptr);
+        o->ptr = sdscatlen(objectGetVal(o), objectGetVal(append), sdslen(objectGetVal(append)));
+        totlen = sdslen(objectGetVal(o));
     }
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING, "append", c->argv[1], c->db->id);
@@ -805,11 +805,11 @@ void lcsCommand(client *c) {
     }
     obja = obja ? getDecodedObject(obja) : createStringObject("", 0);
     objb = objb ? getDecodedObject(objb) : createStringObject("", 0);
-    a = obja->ptr;
-    b = objb->ptr;
+    a = objectGetVal(obja);
+    b = objectGetVal(objb);
 
     for (j = 3; j < (uint32_t)c->argc; j++) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         int moreargs = (c->argc - 1) - j;
 
         if (!strcasecmp(opt, "IDX")) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -593,26 +593,26 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
      * ZRANGEBYSCORE zset (1.5 (2.5 will match min < x < max
      * ZRANGEBYSCORE zset 1.5 2.5 will instead match min <= x <= max */
     if (min->encoding == OBJ_ENCODING_INT) {
-        spec->min = (long)min->ptr;
+        spec->min = (long)objectGetVal(min);
     } else {
-        if (((char *)min->ptr)[0] == '(') {
-            spec->min = valkey_strtod((char *)min->ptr + 1, &eptr);
+        if (((char *)objectGetVal(min))[0] == '(') {
+            spec->min = valkey_strtod((char *)objectGetVal(min) + 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
         } else {
-            spec->min = valkey_strtod((char *)min->ptr, &eptr);
+            spec->min = valkey_strtod((char *)objectGetVal(min), &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
     }
     if (max->encoding == OBJ_ENCODING_INT) {
-        spec->max = (long)max->ptr;
+        spec->max = (long)objectGetVal(max);
     } else {
-        if (((char *)max->ptr)[0] == '(') {
-            spec->max = valkey_strtod((char *)max->ptr + 1, &eptr);
+        if (((char *)objectGetVal(max))[0] == '(') {
+            spec->max = valkey_strtod((char *)objectGetVal(max) + 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;
         } else {
-            spec->max = valkey_strtod((char *)max->ptr, &eptr);
+            spec->max = valkey_strtod((char *)objectGetVal(max), &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
         }
     }
@@ -636,7 +636,7 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
  * If the string is not a valid range C_ERR is returned, and the value
  * of *dest and *ex is undefined. */
 static int zslParseLexRangeItem(robj *item, sds *dest, int *ex) {
-    char *c = item->ptr;
+    char *c = objectGetVal(item);
 
     switch (c[0]) {
     case '+':
@@ -1224,9 +1224,9 @@ unsigned char *zzlDeleteRangeByRank(unsigned char *zl, unsigned int start, unsig
 unsigned long zsetLength(const robj *zobj) {
     unsigned long length = 0;
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        length = zzlLength(zobj->ptr);
+        length = zzlLength(objectGetVal(zobj));
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        length = ((const zset *)zobj->ptr)->zsl->length;
+        length = ((const zset *)objectGetVal(zobj))->zsl->length;
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -1247,7 +1247,7 @@ robj *zsetTypeCreate(size_t size_hint, size_t val_len_hint) {
     }
 
     robj *zobj = createZsetObject();
-    zset *zs = zobj->ptr;
+    zset *zs = objectGetVal(zobj);
     hashtableExpand(zs->ht, size_hint);
     return zobj;
 }
@@ -1277,7 +1277,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
     if (zobj->encoding == encoding) return;
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
         unsigned int vlen;
@@ -1311,7 +1311,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
             zzlNext(zl, &eptr, &sptr);
         }
 
-        zfree(zobj->ptr);
+        zfree(objectGetVal(zobj));
         zobj->ptr = zs;
         zobj->encoding = OBJ_ENCODING_SKIPLIST;
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
@@ -1321,7 +1321,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         /* Approach similar to zslFree(), since we want to free the skiplist at
          * the same time as creating the listpack. */
-        zs = zobj->ptr;
+        zs = objectGetVal(zobj);
         hashtableRelease(zs->ht);
         node = zs->zsl->header->level[0].forward;
         zfree(zs->zsl->header);
@@ -1347,7 +1347,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
  * are within the expected ranges. */
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen) {
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) return;
-    zset *zset = zobj->ptr;
+    zset *zset = objectGetVal(zobj);
 
     if (zset->zsl->length <= server.zset_max_listpack_entries && maxelelen <= server.zset_max_listpack_value &&
         lpSafeToAdd(NULL, totelelen)) {
@@ -1363,9 +1363,9 @@ int zsetScore(robj *zobj, sds member, double *score) {
     if (!zobj || !member) return C_ERR;
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        if (zzlFind(zobj->ptr, member, score) == NULL) return C_ERR;
+        if (zzlFind(objectGetVal(zobj), member, score) == NULL) return C_ERR;
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         void *entry;
         if (!hashtableFind(zs->ht, member, &entry)) return C_ERR;
         zskiplistNode *setElement = entry;
@@ -1441,7 +1441,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *eptr;
 
-        if ((eptr = zzlFind(zobj->ptr, ele, &curscore)) != NULL) {
+        if ((eptr = zzlFind(objectGetVal(zobj), ele, &curscore)) != NULL) {
             /* NX? Return, same element already exists. */
             if (nx) {
                 *out_flags |= ZADD_OUT_NOP;
@@ -1467,19 +1467,19 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changed. */
             if (score != curscore) {
-                zobj->ptr = zzlDelete(zobj->ptr, eptr);
-                zobj->ptr = zzlInsert(zobj->ptr, ele, score);
+                zobj->ptr = zzlDelete(objectGetVal(zobj), eptr);
+                zobj->ptr = zzlInsert(objectGetVal(zobj), ele, score);
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;
         } else if (!xx) {
             /* check if the element is too large or the list
              * becomes too long *before* executing zzlInsert. */
-            if (zzlLength(zobj->ptr) + 1 > server.zset_max_listpack_entries ||
-                sdslen(ele) > server.zset_max_listpack_value || !lpSafeToAdd(zobj->ptr, sdslen(ele))) {
+            if (zzlLength(objectGetVal(zobj)) + 1 > server.zset_max_listpack_entries ||
+                sdslen(ele) > server.zset_max_listpack_value || !lpSafeToAdd(objectGetVal(zobj), sdslen(ele))) {
                 zsetConvertAndExpand(zobj, OBJ_ENCODING_SKIPLIST, zsetLength(zobj) + 1);
             } else {
-                zobj->ptr = zzlInsert(zobj->ptr, ele, score);
+                zobj->ptr = zzlInsert(objectGetVal(zobj), ele, score);
                 if (newscore) *newscore = score;
                 *out_flags |= ZADD_OUT_ADDED;
                 return 1;
@@ -1493,7 +1493,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
     /* Note that the above block handling listpack would have either returned or
      * converted the key to skiplist. */
     if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
 
         void **node_ref_in_hashtable = hashtableFindRef(zs->ht, ele);
         if (node_ref_in_hashtable != NULL) {
@@ -1571,12 +1571,12 @@ int zsetDel(robj *zobj, sds ele) {
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *eptr;
 
-        if ((eptr = zzlFind(zobj->ptr, ele, NULL)) != NULL) {
-            zobj->ptr = zzlDelete(zobj->ptr, eptr);
+        if ((eptr = zzlFind(objectGetVal(zobj), ele, NULL)) != NULL) {
+            zobj->ptr = zzlDelete(objectGetVal(zobj), eptr);
             return 1;
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         if (zsetRemoveFromSkiplist(zs, ele)) {
             return 1;
         }
@@ -1604,7 +1604,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
     llen = zsetLength(zobj);
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
 
         eptr = lpSeek(zl, 0);
@@ -1629,7 +1629,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
             return -1;
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
 
         void *entry;
         if (!hashtableFind(zs->ht, ele, &entry)) return -1;
@@ -1662,7 +1662,7 @@ robj *zsetDup(robj *o) {
 
     /* Create a new sorted set object that have the same encoding as the original object's encoding */
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = o->ptr;
+        unsigned char *zl = objectGetVal(o);
         size_t sz = lpBytes(zl);
         unsigned char *new_zl = zmalloc(sz);
         memcpy(new_zl, zl, sz);
@@ -1670,8 +1670,8 @@ robj *zsetDup(robj *o) {
         zobj->encoding = OBJ_ENCODING_LISTPACK;
     } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
         zobj = createZsetObject();
-        zs = o->ptr;
-        new_zs = zobj->ptr;
+        zs = objectGetVal(o);
+        new_zs = objectGetVal(zobj);
         hashtableExpand(new_zs->ht, hashtableSize(zs->ht));
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
@@ -1718,7 +1718,7 @@ void zsetReplyFromListpackEntry(client *c, listpackEntry *e) {
  * 'score' can be NULL in which case it's not extracted. */
 static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry *key, double *score) {
     if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zsetobj->ptr;
+        zset *zs = objectGetVal(zsetobj);
         void *entry;
         hashtableFairRandomEntry(zs->ht, &entry);
         zskiplistNode *node = entry;
@@ -1727,7 +1727,7 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
         if (score) *score = node->score;
     } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
         listpackEntry val;
-        lpRandomPair(zsetobj->ptr, zsetsize, key, &val);
+        lpRandomPair(objectGetVal(zsetobj), zsetsize, key, &val);
         if (score) {
             if (val.sval) {
                 *score = zzlStrtod(val.sval, val.slen);
@@ -1766,7 +1766,7 @@ static void zaddGenericCommand(client *c, int flags) {
      * of the score of the first score-element pair. */
     scoreidx = 2;
     while (scoreidx < c->argc) {
-        char *opt = c->argv[scoreidx]->ptr;
+        char *opt = objectGetVal(c->argv[scoreidx]);
         if (!strcasecmp(opt, "nx"))
             flags |= ZADD_IN_NX;
         else if (!strcasecmp(opt, "xx"))
@@ -1823,7 +1823,7 @@ static void zaddGenericCommand(client *c, int flags) {
     scores = zmalloc(sizeof(double) * elements);
     for (j = 0; j < elements; j++) {
         if (getDoubleFromObjectOrReply(c, c->argv[scoreidx + j * 2], &scores[j], NULL) != C_OK) goto cleanup;
-        ele = c->argv[scoreidx + 1 + j * 2]->ptr;
+        ele = objectGetVal(c->argv[scoreidx + 1 + j * 2]);
         size_t elelen = sdslen(ele);
         if (elelen > maxelelen) maxelelen = elelen;
     }
@@ -1844,7 +1844,7 @@ static void zaddGenericCommand(client *c, int flags) {
         score = scores[j];
         int retflags = 0;
 
-        ele = c->argv[scoreidx + 1 + j * 2]->ptr;
+        ele = objectGetVal(c->argv[scoreidx + 1 + j * 2]);
         int retval = zsetAdd(zobj, score, ele, flags, &retflags, &newscore);
         if (retval == 0) {
             addReplyError(c, nanerr);
@@ -1891,7 +1891,7 @@ void zremCommand(client *c) {
     if ((zobj = lookupKeyWriteOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
     for (j = 2; j < c->argc; j++) {
-        if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
+        if (zsetDel(zobj, objectGetVal(c->argv[j]))) deleted++;
         if (zsetLength(zobj) == 0) {
             dbDelete(c->db, key);
             keyremoved = 1;
@@ -1971,16 +1971,16 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         switch (rangetype) {
         case ZRANGE_AUTO:
-        case ZRANGE_RANK: zobj->ptr = zzlDeleteRangeByRank(zobj->ptr, start + 1, end + 1, &deleted); break;
-        case ZRANGE_SCORE: zobj->ptr = zzlDeleteRangeByScore(zobj->ptr, &range, &deleted); break;
-        case ZRANGE_LEX: zobj->ptr = zzlDeleteRangeByLex(zobj->ptr, &lexrange, &deleted); break;
+        case ZRANGE_RANK: zobj->ptr = zzlDeleteRangeByRank(objectGetVal(zobj), start + 1, end + 1, &deleted); break;
+        case ZRANGE_SCORE: zobj->ptr = zzlDeleteRangeByScore(objectGetVal(zobj), &range, &deleted); break;
+        case ZRANGE_LEX: zobj->ptr = zzlDeleteRangeByLex(objectGetVal(zobj), &lexrange, &deleted); break;
         }
-        if (zzlLength(zobj->ptr) == 0) {
+        if (zzlLength(objectGetVal(zobj)) == 0) {
             dbDelete(c->db, key);
             keyremoved = 1;
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         hashtablePauseAutoShrink(zs->ht);
         switch (rangetype) {
         case ZRANGE_AUTO:
@@ -2089,12 +2089,12 @@ static void zuiInitIterator(zsetopsrc *op) {
     if (op->type == OBJ_SET) {
         iterset *it = &op->iter.set;
         if (op->encoding == OBJ_ENCODING_INTSET) {
-            it->is.is = op->subject->ptr;
+            it->is.is = objectGetVal(op->subject);
             it->is.ii = 0;
         } else if (op->encoding == OBJ_ENCODING_HASHTABLE) {
-            it->ht.iter = hashtableCreateIterator(op->subject->ptr, 0);
+            it->ht.iter = hashtableCreateIterator(objectGetVal(op->subject), 0);
         } else if (op->encoding == OBJ_ENCODING_LISTPACK) {
-            it->lp.lp = op->subject->ptr;
+            it->lp.lp = objectGetVal(op->subject);
             it->lp.p = lpFirst(it->lp.lp);
         } else {
             serverPanic("Unknown set encoding");
@@ -2105,14 +2105,14 @@ static void zuiInitIterator(zsetopsrc *op) {
          * ZDIFF/ZINTER/ZUNION */
         iterzset *it = &op->iter.zset;
         if (op->encoding == OBJ_ENCODING_LISTPACK) {
-            it->zl.zl = op->subject->ptr;
+            it->zl.zl = objectGetVal(op->subject);
             it->zl.eptr = lpSeek(it->zl.zl, -2);
             if (it->zl.eptr != NULL) {
                 it->zl.sptr = lpNext(it->zl.zl, it->zl.eptr);
                 serverAssert(it->zl.sptr != NULL);
             }
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
-            it->sl.zs = op->subject->ptr;
+            it->sl.zs = objectGetVal(op->subject);
             it->sl.node = it->sl.zs->zsl->tail;
         } else {
             serverPanic("Unknown sorted set encoding");
@@ -2165,9 +2165,9 @@ static unsigned long zuiLength(zsetopsrc *op) {
         return setTypeSize(op->subject);
     } else if (op->type == OBJ_ZSET) {
         if (op->encoding == OBJ_ENCODING_LISTPACK) {
-            return zzlLength(op->subject->ptr);
+            return zzlLength(objectGetVal(op->subject));
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = op->subject->ptr;
+            zset *zs = objectGetVal(op->subject);
             return zs->zsl->length;
         } else {
             serverPanic("Unknown sorted set encoding");
@@ -2287,14 +2287,14 @@ static int zuiFind(zsetopsrc *op, zsetopval *val, double *score) {
         zuiSdsFromValue(val);
 
         if (op->encoding == OBJ_ENCODING_LISTPACK) {
-            if (zzlFind(op->subject->ptr, val->ele, score) != NULL) {
+            if (zzlFind(objectGetVal(op->subject), val->ele, score) != NULL) {
                 /* Score is already set by zzlFind. */
                 return 1;
             } else {
                 return 0;
             }
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = op->subject->ptr;
+            zset *zs = objectGetVal(op->subject);
             void *entry;
             if (hashtableFind(zs->ht, val->ele, &entry)) {
                 zskiplistNode *node = entry;
@@ -2594,7 +2594,7 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
 
         while (remaining) {
             if (op != SET_OP_DIFF && !cardinality_only && remaining >= (setnum + 1) &&
-                !strcasecmp(c->argv[j]->ptr, "weights")) {
+                !strcasecmp(objectGetVal(c->argv[j]), "weights")) {
                 j++;
                 remaining--;
                 for (i = 0; i < setnum; i++, j++, remaining--) {
@@ -2605,14 +2605,14 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                     }
                 }
             } else if (op != SET_OP_DIFF && !cardinality_only && remaining >= 2 &&
-                       !strcasecmp(c->argv[j]->ptr, "aggregate")) {
+                       !strcasecmp(objectGetVal(c->argv[j]), "aggregate")) {
                 j++;
                 remaining--;
-                if (!strcasecmp(c->argv[j]->ptr, "sum")) {
+                if (!strcasecmp(objectGetVal(c->argv[j]), "sum")) {
                     aggregate = REDIS_AGGR_SUM;
-                } else if (!strcasecmp(c->argv[j]->ptr, "min")) {
+                } else if (!strcasecmp(objectGetVal(c->argv[j]), "min")) {
                     aggregate = REDIS_AGGR_MIN;
-                } else if (!strcasecmp(c->argv[j]->ptr, "max")) {
+                } else if (!strcasecmp(objectGetVal(c->argv[j]), "max")) {
                     aggregate = REDIS_AGGR_MAX;
                 } else {
                     zfree(src);
@@ -2621,11 +2621,11 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                 }
                 j++;
                 remaining--;
-            } else if (remaining >= 1 && !dstkey && !cardinality_only && !strcasecmp(c->argv[j]->ptr, "withscores")) {
+            } else if (remaining >= 1 && !dstkey && !cardinality_only && !strcasecmp(objectGetVal(c->argv[j]), "withscores")) {
                 j++;
                 remaining--;
                 withscores = 1;
-            } else if (cardinality_only && remaining >= 2 && !strcasecmp(c->argv[j]->ptr, "limit")) {
+            } else if (cardinality_only && remaining >= 2 && !strcasecmp(objectGetVal(c->argv[j]), "limit")) {
                 j++;
                 remaining--;
                 if (getPositiveLongFromObjectOrReply(c, c->argv[j], &limit, "LIMIT can't be negative") != C_OK) {
@@ -2654,7 +2654,7 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
      * In SINTERCARD case, we don't need the temp obj, so we can avoid creating it. */
     if (!cardinality_only) {
         dstobj = createZsetObject();
-        dstzset = dstobj->ptr;
+        dstzset = objectGetVal(dstobj);
     }
     memset(&zval, 0, sizeof(zval));
 
@@ -3048,7 +3048,7 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
 
     handler->beginResultEmission(handler, rangelen);
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
         unsigned int vlen;
@@ -3083,7 +3083,7 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
         }
 
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
 
@@ -3150,7 +3150,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
     }
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
         unsigned int vlen;
@@ -3202,7 +3202,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
             }
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
 
@@ -3268,7 +3268,7 @@ void zcountCommand(client *c) {
     if ((zobj = lookupKeyReadOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         double score;
 
@@ -3299,7 +3299,7 @@ void zcountCommand(client *c) {
             }
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *zn;
         unsigned long rank;
@@ -3347,7 +3347,7 @@ void zlexcountCommand(client *c) {
     }
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
 
         /* Use the first element in range as the starting point */
@@ -3375,7 +3375,7 @@ void zlexcountCommand(client *c) {
             }
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *zn;
         unsigned long rank;
@@ -3418,7 +3418,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
     handler->beginResultEmission(handler, -1);
 
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl = zobj->ptr;
+        unsigned char *zl = objectGetVal(zobj);
         unsigned char *eptr, *sptr;
         unsigned char *vstr;
         unsigned int vlen;
@@ -3472,7 +3472,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
             }
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        zset *zs = zobj->ptr;
+        zset *zs = objectGetVal(zobj);
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
 
@@ -3555,19 +3555,19 @@ void zrangeGenericCommand(zrange_result_handler *handler,
     /* Step 1: Skip the <src> <min> <max> args and parse remaining optional arguments. */
     for (int j = argc_start + 3; j < c->argc; j++) {
         int leftargs = c->argc - j - 1;
-        if (!store && !strcasecmp(c->argv[j]->ptr, "withscores")) {
+        if (!store && !strcasecmp(objectGetVal(c->argv[j]), "withscores")) {
             opt_withscores = 1;
-        } else if (!strcasecmp(c->argv[j]->ptr, "limit") && leftargs >= 2) {
+        } else if (!strcasecmp(objectGetVal(c->argv[j]), "limit") && leftargs >= 2) {
             if ((getLongFromObjectOrReply(c, c->argv[j + 1], &opt_offset, NULL) != C_OK) ||
                 (getLongFromObjectOrReply(c, c->argv[j + 2], &opt_limit, NULL) != C_OK)) {
                 return;
             }
             j += 2;
-        } else if (direction == ZRANGE_DIRECTION_AUTO && !strcasecmp(c->argv[j]->ptr, "rev")) {
+        } else if (direction == ZRANGE_DIRECTION_AUTO && !strcasecmp(objectGetVal(c->argv[j]), "rev")) {
             direction = ZRANGE_DIRECTION_REVERSE;
-        } else if (rangetype == ZRANGE_AUTO && !strcasecmp(c->argv[j]->ptr, "bylex")) {
+        } else if (rangetype == ZRANGE_AUTO && !strcasecmp(objectGetVal(c->argv[j]), "bylex")) {
             rangetype = ZRANGE_LEX;
-        } else if (rangetype == ZRANGE_AUTO && !strcasecmp(c->argv[j]->ptr, "byscore")) {
+        } else if (rangetype == ZRANGE_AUTO && !strcasecmp(objectGetVal(c->argv[j]), "byscore")) {
             rangetype = ZRANGE_SCORE;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
@@ -3686,7 +3686,7 @@ void zscoreCommand(client *c) {
 
     if ((zobj = lookupKeyReadOrReply(c, key, shared.null[c->resp])) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
-    if (zsetScore(zobj, c->argv[2]->ptr, &score) == C_ERR) {
+    if (zsetScore(zobj, objectGetVal(c->argv[2]), &score) == C_ERR) {
         addReplyNull(c);
     } else {
         addReplyDouble(c, score);
@@ -3703,7 +3703,7 @@ void zmscoreCommand(client *c) {
     addReplyArrayLen(c, c->argc - 2);
     for (int j = 2; j < c->argc; j++) {
         /* Treat a missing set the same way as an empty set */
-        if (zobj == NULL || zsetScore(zobj, c->argv[j]->ptr, &score) == C_ERR) {
+        if (zobj == NULL || zsetScore(zobj, objectGetVal(c->argv[j]), &score) == C_ERR) {
             addReplyNull(c);
         } else {
             addReplyDouble(c, score);
@@ -3725,7 +3725,7 @@ void zrankGenericCommand(client *c, int reverse) {
         return;
     }
     if (c->argc > 3) {
-        if (!strcasecmp(c->argv[3]->ptr, "withscore")) {
+        if (!strcasecmp(objectGetVal(c->argv[3]), "withscore")) {
             opt_withscore = 1;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
@@ -3737,7 +3737,7 @@ void zrankGenericCommand(client *c, int reverse) {
         return;
     }
     serverAssertWithInfo(c, ele, sdsEncodedObject(ele));
-    rank = zsetRank(zobj, ele->ptr, reverse, opt_withscore ? &score : NULL);
+    rank = zsetRank(zobj, objectGetVal(ele), reverse, opt_withscore ? &score : NULL);
     if (rank >= 0) {
         if (opt_withscore) {
             addReplyArrayLen(c, 2);
@@ -3864,7 +3864,7 @@ void genericZpopCommand(client *c,
     /* Remove the element. */
     do {
         if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
-            unsigned char *zl = zobj->ptr;
+            unsigned char *zl = objectGetVal(zobj);
             unsigned char *eptr, *sptr;
             unsigned char *vstr;
             unsigned int vlen;
@@ -3884,7 +3884,7 @@ void genericZpopCommand(client *c,
             serverAssertWithInfo(c, zobj, sptr != NULL);
             score = zzlGetScore(sptr);
         } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = zobj->ptr;
+            zset *zs = objectGetVal(zobj);
             zskiplist *zsl = zs->zsl;
             zskiplistNode *zln;
 
@@ -4096,7 +4096,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         else
             addReplyArrayLen(c, count);
         if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
-            zset *zs = zsetobj->ptr;
+            zset *zs = objectGetVal(zsetobj);
             while (count--) {
                 void *entry;
                 serverAssert(hashtableFairRandomEntry(zs->ht, &entry));
@@ -4115,7 +4115,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
             while (count) {
                 sample_count = count > limit ? limit : count;
                 count -= sample_count;
-                lpRandomPairs(zsetobj->ptr, sample_count, keys, vals);
+                lpRandomPairs(objectGetVal(zsetobj), sample_count, keys, vals);
                 zrandmemberReplyWithListpack(c, sample_count, keys, vals);
                 if (c->flag.close_asap) break;
             }
@@ -4165,7 +4165,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         listpackEntry *keys, *vals = NULL;
         keys = zmalloc(sizeof(listpackEntry) * count);
         if (withscores) vals = zmalloc(sizeof(listpackEntry) * count);
-        serverAssert(lpRandomPairsUnique(zsetobj->ptr, count, keys, vals) == count);
+        serverAssert(lpRandomPairsUnique(objectGetVal(zsetobj), count, keys, vals) == count);
         zrandmemberReplyWithListpack(c, count, keys, vals);
         zfree(keys);
         zfree(vals);
@@ -4264,7 +4264,7 @@ void zrandmemberCommand(client *c) {
 
     if (c->argc >= 3) {
         if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
-        if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withscores"))) {
+        if (c->argc > 4 || (c->argc == 4 && strcasecmp(objectGetVal(c->argv[3]), "withscores"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
         } else if (c->argc == 4) {
@@ -4308,9 +4308,9 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
         addReplyErrorObject(c, shared.syntaxerr);
         return;
     }
-    if (!strcasecmp(c->argv[where_idx]->ptr, "MIN")) {
+    if (!strcasecmp(objectGetVal(c->argv[where_idx]), "MIN")) {
         where = ZSET_MIN;
-    } else if (!strcasecmp(c->argv[where_idx]->ptr, "MAX")) {
+    } else if (!strcasecmp(objectGetVal(c->argv[where_idx]), "MAX")) {
         where = ZSET_MAX;
     } else {
         addReplyErrorObject(c, shared.syntaxerr);
@@ -4319,7 +4319,7 @@ void zmpopGenericCommand(client *c, int numkeys_idx, int is_block) {
 
     /* Parse the optional arguments. */
     for (j = where_idx + 1; j < c->argc; j++) {
-        char *opt = c->argv[j]->ptr;
+        char *opt = objectGetVal(c->argv[j]);
         int moreargs = (c->argc - 1) - j;
 
         if (count == -1 && !strcasecmp(opt, "COUNT") && moreargs) {

--- a/src/unit/test_object.c
+++ b/src/unit/test_object.c
@@ -19,7 +19,7 @@ int test_object_with_key(int argc, char **argv, int flags) {
     /* Prevent objectSetKeyAndExpire from freeing the old val when reallocating it. */
     incrRefCount(val);
 
-    /* Create valkey: val with key. */
+    /* Create robj with key. */
     robj *valkey = objectSetKeyAndExpire(val, key, -1);
     TEST_ASSERT(valkey->encoding == OBJ_ENCODING_EMBSTR);
     TEST_ASSERT(objectGetKey(valkey) != NULL);
@@ -31,8 +31,8 @@ int test_object_with_key(int argc, char **argv, int flags) {
     TEST_ASSERT(strcmp(objectGetKey(valkey), "foo") == 0);
 
     /* Check embedded value "bar" (EMBSTR content) */
-    TEST_ASSERT(sdscmp(valkey->ptr, val->ptr) == 0);
-    TEST_ASSERT(strcmp(valkey->ptr, "bar") == 0);
+    TEST_ASSERT(sdscmp(objectGetVal(valkey), objectGetVal(val)) == 0);
+    TEST_ASSERT(strcmp(objectGetVal(valkey), "bar") == 0);
 
     /* Either they're two separate objects, or one object with refcount == 2. */
     if (valkey == val) {


### PR DESCRIPTION
I wanted to know if I could do this by quickly writing some scripts. It probably took twice as long as I thought, but only 4-5 hours so not terrible, and now I know. 🤷🏻‍♀️ All but the necessary references in object.c have been replaced using objectGetVal and objectSetVal.

I know we want to make robj opaque so it's easier to refactor it or change its internal structure. I thought there was an issue for this but I can't find it offhand.