### PR TITLE
feat: add tcp keepalive probes for managed service Valkey by cloud service providers

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -151,7 +151,7 @@ int anetCloexec(int fd) {
 
 /* Enable TCP keep-alive mechanism to detect dead peers,
  * TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT will be set accordingly. */
-int anetKeepAlive(char *err, int fd, int interval, const int probes) {
+int anetKeepAlive(char *err, int fd, int interval, int probes) {
     int enabled = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &enabled, sizeof(enabled))) {
         anetSetError(err, "setsockopt SO_KEEPALIVE: %s", strerror(errno));

--- a/src/anet.c
+++ b/src/anet.c
@@ -151,7 +151,7 @@ int anetCloexec(int fd) {
 
 /* Enable TCP keep-alive mechanism to detect dead peers,
  * TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT will be set accordingly. */
-int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
+int anetKeepAlive(char *err, int fd, int interval, const int probes) {
     int enabled = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &enabled, sizeof(enabled))) {
         anetSetError(err, "setsockopt SO_KEEPALIVE: %s", strerror(errno));
@@ -160,7 +160,6 @@ int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
 
     int idle;
     int intvl;
-    int cnt;
 
     /* There are platforms that are expected to support the full mechanism of TCP keep-alive,
      * we want the compiler to emit warnings of unused variables if the preprocessor directives
@@ -171,7 +170,7 @@ int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
     UNUSED(interval);
     UNUSED(idle);
     UNUSED(intvl);
-    UNUSED(cnt);
+    UNUSED(probes);
 #endif
 
 #ifdef __sun
@@ -216,9 +215,6 @@ int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
         anetSetError(err, "setsockopt TCP_KEEPINTVL: %s\n", strerror(errno));
         return ANET_ERR;
     }
-
-    cnt = 3;
-    if (probes != NULL) cnt = *probes;
 
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &probes, sizeof(probes))) {
         anetSetError(err, "setsockopt TCP_KEEPCNT: %s\n", strerror(errno));
@@ -283,10 +279,7 @@ int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
 #ifdef TCP_KEEPCNT
     /* Consider the socket in error state after three we send three ACK
      * probes without getting a reply. */
-    cnt = 3;
-    if (probes != NULL) cnt = *probes;
-
-    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt))) {
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &probes, sizeof(probes))) {
         anetSetError(err, "setsockopt TCP_KEEPCNT: %s\n", strerror(errno));
         return ANET_ERR;
     }

--- a/src/anet.c
+++ b/src/anet.c
@@ -151,7 +151,7 @@ int anetCloexec(int fd) {
 
 /* Enable TCP keep-alive mechanism to detect dead peers,
  * TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT will be set accordingly. */
-int anetKeepAlive(char *err, int fd, int interval) {
+int anetKeepAlive(char *err, int fd, int interval, const int *probes) {
     int enabled = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &enabled, sizeof(enabled))) {
         anetSetError(err, "setsockopt SO_KEEPALIVE: %s", strerror(errno));
@@ -218,7 +218,9 @@ int anetKeepAlive(char *err, int fd, int interval) {
     }
 
     cnt = 3;
-    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt))) {
+    if (probes != NULL) cnt = *probes;
+
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &probes, sizeof(probes))) {
         anetSetError(err, "setsockopt TCP_KEEPCNT: %s\n", strerror(errno));
         return ANET_ERR;
     }
@@ -282,6 +284,8 @@ int anetKeepAlive(char *err, int fd, int interval) {
     /* Consider the socket in error state after three we send three ACK
      * probes without getting a reply. */
     cnt = 3;
+    if (probes != NULL) cnt = *probes;
+
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt))) {
         anetSetError(err, "setsockopt TCP_KEEPCNT: %s\n", strerror(errno));
         return ANET_ERR;

--- a/src/anet.h
+++ b/src/anet.h
@@ -68,7 +68,7 @@ int anetDisableTcpNoDelay(char *err, int fd);
 int anetSendTimeout(char *err, int fd, long long ms);
 int anetRecvTimeout(char *err, int fd, long long ms);
 int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int remote);
-int anetKeepAlive(char *err, int fd, int interval, const int *probes);
+int anetKeepAlive(char *err, int fd, int interval, int probes);
 int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
 int anetPipe(int fds[2], int read_flags, int write_flags);
 int anetSetSockMarkId(char *err, int fd, uint32_t id);

--- a/src/anet.h
+++ b/src/anet.h
@@ -68,7 +68,7 @@ int anetDisableTcpNoDelay(char *err, int fd);
 int anetSendTimeout(char *err, int fd, long long ms);
 int anetRecvTimeout(char *err, int fd, long long ms);
 int anetFdToString(int fd, char *ip, size_t ip_len, int *port, int remote);
