### PR TITLE
Fix macro redefinition problem in `fmacros.h`

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -34,7 +34,14 @@
 
 #if defined(__linux__)
 #define _GNU_SOURCE
+/*
+ * This macro might have already been defined by including <features.h>, which
+ * is transitively included by <sys/types.h>. Therefore, to avoid redefinition
+ * build warnings, we check if the macro is already defined.
+ */
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 #endif
 
 #if defined(_AIX)


### PR DESCRIPTION
The `_DEFAULT_SOURCE` macro is defined in our code base in `"fmacros.h"`, but it might also be defined by including `<features.h>`, which is transitively included by `<sys/types.h>`.

Therefore, to avoid redefinition build warnings, we check if the macro is already defined.