### PR TITLE
Fix murmur32 on large strings

### DIFF
--- a/deps/lua/src/lstring.c
+++ b/deps/lua/src/lstring.c
@@ -81,9 +81,9 @@ uint32_t murmur32(const uint8_t* key, size_t len, uint32_t seed) {
   static const uint32_t n = 0xe6546b64;
   uint32_t hash = seed;
 
-  const int nblocks = len / 4;
+  const size_t nblocks = len / 4;
   const uint32_t* blocks = (const uint32_t*) key;
-  for (int i = 0; i < nblocks; i++) {
+  for (size_t i = 0; i < nblocks; i++) {
     uint32_t k = blocks[i];
     k *= c1;
     k = (k << r1) | (k >> (32 - r1));
@@ -116,7 +116,7 @@ uint32_t murmur32(const uint8_t* key, size_t len, uint32_t seed) {
     hash ^= (hash >> 16);
   
     return hash;
-  }
+}
 
 TString *luaS_newlstr (lua_State *L, const char *str, size_t l) {
   GCObject *o;


### PR DESCRIPTION
Current murmur32 implementation fails on large strings.
Way to reproduce crash:
```
eval 'local s = string.rep("a", 1024 * 1024 * 1024) return #cjson.encode(s..s..s)' 0
```
(Basically this is a copy-paste from large test in `tests/unit/scripting.tcl`).

Shouldn't we run tests with `--large-memory` on daily CI so we could find this earlier?

I think we need to backport this to 8.1 branch.