### PR TITLE
Correctly detect address sanitizer with Clang

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -172,6 +172,16 @@
 #define VALKEY_NO_SANITIZE(sanitizer)
 #endif
 
+#if defined(__SANITIZE_ADDRESS__)
+/* GCC */
+#define VALKEY_ADDRESS_SANITIZER 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+/* Clang */
+#define VALKEY_ADDRESS_SANITIZER 1
+#endif
+#endif
+
 /* Define rdb_fsync_range to sync_file_range() on Linux, otherwise we use
  * the plain fsync() call. */
 #if (defined(__linux__) && defined(SYNC_FILE_RANGE_WAIT_BEFORE))

--- a/src/module.c
+++ b/src/module.c
@@ -12285,7 +12285,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     }
 
     int dlopen_flags = RTLD_NOW | RTLD_LOCAL;
-#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__SANITIZE_ADDRESS__) && defined(__GLIBC__) && __has_include(<dlfcn.h>)
+#if (defined(__GLIBC__) || defined(__FreeBSD__)) && !defined(VALKEY_ADDRESS_SANITIZER) && __has_include(<dlfcn.h>)
     /* RTLD_DEEPBIND, which is required for loading modules that contains the
      * same symbols, does not work with ASAN. Therefore, we exclude
      * RTLD_DEEPBIND when doing test builds with ASAN.


### PR DESCRIPTION
Fixes the failure trying to use dlopen with DEEPBIND with ASAN when compiling with Clang:

==90510==You are trying to dlopen a /home/runner/work/valkey/valkey/tests/modules/keyspecs.so shared library with RTLD_DEEPBIND flag which is incompatible with sanitizer runtime (see https://github.com/google/sanitizers/issues/611 for details). If you want to run /home/runner/work/valkey/valkey/tests/modules/keyspecs.so library under sanitizers please remove RTLD_DEEPBIND from dlopen flags.

https://github.com/valkey-io/valkey/actions/runs/13261241213/job/37018133361

The previous check only covers GCC.

Additionally, don't require GLIBC when FreeBSD is used. FreeBSD has it's own libc which supports DEEPBIND according to its docs.

Follow-up of #1703, #1707