### PR TITLE
Code cleanup in object.c to support future work

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -569,6 +569,7 @@ void dismissSds(sds s) {
     sdsfree(s);
 }
 
+#if defined(USE_JEMALLOC) && defined(__linux__)
 /* See dismissObject() */
 static void dismissStringObject(robj *o) {
     if (o->encoding == OBJ_ENCODING_RAW) {
@@ -697,6 +698,7 @@ static void dismissStreamObject(robj *o, size_t size_hint) {
         raxStop(&ri);
     }
 }
+#endif
 
 /* When creating a snapshot in a fork child process, the main process and child
  * process share the same physical memory pages, and if / when the parent

--- a/src/server.h
+++ b/src/server.h
@@ -2894,11 +2894,11 @@ void trimStringObjectIfNeeded(robj *o, int trim_small_values);
 #define sdsEncodedObject(objptr) (objptr->encoding == OBJ_ENCODING_RAW || objptr->encoding == OBJ_ENCODING_EMBSTR)
 
 /* Objects with key attached, AKA valkey (val+key) objects */
-robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long expire);
-robj *objectSetKeyAndExpire(robj *val, sds key, long long expire);
-robj *objectSetExpire(robj *val, long long expire);
-sds objectGetKey(const robj *val);
-long long objectGetExpire(const robj *val);
+robj *createObjectWithEmbeddedData(int type, void *val_ptr, const sds key, long long expire, size_t val_embedded_size, size_t *val_embed_capacity);
+robj *objectSetKeyAndExpire(robj *o, sds key, long long expire);
+robj *objectSetExpire(robj *o, long long expire);
+sds objectGetKey(const robj *o);
+long long objectGetExpire(const robj *o);
 
 /* Synchronous I/O with timeout */
 ssize_t syncWrite(int fd, char *ptr, ssize_t size, long long timeout);
@@ -3404,7 +3404,7 @@ robj *lookupKeyReadWithFlags(serverDb *db, robj *key, int flags);
 robj *lookupKeyWriteWithFlags(serverDb *db, robj *key, int flags);
 robj *objectCommandLookup(client *c, robj *key);
 robj *objectCommandLookupOrReply(client *c, robj *key, robj *reply);
-int objectSetLRUOrLFU(robj *val, long long lfu_freq, long long lru_idle, long long lru_clock, int lru_multiplier);
+int objectSetLRUOrLFU(robj *o, long long lfu_freq, long long lru_idle, long long lru_clock, int lru_multiplier);
 #define LOOKUP_NONE 0
 #define LOOKUP_NOTOUCH (1 << 0)  /* Don't update LRU. */
 #define LOOKUP_NONOTIFY (1 << 1) /* Don't trigger keyspace event on key misses. */


### PR DESCRIPTION
Summary of changes:
- Define/allocate layout of robj's embedded data in once place instead of two
- More consistent naming: o to refer to robj, val/ptr/val_ptr to refer to contained value
- Add static to helpers to clarify scope/usage and improve compiler optimization

My primary goal is to make the structure and memory layout of robj easier to change and work with in the future. This will support future work like eliminating the 8 byte `ptr` when value is embedded directly, and potentially expand value embedding beyond `OBJ_ENCODING_EMBSTR` and `OBJ_ENCODING_INT`.

I'm a bit unsure about the function signature of `createObjectWithEmbeddedData` - let me know if you have a cleaner idea!