### PR TITLE
Fix hashtable memory leak and kvstore `overhead_hashtable_lut` assert

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1058,7 +1058,7 @@ void hashtableEmpty(hashtable *ht, void(callback)(hashtable *)) {
                 } while (b != NULL);
             }
         }
-        
+
         zfree(ht->tables[table_index]);
         if (ht->type->trackMemUsage) {
             ht->type->trackMemUsage(ht, -sizeof(bucket) * numBuckets(ht->bucket_exp[table_index]));

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1032,30 +1032,33 @@ void hashtableEmpty(hashtable *ht, void(callback)(hashtable *)) {
         if (ht->bucket_exp[table_index] < 0) {
             continue;
         }
-        for (size_t idx = 0; idx < numBuckets(ht->bucket_exp[table_index]); idx++) {
-            if (callback && (idx & 65535) == 0) callback(ht);
-            bucket *b = &ht->tables[table_index][idx];
-            do {
-                /* Call the destructor with each entry. */
-                if (ht->type->entryDestructor != NULL && b->presence != 0) {
-                    for (int pos = 0; pos < ENTRIES_PER_BUCKET; pos++) {
-                        if (isPositionFilled(b, pos)) {
-                            ht->type->entryDestructor(b->entries[pos]);
+        if (ht->used[table_index] > 0 || ht->child_buckets[table_index] > 0) {
+            for (size_t idx = 0; idx < numBuckets(ht->bucket_exp[table_index]); idx++) {
+                if (callback && (idx & 65535) == 0) callback(ht);
+                bucket *b = &ht->tables[table_index][idx];
+                do {
+                    /* Call the destructor with each entry. */
+                    if (ht->type->entryDestructor != NULL && b->presence != 0) {
+                        for (int pos = 0; pos < ENTRIES_PER_BUCKET; pos++) {
+                            if (isPositionFilled(b, pos)) {
+                                ht->type->entryDestructor(b->entries[pos]);
+                            }
                         }
                     }
-                }
-                bucket *next = getChildBucket(b);
+                    bucket *next = getChildBucket(b);
 
-                /* Free allocated bucket. */
-                if (b != &ht->tables[table_index][idx]) {
-                    zfree(b);
-                    if (ht->type->trackMemUsage) {
-                        ht->type->trackMemUsage(ht, -sizeof(bucket));
+                    /* Free allocated bucket. */
+                    if (b != &ht->tables[table_index][idx]) {
+                        zfree(b);
+                        if (ht->type->trackMemUsage) {
+                            ht->type->trackMemUsage(ht, -sizeof(bucket));
+                        }
                     }
-                }
-                b = next;
-            } while (b != NULL);
+                    b = next;
+                } while (b != NULL);
+            }
         }
+        
         zfree(ht->tables[table_index]);
         if (ht->type->trackMemUsage) {
             ht->type->trackMemUsage(ht, -sizeof(bucket) * numBuckets(ht->bucket_exp[table_index]));
@@ -1871,6 +1874,7 @@ void hashtableInitIterator(hashtableIterator *iterator, hashtable *ht, uint8_t f
  * preserving the flags from its previous initialization. */
 void hashtableReinitIterator(hashtableIterator *iterator, hashtable *ht) {
     iter *iter = iteratorFromOpaque(iterator);
+    hashtableResetIterator(iterator);
     hashtableInitIterator(iterator, ht, iter->flags);
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1874,7 +1874,6 @@ void hashtableInitIterator(hashtableIterator *iterator, hashtable *ht, uint8_t f
  * preserving the flags from its previous initialization. */
 void hashtableReinitIterator(hashtableIterator *iterator, hashtable *ht) {
     iter *iter = iteratorFromOpaque(iterator);
-    hashtableResetIterator(iterator);
     hashtableInitIterator(iterator, ht, iter->flags);
 }
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -319,8 +319,7 @@ void kvstoreRelease(kvstore *kvs) {
         if (metadata->rehashing_node) metadata->rehashing_node = NULL;
         hashtableRelease(ht);
     }
-    /* TODO: The assert below causes a flaky unit test. Find out why. */
-    /* assert(kvs->overhead_hashtable_lut == 0); */
+    assert(kvs->overhead_hashtable_lut == 0);
     zfree(kvs->hashtables);
 
     listRelease(kvs->rehashing);

--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -70,6 +70,13 @@ int test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyHashtable(int argc, char **arg
     UNUSED(argv);
     UNUSED(flags);
 
+    uint8_t seed[16];
+    int cycle = 17;
+    for (unsigned int i = 0; i < sizeof(seed); i++) {
+        seed[i] = (i + cycle) % 0xFF;
+    }
+    hashtableSetHashFunctionSeed(seed);
+
     int i;
     void *key;
     kvstoreIterator *kvs_it;

--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -5,6 +5,11 @@ uint64_t hashTestCallback(const void *key) {
     return hashtableGenHashFunction((char *)key, strlen((char *)key));
 }
 
+uint64_t hashConflictTestCallback(const void *key) {
+    UNUSED(key);
+    return 0;
+}
+
 int cmpTestCallback(const void *k1, const void *k2) {
     return strcmp(k1, k2);
 }
@@ -15,6 +20,16 @@ void freeTestCallback(void *val) {
 
 hashtableType KvstoreHashtableTestType = {
     .hashFunction = hashTestCallback,
+    .keyCompare = cmpTestCallback,
+    .entryDestructor = freeTestCallback,
+    .rehashingStarted = kvstoreHashtableRehashingStarted,
+    .rehashingCompleted = kvstoreHashtableRehashingCompleted,
+    .trackMemUsage = kvstoreHashtableTrackMemUsage,
+    .getMetadataSize = kvstoreHashtableMetadataSize,
+};
+
+hashtableType KvstoreConflictHashtableTestType = {
+    .hashFunction = hashConflictTestCallback,
     .keyCompare = cmpTestCallback,
     .entryDestructor = freeTestCallback,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
@@ -69,39 +84,44 @@ int test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyHashtable(int argc, char **arg
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
+    
+    hashtableType *type[] = {
+        &KvstoreHashtableTestType,
+        &KvstoreConflictHashtableTestType,
+        NULL,
+    };
 
-    uint8_t seed[16];
-    int cycle = 17;
-    for (unsigned int i = 0; i < sizeof(seed); i++) {
-        seed[i] = (i + cycle) % 0xFF;
+    for(int t = 0; type[t] != NULL; t++) {
+        hashtableType *testType = type[t];
+        TEST_PRINT_INFO("Testing %d hashtableType\n", t);
+
+        int i;
+        void *key;
+        kvstoreIterator *kvs_it;
+
+        int didx = 0;
+        int curr_slot = 0;
+        kvstore *kvs1 = kvstoreCreate(testType, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND);
+
+        for (i = 0; i < 16; i++) {
+            TEST_ASSERT(kvstoreHashtableAdd(kvs1, didx, stringFromInt(i)));
+        }
+
+        kvs_it = kvstoreIteratorInit(kvs1, HASHTABLE_ITER_SAFE);
+        while (kvstoreIteratorNext(kvs_it, &key)) {
+            curr_slot = kvstoreIteratorGetCurrentHashtableIndex(kvs_it);
+            TEST_ASSERT(kvstoreHashtableDelete(kvs1, curr_slot, key));
+        }
+        kvstoreIteratorRelease(kvs_it);
+    
+        hashtable *ht = kvstoreGetHashtable(kvs1, didx);
+        TEST_ASSERT(ht != NULL);
+        TEST_ASSERT(kvstoreHashtableSize(kvs1, didx) == 0);
+        TEST_ASSERT(kvstoreSize(kvs1) == 0);
+    
+        kvstoreRelease(kvs1);
     }
-    hashtableSetHashFunctionSeed(seed);
 
-    int i;
-    void *key;
-    kvstoreIterator *kvs_it;
-
-    int didx = 0;
-    int curr_slot = 0;
-    kvstore *kvs1 = kvstoreCreate(&KvstoreHashtableTestType, 0, KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND);
-
-    for (i = 0; i < 16; i++) {
-        TEST_ASSERT(kvstoreHashtableAdd(kvs1, didx, stringFromInt(i)));
-    }
-
-    kvs_it = kvstoreIteratorInit(kvs1, HASHTABLE_ITER_SAFE);
-    while (kvstoreIteratorNext(kvs_it, &key)) {
-        curr_slot = kvstoreIteratorGetCurrentHashtableIndex(kvs_it);
-        TEST_ASSERT(kvstoreHashtableDelete(kvs1, curr_slot, key));
-    }
-    kvstoreIteratorRelease(kvs_it);
-
-    hashtable *ht = kvstoreGetHashtable(kvs1, didx);
-    TEST_ASSERT(ht != NULL);
-    TEST_ASSERT(kvstoreHashtableSize(kvs1, didx) == 0);
-    TEST_ASSERT(kvstoreSize(kvs1) == 0);
-
-    kvstoreRelease(kvs1);
     return 0;
 }
 

--- a/src/unit/test_kvstore.c
+++ b/src/unit/test_kvstore.c
@@ -84,14 +84,14 @@ int test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyHashtable(int argc, char **arg
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
-    
+
     hashtableType *type[] = {
         &KvstoreHashtableTestType,
         &KvstoreConflictHashtableTestType,
         NULL,
     };
 
-    for(int t = 0; type[t] != NULL; t++) {
+    for (int t = 0; type[t] != NULL; t++) {
         hashtableType *testType = type[t];
         TEST_PRINT_INFO("Testing %d hashtableType\n", t);
 
@@ -113,12 +113,12 @@ int test_kvstoreIteratorRemoveAllKeysNoDeleteEmptyHashtable(int argc, char **arg
             TEST_ASSERT(kvstoreHashtableDelete(kvs1, curr_slot, key));
         }
         kvstoreIteratorRelease(kvs_it);
-    
+
         hashtable *ht = kvstoreGetHashtable(kvs1, didx);
         TEST_ASSERT(ht != NULL);
         TEST_ASSERT(kvstoreHashtableSize(kvs1, didx) == 0);
         TEST_ASSERT(kvstoreSize(kvs1) == 0);
-    
+
         kvstoreRelease(kvs1);
     }
 


### PR DESCRIPTION
When releasing a kvstore and its hashtables, if it is still rehashed and table 0 has no data, it may still have allocated buckets that were not released. This lead to allocated hashtable buckets being leaked. This looked like missed statistics but it was actually a memory leak.

fix: https://github.com/valkey-io/valkey/issues/1657