### PR TITLE
Fix memory usage check in test for embedded objects

### DIFF
--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -778,8 +778,5 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         regexp {val_sds_len:5 val_sds_avail:(\d+) val_alloc:(\d+)} $debug_sdslen _ avail val_alloc
         set sds_overhead [expr {$obj_alloc + $val_alloc - $obj_header_size - 1 - $content_size - $avail}]
         assert_equal 6 $sds_overhead
-
-        # Check that DEBUG SDSLEN reported allocation sizes matching MEMORY USAGE.
-        assert_equal [r memory usage quux] [expr {$obj_alloc + $val_alloc}]
     } {} {needs:debug}
 }


### PR DESCRIPTION
Fixes the following test case which fails in builds with allocators that don't have usable size:

```
*** [err]: Memory usage of embedded string value in tests/unit/type/string.tcl
Expected '40' to be less than or equal to '32' (context: type eval line 5 cmd {assert_lessthan_equal [r memory usage quux] 32} proc ::test)
```

With allocators like libc malloc that doesn't have usable size, zmalloc stores an extra size field in the allocation. This makes the memory usage 8 bytes larger than we expected in this test case. We can just skip this check. It's not the main thing tested in this test case.

The failure was introduced in #1613.