### PR TITLE
Fix new benchmark test under the TLS

### DIFF
--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -12,6 +12,9 @@ proc common_bench_setup {cmd} {
     if {[catch { exec {*}$cmd } error]} {
         set first_line [lindex [split $error "\n"] 0]
         puts [colorstr red "valkey-benchmark non zero code. first line: $first_line"]
+        if {$::verbose} {
+            puts [colorstr red "valkey-benchmark non zero code, the output is: $error"]
+        }
         fail "valkey-benchmark non zero code. first line: $first_line"
     }
 }

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -12,9 +12,7 @@ proc common_bench_setup {cmd} {
     if {[catch { exec {*}$cmd } error]} {
         set first_line [lindex [split $error "\n"] 0]
         puts [colorstr red "valkey-benchmark non zero code. first line: $first_line"]
-        if {$::verbose} {
-            puts [colorstr red "valkey-benchmark non zero code, the output is: $error"]
-        }
+        puts [colorstr red "valkey-benchmark non zero code, the output is: $error"]
         fail "valkey-benchmark non zero code. first line: $first_line"
     }
 }

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -11,7 +11,6 @@ proc common_bench_setup {cmd} {
     r flushall
     if {[catch { exec {*}$cmd } error]} {
         set first_line [lindex [split $error "\n"] 0]
-        puts [colorstr red "valkey-benchmark non zero code. first line: $first_line"]
         puts [colorstr red "valkey-benchmark non zero code, the output is: $error"]
         fail "valkey-benchmark non zero code. first line: $first_line"
     }


### PR DESCRIPTION
We need to call cliSecureConnection if we are runing under the TLS, otherwise the connection can not be use.