### PR TITLE
Fix client trackinginfo crash when tracking off by default

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4100,8 +4100,7 @@ void clientTrackingInfoCommand(client *c) {
 
     /* Prefixes */
     addReplyBulkCString(c, "prefixes");
-    if (c->flag.tracking) {
-        serverAssert(c->pubsub_data && c->pubsub_data->client_tracking_prefixes);
+    if (c->flag.tracking && c->pubsub_data->client_tracking_prefixes) {
         addReplyArrayLen(c, raxSize(c->pubsub_data->client_tracking_prefixes));
         raxIterator ri;
         raxStart(&ri, c->pubsub_data->client_tracking_prefixes);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4100,7 +4100,8 @@ void clientTrackingInfoCommand(client *c) {
 
     /* Prefixes */
     addReplyBulkCString(c, "prefixes");
-    if (c->pubsub_data && c->pubsub_data->client_tracking_prefixes) {
+    if (c->flag.tracking) {
+        serverAssert(c->pubsub_data && c->pubsub_data->client_tracking_prefixes);
         addReplyArrayLen(c, raxSize(c->pubsub_data->client_tracking_prefixes));
         raxIterator ri;
         raxStart(&ri, c->pubsub_data->client_tracking_prefixes);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4100,7 +4100,7 @@ void clientTrackingInfoCommand(client *c) {
 
     /* Prefixes */
     addReplyBulkCString(c, "prefixes");
-    if (c->pubsub_data->client_tracking_prefixes) {
+    if (c->pubsub_data && c->pubsub_data->client_tracking_prefixes) {
         addReplyArrayLen(c, raxSize(c->pubsub_data->client_tracking_prefixes));
         raxIterator ri;
         raxStart(&ri, c->pubsub_data->client_tracking_prefixes);

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -865,6 +865,16 @@ start_server {tags {"tracking network logreqres:skip"}} {
 # Just some extra coverage for --log-req-res, because we do not
 # run the full tracking unit in that mode
 start_server {tags {"tracking network"}} {
+    test {CLIENT TRACKINGINFO when start} {
+        set res [r client trackinginfo]
+        set flags [dict get $res flags]
+        assert_equal {off} $flags
+        set redirect [dict get $res redirect]
+        assert_equal {-1} $redirect
+        set prefixes [dict get $res prefixes]
+        assert_equal {} $prefixes
+    }
+
     test {Coverage: Basic CLIENT CACHING} {
         set rd_redirection [valkey_deferring_client]
         $rd_redirection client id


### PR DESCRIPTION
After #1405, `client trackinginfo` will crash when tracking is off
```
/lib64/libpthread.so.0(+0xf630)[0x7fab74931630]
./src/valkey-server *:6379(clientTrackingInfoCommand+0x12b)[0x57f8db]
./src/valkey-server *:6379(call+0x5ba)[0x5a791a]
./src/valkey-server *:6379(processCommand+0x968)[0x5a8938]
./src/valkey-server *:6379(processInputBuffer+0x18d)[0x58381d]
./src/valkey-server *:6379(readQueryFromClient+0x59)[0x585ea9]
./src/valkey-server *:6379[0x46fa4d]
./src/valkey-server *:6379(aeMain+0x89)[0x5bf3e9]
./src/valkey-server *:6379(main+0x4e1)[0x455821]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7fab74576555]
./src/valkey-server *:6379[0x4564f2]
```

The reason is that we did not init pubsub_data by default, we only
init it when tracking on.

Fixes #1683.