### PR TITLE
Fix undefined behavior warning in UBSAN

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -101,7 +101,7 @@ void evalInit(void) {
      * and we need to free them respectively. */
     evalCtx.scripts = dictCreate(&shaScriptObjectDictType);
     evalCtx.scripts_lru_list = listCreate();
-    listSetFreeMethod(evalCtx.scripts_lru_list, (void (*)(void *))sdsfree);
+    listSetFreeMethod(evalCtx.scripts_lru_list, sdsfreeVoid);
     evalCtx.scripts_mem = 0;
 }
 

--- a/src/lua/debug_lua.c
+++ b/src/lua/debug_lua.c
@@ -47,7 +47,7 @@ void ldbInit(void) {
     ldb.conn = NULL;
     ldb.active = 0;
     ldb.logs = listCreate();
-    listSetFreeMethod(ldb.logs, (void (*)(void *))sdsfree);
+    listSetFreeMethod(ldb.logs, sdsfreeVoid);
     ldb.children = listCreate();
     ldb.src = NULL;
     ldb.lines = 0;


### PR DESCRIPTION
This casue this warning in the undefined-behaviour santitizer test:
```
adlist.c:63:25: runtime error: call to function sdsfree through pointer to incorrect function type 'void (*)(void *)'
/home/runner/work/valkey/valkey/src/sds.c:205: note: sdsfree defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior adlist.c:63:25
```