### PR TITLE
Fixed issue with `CONFIG RESETSTAT` in cluster module message callback test

### DIFF
--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -22,10 +22,12 @@ start_cluster 3 0 [list config_lines $modules] {
             fail "node 2 or node 3 didn't receive cluster module message"
         }
     }
+}
 
-    $node1 CONFIG RESETSTAT
-    $node2 CONFIG RESETSTAT
-    $node3 CONFIG RESETSTAT
+start_cluster 3 0 [list config_lines $modules] {
+    set node1 [srv 0 client]
+    set node2 [srv -1 client]
+    set node3 [srv -2 client]
 
     test "Cluster module message DING/DONG acknowledgment" {
         assert_equal OK [$node1 test.pingall]

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -21,26 +21,16 @@ start_cluster 3 0 [list config_lines $modules] {
         } else {
             fail "node 2 or node 3 didn't receive cluster module message"
         }
-    }
-}
-
-start_cluster 3 0 [list config_lines $modules] {
-    set node1 [srv 0 client]
-    set node2 [srv -1 client]
-    set node3 [srv -2 client]
-
-    test "Cluster module message DING/DONG acknowledgment" {
-        assert_equal OK [$node1 test.pingall]
-        wait_for_condition 50 100 {
-            [CI 0 cluster_stats_messages_module_received] eq 2 &&
-            [CI 1 cluster_stats_messages_module_received] eq 1 &&
-            [CI 2 cluster_stats_messages_module_received] eq 1
-        } else {
-            fail "node 2 or node 3 didn't receive DING messages or node 1 didn't receive DONG message"
-        }
-
         verify_log_message -1 "*DING (type 1) RECEIVED*Hey*" 0
         verify_log_message -2 "*DING (type 1) RECEIVED*Hey*" 0
+    }
+
+    test "Cluster module receive message API - VM_RegisterClusterMessageReceiver" {
+        wait_for_condition 50 100 {
+            [CI 0 cluster_stats_messages_module_received] eq 2
+        } else {
+            fail "node 1 didn't receive DONG messages"
+        }
         assert_equal 2 [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"]
     }
 }


### PR DESCRIPTION
**Problem**
The cluster module test "Cluster module message DING/DONG acknowledgment" is failing despite successful message exchanges between nodes.  While these messages are being properly exchanged between the nodes, running multiple tests on the same cluster instance is causing issues with message statistics tracking. `CONFIG RESETSTAT` doesn't seem to reset the stats under certain cases which causes the error as the stats are adding onto each other from previous tests.

**Solution**
Remove some overlap with the previous test case so we don't need `CONFIG RESETSTAT` between the test cases.

Resolves #1764  

