### PR TITLE
valkey-cli: ensure output ends with a newline if missing when printing reply

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2338,26 +2338,26 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     if (context == NULL) return REDIS_ERR;
 
     output_raw = 0;
-    if (config.in_multi) {
-        /* In a multi block, commands will return status strings instead of verbatim strings. */
-        output_raw = 0;
-    } else if (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
-               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
-               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
-               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
-               (argc >= 2 && !strcasecmp(command, "memory") &&
-                (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
-               (argc == 2 && !strcasecmp(command, "cluster") &&
-                (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
-               (argc >= 2 && !strcasecmp(command, "client") &&
-                (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
-               (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
-               (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
-               /* Format PROXY INFO command for Cluster Proxy:
-                * https://github.com/artix75/redis-cluster-proxy */
-               (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info"))) {
+    if (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
+        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
+        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
+        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
+        (argc >= 2 && !strcasecmp(command, "memory") &&
+         (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
+        (argc == 2 && !strcasecmp(command, "cluster") &&
+         (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
+        (argc >= 2 && !strcasecmp(command, "client") &&
+         (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
+        (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
+        (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
+        /* Format PROXY INFO command for Cluster Proxy:
+         * https://github.com/artix75/redis-cluster-proxy */
+        (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info"))) {
         output_raw = 1;
     }
+
+    /* In a multi block, commands will return status strings instead of verbatim strings. */
+    if (config.in_multi) output_raw = 0;
 
     if (!strcasecmp(command, "shutdown")) config.shutdown = 1;
     if (!strcasecmp(command, "monitor")) config.monitor_mode = 1;

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2339,7 +2339,7 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
 
     output_raw = 0;
     if (config.in_multi) {
-        /* In a multi block, commands will return status instead of verbatim. */
+        /* In a multi block, commands will return status strings instead of verbatim strings. */
         output_raw = 0;
     } else if (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
                (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2338,22 +2338,24 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     if (context == NULL) return REDIS_ERR;
 
     output_raw = 0;
-    if (!config.in_multi &&
-        (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
-         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
-         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
-         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
-         (argc >= 2 && !strcasecmp(command, "memory") &&
-          (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
-         (argc == 2 && !strcasecmp(command, "cluster") &&
-          (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
-         (argc >= 2 && !strcasecmp(command, "client") &&
-          (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
-         (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
-         (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
-         /* Format PROXY INFO command for Cluster Proxy:
-          * https://github.com/artix75/redis-cluster-proxy */
-         (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info")))) {
+    if (config.in_multi) {
+        /* In a multi block, commands will return status instead of verbatim. */
+        output_raw = 0;
+    } else if (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
+               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
+               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
+               (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
+               (argc >= 2 && !strcasecmp(command, "memory") &&
+                (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
+               (argc == 2 && !strcasecmp(command, "cluster") &&
+                (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
+               (argc >= 2 && !strcasecmp(command, "client") &&
+                (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
+               (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
+               (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
+               /* Format PROXY INFO command for Cluster Proxy:
+                * https://github.com/artix75/redis-cluster-proxy */
+               (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info"))) {
         output_raw = 1;
     }
 

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1989,6 +1989,10 @@ static sds cliFormatReplyRaw(redisReply *r) {
         break;
     default: fprintf(stderr, "Unknown reply type: %d\n", r->type); exit(1);
     }
+    /* Append newline only if the last character isn't already '\n' */
+    if (sdslen(out) > 0 && out[sdslen(out) - 1] != '\n') {
+        out = sdscatlen(out, "\n", 1);
+    }
     return out;
 }
 

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1989,10 +1989,6 @@ static sds cliFormatReplyRaw(redisReply *r) {
         break;
     default: fprintf(stderr, "Unknown reply type: %d\n", r->type); exit(1);
     }
-    /* Append newline only if the last character isn't already '\n' */
-    if (sdslen(out) > 0 && out[sdslen(out) - 1] != '\n') {
-        out = sdscatlen(out, "\n", 1);
-    }
     return out;
 }
 
@@ -2342,21 +2338,22 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
     if (context == NULL) return REDIS_ERR;
 
     output_raw = 0;
-    if (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
-        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
-        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
-        (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
-        (argc >= 2 && !strcasecmp(command, "memory") &&
-         (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
-        (argc == 2 && !strcasecmp(command, "cluster") &&
-         (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
-        (argc >= 2 && !strcasecmp(command, "client") &&
-         (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
-        (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
-        (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
-        /* Format PROXY INFO command for Cluster Proxy:
-         * https://github.com/artix75/redis-cluster-proxy */
-        (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info"))) {
+    if (!config.in_multi &&
+        (!strcasecmp(command, "info") || !strcasecmp(command, "lolwut") ||
+         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats")) ||
+         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "htstats-key")) ||
+         (argc >= 2 && !strcasecmp(command, "debug") && !strcasecmp(argv[1], "client-eviction")) ||
+         (argc >= 2 && !strcasecmp(command, "memory") &&
+          (!strcasecmp(argv[1], "malloc-stats") || !strcasecmp(argv[1], "doctor"))) ||
+         (argc == 2 && !strcasecmp(command, "cluster") &&
+          (!strcasecmp(argv[1], "nodes") || !strcasecmp(argv[1], "info"))) ||
+         (argc >= 2 && !strcasecmp(command, "client") &&
+          (!strcasecmp(argv[1], "list") || !strcasecmp(argv[1], "info"))) ||
+         (argc == 3 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "graph")) ||
+         (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
+         /* Format PROXY INFO command for Cluster Proxy:
+          * https://github.com/artix75/redis-cluster-proxy */
+         (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info")))) {
         output_raw = 1;
     }
 


### PR DESCRIPTION
Example:
```
   127.0.0.1:6379> multi
   OK
   127.0.0.1:6379(TX)> client info
   QUEUED127.0.0.1:6379(TX)>
```

Fixes:  https://github.com/valkey-io/valkey/issues/1778
