### PR TITLE
Explicitly use github arm runners for ARM release

### DIFF
--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -35,7 +35,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04-arm"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}


### PR DESCRIPTION
In the last 8.1.0-rc1 release attempt we identified that the cross compilation on x86 for ARM is broken
(example: https://github.com/valkey-io/valkey/actions/runs/13324096504/job/37225952044)

This PR sets use of arm runners during release binaries.