### PR TITLE
Increase the HZ to make test more reliable

### DIFF
--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -337,7 +337,7 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             r config set hz 100
             set retries 0
             for {set retries 1} {$retries < 4} {incr retries} {
-                after 1600 ;# Wait for 16 cron tick so that sample array is fulfilled
+                after 200 ;# Wait for at least 16 cron tick so that sample array is fulfilled
                 set value [s instantaneous_eventloop_cycles_per_sec]
                 if {$value > 0} break
             }

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -334,9 +334,10 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
 
         test {stats: instantaneous metrics} {
             r config resetstat
+            r config set hz 100
             set retries 0
             for {set retries 1} {$retries < 4} {incr retries} {
-                after 1600 ;# hz is 10, wait for 16 cron tick so that sample array is fulfilled
+                after 1600 ;# Wait for 16 cron tick so that sample array is fulfilled
                 set value [s instantaneous_eventloop_cycles_per_sec]
                 if {$value > 0} break
             }
@@ -344,11 +345,14 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             assert_lessthan $retries 4
             if {$::verbose} { puts "instantaneous metrics instantaneous_eventloop_cycles_per_sec: $value" }
             assert_morethan $value 0
-            assert_lessthan $value [expr $retries*15] ;# default hz is 10
+            # Hz is configured to 100, so we expect a value of about 100, but in practice it will be lower
+            # because of imprecision in kernel wakeups, but we also have some other wakeups like clients cron.
+            assert_lessthan $value 100
             set value [s instantaneous_eventloop_duration_usec]
+            r config set hz 10
             if {$::verbose} { puts "instantaneous metrics instantaneous_eventloop_duration_usec: $value" }
             assert_morethan $value 0
-            assert_lessthan $value [expr $retries*22000] ;# default hz is 10, so duration < 1000 / 10, allow some tolerance
+            assert_lessthan $value 22000 ;# Sanity check to make sure the duration is within a couple of ms
         } {} {io-threads:skip} ; # skip with io-threads as the eventloop metrics are different in that case.
         
 

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -337,7 +337,7 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             r config set hz 100
             set retries 0
             for {set retries 1} {$retries < 4} {incr retries} {
-                after 1600 ;# Wait for at least 160 cron tick so that sample array is filled
+                after 2000 ;# Wait for at least 160 cron tick so that sample array is filled
                 set value [s instantaneous_eventloop_cycles_per_sec]
                 if {$value > 0} break
             }

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -342,7 +342,6 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             assert_morethan $value 0
             # Hz is configured to 100, so we expect a value of about 100, but in practice it will be lower
             # because of imprecision in kernel wakeups, but we also have some other wakeups like clients cron.
-            assert_morethan $value 50
             assert_lessthan $value 150
             set value [s instantaneous_eventloop_duration_usec]
             r config set hz 10

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -337,7 +337,7 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             r config set hz 100
             set retries 0
             for {set retries 1} {$retries < 4} {incr retries} {
-                after 200 ;# Wait for at least 16 cron tick so that sample array is fulfilled
+                after 1600 ;# Wait for at least 160 cron tick so that sample array is filled
                 set value [s instantaneous_eventloop_cycles_per_sec]
                 if {$value > 0} break
             }
@@ -347,7 +347,8 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
             assert_morethan $value 0
             # Hz is configured to 100, so we expect a value of about 100, but in practice it will be lower
             # because of imprecision in kernel wakeups, but we also have some other wakeups like clients cron.
-            assert_lessthan $value 100
+            assert_morethan $value 50
+            assert_lessthan $value 150
             set value [s instantaneous_eventloop_duration_usec]
             r config set hz 10
             if {$::verbose} { puts "instantaneous metrics instantaneous_eventloop_duration_usec: $value" }

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -335,12 +335,14 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
         test {stats: instantaneous metrics} {
             r config resetstat
             r config set hz 100
-            after 2000 ;# Wait for at least 1600 cron ticks so that sample array is filled
+            after 2000 ;# Wait for at least 160 cron tick so that sample array is filled
+            set value [s instantaneous_eventloop_cycles_per_sec]
 
             if {$::verbose} { puts "instantaneous metrics instantaneous_eventloop_cycles_per_sec: $value" }
             assert_morethan $value 0
             # Hz is configured to 100, so we expect a value of about 100, but in practice it will be lower
             # because of imprecision in kernel wakeups, but we also have some other wakeups like clients cron.
+            assert_morethan $value 50
             assert_lessthan $value 150
             set value [s instantaneous_eventloop_duration_usec]
             r config set hz 10

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -335,19 +335,12 @@ start_server {tags {"info" "external:skip" "debug_defrag:skip"}} {
         test {stats: instantaneous metrics} {
             r config resetstat
             r config set hz 100
-            set retries 0
-            for {set retries 1} {$retries < 4} {incr retries} {
-                after 2000 ;# Wait for at least 160 cron tick so that sample array is filled
-                set value [s instantaneous_eventloop_cycles_per_sec]
-                if {$value > 0} break
-            }
+            after 2000 ;# Wait for at least 1600 cron ticks so that sample array is filled
 
-            assert_lessthan $retries 4
             if {$::verbose} { puts "instantaneous metrics instantaneous_eventloop_cycles_per_sec: $value" }
             assert_morethan $value 0
             # Hz is configured to 100, so we expect a value of about 100, but in practice it will be lower
             # because of imprecision in kernel wakeups, but we also have some other wakeups like clients cron.
-            assert_morethan $value 50
             assert_lessthan $value 150
             set value [s instantaneous_eventloop_duration_usec]
             r config set hz 10


### PR DESCRIPTION
After introducing, https://github.com/valkey-io/valkey/pull/1387, we saw a significant increase in other spurious wakeups because of the client cron that was added, which affected the "instantaneous eventloops per second" metric (showing it higher than before". All I did was increase the server hz to get more samples and increase the target value. This seems to work more consistently now. I also removed retries since the instantaneous value isn't dependent on number of retries. 

Additionally, `assert_lessthan $value [expr $retries*22000]` makes no sense to me. The value is usually around 30-100us, since all it's doing is waking up and running a little bit of cron. The retries doesn't make much sense, since the retries don't impact the instantaneous value. I just removed the retries and left the 22k value for now, maybe valgrind is slow.