### PR TITLE
Increase max robj embedded key + value to 128 bytes

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -232,7 +232,7 @@ robj *createStringObjectWithKeyAndExpire(const char *ptr, size_t len, const sds 
     size += (key != NULL) * (sdslen(key) + 3); /* hdr size (1) + hdr (1) + nullterm (1) */
     size += (expire != -1) * sizeof(long long);
     size += 4 + len; /* embstr header (3) + nullterm (1) */
-    if (size <= 64) {
+    if (size <= 128) {
         return createEmbeddedStringObjectWithKeyAndExpire(ptr, len, key, expire);
     } else {
         return createObjectWithKeyAndExpire(OBJ_STRING, sdsnewlen(ptr, len), key, expire);


### PR DESCRIPTION
This change permits string values to be stored embedded in the refcounted object (robj) if the size of robj including embedded key and value fits in 128 bytes. The benefit is less memory usage on average, better cache locality and fewer allocations.

The jemalloc size classes in the range 64-128 bytes are in intervals of 16 bytes. The size classes below 64 come in intervals of 8. Above 128, the size classes come in intervals of 32 bytes. The interesting range for this PR is 64-128 bytes.

* When the size classes come in intervals of 8, a string of a random size in this interval has 0-7 bytes of wasted space, 3.5 on average. With two such allocations (one for robj and key and one for the value) we have 7 bytes wasted on average (3.5 + 3.5).

* If the key is ~17 bytes and the value is ~80 bytes, the allocation holding the robj with the key has 0-7 bytes wasted and the value allocation has 0-15 bytes wasted. This is 3.5 + 7.5 = 11 bytes on average.

* If we embed key and value in one allocation and it fits within 64-128 bytes, it has 0-15 bytes wasted, which is 7.5 bytes on average, and fewer allocations may imply less overhead in the allocator itself, and better locality which may imply faster access.

This needs to be benchmarked though, for memory and CPU.

The total size of key + value to be affected by this change needs to be 41-105 bytes. For example key size 17 and value size 85.

@SoftlyRaining Do you want to test this and compare to unstable?

If we finish your PR (that removes the robj->ptr for EMBSTR) we save another 8 bytes for EMBSTR.