### PR TITLE
Deflake dual-channel test in integration/replication-buffer

### DIFF
--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -155,7 +155,11 @@ start_server {} {
         # Replication actual backlog grow more than backlog setting since
         # the slow replica2 kept replication buffer.
         populate 20000 master 10000
-        assert {[s repl_backlog_histlen] > [expr 10000*10000]}
+        wait_for_condition 10000 100 {
+            ([s repl_backlog_histlen] > [expr 10000*10000])
+        } else {
+            fail "Unexpected backlog size"
+        }        
     }
 
     # Wait replica1 catch up with the master


### PR DESCRIPTION
Fix flaky dual-channel test by allowing time for replication data to propagate.

Try to solve #1747