### PR TITLE
Fix log message "DB 9: 100 keys (0 volatile) in 16 slots HT"

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1104,6 +1104,11 @@ size_t hashtableChainedBuckets(hashtable *ht, int table) {
     return ht->child_buckets[table];
 }
 
+/* Returns the number of entry positions per bucket. */
+unsigned hashtableEntriesPerBucket(void) {
+    return ENTRIES_PER_BUCKET;
+}
+
 /* Returns the size of the hashtable structures, in bytes (not including the sizes
  * of the entries, if the entries are pointers to allocated objects). */
 size_t hashtableMemUsage(hashtable *ht) {

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -117,6 +117,7 @@ void *hashtableMetadata(hashtable *ht);
 size_t hashtableSize(const hashtable *ht);
 size_t hashtableBuckets(hashtable *ht);
 size_t hashtableChainedBuckets(hashtable *ht, int table);
+unsigned hashtableEntriesPerBucket(void);
 size_t hashtableMemUsage(hashtable *ht);
 void hashtablePauseAutoShrink(hashtable *ht);
 void hashtableResumeAutoShrink(hashtable *ht);

--- a/src/server.c
+++ b/src/server.c
@@ -1540,7 +1540,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
             for (j = 0; j < server.dbnum; j++) {
                 long long size, used, vkeys;
 
-                size = kvstoreBuckets(server.db[j].keys);
+                size = kvstoreBuckets(server.db[j].keys) * hashtableEntriesPerBucket();
                 used = kvstoreSize(server.db[j].keys);
                 vkeys = kvstoreSize(server.db[j].expires);
                 if (used || vkeys) {


### PR DESCRIPTION
With verbose logging, this message is logged every 5 seconds.

Before #1186, there were 128 slots in a database with 100 keys. Slots here means the number of entries that can be stored on the top-level of a hash table, which in the dict was the same as the number of buckets. With the new hash table, there are multiple entries per bucket, so the number of buckets is not a useful metric to show.

This PR multiplies the number of buckets with the number of entry positions per bucket. With this change, the log message is instead

    36236:M 09 Feb 2025 15:47:18.923 - DB 9: 100 keys (0 volatile) in 112 slots HT.
