### PR TITLE
Pass null-terminated node ID for `VM_RegisterClusterMessageReceiver` and add test coverage

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3045,7 +3045,13 @@ static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNod
     uint32_t len = ntohl(module_data->len);
     uint8_t type = module_data->type;
     unsigned char *payload = module_data->bulk_data;
-    moduleCallClusterReceivers(sender->name, module_id, type, payload, len);
+
+    /* Ensure sender name is properly truncated to 40 characters */
+    char truncated_name[41];  /* 40 chars + null terminator */
+    strncpy(truncated_name, sender->name, 40);
+    truncated_name[40] = '\0';
+
+    moduleCallClusterReceivers(truncated_name, module_id, type, payload, len);
 }
 
 static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3047,11 +3047,9 @@ static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNod
     unsigned char *payload = module_data->bulk_data;
 
     /* Ensure sender name is properly truncated to 40 characters */
-    char truncated_name[41]; /* 40 chars + null terminator */
-    strncpy(truncated_name, sender->name, 40);
-    truncated_name[40] = '\0';
-
+    sds truncated_name = sdsnewlen(sender->name, 40);
     moduleCallClusterReceivers(truncated_name, module_id, type, payload, len);
+    sdsfree(truncated_name);
 }
 
 static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3047,7 +3047,7 @@ static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNod
     unsigned char *payload = module_data->bulk_data;
 
     /* Ensure sender name is properly truncated to 40 characters */
-    char truncated_name[41];  /* 40 chars + null terminator */
+    char truncated_name[41]; /* 40 chars + null terminator */
     strncpy(truncated_name, sender->name, 40);
     truncated_name[40] = '\0';
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3046,10 +3046,9 @@ static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNod
     uint8_t type = module_data->type;
     unsigned char *payload = module_data->bulk_data;
 
