### PR TITLE
Implement rps control for benchmark using token bucket algorithm

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -140,7 +140,7 @@ static struct config {
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
     int rps;
-    _Atomic long last_time_ns;
+    atomic_uint_fast64_t last_time_ns;
     long long time_per_token;
     long long time_per_burst;
 } config;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -73,6 +73,9 @@
 #define CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE 3000000L /* <= 3 secs(us precision) */
 #define SHOW_THROUGHPUT_INTERVAL 250                        /* 250ms */
 
+#define CLIENT_PAUSED (1 << 0)
+#define CLIENT_REUSE (1 << 1)
+
 #define CLIENT_GET_EVENTLOOP(c) (c->thread_id >= 0 ? config.threads[c->thread_id]->el : config.el)
 
 struct benchmarkThread;
@@ -112,6 +115,7 @@ static struct config {
     long long totlatency;
     const char *title;
     list *clients;
+    list *pause_clients;
     int quiet;
     int csv;
     int loop;
@@ -138,7 +142,7 @@ static struct config {
     pthread_mutex_t liveclients_mutex;
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
-    int qps;
+    int rps;
     pthread_mutex_t token_bucket_mutex;
     long long last_time;
     long long time_per_token;
@@ -163,6 +167,7 @@ typedef struct _client {
                            such as auth and select are prefixed to the pipeline of
                            benchmark commands and discarded after the first send. */
     int prefixlen;      /* Size in bytes of the pending prefix commands */
+    int flags;
     int thread_id;
     struct clusterNode *cluster_node;
     int slots_last_update;
@@ -174,6 +179,7 @@ typedef struct benchmarkThread {
     int index;
     pthread_t thread;
     aeEventLoop *el;
+    list *pause_clients;
 } benchmarkThread;
 
 /* Cluster. */
@@ -363,6 +369,19 @@ static void freeServerConfig(serverConfig *cfg) {
     zfree(cfg);
 }
 
+static void releasePauseClient(client c) {
+    if (c->thread_id >= 0) {
+        benchmarkThread *thread = config.threads[c->thread_id];
+        listNode *ln = listSearchKey(thread->pause_clients, c);
+        assert(ln != NULL);
+        listDelNode(thread->pause_clients, ln);
+    } else {
+        listNode *ln = listSearchKey(config.pause_clients, c);
+        assert(ln != NULL);
+        listDelNode(config.pause_clients, ln);
+    }
+}
+
 static void freeClient(client c) {
     aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
     listNode *ln;
@@ -375,6 +394,7 @@ static void freeClient(client c) {
         }
     }
     valkeyFree(c->context);
+    releasePauseClient(c);
     sdsfree(c->obuf);
     zfree(c->randptr);
     zfree(c->stagptr);
@@ -611,6 +631,41 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     }
 }
 
+static long long awakenPauseClient(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+    UNUSED(id);
+    benchmarkThread *thread = (benchmarkThread *)clientData;
+
+    list *pause_clients;
+    if (thread == NULL) {
+        pause_clients = config.pause_clients;
+    } else {
+        pause_clients = thread->pause_clients;
+    }
+
+    listIter li;
+    listNode *ln;
+    long long delay_ns = 0;
+    listRewind(pause_clients, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        client c = ln->value;
+        delay_ns = acquireTokenOrWait(config.pipeline);
+        if (delay_ns > 1000000) {
+            break;
+        } else {
+            c->flags &= ~CLIENT_PAUSED;
+            c->flags |= CLIENT_REUSE;
+            writeHandler(eventLoop, c->context->fd, c, AE_WRITABLE);
+            listDelNode(pause_clients, ln);
+        }
+    }
+
+    if (delay_ns > 0) {
+        return delay_ns / 1000000;
+    } else {
+        return AE_NOMORE;
+    }
+}
+
 static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     client c = privdata;
     UNUSED(el);
@@ -618,16 +673,25 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     UNUSED(mask);
 
     /* Acquire a token from the token bucket. */
-    if (config.qps > 0) {
-        do {
-            long long delay = acquireTokenOrWait(config.pipeline);
-            if (delay > 1000) {
-                usleep(delay / 1000);
+    if (config.rps > 0 && (c->flags & CLIENT_REUSE) == 0) {
+        long long delay_ns = acquireTokenOrWait(config.pipeline);
+        if (delay_ns > 1000000) {
+            int thread_id = c->thread_id;
+            c->flags |= CLIENT_PAUSED;
+            aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
+
+            benchmarkThread *thread = NULL;
+            if (thread_id < 0) {
+                listAddNodeTail(config.pause_clients, c);
             } else {
-                break;
+                thread = config.threads[thread_id];
+                listAddNodeTail(thread->pause_clients, c);
             }
-        } while (1);
+            aeCreateTimeEvent(el, delay_ns / 1000000, awakenPauseClient, (void *)thread, NULL);
+            return;
+        }
     }
+    c->flags &= ~CLIENT_REUSE;
 
     /* Initialize request when nothing was written. */
     if (c->written == 0) {
@@ -735,6 +799,7 @@ static client createClient(char *cmd, int len, int seqlen, client from, int thre
             exit(1);
         }
     }
+    c->flags = 0;
     c->thread_id = thread_id;
     /* Suppress libvalkey cleanup of unused buffers for max speed. */
     c->context->reader->maxbuf = 0;
@@ -1044,9 +1109,9 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
 
     if (config.num_threads) initBenchmarkThreads();
 
-    if (config.qps > 0) {
-        config.time_per_token = 1000000000 / config.qps;
-        config.time_per_burst = config.time_per_token * config.qps;
+    if (config.rps > 0) {
+        config.time_per_token = 1000000000 / config.rps;
+        config.time_per_burst = config.time_per_token * config.rps;
     }
 
     int thread_id = config.num_threads > 0 ? 0 : -1;
@@ -1079,12 +1144,14 @@ static benchmarkThread *createBenchmarkThread(int index) {
     if (thread == NULL) return NULL;
     thread->index = index;
     thread->el = aeCreateEventLoop(1024 * 10);
+    thread->pause_clients = listCreate();
     aeCreateTimeEvent(thread->el, 1, showThroughput, (void *)thread, NULL);
     return thread;
 }
 
 static void freeBenchmarkThread(benchmarkThread *thread) {
     if (thread->el) aeDeleteEventLoop(thread->el);
+    listRelease(thread->pause_clients);
     zfree(thread);
 }
 
@@ -1422,9 +1489,9 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--user")) {
             if (lastarg) goto invalid;
             config.conn_info.user = sdsnew(argv[++i]);
-        } else if (!strcmp(argv[i], "--qps")) {
+        } else if (!strcmp(argv[i], "--rps")) {
             if (lastarg) goto invalid;
-            config.qps = atoi(argv[++i]);
+            config.rps = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
             parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
@@ -1844,6 +1911,7 @@ int main(int argc, char **argv) {
     config.loop = 0;
     config.idlemode = 0;
     config.clients = listCreate();
+    config.pause_clients = listCreate();
     config.conn_info.hostip = sdsnew("127.0.0.1");
     config.conn_info.hostport = 6379;
     config.tests = NULL;
@@ -1854,7 +1922,7 @@ int main(int argc, char **argv) {
     config.num_threads = 0;
     config.threads = NULL;
     config.cluster_mode = 0;
-    config.qps = 0;
+    config.rps = 0;
     config.read_from_replica = FROM_PRIMARY_ONLY;
     config.cluster_node_count = 0;
     config.cluster_nodes = NULL;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -393,7 +393,7 @@ static void freeClient(client c) {
         }
     }
     valkeyFree(c->context);
-    releasePausedClient(c);
+    if (c->paused)  releasePausedClient(c);
     sdsfree(c->obuf);
     zfree(c->randptr);
     zfree(c->stagptr);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -140,8 +140,7 @@ static struct config {
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
     int rps;
-    pthread_mutex_t token_bucket_mutex;
-    long long last_time;
+    _Atomic long last_time_ns;
     long long time_per_token;
     long long time_per_burst;
 } config;
@@ -489,36 +488,49 @@ static void setClusterKeyHashTag(client c) {
  * 
  * The function is thread-safe. */
 static long long acquireTokenOrWait(int tokens) {
-    if (config.num_threads) pthread_mutex_lock(&(config.token_bucket_mutex));
 
-    long long last_time = config.last_time;
     long long time_per_token = config.time_per_token;
     long long time_per_burst = config.time_per_burst;
-    long long new_time = 0;
+    long long new_time = 0, delay_time;
+    long long now_epoch, next_epoch, min_time;
+    long long last_time_ns, old_last_time_ns;
 
-    long long now_epoch = nstime();
-    // If the last_time is 0, it means this is the first request, so we set it to now_epoch.
-    if (last_time == 0) {
-        config.last_time = last_time = now_epoch;
+    while (1) {
+        old_last_time_ns = atomic_load_explicit(&config.last_time_ns, memory_order_relaxed);
+        last_time_ns = old_last_time_ns;
+        now_epoch = nstime();
+
+        // If the last_time_ns is 0, it means this is the first request, so we set it to now_epoch.
+        if (last_time_ns == 0) {
+            last_time_ns = now_epoch;
+        }
+
+        next_epoch = now_epoch + 1000000;
+        min_time = next_epoch - time_per_burst;
+    
+        if (min_time > last_time_ns) { // if the last time is too old, reset it
+            new_time = min_time + (time_per_token * tokens);
+        } else {
+            new_time = last_time_ns + (time_per_token * tokens);
+        }
+
+        delay_time = 0;
+        if (new_time > next_epoch) {    // if the new time is in the next epoch, we need to wait
+            delay_time = new_time - now_epoch;
+        } else {
+            last_time_ns = new_time;
+        }
+
+        if (atomic_compare_exchange_weak_explicit(
+                &config.last_time_ns,
+                &old_last_time_ns,
+                last_time_ns,
+                memory_order_release,
+                memory_order_relaxed)) {
+            break;
+        }
     }
 
-    long long next_epoch = now_epoch + 1000000;
-    long long min_time = next_epoch - time_per_burst;
-
-    if (min_time > last_time) { // if the last time is too old, reset it
-        new_time = min_time + (time_per_token * tokens);
-    } else {
-        new_time = last_time + (time_per_token * tokens);
-    }
-
-    long long delay_time = 0;
-    if (new_time > next_epoch) {    // if the new time is in the next epoch, we need to wait
-        delay_time = new_time - now_epoch;
-    } else {
-        config.last_time = new_time;
-    }
-
-    if (config.num_threads) pthread_mutex_unlock(&(config.token_bucket_mutex));
     return delay_time / 1000000;
 }
 
@@ -1150,7 +1162,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     if (config.rps > 0) {
         config.time_per_token = 1000000000 / config.rps;
         config.time_per_burst = config.time_per_token * config.rps;
-        config.last_time = 0;
+        config.last_time_ns = 0;
     }
 
     int thread_id = config.num_threads > 0 ? 0 : -1;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -141,8 +141,8 @@ static struct config {
     int resp3; /* use RESP3 */
     int rps;
     atomic_uint_fast64_t last_time_ns;
-    long long time_per_token;
-    long long time_per_burst;
+    uint64_t time_per_token;
+    uint64_t time_per_burst;
 } config;
 
 typedef struct _client {
@@ -489,11 +489,11 @@ static void setClusterKeyHashTag(client c) {
  * The function is thread-safe. */
 static long long acquireTokenOrWait(int tokens) {
 
-    long long time_per_token = config.time_per_token;
-    long long time_per_burst = config.time_per_burst;
-    long long new_time = 0, delay_time;
-    long long now_epoch, next_epoch, min_time;
-    long long last_time_ns, old_last_time_ns;
+    uint64_t time_per_token = config.time_per_token;
+    uint64_t time_per_burst = config.time_per_burst;
+    uint64_t new_time = 0;
+    uint64_t now_epoch, next_epoch, min_time, delay_time;
+    uint64_t last_time_ns, old_last_time_ns;
 
     while (1) {
         old_last_time_ns = atomic_load_explicit(&config.last_time_ns, memory_order_relaxed);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -494,6 +494,9 @@ static long long acquireTokenOrWait(int tokens) {
 
     long long now_since_epoch = nstime();
     long long min_time = now_since_epoch - time_per_burst;
+    if (last_time == 0) {
+        last_time = now_since_epoch;
+    }
     if (min_time > last_time) {
         new_time = min_time + (time_per_token * tokens);
     } else {
@@ -702,18 +705,24 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
 
         if (delay) {
             int thread_id = c->thread_id;
+            int paused_clients_count = 0;
+
             c->paused = 1;
             aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
 
             benchmarkThread *thread = NULL;
             if (thread_id < 0) {
+                paused_clients_count = listLength(config.paused_clients);
                 listAddNodeTail(config.paused_clients, c);
             } else {
                 thread = config.threads[thread_id];
+                paused_clients_count = listLength(thread->paused_clients);
                 listAddNodeTail(thread->paused_clients, c);
             }
-            /* Create a time event to awaken the client. */
-            aeCreateTimeEvent(el, delay, awakenPausedClient, (void *)thread, NULL);
+            if (paused_clients_count == 0) {
+                /* Create a time event to awaken the client. */
+                aeCreateTimeEvent(el, delay, awakenPausedClient, (void *)thread, NULL);
+            }
             return;
         }
     }
@@ -1139,6 +1148,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     if (config.rps > 0) {
         config.time_per_token = 1000000000 / config.rps;
         config.time_per_burst = config.time_per_token * config.rps;
+        config.last_time = 0;
     }
 
     int thread_id = config.num_threads > 0 ? 0 : -1;
@@ -1519,6 +1529,11 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--rps")) {
             if (lastarg) goto invalid;
             config.rps = atoi(argv[++i]);
+            if (config.rps <= 1000) {
+                // TODO: remove this check when we support --rps option < 1000.
+                fprintf(stderr, "WARNING: --rps option must be >= 1000.\n");
+                config.rps = 0;
+            }
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
             parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1543,11 +1543,6 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--rps")) {
             if (lastarg) goto invalid;
             config.rps = atoi(argv[++i]);
-            // if (config.rps <= 1000) {
-            //     // TODO: remove this check when we support --rps option < 1000.
-            //     fprintf(stderr, "WARNING: --rps option must be >= 1000.\n");
-            //     config.rps = 0;
-            // }
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
             parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
@@ -1812,6 +1807,7 @@ usage:
         "                    on the command line.\n"
         " -I                 Idle mode. Just open N idle connections and wait.\n"
         " -x                 Read last argument from STDIN.\n"
+        " --rps <requests>   Limit the total number of requests per second. Default 0 (no limit)\n"
         " --seed <num>       Set the seed for random number generator. Default seed is based on time.\n"
         " --num-functions <num>\n"
         "                    Sets the number of functions present in the Lua lib that is\n"

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -393,7 +393,7 @@ static void freeClient(client c) {
         }
     }
     valkeyFree(c->context);
-    if (c->paused)  releasePausedClient(c);
+    if (c->paused) releasePausedClient(c);
     sdsfree(c->obuf);
     zfree(c->randptr);
     zfree(c->stagptr);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -115,7 +115,7 @@ static struct config {
     long long totlatency;
     const char *title;
     list *clients;
-    list *pause_clients;
+    list *paused_clients;
     int quiet;
     int csv;
     int loop;
@@ -167,10 +167,11 @@ typedef struct _client {
                            such as auth and select are prefixed to the pipeline of
                            benchmark commands and discarded after the first send. */
     int prefixlen;      /* Size in bytes of the pending prefix commands */
-    int flags;
     int thread_id;
     struct clusterNode *cluster_node;
     int slots_last_update;
+    uint64_t paused : 1;
+    uint64_t reuse : 1;
 } *client;
 
 /* Threads. */
@@ -179,7 +180,7 @@ typedef struct benchmarkThread {
     int index;
     pthread_t thread;
     aeEventLoop *el;
-    list *pause_clients;
+    list *paused_clients;
 } benchmarkThread;
 
 /* Cluster. */
@@ -372,13 +373,13 @@ static void freeServerConfig(serverConfig *cfg) {
 static void releasePauseClient(client c) {
     if (c->thread_id >= 0) {
         benchmarkThread *thread = config.threads[c->thread_id];
-        listNode *ln = listSearchKey(thread->pause_clients, c);
+        listNode *ln = listSearchKey(thread->paused_clients, c);
         assert(ln != NULL);
-        listDelNode(thread->pause_clients, ln);
+        listDelNode(thread->paused_clients, ln);
     } else {
-        listNode *ln = listSearchKey(config.pause_clients, c);
+        listNode *ln = listSearchKey(config.paused_clients, c);
         assert(ln != NULL);
-        listDelNode(config.pause_clients, ln);
+        listDelNode(config.paused_clients, ln);
     }
 }
 
@@ -479,17 +480,17 @@ static void setClusterKeyHashTag(client c) {
 static long long acquireTokenOrWait(int tokens) {
     if (config.num_threads) pthread_mutex_lock(&(config.token_bucket_mutex));
 
-    long long last_time_ = config.last_time;
-    long long time_per_token_ = config.time_per_token;
-    long long time_per_burst_ = config.time_per_burst;
+    long long last_time = config.last_time;
+    long long time_per_token = config.time_per_token;
+    long long time_per_burst = config.time_per_burst;
     long long new_time = 0;
 
     long long now_since_epoch = nstime();
-    long long min_time = now_since_epoch - time_per_burst_;
-    if (min_time > last_time_) {
-        new_time = min_time + (time_per_token_ * tokens);
+    long long min_time = now_since_epoch - time_per_burst;
+    if (min_time > last_time) {
+        new_time = min_time + (time_per_token * tokens);
     } else {
-        new_time = last_time_ + (time_per_token_ * tokens);
+        new_time = last_time + (time_per_token * tokens);
     }
 
     long long delay_time = 0;
@@ -631,31 +632,31 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     }
 }
 
-static long long awakenPauseClient(struct aeEventLoop *eventLoop, long long id, void *clientData) {
+static long long awakenPausedClient(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(id);
     benchmarkThread *thread = (benchmarkThread *)clientData;
 
-    list *pause_clients;
+    list *paused_clients;
     if (thread == NULL) {
-        pause_clients = config.pause_clients;
+        paused_clients = config.paused_clients;
     } else {
-        pause_clients = thread->pause_clients;
+        paused_clients = thread->paused_clients;
     }
 
     listIter li;
     listNode *ln;
     long long delay_ns = 0;
-    listRewind(pause_clients, &li);
+    listRewind(paused_clients, &li);
     while ((ln = listNext(&li)) != NULL) {
         client c = ln->value;
         delay_ns = acquireTokenOrWait(config.pipeline);
         if (delay_ns > 1000000) {
             break;
         } else {
-            c->flags &= ~CLIENT_PAUSED;
-            c->flags |= CLIENT_REUSE;
+            c->paused = 0;
+            c->reuse = 1;
             writeHandler(eventLoop, c->context->fd, c, AE_WRITABLE);
-            listDelNode(pause_clients, ln);
+            listDelNode(paused_clients, ln);
         }
     }
 
@@ -673,25 +674,25 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     UNUSED(mask);
 
     /* Acquire a token from the token bucket. */
-    if (config.rps > 0 && (c->flags & CLIENT_REUSE) == 0) {
+    if (config.rps > 0 && c->reuse) {
         long long delay_ns = acquireTokenOrWait(config.pipeline);
         if (delay_ns > 1000000) {
             int thread_id = c->thread_id;
-            c->flags |= CLIENT_PAUSED;
+            c->paused = 1;
             aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
 
             benchmarkThread *thread = NULL;
             if (thread_id < 0) {
-                listAddNodeTail(config.pause_clients, c);
+                listAddNodeTail(config.paused_clients, c);
             } else {
                 thread = config.threads[thread_id];
-                listAddNodeTail(thread->pause_clients, c);
+                listAddNodeTail(thread->paused_clients, c);
             }
-            aeCreateTimeEvent(el, delay_ns / 1000000, awakenPauseClient, (void *)thread, NULL);
+            aeCreateTimeEvent(el, delay_ns / 1000000, awakenPausedClient, (void *)thread, NULL);
             return;
         }
     }
-    c->flags &= ~CLIENT_REUSE;
+    c->paused = 0;
 
     /* Initialize request when nothing was written. */
     if (c->written == 0) {
@@ -799,7 +800,8 @@ static client createClient(char *cmd, int len, int seqlen, client from, int thre
             exit(1);
         }
     }
-    c->flags = 0;
+    c->paused = 0;
+    c->reuse = 0;
     c->thread_id = thread_id;
     /* Suppress libvalkey cleanup of unused buffers for max speed. */
     c->context->reader->maxbuf = 0;
@@ -1144,14 +1146,14 @@ static benchmarkThread *createBenchmarkThread(int index) {
     if (thread == NULL) return NULL;
     thread->index = index;
     thread->el = aeCreateEventLoop(1024 * 10);
-    thread->pause_clients = listCreate();
+    thread->paused_clients = listCreate();
     aeCreateTimeEvent(thread->el, 1, showThroughput, (void *)thread, NULL);
     return thread;
 }
 
 static void freeBenchmarkThread(benchmarkThread *thread) {
     if (thread->el) aeDeleteEventLoop(thread->el);
-    listRelease(thread->pause_clients);
+    listRelease(thread->paused_clients);
     zfree(thread);
 }
 
@@ -1911,7 +1913,7 @@ int main(int argc, char **argv) {
     config.loop = 0;
     config.idlemode = 0;
     config.clients = listCreate();
-    config.pause_clients = listCreate();
+    config.paused_clients = listCreate();
     config.conn_info.hostip = sdsnew("127.0.0.1");
     config.conn_info.hostport = 6379;
     config.tests = NULL;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -138,6 +138,11 @@ static struct config {
     pthread_mutex_t liveclients_mutex;
     pthread_mutex_t is_updating_slots_mutex;
     int resp3; /* use RESP3 */
+    int qps;
+    pthread_mutex_t token_bucket_mutex;
+    long long last_time;
+    long long time_per_token;
+    long long time_per_burst;
 } config;
 
 typedef struct _client {
@@ -223,6 +228,12 @@ static long long ustime(void) {
 
 static long long mstime(void) {
     return ustime() / 1000;
+}
+
+static long long nstime(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
 }
 
 static uint64_t dictSdsHash(const void *key) {
@@ -445,6 +456,32 @@ static void setClusterKeyHashTag(client c) {
     }
 }
 
+static long long acquireTokenOrWait(int tokens) {
+    if (config.num_threads) pthread_mutex_lock(&(config.token_bucket_mutex));
+
+    long long last_time_ = config.last_time;
+    long long time_per_token_ = config.time_per_token;
+    long long time_per_burst_ = config.time_per_burst;
+    long long new_time = 0;
+
+    long long now_since_epoch = nstime();
+    long long min_time = now_since_epoch - time_per_burst_;
+    if (min_time > last_time_) {
+        new_time = min_time + (time_per_token_ * tokens);
+    } else {
+        new_time = last_time_ + (time_per_token_ * tokens);
+    }
+
+    long long delay_time = 0;
+    if (new_time > now_since_epoch) {
+        delay_time = new_time - now_since_epoch;
+    } else {
+        config.last_time = new_time;
+    }
+    if (config.num_threads) pthread_mutex_unlock(&(config.token_bucket_mutex));
+    return delay_time;
+}
+
 static void clientDone(client c) {
     int requests_finished = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
     if (requests_finished >= config.requests) {
@@ -579,6 +616,18 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     UNUSED(el);
     UNUSED(fd);
     UNUSED(mask);
+
+    /* Acquire a token from the token bucket. */
+    if (config.qps > 0) {
+        do {
+            long long delay = acquireTokenOrWait(config.pipeline);
+            if (delay > 1000) {
+                usleep(delay / 1000);
+            } else {
+                break;
+            }
+        } while (1);
+    }
 
     /* Initialize request when nothing was written. */
     if (c->written == 0) {
@@ -995,6 +1044,11 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
 
     if (config.num_threads) initBenchmarkThreads();
 
+    if (config.qps > 0) {
+        config.time_per_token = 1000000000 / config.qps;
+        config.time_per_burst = config.time_per_token * config.qps;
+    }
+
     int thread_id = config.num_threads > 0 ? 0 : -1;
     c = createClient(cmd, len, seqlen, NULL, thread_id);
     createMissingClients(c);
@@ -1368,6 +1422,9 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--user")) {
             if (lastarg) goto invalid;
             config.conn_info.user = sdsnew(argv[++i]);
+        } else if (!strcmp(argv[i], "--qps")) {
+            if (lastarg) goto invalid;
+            config.qps = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
             parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
@@ -1797,6 +1854,7 @@ int main(int argc, char **argv) {
     config.num_threads = 0;
     config.threads = NULL;
     config.cluster_mode = 0;
+    config.qps = 0;
     config.read_from_replica = FROM_PRIMARY_ONLY;
     config.cluster_node_count = 0;
     config.cluster_nodes = NULL;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -476,13 +476,17 @@ static void setClusterKeyHashTag(client c) {
     }
 }
 
-/* Acquire a token from the token bucket.
+/**
+ * Acquires the specified number of tokens from the token bucket or calculates the wait time if tokens are not available.
+ * This function implements a token bucket rate limiting algorithm to control access to a resource.
  *
- * This function is used to throttle the number of requests per second.
+ * @param tokens The number of tokens to acquire.
+ * @return The delay time in milliseconds that the caller should wait before proceeding, or 0 if tokens are immediately available.
  *
- * The function returns the number of milliseconds that the caller should
- * wait before issuing the next request.
- *
+ * Token Bucket Algorithm Explanation:
+ * - The token bucket algorithm allows a certain number of tokens to be accumulated over time, which can then be used to control the rate of requests.
+ * - Due to the time event only allowing a delay of 1ms, a request for the next 1ms is issued.
+ * 
  * The function is thread-safe. */
 static long long acquireTokenOrWait(int tokens) {
     if (config.num_threads) pthread_mutex_lock(&(config.token_bucket_mutex));
@@ -492,30 +496,28 @@ static long long acquireTokenOrWait(int tokens) {
     long long time_per_burst = config.time_per_burst;
     long long new_time = 0;
 
-    long long now_since_epoch = nstime();
-    long long min_time = now_since_epoch - time_per_burst;
+    long long now_epoch = nstime();
+    // If the last_time is 0, it means this is the first request, so we set it to now_epoch.
     if (last_time == 0) {
-        last_time = now_since_epoch;
+        config.last_time = last_time = now_epoch;
     }
-    if (min_time > last_time) {
+
+    long long next_epoch = now_epoch + 1000000;
+    long long min_time = next_epoch - time_per_burst;
+
+    if (min_time > last_time) { // if the last time is too old, reset it
         new_time = min_time + (time_per_token * tokens);
     } else {
         new_time = last_time + (time_per_token * tokens);
     }
 
     long long delay_time = 0;
-    if (new_time > now_since_epoch) {
-        delay_time = new_time - now_since_epoch;
-
-        // Due to the fact that the minimum time interval for event loops is in the millisecond range,
-        // when the delay is less than 1ms, we don't need to wait, 
-        if (delay_time <= 1000000) {
-            config.last_time = now_since_epoch + delay_time;
-            delay_time = 0;
-        }
+    if (new_time > next_epoch) {    // if the new time is in the next epoch, we need to wait
+        delay_time = new_time - now_epoch;
     } else {
         config.last_time = new_time;
     }
+
     if (config.num_threads) pthread_mutex_unlock(&(config.token_bucket_mutex));
     return delay_time / 1000000;
 }
@@ -1529,11 +1531,11 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--rps")) {
             if (lastarg) goto invalid;
             config.rps = atoi(argv[++i]);
-            if (config.rps <= 1000) {
-                // TODO: remove this check when we support --rps option < 1000.
-                fprintf(stderr, "WARNING: --rps option must be >= 1000.\n");
-                config.rps = 0;
-            }
+            // if (config.rps <= 1000) {
+            //     // TODO: remove this check when we support --rps option < 1000.
+            //     fprintf(stderr, "WARNING: --rps option must be >= 1000.\n");
+            //     config.rps = 0;
+            // }
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
             parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -73,9 +73,6 @@
 #define CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE 3000000L /* <= 3 secs(us precision) */
 #define SHOW_THROUGHPUT_INTERVAL 250                        /* 250ms */
 
-#define CLIENT_PAUSED (1 << 0)
-#define CLIENT_REUSE (1 << 1)
-
 #define CLIENT_GET_EVENTLOOP(c) (c->thread_id >= 0 ? config.threads[c->thread_id]->el : config.el)
 
 struct benchmarkThread;
@@ -370,16 +367,18 @@ static void freeServerConfig(serverConfig *cfg) {
     zfree(cfg);
 }
 
-static void releasePauseClient(client c) {
+static void releasePausedClient(client c) {
     if (c->thread_id >= 0) {
         benchmarkThread *thread = config.threads[c->thread_id];
         listNode *ln = listSearchKey(thread->paused_clients, c);
-        assert(ln != NULL);
-        listDelNode(thread->paused_clients, ln);
+        if (ln != NULL) {
+            listDelNode(thread->paused_clients, ln);
+        }
     } else {
         listNode *ln = listSearchKey(config.paused_clients, c);
-        assert(ln != NULL);
-        listDelNode(config.paused_clients, ln);
+        if (ln != NULL) {
+            listDelNode(config.paused_clients, ln);
+        }
     }
 }
 
@@ -395,7 +394,7 @@ static void freeClient(client c) {
         }
     }
     valkeyFree(c->context);
-    releasePauseClient(c);
+    releasePausedClient(c);
     sdsfree(c->obuf);
     zfree(c->randptr);
     zfree(c->stagptr);
@@ -477,6 +476,14 @@ static void setClusterKeyHashTag(client c) {
     }
 }
 
+/* Acquire a token from the token bucket.
+ *
+ * This function is used to throttle the number of requests per second.
+ *
+ * The function returns the number of milliseconds that the caller should
+ * wait before issuing the next request.
+ *
+ * The function is thread-safe. */
 static long long acquireTokenOrWait(int tokens) {
     if (config.num_threads) pthread_mutex_lock(&(config.token_bucket_mutex));
 
@@ -496,11 +503,18 @@ static long long acquireTokenOrWait(int tokens) {
     long long delay_time = 0;
     if (new_time > now_since_epoch) {
         delay_time = new_time - now_since_epoch;
+
+        // Due to the fact that the minimum time interval for event loops is in the millisecond range,
+        // when the delay is less than 1ms, we don't need to wait, 
+        if (delay_time <= 1000000) {
+            config.last_time = now_since_epoch + delay_time;
+            delay_time = 0;
+        }
     } else {
         config.last_time = new_time;
     }
     if (config.num_threads) pthread_mutex_unlock(&(config.token_bucket_mutex));
-    return delay_time;
+    return delay_time / 1000000;
 }
 
 static void clientDone(client c) {
@@ -632,11 +646,19 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     }
 }
 
+/*
+ * When a client is paused, the function is called by the event loop to
+ * awaken the client.
+ *
+ * Return the number of milliseconds to wait before calling the function again.
+ *
+ * If the function returns AE_NOMORE, the event is removed.
+ */
 static long long awakenPausedClient(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(id);
     benchmarkThread *thread = (benchmarkThread *)clientData;
 
-    list *paused_clients;
+    list *paused_clients = NULL;
     if (thread == NULL) {
         paused_clients = config.paused_clients;
     } else {
@@ -645,26 +667,26 @@ static long long awakenPausedClient(struct aeEventLoop *eventLoop, long long id,
 
     listIter li;
     listNode *ln;
-    long long delay_ns = 0;
+    long long delay = 0;
     listRewind(paused_clients, &li);
     while ((ln = listNext(&li)) != NULL) {
         client c = ln->value;
-        delay_ns = acquireTokenOrWait(config.pipeline);
-        if (delay_ns > 1000000) {
+        delay = acquireTokenOrWait(config.pipeline);
+        if (delay) {
             break;
-        } else {
-            c->paused = 0;
-            c->reuse = 1;
-            writeHandler(eventLoop, c->context->fd, c, AE_WRITABLE);
-            listDelNode(paused_clients, ln);
         }
+        // When client acquires a token, try to write with `reuse`.
+        c->paused = 0;
+        c->reuse = 1;
+        writeHandler(eventLoop, c->context->fd, c, AE_WRITABLE);
+        listDelNode(paused_clients, ln);
     }
-
-    if (delay_ns > 0) {
-        return delay_ns / 1000000;
-    } else {
+    
+    // If there are no more paused clients, remove the event.
+    if (delay == 0) {
         return AE_NOMORE;
     }
+    return delay;
 }
 
 static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
@@ -673,10 +695,12 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     UNUSED(fd);
     UNUSED(mask);
 
-    /* Acquire a token from the token bucket. */
-    if (config.rps > 0 && c->reuse) {
-        long long delay_ns = acquireTokenOrWait(config.pipeline);
-        if (delay_ns > 1000000) {
+    // When benchmark with rps control, and client is not reuse, try to acquire a token.
+    if (config.rps > 0 && c->reuse == 0) {
+        /* Acquire a token from the token bucket. */
+        long long delay = acquireTokenOrWait(config.pipeline);
+
+        if (delay) {
             int thread_id = c->thread_id;
             c->paused = 1;
             aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
@@ -688,11 +712,12 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 thread = config.threads[thread_id];
                 listAddNodeTail(thread->paused_clients, c);
             }
-            aeCreateTimeEvent(el, delay_ns / 1000000, awakenPausedClient, (void *)thread, NULL);
+            /* Create a time event to awaken the client. */
+            aeCreateTimeEvent(el, delay, awakenPausedClient, (void *)thread, NULL);
             return;
         }
     }
-    c->paused = 0;
+    c->reuse = 0;
 
     /* Initialize request when nothing was written. */
     if (c->written == 0) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -475,20 +475,19 @@ static void setClusterKeyHashTag(client c) {
     }
 }
 
-/**
- * Acquires the specified number of tokens from the token bucket or calculates the wait time if tokens are not available.
+/* Acquires the specified number of tokens from the token bucket or calculates the wait time if tokens are not available.
  * This function implements a token bucket rate limiting algorithm to control access to a resource.
  *
- * @param tokens The number of tokens to acquire.
- * @return The delay time in milliseconds that the caller should wait before proceeding, or 0 if tokens are immediately available.
+ * The tokens parameter is the number of tokens to acquire.
+ *
+ * Returns the delay time in milliseconds that the caller should wait before proceeding, or 0 if tokens are immediately available.
  *
  * Token Bucket Algorithm Explanation:
  * - The token bucket algorithm allows a certain number of tokens to be accumulated over time, which can then be used to control the rate of requests.
  * - Due to the time event only allowing a delay of 1ms, a request for the next 1ms is issued.
- * 
+ *
  * The function is thread-safe. */
 static long long acquireTokenOrWait(int tokens) {
-
     uint64_t time_per_token = config.time_per_token;
     uint64_t time_per_burst = config.time_per_burst;
     uint64_t new_time = 0;
@@ -507,7 +506,7 @@ static long long acquireTokenOrWait(int tokens) {
 
         next_epoch = now_epoch + 1000000;
         min_time = next_epoch - time_per_burst;
-    
+
         if (min_time > last_time_ns) { // if the last time is too old, reset it
             new_time = min_time + (time_per_token * tokens);
         } else {
@@ -515,7 +514,7 @@ static long long acquireTokenOrWait(int tokens) {
         }
 
         delay_time = 0;
-        if (new_time > next_epoch) {    // if the new time is in the next epoch, we need to wait
+        if (new_time > next_epoch) { // if the new time is in the next epoch, we need to wait
             delay_time = new_time - now_epoch;
         } else {
             last_time_ns = new_time;
@@ -698,7 +697,7 @@ static long long awakenPausedClient(struct aeEventLoop *eventLoop, long long id,
         writeHandler(eventLoop, c->context->fd, c, AE_WRITABLE);
         listDelNode(paused_clients, ln);
     }
-    
+
     // If there are no more paused clients, remove the event.
     if (delay == 0) {
         return AE_NOMORE;


### PR DESCRIPTION
Implemented a benchmark for constant RPS (AKA QPS) through token bucket algorithm.

Adds new option `--rps NUMBER` to `valkey-benchmark`.

## Client Status

- Check the token bucket status before writing requests on the client side
- Added a pause logic to delay sending requests
- Implemented wake-up operation using AE's time events

```


                        ┌────────┐
                        │        │
       ┌────────────────┤ Paused │
       │                │        │
       │                └────────┘
 Time trigered              ▲
       │                    │
       │             No,AddTimeEvent
       ▼                    │
   ┌───────┐         ┌──────┴──────┐        ┌────────┐
   │       │         │             │        │        │
   │ Ready ├─────────►acquire Token├──Yes──►│ Writed │
   │       │         │             │        │        │
   └───────┘         └─────────────┘        └────┬───┘
       ▲                                         │
       │                                         │
       │                                         │
       └─────────────────Read┼Done───────────────┘

```
## Speed limit algorithm

Common algorithms were used: https://en.wikipedia.org/wiki/Token_bucket

Closes https://github.com/valkey-io/valkey/issues/1201

