### PR TITLE
Fixed active-expire-effort description in conf file

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -1320,8 +1320,8 @@ acllog-max-len 128
 # replica-ignore-maxmemory yes
 
 # The server reclaims expired keys in two ways: upon access when those keys are
-# found to be expired, and also in background, in what is called the
-# "active expire key". The key space is slowly and interactively scanned
+# found to be expired, and also in the background, in what is called the
+# "active expire key". The key space is slowly and iteractively scanned
 # looking for expired keys to reclaim, so that it is possible to free memory
 # of keys that are expired and will never be accessed again in a short time.
 #

--- a/valkey.conf
+++ b/valkey.conf
@@ -1321,7 +1321,7 @@ acllog-max-len 128
 
 # The server reclaims expired keys in two ways: upon access when those keys are
 # found to be expired, and also in the background, in what is called the
-# "active expire key". The key space is slowly and iteractively scanned
+# "active expire key". The key space is slowly and incrementally scanned
 # looking for expired keys to reclaim, so that it is possible to free memory
 # of keys that are expired and will never be accessed again in a short time.
 #


### PR DESCRIPTION
Expired keys search happens without user actions. Therefore, the "interactively" word in the description of the active-expire-key parameter is confusing and is changed to "incrementally."
 
modified:   valkey.conf