### PR TITLE
Use `DEEPBIND` flag when loading external modules using `dlopen`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12280,8 +12280,9 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
      * same symbols, does not work with ASAN. Therefore, we exclude
      * RTLD_DEEPBIND when doing test builds with ASAN.
      * See https://github.com/google/sanitizers/issues/611 for more details.
-     * This flag is also not available in OSX, but the default symbol resolution
-     * behavior in OSX is the same as when we use DEEPBIND in Linux. */
+     * This flag is also not available in macos, but the default symbol
+     * resolution behavior in macos is the same as when we use DEEPBIND in
+     * Linux. */
     dlopen_flags |= RTLD_DEEPBIND;
 #endif
 

--- a/src/module.c
+++ b/src/module.c
@@ -12274,7 +12274,16 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
         }
     }
 
-    handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    int dlopen_flags = RTLD_NOW | RTLD_LOCAL;
+#ifndef __SANITIZE_ADDRESS__
+    /* RTLD_DEEPBIND, which is required for loading modules that contains the
+     * same symbols, does not work with ASAN. Therefore, we exclude
+     * RTLD_DEEPBIND when doing test builds with ASAN.
+     * See https://github.com/google/sanitizers/issues/611 for more details.*/
+    dlopen_flags |= RTLD_DEEPBIND;
+#endif
+
+    handle = dlopen(path, dlopen_flags);
     if (handle == NULL) {
         serverLog(LL_WARNING, "Module %s failed to load: %s", path, dlerror());
         return C_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -12275,11 +12275,13 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     }
 
     int dlopen_flags = RTLD_NOW | RTLD_LOCAL;
-#ifndef __SANITIZE_ADDRESS__
+#if !defined(__SANITIZE_ADDRESS__) && !defined(__APPLE__)
     /* RTLD_DEEPBIND, which is required for loading modules that contains the
      * same symbols, does not work with ASAN. Therefore, we exclude
      * RTLD_DEEPBIND when doing test builds with ASAN.
-     * See https://github.com/google/sanitizers/issues/611 for more details.*/
+     * See https://github.com/google/sanitizers/issues/611 for more details.
+     * This flag is also not available in OSX, but the default symbol resolution
+     * behavior in OSX is the same as when we use DEEPBIND in Linux. */
     dlopen_flags |= RTLD_DEEPBIND;
 #endif
 

--- a/src/module.c
+++ b/src/module.c
@@ -12275,14 +12275,13 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     }
 
     int dlopen_flags = RTLD_NOW | RTLD_LOCAL;
-#if !defined(__SANITIZE_ADDRESS__) && !defined(__APPLE__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__SANITIZE_ADDRESS__)
     /* RTLD_DEEPBIND, which is required for loading modules that contains the
      * same symbols, does not work with ASAN. Therefore, we exclude
      * RTLD_DEEPBIND when doing test builds with ASAN.
      * See https://github.com/google/sanitizers/issues/611 for more details.
-     * This flag is also not available in macos, but the default symbol
-     * resolution behavior in macos is the same as when we use DEEPBIND in
-     * Linux. */
+     *
+     * This flag is also currently only available in Linux and FreeBSD. */
     dlopen_flags |= RTLD_DEEPBIND;
 #endif
 


### PR DESCRIPTION
The current flags used in `dlopen` to load external modules don't allow modules to define symbols that are already defined by the valkey server binary because the symbol resolution first looks in the server memory and only if it does not find anything, it looks in the module (shared library) memory.

This might become a problem if, for instance, we try to implement a new scripting engine based on a newer version of Lua. The Lua interpreter library shares many symbol names with the Lua interpreter included in the Valkey server binary.

To fix the above problem, this PR adds the flag `RTLD_DEEPBIND` to the flags used in `dlopen` on systems that support it, which changes the symbol resolution strategy to look for the symbol in the module memory first, if the code executing is from the module.