### PR TITLE
Fix: Exclude RTLD_DEEPBIND for Alpine Linux (musl-based systems)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -12285,7 +12285,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     }
 
     int dlopen_flags = RTLD_NOW | RTLD_LOCAL;
-#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__SANITIZE_ADDRESS__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__SANITIZE_ADDRESS__) && defined(__GLIBC__) && __has_include(<dlfcn.h>)
     /* RTLD_DEEPBIND, which is required for loading modules that contains the
      * same symbols, does not work with ASAN. Therefore, we exclude
      * RTLD_DEEPBIND when doing test builds with ASAN.


### PR DESCRIPTION
Fixes #1705 
**Problem**
Alpine Linux uses `musl libc`, which does not support `RTLD_DEEPBIND`. This causes compilation errors when building on Alpine:
```
module.c: In function 'moduleLoad':
module.c:12295:21: error: 'RTLD_DEEPBIND' undeclared (first use in this function)
12295 |     dlopen_flags |= RTLD_DEEPBIND;
      |                     ^~~~~~~~~~~~~
module.c:12295:21: note: each undeclared identifier is reported only once for each function it appears in
    CC expire.o
make[1]: *** [Makefile:538: module.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/usr/src/valkey/src'
make: *** [Makefile:6: all] Error 2
```

Currently, `RTLD_DEEPBIND` is conditionally included for `Linux` and `FreeBSD`, but this assumption does not account for `musl-based` systems like `Alpine`.

**Solution**
Modify the preprocessor condition to ensure `RTLD_DEEPBIND` is only included when:

1. The system is Linux (glibc-based) or FreeBSD
2. Address Sanitizer (ASAN) is not enabled
3. `glibc` is used `(defined(__GLIBC__)` ensures `musl-based` systems like Alpine are excluded
4. `<dlfcn.h>` is available `(__has_include(<dlfcn.h>)` provides an additional safety check

New Condition:
```
#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__SANITIZE_ADDRESS__) && defined(__GLIBC__) && __has_include(<dlfcn.h>)
```