-int anetKeepAlive(char *err, int fd, int interval);
+int anetKeepAlive(char *err, int fd, int interval, const int *probes);
 int anetFormatAddr(char *fmt, size_t fmt_len, char *ip, int port);
 int anetPipe(int fds[2], int read_flags, int write_flags);
 int anetSetSockMarkId(char *err, int fd, uint32_t id);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1494,7 +1494,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-        connKeepAlive(conn, server.cluster_node_timeout / 1000 * 2, &server.tcp_keepalive_probes);
+        connKeepAlive(conn, server.cluster_node_timeout / 1000 * 2, server.tcp_keepalive_probes);
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE, "Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1494,7 +1494,7 @@ void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
             return;
         }
         connEnableTcpNoDelay(conn);
-        connKeepAlive(conn, server.cluster_node_timeout / 1000 * 2);
+        connKeepAlive(conn, server.cluster_node_timeout / 1000 * 2, &server.tcp_keepalive_probes);
 
         /* Use non-blocking I/O for cluster messages. */
         serverLog(LL_VERBOSE, "Accepting cluster node connection from %s:%d", cip, cport);

--- a/src/config.c
+++ b/src/config.c
@@ -3261,6 +3261,7 @@ standardConfig static_configs[] = {
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_replica_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* replica max data age factor. */
     createIntConfig("list-max-listpack-size", "list-max-ziplist-size", MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_listpack_size, -2, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-keepalive", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcpkeepalive, 300, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("tcp-keepalive-probes", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tcp_keepalive_probes, 3, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-migration-barrier", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_migration_barrier, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("active-defrag-cycle-min", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cpu_min, 1, INTEGER_CONFIG, NULL, updateDefragConfiguration),                   /* Default: 1% CPU min (at lower threshold) */
     createIntConfig("active-defrag-cycle-max", NULL, MODIFIABLE_CONFIG, 1, 99, server.active_defrag_cpu_max, 25, INTEGER_CONFIG, NULL, updateDefragConfiguration),                  /* Default: 25% CPU max (at upper threshold) */

--- a/src/connection.h
+++ b/src/connection.h
@@ -382,7 +382,7 @@ int connBlock(connection *conn);
 int connNonBlock(connection *conn);
 int connEnableTcpNoDelay(connection *conn);
 int connDisableTcpNoDelay(connection *conn);
-int connKeepAlive(connection *conn, int interval);
+int connKeepAlive(connection *conn, int interval, const int *probes);
 int connSendTimeout(connection *conn, long long ms);
 int connRecvTimeout(connection *conn, long long ms);
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -382,7 +382,7 @@ int connBlock(connection *conn);
 int connNonBlock(connection *conn);
 int connEnableTcpNoDelay(connection *conn);
 int connDisableTcpNoDelay(connection *conn);
-int connKeepAlive(connection *conn, int interval, const int *probes);
+int connKeepAlive(connection *conn, int interval, int probes);
 int connSendTimeout(connection *conn, long long ms);
 int connRecvTimeout(connection *conn, long long ms);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1764,6 +1764,7 @@ struct valkeyServer {
     int hide_user_data_from_log; /* Hide or redact user data, or data that may contain user data, from the log. */
     int maxidletime;             /* Client timeout in seconds */
     int tcpkeepalive;            /* Set SO_KEEPALIVE if non-zero. */
+    int tcp_keepalive_probes;    /* Number of TCP keepalive probes. */
     int active_expire_enabled;   /* Can be disabled for testing purposes. */
     int active_expire_effort;    /* From 1 (default) to 10, active effort. */
     int lazy_expire_disabled;    /* If > 0, don't trigger lazy expire */

--- a/src/socket.c
+++ b/src/socket.c
@@ -328,7 +328,7 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
 
         anetEnableTcpNoDelay(NULL, cfd);
-        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive, &server.tcp_keepalive_probes);
+        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive, server.tcp_keepalive_probes);
         acceptCommonHandler(connCreateAcceptedSocket(cfd, NULL), flags, cip);
     }
 }
@@ -475,7 +475,7 @@ int connDisableTcpNoDelay(connection *conn) {
     return anetDisableTcpNoDelay(NULL, conn->fd);
 }
 
-int connKeepAlive(connection *conn, int interval, const int *probes) {
+int connKeepAlive(connection *conn, int interval, int probes) {
     if (conn->fd == -1) return C_ERR;
     return anetKeepAlive(NULL, conn->fd, interval, probes);
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -328,7 +328,7 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
 
         anetEnableTcpNoDelay(NULL, cfd);
-        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);
+        if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive, &server.tcp_keepalive_probes);
         acceptCommonHandler(connCreateAcceptedSocket(cfd, NULL), flags, cip);
     }
 }
@@ -475,9 +475,9 @@ int connDisableTcpNoDelay(connection *conn) {
     return anetDisableTcpNoDelay(NULL, conn->fd);
 }
 
