### PR TITLE
Introduce valkey_version_full info field which includes the release stage

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5668,6 +5668,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "redis_version:%s\r\n", REDIS_VERSION,
                 "server_name:%s\r\n", SERVER_NAME,
                 "valkey_version:%s\r\n", VALKEY_VERSION,
+                "valkey_version_full:%s\r\n", VALKEY_VERSION "-" VALKEY_RELEASE_EXT,
                 "redis_git_sha1:%s\r\n", serverGitSHA1(),
                 "redis_git_dirty:%i\r\n", strtol(serverGitDirty(), NULL, 10) > 0,
                 "redis_build_id:%s\r\n", serverBuildIdString(),

--- a/src/version.h
+++ b/src/version.h
@@ -6,6 +6,11 @@
 #define SERVER_TITLE "Valkey"
 #define VALKEY_VERSION "255.255.255"
 #define VALKEY_VERSION_NUM 0x00ffffff
+/* The release extension is used in order to provide release metadata information
+ * about the version release status. In unstable branch the status is always "dev".
+ * during release process the status will be set to rc1,rc2...rcN. When the version is released
+ * the status will be "ga". */
+#define VALKEY_RELEASE_EXT "dev"
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
This will introduce a new info field indicating the Valkey version and the release status.
The release status is used in order to provide release metadata information about the current version
release state. 
- In unstable branch the status is always "dev". 
- during release process the status will be set to rc1,rc2...rcN. 
- When the version is released the status will be "ga".

The reflected full version will be introduced to the info command output in valkey_version_full info field.
example:

in unstable:
```
# Server
redis_version:7.2.4
server_name:valkey
valkey_version:255.255.255
valkey_version_full:255.255.255-dev
redis_git_sha1:2f2b8d15
redis_git_dirty:1
redis_build_id:2f18af70ce63295b
```

during RC release:

```
# Server
redis_version:7.2.4
server_name:valkey
valkey_version:8.1.0
valkey_version_full:8.1.0-rc1
redis_git_sha1:2f2b8d15
redis_git_dirty:1
redis_build_id:2f18af70ce63295b
```

during Major/Minor/Patch release:

```
# Server
redis_version:7.2.4
server_name:valkey
valkey_version:8.1.3
valkey_version_full:8.1.3-ga
redis_git_sha1:2f2b8d15
redis_git_dirty:1
redis_build_id:2f18af70ce63295b
```