-    /* Ensure sender name is properly truncated to 40 characters */
-    sds truncated_name = sdsnewlen(sender->name, 40);
-    moduleCallClusterReceivers(truncated_name, module_id, type, payload, len);
-    sdsfree(truncated_name);
+    sds sender_name = sdsnewlen(sender->name, 40);
+    moduleCallClusterReceivers(sender_name, module_id, type, payload, len);
+    sdsfree(sender_name);
 }
 
 static void clusterProcessLightPacket(clusterNode *sender, clusterLink *link, uint16_t type) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3046,7 +3046,7 @@ static void clusterProcessModulePacket(clusterMsgModule *module_data, clusterNod
     uint8_t type = module_data->type;
     unsigned char *payload = module_data->bulk_data;
 
-    sds sender_name = sdsnewlen(sender->name, 40);
+    sds sender_name = sdsnewlen(sender->name, CLUSTER_NAMELEN);
     moduleCallClusterReceivers(sender_name, module_id, type, payload, len);
     sdsfree(sender_name);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -8940,7 +8940,14 @@ void moduleCallClusterReceivers(const char *sender_id,
  * was already a registered callback, this will replace the callback function
  * with the one provided, otherwise if the callback is set to NULL and there
  * is already a callback for this function, the callback is unregistered
- * (so this API call is also used in order to delete the receiver). */
+ * (so this API call is also used in order to delete the receiver).
+ *
+ * When a message of this type is received, the registered callback function
+ * will be invoked with details, including the node ID.
+ *
+ * Behavior Change:
+ * Before Valkey 8.1: The node ID was not null-terminated.
+ * Currently: The node ID is now null-terminated for easier handling. */
 void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
                                        uint8_t type,
                                        ValkeyModuleClusterMessageReceiver callback) {

--- a/src/module.c
+++ b/src/module.c
@@ -8946,8 +8946,9 @@ void moduleCallClusterReceivers(const char *sender_id,
  * will be invoked with details, including the node ID.
  *
  * Behavior Change:
- * Before Valkey 8.1: The node ID was not null-terminated.
- * Currently: The node ID is now null-terminated for easier handling. */
+ * Before Valkey 8.1: The node ID was not NULL terminated.
+ * Currently: The node ID 'sender_id' in the callback receiver is now a
+ * NULL terminated string for easier handling. */
 void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
                                        uint8_t type,
                                        ValkeyModuleClusterMessageReceiver callback) {

--- a/src/module.c
+++ b/src/module.c
@@ -8943,12 +8943,10 @@ void moduleCallClusterReceivers(const char *sender_id,
  * (so this API call is also used in order to delete the receiver).
  *
  * When a message of this type is received, the registered callback function
- * will be invoked with details, including the node ID.
+ * will be invoked with details, including the 40-byte node ID of the sender.
  *
- * Behavior Change:
- * Before Valkey 8.1: The node ID was not NULL terminated.
- * Currently: The node ID 'sender_id' in the callback receiver is now a
- * NULL terminated string for easier handling. */
+ * In Valkey 8.1 and later, the node ID is null-terminated. Prior to 8.1, it was
+ * not null-terminated */
 void VM_RegisterClusterMessageReceiver(ValkeyModuleCtx *ctx,
                                        uint8_t type,
                                        ValkeyModuleClusterMessageReceiver callback) {

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -48,7 +48,7 @@ int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
 void DingReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {
     ValkeyModule_Log(ctx, "notice", "DING (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN, sender_id, (int)len, payload);
-    ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_DONG, "Message Received!", 17);
+    ValkeyModule_SendClusterMessage(ctx, sender_id, MSGTYPE_DONG, "Message Received!", 17);
 }
 
 void DongReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {
@@ -72,9 +72,8 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_CreateCommand(ctx, "test.cluster_shards", test_cluster_shards, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    // Register the receivers
+    /* Register our handlers for different message types. */
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_DING, DingReceiver);
     ValkeyModule_RegisterClusterMessageReceiver(ctx, MSGTYPE_DONG, DongReceiver);
-
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -49,10 +49,6 @@ int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 void DingReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {
     ValkeyModule_Log(ctx, "notice", "DING (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN, sender_id, (int)len, payload);
     ValkeyModule_SendClusterMessage(ctx, NULL, MSGTYPE_DONG, "Message Received!", 17);
-    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, "INCR", "c", "dings_received");
-    if (reply != NULL) { 
-        ValkeyModule_FreeCallReply(reply);
-    }
 }
 
 void DongReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -16,11 +16,25 @@ start_cluster 3 0 [list config_lines $modules] {
         assert_equal OK [$node1 test.pingall]
         assert_equal 2 [CI 0 cluster_stats_messages_module_sent]
         wait_for_condition 50 100 {
-            [CI 1 cluster_stats_messages_module_received] eq 1 &&
-            [CI 2 cluster_stats_messages_module_received] eq 1
+            [CI 1 cluster_stats_messages_module_received] eq 2 &&
+            [CI 2 cluster_stats_messages_module_received] eq 2
         } else {
             fail "node 2 or node 3 didn't receive cluster module message"
         }
+    }
+
+    test "Cluster module message DING/DONG acknowledgment" {
+        assert_equal OK [$node1 test.pingall]
+        wait_for_condition 100 100 {
+            [CI 0 cluster_stats_messages_module_received] eq 4  &&
+            [CI 1 cluster_stats_messages_module_received] eq 4 &&
+            [CI 2 cluster_stats_messages_module_received] eq 4
+        } else {
+            fail "node 2 or node 3 didn't receive DING/DONG messages"
+        }
+
+        verify_log_message -1 "*DING (type 1) RECEIVED*Hey*" 0
+        verify_log_message 0 "*DONG (type 2) RECEIVED*Message Received*" 0
     }
 }
 

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -38,7 +38,8 @@ start_cluster 3 0 [list config_lines $modules] {
         }
 
         verify_log_message -1 "*DING (type 1) RECEIVED*Hey*" 0
-        verify_log_message 0 "*DONG (type 2) RECEIVED*Message Received*" 0
+        verify_log_message -2 "*DING (type 1) RECEIVED*Hey*" 0
+        assert_equal 2 [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"]
     }
 }
 

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -22,12 +22,10 @@ start_cluster 3 0 [list config_lines $modules] {
             fail "node 2 or node 3 didn't receive cluster module message"
         }
     }
-}
 
-start_cluster 3 0 [list config_lines $modules] {
-    set node1 [srv 0 client]
-    set node2 [srv -1 client]
-    set node3 [srv -2 client]
+    $node1 CONFIG RESETSTAT
+    $node2 CONFIG RESETSTAT
+    $node3 CONFIG RESETSTAT
 
     test "Cluster module message DING/DONG acknowledgment" {
         assert_equal OK [$node1 test.pingall]

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -16,21 +16,27 @@ start_cluster 3 0 [list config_lines $modules] {
         assert_equal OK [$node1 test.pingall]
         assert_equal 2 [CI 0 cluster_stats_messages_module_sent]
         wait_for_condition 50 100 {
-            [CI 1 cluster_stats_messages_module_received] eq 2 &&
-            [CI 2 cluster_stats_messages_module_received] eq 2
+            [CI 1 cluster_stats_messages_module_received] eq 1 &&
+            [CI 2 cluster_stats_messages_module_received] eq 1
         } else {
             fail "node 2 or node 3 didn't receive cluster module message"
         }
     }
+}
+
+start_cluster 3 0 [list config_lines $modules] {
+    set node1 [srv 0 client]
+    set node2 [srv -1 client]
+    set node3 [srv -2 client]
 
     test "Cluster module message DING/DONG acknowledgment" {
         assert_equal OK [$node1 test.pingall]
-        wait_for_condition 100 100 {
-            [CI 0 cluster_stats_messages_module_received] eq 4  &&
-            [CI 1 cluster_stats_messages_module_received] eq 4 &&
-            [CI 2 cluster_stats_messages_module_received] eq 4
+        wait_for_condition 50 100 {
+            [CI 0 cluster_stats_messages_module_received] eq 2  &&
+            [CI 1 cluster_stats_messages_module_received] eq 1 &&
+            [CI 2 cluster_stats_messages_module_received] eq 1
         } else {
-            fail "node 2 or node 3 didn't receive DING/DONG messages"
+            fail "node 2 or node 3 didn't receive DING messages or node 1 didn't receive DONG message"
         }
 
         verify_log_message -1 "*DING (type 1) RECEIVED*Hey*" 0

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -30,7 +30,7 @@ start_cluster 3 0 [list config_lines $modules] {
     test "Cluster module message DING/DONG acknowledgment" {
         assert_equal OK [$node1 test.pingall]
         wait_for_condition 50 100 {
-            [CI 0 cluster_stats_messages_module_received] eq 2  &&
+            [CI 0 cluster_stats_messages_module_received] eq 2 &&
             [CI 1 cluster_stats_messages_module_received] eq 1 &&
             [CI 2 cluster_stats_messages_module_received] eq 1
         } else {

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -37,9 +37,9 @@ tags {external:skip needs:other-server cluster modules} {
 
             test "Send cluster message via module from latest to other server" {
                 assert_equal OK [r test.pingall]
-                assert_match "*cluster_stats_messages_module_sent:2*" [r CLUSTER INFO]
+                assert_match "*cluster_stats_messages_module_sent:1*" [r CLUSTER INFO]
                 wait_for_condition 50 100 {
-                    [string match {*cluster_stats_messages_module_received:2*} [r -1 CLUSTER INFO]]
+                    [string match {*cluster_stats_messages_module_received:1*} [r -1 CLUSTER INFO]]
                 } else {
                     fail "Node didn't receive the message"
                 }
@@ -49,9 +49,9 @@ tags {external:skip needs:other-server cluster modules} {
                 r CONFIG resetstat
                 r -1 CONFIG resetstat
                 assert_equal OK [r -1 test.pingall]
-                assert_match "*cluster_stats_messages_module_sent:2*" [r -1 CLUSTER INFO]
+                assert_match "*cluster_stats_messages_module_sent:1*" [r -1 CLUSTER INFO]
                 wait_for_condition 50 100 {
-                    [string match {*cluster_stats_messages_module_received:2*} [r CLUSTER INFO]]
+                    [string match {*cluster_stats_messages_module_received:1*} [r CLUSTER INFO]]
                 } else {
                     fail "Node didn't receive the message"
                 }

--- a/tests/unit/moduleapi/cross-version-cluster.tcl
+++ b/tests/unit/moduleapi/cross-version-cluster.tcl
@@ -37,9 +37,9 @@ tags {external:skip needs:other-server cluster modules} {
 
             test "Send cluster message via module from latest to other server" {
                 assert_equal OK [r test.pingall]
-                assert_match "*cluster_stats_messages_module_sent:1*" [r CLUSTER INFO]
+                assert_match "*cluster_stats_messages_module_sent:2*" [r CLUSTER INFO]
                 wait_for_condition 50 100 {
-                    [string match {*cluster_stats_messages_module_received:1*} [r -1 CLUSTER INFO]]
+                    [string match {*cluster_stats_messages_module_received:2*} [r -1 CLUSTER INFO]]
                 } else {
                     fail "Node didn't receive the message"
                 }
@@ -49,9 +49,9 @@ tags {external:skip needs:other-server cluster modules} {
                 r CONFIG resetstat
                 r -1 CONFIG resetstat
                 assert_equal OK [r -1 test.pingall]
-                assert_match "*cluster_stats_messages_module_sent:1*" [r -1 CLUSTER INFO]
+                assert_match "*cluster_stats_messages_module_sent:2*" [r -1 CLUSTER INFO]
                 wait_for_condition 50 100 {
-                    [string match {*cluster_stats_messages_module_received:1*} [r CLUSTER INFO]]
+                    [string match {*cluster_stats_messages_module_received:2*} [r CLUSTER INFO]]
                 } else {
                     fail "Node didn't receive the message"
                 }


### PR DESCRIPTION
* Pass `sender_id` as `NULL` terminated string as part of `ValkeyModuleClusterMessageReceiver` for ease of usage by the module(s).

* Implement test coverage described in #1656 and ensures that nodes in the cluster module properly acknowledge a "DING" message by sending a "DONG" response.

Closes #1656.
