### PR TITLE
Cleaned up .gcda files to fix AOF issues related to code coverage

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -437,7 +437,22 @@ proc run_external_server_test {code overrides} {
     }
 }
 
+proc cleanup_gcda_files {} {
+    set error_message "";
+    catch {
+        set gcda_files [glob -nocomplain src/*.gcda]
+        foreach file $gcda_files {
+            file delete -force $file
+        }
+    } error_message
+    if {$error_message ne ""} {
+        puts "Warning: Failed to delete some .gcda files - $error_message"
+    }
+}
+
 proc start_server {options {code undefined}} {
+    cleanup_gcda_files
+
     # setup defaults
     set baseconfig "default.conf"
     set overrides {}


### PR DESCRIPTION
**Problem**
The main issue stems from how we experience data corruption when multiple server instances are executing the code coverage tests in quick succession. This leads to mismatched coverage data when one server tries to merge its data with existing corrupted files or when multiple server processes try to write their coverage information to the same files.

**Solution** 
I resolved this issue by deleting all existing .gcda files before starting a new server instance. This ensures that old or corrupted coverage data doesn't interfere with the new test run

Resolves #1453 

