### PR TITLE
Fix kvstore overhead_hashtable_lut

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -282,18 +282,11 @@ kvstore *kvstoreCreate(hashtableType *type, int num_hashtables_bits, int flags) 
     kvs->num_hashtables_bits = num_hashtables_bits;
     kvs->num_hashtables = 1 << kvs->num_hashtables_bits;
     kvs->hashtables = zcalloc(sizeof(hashtable *) * kvs->num_hashtables);
+    kvs->rehashing = listCreate();
+    kvs->hashtable_size_index = kvs->num_hashtables > 1 ? zcalloc(sizeof(unsigned long long) * (kvs->num_hashtables + 1)) : NULL;
     if (!(kvs->flags & KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND)) {
         for (int i = 0; i < kvs->num_hashtables; i++) createHashtableIfNeeded(kvs, i);
     }
-
-    kvs->rehashing = listCreate();
-    kvs->key_count = 0;
-    kvs->non_empty_hashtables = 0;
-    kvs->resize_cursor = 0;
-    kvs->hashtable_size_index = kvs->num_hashtables > 1 ? zcalloc(sizeof(unsigned long long) * (kvs->num_hashtables + 1)) : NULL;
-    kvs->bucket_count = 0;
-    kvs->overhead_hashtable_lut = 0;
-    kvs->overhead_hashtable_rehashing = 0;
 
     return kvs;
 }

--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -43,18 +43,23 @@ int test_kvstoreAdd16Keys(int argc, char **argv, int flags) {
     int i;
 
     int didx = 0;
+    kvstore *kvs0 = kvstoreCreate(&KvstoreHashtableTestType, 0, 0);
     kvstore *kvs1 = kvstoreCreate(&KvstoreHashtableTestType, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND);
     kvstore *kvs2 = kvstoreCreate(&KvstoreHashtableTestType, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND | KVSTORE_FREE_EMPTY_HASHTABLES);
 
     for (i = 0; i < 16; i++) {
+        TEST_ASSERT(kvstoreHashtableAdd(kvs0, didx, stringFromInt(i)));
         TEST_ASSERT(kvstoreHashtableAdd(kvs1, didx, stringFromInt(i)));
         TEST_ASSERT(kvstoreHashtableAdd(kvs2, didx, stringFromInt(i)));
     }
+    TEST_ASSERT(kvstoreHashtableSize(kvs0, didx) == 16);
+    TEST_ASSERT(kvstoreSize(kvs0) == 16);
     TEST_ASSERT(kvstoreHashtableSize(kvs1, didx) == 16);
     TEST_ASSERT(kvstoreSize(kvs1) == 16);
     TEST_ASSERT(kvstoreHashtableSize(kvs2, didx) == 16);
     TEST_ASSERT(kvstoreSize(kvs2) == 16);
 
+    kvstoreRelease(kvs0);
     kvstoreRelease(kvs1);
     kvstoreRelease(kvs2);
     return 0;


### PR DESCRIPTION
Fix calculation of overhead_hashtable_lut in kvstore when the flag `KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND` is *not* given.

The memory overhead is incremented when a hashtable is created, but in kvstoreCreate, we reset the sum after creating the tables.

Removed a bunch of fields that are initialized to zero by zcalloc already. Moved some other initialization to before creating the hashtables (not strictly necessary but more logical to init stuff before creating stuff that may modify these numbers).