### PR TITLE
defrag: remove assert on defrag_later

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1042,7 +1042,6 @@ static void endDefragCycle(bool normal_termination) {
         // For normal termination, we expect...
         serverAssert(!defrag.current_stage);
         serverAssert(listLength(defrag.remaining_stages) == 0);
-        serverAssert(!defrag_later || listLength(defrag_later) == 0);
     } else {
         // Defrag is being terminated abnormally
         aeDeleteTimeEvent(server.el, defrag.timeproc_id);
@@ -1058,6 +1057,8 @@ static void endDefragCycle(bool normal_termination) {
     listRelease(defrag.remaining_stages);
     defrag.remaining_stages = NULL;
 
+    /* For a normal termination, this list is usually empty, but it might contain elements
+     *  if a stage was aborted due to a flushall or some other DB swap. */
     if (defrag_later) {
         listRelease(defrag_later);
         defrag_later = NULL;


### PR DESCRIPTION
If a flushall is performed in the middle of defrag, the current stage will be aborted when the change in kvs is detected.  However the defrag cycle will continue and defrag will complete normally.  In a normal termination, we expect the `defrag_later` list to be empty - and it might not be in this condition.

This update removes the incorrect assertion, allowing the list to be freed just like for an abnormal termination.