### PR TITLE
valkey-cli hints: Adjust "since" check for release candidates

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -710,7 +710,7 @@ void cliInitCommandHelpEntries(redisReply *commandTable, dict *groups) {
 }
 
 /* Convert a version on the form "x.y.z" to a number to easily compare versions.
- * Threat release canditates as GA release. */
+ * Threat release candidates as GA release. */
 static int parseVersion(const char *v) {
     if (!v) return -1;
     int major = atoi(v);


### PR DESCRIPTION
valkey-cli uses the COMMAND "since" field to find the supported commands and arguments of the connected server.

Adjust this check so release candidate versions like 8.0.240 are rounded up to the GA release numbers like 8.1.0.

Fixes test issues in release candidates like this one:
https://github.com/valkey-io/valkey/actions/runs/13281314141/job/37080127772#step:5:9605