### PR TITLE
Introduce Valkey release stage indication

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5668,6 +5668,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "redis_version:%s\r\n", REDIS_VERSION,
                 "server_name:%s\r\n", SERVER_NAME,
                 "valkey_version:%s\r\n", VALKEY_VERSION,
+                "valkey_version_full:%s\r\n", VALKEY_VERSION "-" VALKEY_RELEASE_EXT,
                 "redis_git_sha1:%s\r\n", serverGitSHA1(),
                 "redis_git_dirty:%i\r\n", strtol(serverGitDirty(), NULL, 10) > 0,
                 "redis_build_id:%s\r\n", serverBuildIdString(),

--- a/src/server.c
+++ b/src/server.c
@@ -5668,7 +5668,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "redis_version:%s\r\n", REDIS_VERSION,
                 "server_name:%s\r\n", SERVER_NAME,
                 "valkey_version:%s\r\n", VALKEY_VERSION,
-                "valkey_version_full:%s\r\n", VALKEY_VERSION "-" VALKEY_RELEASE_EXT,
+                "valkey_release_stage:%s\r\n", VALKEY_RELEASE_STAGE,
                 "redis_git_sha1:%s\r\n", serverGitSHA1(),
                 "redis_git_dirty:%i\r\n", strtol(serverGitDirty(), NULL, 10) > 0,
                 "redis_build_id:%s\r\n", serverBuildIdString(),

--- a/src/version.h
+++ b/src/version.h
@@ -6,6 +6,11 @@
 #define SERVER_TITLE "Valkey"
 #define VALKEY_VERSION "255.255.255"
 #define VALKEY_VERSION_NUM 0x00ffffff
+/* The release extension is used in order to provide release metadata information
+ * about the version release status. In unstable branch the status is always "dev".
+ * during release process the status will be set to rc1,rc2...rcN. When the version is released
+ * the status will be "ga". */
+#define VALKEY_RELEASE_EXT "dev"
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */

--- a/src/version.h
+++ b/src/version.h
@@ -8,7 +8,7 @@
 #define VALKEY_VERSION_NUM 0x00ffffff
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
- * During release process the status will be set to rc1,rc2...rcN. 
+ * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
 #define VALKEY_RELEASE_STAGE "dev"
 

--- a/src/version.h
+++ b/src/version.h
@@ -6,11 +6,11 @@
 #define SERVER_TITLE "Valkey"
 #define VALKEY_VERSION "255.255.255"
 #define VALKEY_VERSION_NUM 0x00ffffff
-/* The release extension is used in order to provide release metadata information
- * about the version release status. In unstable branch the status is always "dev".
- * during release process the status will be set to rc1,rc2...rcN. When the version is released
- * the status will be "ga". */
-#define VALKEY_RELEASE_EXT "dev"
+/* The release stage is used in order to provide release status information.
+ * In unstable branch the status is always "dev".
+ * During release process the status will be set to rc1,rc2...rcN. 
+ * When the version is released the status will be "ga". */
+#define VALKEY_RELEASE_STAGE "dev"
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
In #1723 we introduced the release status as a full version info field (valkey_version_full)
However this does not follow the [SemVer version specifications](https://semver.org/).
We considered some alternatives:
1. using `git describe --tags --always --dirty` during the build process in order to place the current tag information.
   The problem with this laternative is that sometimes builds are done on untrackes sources (eg tar.gz downloads) and lack 
   the git info in order to correctly manage this data.
2. Include a [pre-release indication](https://semver.org/#spec-item-9) as part of the [VALKEY_VERSION](https://github.com/valkey-io/valkey/blob/unstable/src/version.h#L7) string - however this might break some clients testing with RC versions and would require to support/chop the prerelease indicator on REPLCONF other places.

In this PR we introduce reporting the release stage as a dedicated info field.
The release status value will reflect the release stage:
 * In unstable branch the status is always "dev".
 * During release process the status will be set to rc1,rc2...rcN. 
 * When the version is released the status will be "ga".
 