### PR TITLE
Prevent double writing out of responses

### DIFF
--- a/tests/modules/helloscripting.c
+++ b/tests/modules/helloscripting.c
@@ -424,9 +424,11 @@ callHelloLangFunction(ValkeyModuleCtx *module_ctx,
     if (state == VMSE_STATE_KILLED) {
         if (type == VMSE_EVAL) {
             ValkeyModule_ReplyWithError(module_ctx, "ERR Script killed by user with SCRIPT KILL.");
+            return;
         }
         if (type == VMSE_FUNCTION) {
             ValkeyModule_ReplyWithError(module_ctx, "ERR Script killed by user with FUNCTION KILL");
+            return;
         }
     }
 

--- a/tests/unit/moduleapi/scriptingengine.tcl
+++ b/tests/unit/moduleapi/scriptingengine.tcl
@@ -136,6 +136,8 @@ start_server {tags {"modules"}} {
         after 1000 ;
         assert_equal [r ping] "PONG"
         assert_error {ERR Script killed by user with FUNCTION KILL*} {$rd read}
+        $rd ping
+        assert_equal [$rd read] "PONG"
         $rd close
     }
 


### PR DESCRIPTION
Fix issue https://github.com/valkey-io/valkey/actions/runs/13268563078/job/37042222814.

We were writing out a second response on the error.