### PR TITLE
Disable mem usage test case for non-jemalloc allocators

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -195,8 +195,10 @@ static robj *createEmbeddedStringObjectWithKeyAndExpire(const char *val_ptr,
         data += key_sds_size;
     }
 
-    /* Copy embedded value (EMBSTR) always as SDS TYPE 8. */
-    o->ptr = sdswrite(data, val_sds_size, SDS_TYPE_8, val_ptr, val_len);
+    /* Copy embedded value (EMBSTR) always as SDS TYPE 8. Account for unused
+     * memory in the SDS alloc field. */
+    size_t remaining_size = bufsize - (data - (char *)(void *)o);
+    o->ptr = sdswrite(data, remaining_size, SDS_TYPE_8, val_ptr, val_len);
 
     return o;
 }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -756,6 +756,7 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         lappend res [r get bar]
     } {12 12}
 
+if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {Memory usage of embedded string value} {
         # Check that we can fit 9 bytes of key + value into a 32 byte
         # allocation, including the serverObject itself.
@@ -779,4 +780,6 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         set sds_overhead [expr {$obj_alloc + $val_alloc - $obj_header_size - 1 - $content_size - $avail}]
         assert_equal 6 $sds_overhead
     } {} {needs:debug}
+} ; # if jemalloc
+
 }


### PR DESCRIPTION
Attempt to fix non-jemalloc builds by disabling this test case on non-jemalloc builds:

```
*** [err]: Memory usage of embedded string value in tests/unit/type/string.tcl
Expected '40' to be less than or equal to '32' (context: type eval line 5 cmd {assert_lessthan_equal [r memory usage quux] 32} proc ::test)
```

We can't assume anything about allocation size classes for arbitrary allocators.

Glibc malloc seems to give usable sizes of 24, 40, 56, 72, 88, 104, ..., not similar to jemalloc size classes.

Additional change: encode unused robj allocation space in the EMBSTR sds header. This makes the test case able to correctly calculate the memory overhead of the different structures in 32-bit builds, where there is some unused space in the allocation (because the `robj` header is smaller).