### PR TITLE
Fix temp file leak druing replication error handling

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3887,7 +3887,7 @@ void cleanupTransferResources(void) {
         return;
     }
 
-    serverAssert(server.repl_transfer_fd != -1 && server.repl_transfer_tmpfile != NULL);
+    serverAssert(server.repl_transfer_tmpfile != NULL);
     close(server.repl_transfer_fd);
     bg_unlink(server.repl_transfer_tmpfile);
     zfree(server.repl_transfer_tmpfile);

--- a/src/replication.c
+++ b/src/replication.c
@@ -3842,6 +3842,8 @@ no_response_error: /* Handle receiveSynchronousResponse() error when primary has
     /* Fall through to regular error handling */
 
 error:
+    connClose(conn);
+    server.repl_transfer_s = NULL;
     if (server.repl_rdb_transfer_s) {
         connClose(server.repl_rdb_transfer_s);
         server.repl_rdb_transfer_s = NULL;
@@ -3898,6 +3900,8 @@ void cleanupTransferResources(void) {
  * Never call this function directly, use cancelReplicationHandshake() instead.
  */
 void undoConnectWithPrimary(void) {
+    if (server.repl_transfer_s == NULL) return;
+
     connClose(server.repl_transfer_s);
     server.repl_transfer_s = NULL;
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -46,6 +46,7 @@
 #include <sys/stat.h>
 #include <ctype.h>
 
+void cleanupTransferResources(void);
 void replicationDiscardCachedPrimary(void);
 void replicationResurrectCachedPrimary(connection *conn);
 void replicationResurrectProvisionalPrimary(void);
@@ -2653,12 +2654,7 @@ void replicationAbortDualChannelSyncTransfer(void) {
         connClose(server.repl_rdb_transfer_s);
         server.repl_rdb_transfer_s = NULL;
     }
-    zfree(server.repl_transfer_tmpfile);
-    server.repl_transfer_tmpfile = NULL;
-    if (server.repl_transfer_fd != -1) {
-        close(server.repl_transfer_fd);
-        server.repl_transfer_fd = -1;
-    }
+    cleanupTransferResources();
     server.repl_rdb_channel_state = REPL_DUAL_CHANNEL_STATE_NONE;
     server.repl_provisional_primary.read_reploff = 0;
     server.repl_provisional_primary.reploff = 0;
@@ -2871,8 +2867,7 @@ error:
         connClose(server.repl_rdb_transfer_s);
         server.repl_rdb_transfer_s = NULL;
     }
-    if (server.repl_transfer_fd != -1) close(server.repl_transfer_fd);
-    server.repl_transfer_fd = -1;
+    cleanupTransferResources();
     server.repl_state = REPL_STATE_CONNECT;
     replicationAbortDualChannelSyncTransfer();
 }
@@ -3816,7 +3811,8 @@ void syncWithPrimary(connection *conn) {
         server.repl_rdb_transfer_s = connCreate(connTypeOfReplication());
         if (connConnect(server.repl_rdb_transfer_s, server.primary_host, server.primary_port, server.bind_source_addr,
                         dualChannelFullSyncWithPrimary) == C_ERR) {
-            serverLog(LL_WARNING, "Unable to connect to Primary: %s", connGetLastError(server.repl_transfer_s));
+            dualChannelServerLog(LL_WARNING, "Unable to connect to Primary: %s",
+                                 connGetLastError(server.repl_transfer_s));
             connClose(server.repl_rdb_transfer_s);
             server.repl_rdb_transfer_s = NULL;
             goto error;
@@ -3856,10 +3852,7 @@ error:
         connClose(server.repl_rdb_transfer_s);
         server.repl_rdb_transfer_s = NULL;
     }
-    if (server.repl_transfer_fd != -1) close(server.repl_transfer_fd);
-    if (server.repl_transfer_tmpfile) zfree(server.repl_transfer_tmpfile);
-    server.repl_transfer_tmpfile = NULL;
-    server.repl_transfer_fd = -1;
+    cleanupTransferResources();
     server.repl_state = REPL_STATE_CONNECT;
     return;
 
@@ -3886,6 +3879,26 @@ int connectWithPrimary(void) {
     return C_OK;
 }
 
+/* In disk-based replication, replica will open a temp db file to store the RDB file.
+ * Before entering the REPL_STATE_TRANSFER or after entering the REPL_STATE_TRANSFER,
+ * if an error occurs, we need to clean up related resources, such as closing the tmp
+ * file fd and deleting the temp file.
+ *
+ * Noted that repl_transfer_fd and repl_transfer_tmpfile should be set/unset together. */
+void cleanupTransferResources(void) {
+    if (server.repl_transfer_fd == -1) {
+        serverAssert(server.repl_transfer_tmpfile == NULL);
+        return;
+    }
+
+    serverAssert(server.repl_transfer_fd != -1 && server.repl_transfer_tmpfile != NULL);
+    close(server.repl_transfer_fd);
+    bg_unlink(server.repl_transfer_tmpfile);
+    zfree(server.repl_transfer_tmpfile);
+    server.repl_transfer_tmpfile = NULL;
+    server.repl_transfer_fd = -1;
+}
+
 /* This function can be called when a non blocking connection is currently
  * in progress to undo it.
  * Never call this function directly, use cancelReplicationHandshake() instead.
@@ -3901,13 +3914,7 @@ void undoConnectWithPrimary(void) {
 void replicationAbortSyncTransfer(void) {
     serverAssert(server.repl_state == REPL_STATE_TRANSFER);
     undoConnectWithPrimary();
-    if (server.repl_transfer_fd != -1) {
-        close(server.repl_transfer_fd);
-        bg_unlink(server.repl_transfer_tmpfile);
-        zfree(server.repl_transfer_tmpfile);
-        server.repl_transfer_tmpfile = NULL;
-        server.repl_transfer_fd = -1;
-    }
+    cleanupTransferResources();
 }
 
 /* This function aborts a non blocking replication attempt if there is one


### PR DESCRIPTION
Before actually entering REPL_STATE_TRANSFER, we usually have
some other things to do, such as registering the ae handler, etc.
If an error occurs at this time, we may leak the previously opened
temp file.

This commit adds a new cleanupTransferResources function to do the
cleanup, avoiding code duplication.