### PR TITLE
Move TCP/TLS specific options from generic client to connection type

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -157,8 +157,14 @@ client *createClient(connection *conn) {
      * in the context of a client. When commands are executed in other
      * contexts (for instance a Lua script) we need a non connected client. */
     if (conn) {
-        connEnableTcpNoDelay(conn);
-        if (server.tcpkeepalive) connKeepAlive(conn, server.tcpkeepalive);
+        /* These options are only applicable to TCP or TLS connection.*/
+        const char *typename = conn->type->get_type(NULL);
+        if (!strcasecmp(CONN_TYPE_SOCKET, typename) ||
+            !strcasecmp(CONN_TYPE_TLS, typename)) {
+            connEnableTcpNoDelay(conn);
+            if (server.tcpkeepalive) connKeepAlive(conn, server.tcpkeepalive);
+        }
+
         connSetReadHandler(conn, readQueryFromClient);
         connSetPrivateData(conn, c);
         conn->flags |= CONN_FLAG_ALLOW_ACCEPT_OFFLOAD;

--- a/src/networking.c
+++ b/src/networking.c
@@ -157,14 +157,6 @@ client *createClient(connection *conn) {
      * in the context of a client. When commands are executed in other
      * contexts (for instance a Lua script) we need a non connected client. */
     if (conn) {
-        /* These options are only applicable to TCP or TLS connection.*/
-        const char *typename = conn->type->get_type(NULL);
-        if (!strcasecmp(CONN_TYPE_SOCKET, typename) ||
-            !strcasecmp(CONN_TYPE_TLS, typename)) {
-            connEnableTcpNoDelay(conn);
-            if (server.tcpkeepalive) connKeepAlive(conn, server.tcpkeepalive);
-        }
-
         connSetReadHandler(conn, readQueryFromClient);
         connSetPrivateData(conn, c);
         conn->flags |= CONN_FLAG_ALLOW_ACCEPT_OFFLOAD;

--- a/src/socket.c
+++ b/src/socket.c
@@ -326,6 +326,9 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
             return;
         }
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
+
+        anetEnableTcpNoDelay(NULL, cfd);
+        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);
         acceptCommonHandler(connCreateAcceptedSocket(cfd, NULL), flags, cip);
     }
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -798,6 +798,9 @@ static void tlsAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) 
             return;
         }
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
+
+        anetEnableTcpNoDelay(NULL, cfd);
+        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);
         acceptCommonHandler(connCreateAcceptedTLS(cfd, &server.tls_auth_clients), flags, cip);
     }
 }


### PR DESCRIPTION
### Issue https://github.com/valkey-io/valkey/issues/1702

### Problem
Unix domain socket doesn't operate over the TCP layer, making these options unnecessary and, in some cases, unsupported. This results in errors like EOPNOTSUPP (Operation not supported) when attempting to apply these settings using setsockopt

### Test
* UNIX
```
192903:M 10 Feb 2025 19:51:15.617 * Ready to accept connections unix
accept4(10, {sa_family=AF_UNIX}, [110->2], SOCK_CLOEXEC|SOCK_NONBLOCK) = 11
```

* TCP
```
192043:M 10 Feb 2025 19:48:46.858 * Ready to accept connections tcp
accept4(8, {sa_family=AF_INET, sin_port=htons(47132), sin_addr=inet_addr("127.0.0.1")}, [128->16], SOCK_CLOEXEC|SOCK_NONBLOCK) = 10
setsockopt(10, SOL_TCP, TCP_NODELAY, [1], 4) = 0
setsockopt(10, SOL_SOCKET, SO_KEEPALIVE, [1], 4) = 0
```

* TLS
```
191419:M 10 Feb 2025 19:46:33.504 * Ready to accept connections tls
accept4(8, {sa_family=AF_INET, sin_port=htons(48788), sin_addr=inet_addr("127.0.0.1")}, [128->16], SOCK_CLOEXEC|SOCK_NONBLOCK) = 10
setsockopt(10, SOL_TCP, TCP_NODELAY, [1], 4) = 0
setsockopt(10, SOL_SOCKET, SO_KEEPALIVE, [1], 4) = 0
```