### PR TITLE
Don't leak TCL connections in unit/tracking

### DIFF
--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -23,7 +23,9 @@ start_server {tags {"tracking network logreqres:skip"}} {
             # info which will not be consumed.
             r CLIENT TRACKING off
             $rd QUIT
+            $rd close
             $rd_redirection QUIT
+            $rd_redirection close
             set rd [valkey_deferring_client]
             set rd_redirection [valkey_deferring_client]
             $rd_redirection client id
@@ -243,6 +245,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r GET key1
         $rd_redirection QUIT
         assert_equal OK [$rd_redirection read]
+        $rd_redirection close
         $rd_sg SET key1 2
 
         # Reinstantiating after QUIT


### PR DESCRIPTION
While investigating #1647, I realized we repeatedly start new test clients without closing the old ones. This is leaking file descriptors in TCL, IIUC.

This patch does `close` before opening a new client. Without this patch, running the test locally 1000 times, with 100 parallel test workers ...

    ./runtest --clients 100 --single unit/tracking --loops 200

... it fails with what looks like running out of local ports for sockets:

    [exception]: Executing test client: couldn't open socket: address already in use. 
    ...
    Port 22488 was already busy, trying another port...
    Port 24490 was already busy, trying another port...

With this fix, I can successfully run with `--clients 100` and even increase it to `--clients 1000` and `--loops 2000`. With higher numbers I still get the "address already in use" error.

I don't know if this is related to the timeout in #1647. Maybe the timeout is related to running out of sockets?