-int connKeepAlive(connection *conn, int interval) {
+int connKeepAlive(connection *conn, int interval, const int *probes) {
     if (conn->fd == -1) return C_ERR;
-    return anetKeepAlive(NULL, conn->fd, interval);
+    return anetKeepAlive(NULL, conn->fd, interval, probes);
 }
 
 int connSendTimeout(connection *conn, long long ms) {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -75,6 +75,7 @@
 #define OUTPUT_JSON 3
 #define OUTPUT_QUOTED_JSON 4
 #define CLI_KEEPALIVE_INTERVAL 15   /* seconds */
+#define CLI_KEEPALIVE_PROBES 3
 #define CLI_DEFAULT_PIPE_TIMEOUT 30 /* seconds */
 #define CLI_HISTFILE_ENV "REDISCLI_HISTFILE"
 #define CLI_HISTFILE_DEFAULT ".valkeycli_history"
@@ -1665,7 +1666,7 @@ static int cliConnect(int flags) {
          * in order to prevent timeouts caused by the execution of long
          * commands. At the same time this improves the detection of real
          * errors. */
-        anetKeepAlive(NULL, context->fd, CLI_KEEPALIVE_INTERVAL, NULL);
+        anetKeepAlive(NULL, context->fd, CLI_KEEPALIVE_INTERVAL, CLI_KEEPALIVE_PROBES);
 
         /* State of the current connection. */
         config.current_resp3 = 0;
@@ -3970,7 +3971,7 @@ static int clusterManagerNodeConnect(clusterManagerNode *node) {
      * in order to prevent timeouts caused by the execution of long
      * commands. At the same time this improves the detection of real
      * errors. */
-    anetKeepAlive(NULL, node->context->fd, CLI_KEEPALIVE_INTERVAL, NULL);
+    anetKeepAlive(NULL, node->context->fd, CLI_KEEPALIVE_INTERVAL, CLI_KEEPALIVE_PROBES);
     if (config.conn_info.auth) {
         redisReply *reply;
         if (config.conn_info.user == NULL)

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1665,7 +1665,7 @@ static int cliConnect(int flags) {
          * in order to prevent timeouts caused by the execution of long
          * commands. At the same time this improves the detection of real
          * errors. */
-        anetKeepAlive(NULL, context->fd, CLI_KEEPALIVE_INTERVAL);
+        anetKeepAlive(NULL, context->fd, CLI_KEEPALIVE_INTERVAL, NULL);
 
         /* State of the current connection. */
         config.current_resp3 = 0;
@@ -3970,7 +3970,7 @@ static int clusterManagerNodeConnect(clusterManagerNode *node) {
      * in order to prevent timeouts caused by the execution of long
      * commands. At the same time this improves the detection of real
      * errors. */
-    anetKeepAlive(NULL, node->context->fd, CLI_KEEPALIVE_INTERVAL);
+    anetKeepAlive(NULL, node->context->fd, CLI_KEEPALIVE_INTERVAL, NULL);
     if (config.conn_info.auth) {
         redisReply *reply;
         if (config.conn_info.user == NULL)

--- a/valkey.conf
+++ b/valkey.conf
@@ -174,14 +174,9 @@ timeout 0
 # On other kernels the period depends on the kernel configuration.
 tcp-keepalive 300
 
-# TCP keepalive probes.
+# Number of TCP keepalive probes before closing a dead connection.
 #
-# The number of TCP keepalive probes to send before considering the connection dead.
 # Only valid if tcp-keepalive is non-zero.
-# This is useful below situations:
-#
-# 1) Faster detection of dead peers.
-# 2) Avoiding premature disconnection due to network equipment in the middle.
 tcp-keepalive-probes 3
 
 # Apply OS-specific mechanism to mark the listening socket with the specified

--- a/valkey.conf
+++ b/valkey.conf
@@ -174,6 +174,16 @@ timeout 0
 # On other kernels the period depends on the kernel configuration.
 tcp-keepalive 300
 
+# TCP keepalive probes.
+#
+# The number of TCP keepalive probes to send before considering the connection dead.
+# Only valid if tcp-keepalive is non-zero.
+# This is useful below situations:
+#
+# 1) Faster detection of dead peers.
+# 2) Avoiding premature disconnection due to network equipment in the middle.
+tcp-keepalive-probes 3
+
 # Apply OS-specific mechanism to mark the listening socket with the specified
 # ID, to support advanced routing and filtering capabilities.
 #


### PR DESCRIPTION
I want to use valkey computing resource more efficiently. This is tiny improvement, but it can reduce unnecessary resource usage. Because it can remove dead connections more earlier. 

Even there is lots of transient error in networks can get benefit from it.

out-of-scope:

I'm currently using Amazon ElastiCache for Valkey. After this PR is merged, I wish many CSPs provide "tcp-keepalive-probes" in parameter groups including AWS.