### PR TITLE
Reset failover auth time when myself won the failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4786,9 +4786,7 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     /* Since we have became a new primary node, we may rely on auth_time to
      * determine whether a failover is in progress, so it is best to reset it. */
-    if (server.cluster->failover_auth_time) {
-        server.cluster->failover_auth_time = 0;
-    }
+    server.cluster->failover_auth_time = 0;
 }
 
 /* This function is called if we are a replica node and our primary serving

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4783,6 +4783,12 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     /* 5) If there was a manual failover in progress, clear the state. */
     resetManualFailover();
+
+    /* Since we have became a new primary node, we may rely on auth_time to
+     * determine whether a failover is in progress, so it is best to reset it. */
+    if (server.cluster->failover_auth_time) {
+        server.cluster->failover_auth_time = 0;
+    }
 }
 
 /* This function is called if we are a replica node and our primary serving


### PR DESCRIPTION
We may rely on auth_time to determine whether a failover is in progress, like #1009, so it is best to reset it.