### PR TITLE
Backport - Fix Valkey binary build workflow, version support changes. (#1429)

### DIFF
--- a/.github/actions/generate-package-build-matrix/build-config.json
+++ b/.github/actions/generate-package-build-matrix/build-config.json
@@ -1,28 +1,35 @@
 {
     "linux_targets": [
+
         {
           "arch": "x86_64",
-          "target": "ubuntu18.04",
+          "target": "ubuntu-20.04",
           "type": "deb",
-          "platform": "bionic"
+          "platform": "focal"
         },
         {
           "arch": "x86_64",
+          "target": "ubuntu-22.04",
+          "type": "deb",
+          "platform": "jammy"
+        },
+        {
+          "arch": "x86_64",
+          "target": "ubuntu-24.04",
+          "type": "deb",
+          "platform": "noble"
+        },
+        {
+          "arch": "arm64",
           "target": "ubuntu20.04",
           "type": "deb",
           "platform": "focal"
         },
         {
           "arch": "arm64",
-          "target": "ubuntu18.04",
+          "target": "ubuntu22.04",
           "type": "deb",
-          "platform": "bionic"
-        },
-        {
-          "arch": "arm64",
-          "target": "ubuntu20.04",
-          "type": "deb",
-          "platform": "focal"
+          "platform": "jammy"
         }
       ]
 }

--- a/.github/workflows/call-build-linux-x86-packages.yml
+++ b/.github/workflows/call-build-linux-x86-packages.yml
@@ -35,7 +35,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: "ubuntu-latest"
+    runs-on: ${{matrix.distro.target}}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}


### PR DESCRIPTION
Backport - Fix Valkey binary build workflow, version support changes. (#1429)
This change makes the binary build on the target ubuntu version.

This PR also deprecated ubuntu18 and valkey will not support.

- X86:
  - Ubuntu 20
  - Ubuntu 22
  - Ubuntu 24
 - ARM:
   - Ubuntu 20
   - Ubuntu 22

Removed ARM ubuntu 24 as the action we are using for ARM builds does not support Ubuntu 24.

---------