### PR TITLE
Enable TCP_NODELAY by default in incoming and outgoing connections

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -496,6 +496,9 @@ static int anetTcpGenericConnect(char *err, const char *addr, int port, const ch
             continue;
         }
 
+        /* Enable TCP_NODELAY by default */
+        anetEnableTcpNoDelay(NULL, s);
+
         /* If we ended an iteration of the for loop without errors, we
          * have a connected socket. Let's return to the caller. */
         goto end;
@@ -684,6 +687,10 @@ int anetTcpAccept(char *err, int serversock, char *ip, size_t ip_len, int *port)
         if (ip) inet_ntop(AF_INET6, (void *)&(s->sin6_addr), ip, ip_len);
         if (port) *port = ntohs(s->sin6_port);
     }
+
+    /* Enable TCP_NODELAY by default */
+    anetEnableTcpNoDelay(NULL, fd);
+
     return fd;
 }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -357,7 +357,6 @@ migrateCachedSocket *migrateGetSocket(client *c, robj *host, robj *port, long ti
         sdsfree(name);
         return NULL;
     }
-    connEnableTcpNoDelay(conn);
 
     /* Add to the cache and return it to the caller. */
     cs = zmalloc(sizeof(*cs));

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1493,7 +1493,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             connClose(conn);
             return;
         }
-        connEnableTcpNoDelay(conn);
+
         connKeepAlive(conn, server.cluster_node_timeout / 1000 * 2);
 
         /* Use non-blocking I/O for cluster messages. */

--- a/src/connection.h
+++ b/src/connection.h
@@ -380,8 +380,6 @@ static inline const char *connGetInfo(connection *conn, char *buf, size_t buf_le
 /* anet-style wrappers to conns */
 int connBlock(connection *conn);
 int connNonBlock(connection *conn);
-int connEnableTcpNoDelay(connection *conn);
-int connDisableTcpNoDelay(connection *conn);
 int connKeepAlive(connection *conn, int interval);
 int connSendTimeout(connection *conn, long long ms);
 int connRecvTimeout(connection *conn, long long ms);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1152,7 +1152,7 @@ void syncCommand(client *c) {
     /* Setup the replica as one waiting for BGSAVE to start. The following code
      * paths will change the state if we handle the replica differently. */
     c->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
-    if (server.repl_disable_tcp_nodelay) connDisableTcpNoDelay(c->conn); /* Non critical if it fails. */
+    if (server.repl_disable_tcp_nodelay) anetDisableTcpNoDelay(NULL, c->conn); /* Non critical if it fails. */
     c->repl_data->repldbfd = -1;
     c->flag.replica = 1;
     listAddNodeTail(server.replicas, c);

--- a/src/replication.c
+++ b/src/replication.c
@@ -1152,7 +1152,7 @@ void syncCommand(client *c) {
     /* Setup the replica as one waiting for BGSAVE to start. The following code
      * paths will change the state if we handle the replica differently. */
     c->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
-    if (server.repl_disable_tcp_nodelay) anetDisableTcpNoDelay(NULL, c->conn); /* Non critical if it fails. */
+    if (server.repl_disable_tcp_nodelay) anetDisableTcpNoDelay(NULL, c->conn->fd); /* Non critical if it fails. */
     c->repl_data->repldbfd = -1;
     c->flag.replica = 1;
     listAddNodeTail(server.replicas, c);

--- a/src/socket.c
+++ b/src/socket.c
@@ -327,7 +327,6 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
         }
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
 
-        anetEnableTcpNoDelay(NULL, cfd);
         if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);
         acceptCommonHandler(connCreateAcceptedSocket(cfd, NULL), flags, cip);
     }

--- a/src/socket.c
+++ b/src/socket.c
@@ -464,16 +464,6 @@ int connNonBlock(connection *conn) {
     return anetNonBlock(NULL, conn->fd);
 }
 
-int connEnableTcpNoDelay(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetEnableTcpNoDelay(NULL, conn->fd);
-}
-
-int connDisableTcpNoDelay(connection *conn) {
-    if (conn->fd == -1) return C_ERR;
-    return anetDisableTcpNoDelay(NULL, conn->fd);
-}
-
 int connKeepAlive(connection *conn, int interval) {
     if (conn->fd == -1) return C_ERR;
     return anetKeepAlive(NULL, conn->fd, interval);

--- a/src/tls.c
+++ b/src/tls.c
@@ -803,7 +803,6 @@ static void tlsAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) 
         }
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
 
-        anetEnableTcpNoDelay(NULL, cfd);
         if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);
         acceptCommonHandler(connCreateAcceptedTLS(cfd, &server.tls_auth_clients), flags, cip);
     }


### PR DESCRIPTION
### Issue: https://github.com/valkey-io/valkey/issues/1758
This is a follow up issue from https://github.com/valkey-io/valkey/pull/1706#issuecomment-2669567875


### Problem: 
The absence of TCP_NODELAY can cause unnecessary latency due to [Nagle’s algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm) (buffers small TCP packets), which could be disabled for traffic.
We need to consider enabling TCP_NODELAY by default in both incoming and outgoing connections

@pizhenwei mentioned
* modern computers have high bandwidth networking interface, a few small packets will not affect the bandwidth any more.
* a lot of instances run on cloud virtual machine. Intel VT-x and AMD-v uses software emulated LAPIC to support TSC deadline timer, it uses ~10x CPU cycles (~3000 cycle VS ~300 cycles on physical machine) to setup CPU timer during TCP Nagle's algorithm. Disabling it will reduce CPU cycles for VM and cloud virtual machine.
