### PR TITLE
Allow to specify the random number generator seed in unit tests

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -2584,8 +2584,6 @@ void populateCommandLegacyRangeSpec(struct serverCommand *c);
 long long ustime(void);
 mstime_t mstime(void);
 mstime_t commandTimeSnapshot(void);
-void getRandomHexChars(char *p, size_t len);
-void getRandomBytes(unsigned char *p, size_t len);
 uint64_t crc64(uint64_t crc, const unsigned char *s, uint64_t l);
 void exitFromChild(int retcode);
 long long serverPopcount(void *s, long count);

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -5,9 +5,15 @@
  */
 
 #include <strings.h>
+#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "test_files.h"
 #include "test_help.h"
+#include "../util.h"
+#include "../zmalloc.h"
+#include "../mt19937-64.h"
+#include "../hashtable.h"
 
 /* We override the default assertion mechanism, so that it prints out info and then dies. */
 void _serverAssert(const char *estr, const char *file, int line) {
@@ -40,6 +46,7 @@ int runTestSuite(struct unitTestSuite *test, int argc, char **argv, int flags) {
 int main(int argc, char **argv) {
     int flags = 0;
     char *file = NULL;
+    char *seed = NULL;
     for (int j = 1; j < argc; j++) {
         char *arg = argv[j];
         if (!strcasecmp(arg, "--accurate"))
@@ -51,8 +58,31 @@ int main(int argc, char **argv) {
             file = argv[j + 1];
         } else if (!strcasecmp(arg, "--valgrind")) {
             flags |= UNIT_TEST_VALGRIND;
+        } else if (!strcasecmp(arg, "--seed")) {
+            seed = argv[j + 1];
         }
     }
+
+    if (seed) {
+        /* If the seed parameter was specified, we need to explicitly set the
+         * seed in the several random numbers generator that valkey server uses
+         * so that the unit tests reproduce the random values in a
+         * deterministic way. */
+        setRandomSeedCString(seed, strlen(seed));
+        unsigned long long seed;
+        getRandomBytes((void *)&seed, sizeof(seed));
+
+        init_genrand64(seed);
+        srandom((unsigned)seed);
+
+        uint8_t hashseed[16];
+        getRandomBytes(hashseed, sizeof(hashseed));
+        hashtableSetHashFunctionSeed(hashseed);
+    }
+
+    seed = getRandomSeedCString(NULL);
+    printf("Tests will run with seed=%s\n", seed);
+    zfree(seed);
 
     int numtests = sizeof(unitTestSuite) / sizeof(struct unitTestSuite);
     int failed_num = 0, suites_executed = 0;

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -7,11 +7,9 @@
 #include <strings.h>
 #include <string.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include "test_files.h"
 #include "test_help.h"
 #include "../util.h"
-#include "../zmalloc.h"
 #include "../mt19937-64.h"
 #include "../hashtable.h"
 

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -67,17 +67,10 @@ int main(int argc, char **argv) {
         setRandomSeedCString(seed, strlen(seed));
     }
 
-    /* We need to copy the seed chars returned by getRandomSeedCString into a
-     * buffer allocated with malloc because we need to free the memory of
-     * `seed_str` to avoid assert errors in zmalloc statistics. */
-    size_t seed_len = 0;
-    char *seed_str = getRandomSeedCString(&seed_len);
-    seed = malloc(seed_len + 1);
-    strncpy(seed, seed_str, seed_len);
-    seed[seed_len] = 0;
-    zfree(seed_str);
+    char seed_cstr[129];
+    getRandomSeedCString(seed_cstr, 129);
 
-    printf("Tests will run with seed=%s\n", seed);
+    printf("Tests will run with seed=%s\n", seed_cstr);
 
     unsigned long long genrandseed;
     getRandomBytes((void *)&genrandseed, sizeof(genrandseed));
@@ -94,7 +87,7 @@ int main(int argc, char **argv) {
         /* We need to explicitly set the seed in the several random numbers
          * generator that valkey server uses so that the unit tests reproduce
          * the random values in a deterministic way. */
-        setRandomSeedCString(seed, strlen(seed));
+        setRandomSeedCString(seed_cstr, strlen(seed_cstr));
         init_genrand64(genrandseed);
         srandom((unsigned)genrandseed);
         hashtableSetHashFunctionSeed(hashseed);
@@ -106,8 +99,6 @@ int main(int argc, char **argv) {
     }
     printf("%d test suites executed, %d passed, %d failed\n", suites_executed, suites_executed - failed_num,
            failed_num);
-
-    free(seed);
 
     return failed_num == 0 ? 0 : 1;
 }

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -64,6 +64,26 @@ int main(int argc, char **argv) {
     }
 
     if (seed) {
+        setRandomSeedCString(seed, strlen(seed));
+    }
+
+    /* We need to copy the seed chars returned by getRandomSeedCString into a
+     * buffer allocated with malloc because we need to free the memory of
+     * `seed_str` to avoid assert errors in zmalloc statistics. */
+    size_t seed_len = 0;
+    char *seed_str = getRandomSeedCString(&seed_len);
+    seed = malloc(seed_len + 1);
+    strncpy(seed, seed_str, seed_len);
+    seed[seed_len] = 0;
+    zfree(seed_str);
+
+    printf("Tests will run with seed=%s\n", seed);
+
+    int numtests = sizeof(unitTestSuite) / sizeof(struct unitTestSuite);
+    int failed_num = 0, suites_executed = 0;
+    for (int j = 0; j < numtests; j++) {
+        if (file && strcasecmp(file, unitTestSuite[j].filename)) continue;
+
         /* If the seed parameter was specified, we need to explicitly set the
          * seed in the several random numbers generator that valkey server uses
          * so that the unit tests reproduce the random values in a
@@ -78,16 +98,7 @@ int main(int argc, char **argv) {
         uint8_t hashseed[16];
         getRandomBytes(hashseed, sizeof(hashseed));
         hashtableSetHashFunctionSeed(hashseed);
-    }
 
-    seed = getRandomSeedCString(NULL);
-    printf("Tests will run with seed=%s\n", seed);
-    zfree(seed);
-
-    int numtests = sizeof(unitTestSuite) / sizeof(struct unitTestSuite);
-    int failed_num = 0, suites_executed = 0;
-    for (int j = 0; j < numtests; j++) {
-        if (file && strcasecmp(file, unitTestSuite[j].filename)) continue;
         if (!runTestSuite(&unitTestSuite[j], argc, argv, flags)) {
             failed_num++;
         }
@@ -95,6 +106,8 @@ int main(int argc, char **argv) {
     }
     printf("%d test suites executed, %d passed, %d failed\n", suites_executed, suites_executed - failed_num,
            failed_num);
+
+    free(seed);
 
     return failed_num == 0 ? 0 : 1;
 }

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -79,24 +79,24 @@ int main(int argc, char **argv) {
 
     printf("Tests will run with seed=%s\n", seed);
 
+    unsigned long long genrandseed;
+    getRandomBytes((void *)&genrandseed, sizeof(genrandseed));
+
+    uint8_t hashseed[16];
+    getRandomBytes(hashseed, sizeof(hashseed));
+
+
     int numtests = sizeof(unitTestSuite) / sizeof(struct unitTestSuite);
     int failed_num = 0, suites_executed = 0;
     for (int j = 0; j < numtests; j++) {
         if (file && strcasecmp(file, unitTestSuite[j].filename)) continue;
 
-        /* If the seed parameter was specified, we need to explicitly set the
-         * seed in the several random numbers generator that valkey server uses
-         * so that the unit tests reproduce the random values in a
-         * deterministic way. */
+        /* We need to explicitly set the seed in the several random numbers
+         * generator that valkey server uses so that the unit tests reproduce
+         * the random values in a deterministic way. */
         setRandomSeedCString(seed, strlen(seed));
-        unsigned long long seed;
-        getRandomBytes((void *)&seed, sizeof(seed));
-
-        init_genrand64(seed);
-        srandom((unsigned)seed);
-
-        uint8_t hashseed[16];
-        getRandomBytes(hashseed, sizeof(hashseed));
+        init_genrand64(genrandseed);
+        srandom((unsigned)genrandseed);
         hashtableSetHashFunctionSeed(hashseed);
 
         if (!runTestSuite(&unitTestSuite[j], argc, argv, flags)) {

--- a/src/util.c
+++ b/src/util.c
@@ -51,6 +51,7 @@
 #include "sha256.h"
 #include "config.h"
 #include "zmalloc.h"
+#include "serverassert.h"
 
 #include "valkey_strtod.h"
 
@@ -905,16 +906,38 @@ int version2num(const char *version) {
     return v;
 }
 
+/* Global state. */
+static int seed_initialized = 0;
+static unsigned char seed[64]; /* 512 bit internal block size. */
+
+void setRandomSeedCString(char *seed_str, size_t len) {
+    assert(seed_initialized == 0);
+    assert(len == sizeof(seed) * 2);
+    for (size_t i = 0; i < sizeof(seed); i++) {
+        sscanf(seed_str + (i * 2), "%02hhX", &seed[i]);
+    }
+    seed_initialized = 1;
+}
+
+char *getRandomSeedCString(size_t *len) {
+    char *buff = zmalloc(sizeof(seed) * 2 + 1);
+    for (size_t i = 0; i < sizeof(seed); i++) {
+        snprintf(buff + (i * 2), 3, "%02hhX", seed[i]);
+    }
+    buff[sizeof(seed) * 2] = 0;
+    if (len) {
+        *len = sizeof(seed) * 2;
+    }
+    return buff;
+}
+
 /* Get random bytes, attempts to get an initial seed from /dev/urandom and
  * the uses a one way hash function in counter mode to generate a random
  * stream. However if /dev/urandom is not available, a weaker seed is used.
  *
  * This function is not thread safe, since the state is global. */
 void getRandomBytes(unsigned char *p, size_t len) {
-    /* Global state. */
-    static int seed_initialized = 0;
-    static unsigned char seed[64]; /* 512 bit internal block size. */
-    static uint64_t counter = 0;   /* The counter we hash with the seed. */
+    static uint64_t counter = 0; /* The counter we hash with the seed. */
 
     if (!seed_initialized) {
         /* Initialize a seed and use SHA1 in counter mode, where we hash

--- a/src/util.c
+++ b/src/util.c
@@ -943,7 +943,7 @@ void setRandomSeedCString(char *seed_str, size_t len) {
 }
 
 /* This function populates a char buffer with 129 bytes with the 64 bytes
- * random seed encoded as 128 hexadecimal digits. */
+ * random seed encoded as 128 hexadecimal digits and a null terminator. */
 void getRandomSeedCString(char *buff, size_t len) {
     assert(len == (sizeof(seed) * 2 + 1));
 
@@ -954,7 +954,7 @@ void getRandomSeedCString(char *buff, size_t len) {
     for (size_t i = 0; i < sizeof(seed); i++) {
         snprintf(buff + (i * 2), 3, "%02hhX", seed[i]);
     }
-    buff[sizeof(seed) * 2] = 0;
+    buff[sizeof(seed) * 2] = '\0';
 }
 
 /* Get random bytes, attempts to get an initial seed from /dev/urandom and

--- a/src/util.c
+++ b/src/util.c
@@ -910,8 +910,31 @@ int version2num(const char *version) {
 static int seed_initialized = 0;
 static unsigned char seed[64]; /* 512 bit internal block size. */
 
-void setRandomSeedCString(char *seed_str, size_t len) {
+static void initializeRandomSeed(void) {
     assert(seed_initialized == 0);
+    /* Initialize a seed and use SHA1 in counter mode, where we hash
+     * the same seed with a progressive counter. For the goals of this
+     * function we just need non-colliding strings, there are no
+     * cryptographic security needs. */
+    FILE *fp = fopen("/dev/urandom", "r");
+    if (fp == NULL || fread(seed, sizeof(seed), 1, fp) != 1) {
+        /* Revert to a weaker seed, and in this case reseed again
+         * at every call.*/
+        for (unsigned int j = 0; j < sizeof(seed); j++) {
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            pid_t pid = getpid();
+            seed[j] = tv.tv_sec ^ tv.tv_usec ^ pid ^ (long)fp;
+        }
+    } else {
+        seed_initialized = 1;
+    }
+    if (fp) fclose(fp);
+}
+
+/* This function receives a string with 64 bytes encoded as 128 hexadecimal
+ * digits, and sets the 64 byte random seed. */
+void setRandomSeedCString(char *seed_str, size_t len) {
     assert(len == sizeof(seed) * 2);
     for (size_t i = 0; i < sizeof(seed); i++) {
         sscanf(seed_str + (i * 2), "%02hhX", &seed[i]);
@@ -919,7 +942,13 @@ void setRandomSeedCString(char *seed_str, size_t len) {
     seed_initialized = 1;
 }
 
+/* This function returns a string with 64 bytes encoded as 128 hexadecimal
+ * digits, that represents the 64 bytes random seed. */
 char *getRandomSeedCString(size_t *len) {
+    if (!seed_initialized) {
+        initializeRandomSeed();
+    }
+
     char *buff = zmalloc(sizeof(seed) * 2 + 1);
     for (size_t i = 0; i < sizeof(seed); i++) {
         snprintf(buff + (i * 2), 3, "%02hhX", seed[i]);
@@ -940,24 +969,7 @@ void getRandomBytes(unsigned char *p, size_t len) {
     static uint64_t counter = 0; /* The counter we hash with the seed. */
 
     if (!seed_initialized) {
-        /* Initialize a seed and use SHA1 in counter mode, where we hash
-         * the same seed with a progressive counter. For the goals of this
-         * function we just need non-colliding strings, there are no
-         * cryptographic security needs. */
-        FILE *fp = fopen("/dev/urandom", "r");
-        if (fp == NULL || fread(seed, sizeof(seed), 1, fp) != 1) {
-            /* Revert to a weaker seed, and in this case reseed again
-             * at every call.*/
-            for (unsigned int j = 0; j < sizeof(seed); j++) {
-                struct timeval tv;
-                gettimeofday(&tv, NULL);
-                pid_t pid = getpid();
-                seed[j] = tv.tv_sec ^ tv.tv_usec ^ pid ^ (long)fp;
-            }
-        } else {
-            seed_initialized = 1;
-        }
-        if (fp) fclose(fp);
+        initializeRandomSeed();
     }
 
     while (len) {

--- a/src/util.c
+++ b/src/util.c
@@ -942,22 +942,19 @@ void setRandomSeedCString(char *seed_str, size_t len) {
     seed_initialized = 1;
 }
 
-/* This function returns a string with 64 bytes encoded as 128 hexadecimal
- * digits, that represents the 64 bytes random seed. */
-char *getRandomSeedCString(size_t *len) {
+/* This function populates a char buffer with 129 bytes with the 64 bytes
+ * random seed encoded as 128 hexadecimal digits. */
+void getRandomSeedCString(char *buff, size_t len) {
+    assert(len == (sizeof(seed) * 2 + 1));
+
     if (!seed_initialized) {
         initializeRandomSeed();
     }
 
-    char *buff = zmalloc(sizeof(seed) * 2 + 1);
     for (size_t i = 0; i < sizeof(seed); i++) {
         snprintf(buff + (i * 2), 3, "%02hhX", seed[i]);
     }
     buff[sizeof(seed) * 2] = 0;
-    if (len) {
-        *len = sizeof(seed) * 2;
-    }
-    return buff;
 }
 
 /* Get random bytes, attempts to get an initial seed from /dev/urandom and

--- a/src/util.h
+++ b/src/util.h
@@ -99,7 +99,7 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...);
 #endif
 size_t valkey_strlcpy(char *dst, const char *src, size_t dsize);
 size_t valkey_strlcat(char *dst, const char *src, size_t dsize);
-char *getRandomSeedCString(size_t *len);
+void getRandomSeedCString(char *buff, size_t len);
 void setRandomSeedCString(char *seed_str, size_t len);
 void getRandomHexChars(char *p, size_t len);
 void getRandomBytes(unsigned char *p, size_t len);

--- a/src/util.h
+++ b/src/util.h
@@ -99,5 +99,9 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...);
 #endif
 size_t valkey_strlcpy(char *dst, const char *src, size_t dsize);
 size_t valkey_strlcat(char *dst, const char *src, size_t dsize);
+char *getRandomSeedCString(size_t *len);
+void setRandomSeedCString(char *seed_str, size_t len);
+void getRandomHexChars(char *p, size_t len);
+void getRandomBytes(unsigned char *p, size_t len);
 
 #endif


### PR DESCRIPTION
In this commit, we add a new parameter to the unit tests binary, called `--seed`, that allows to specify the seed used by the several random numbers generators used in the Valkey server code.

We also now print the seed information right before starting the unit tests execution, so that someone that needs to reproduce an error, can use the same seed to re-run the failed tests.