### PR TITLE
Remove unicode optimization in Lua cjson library

### DIFF
--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -473,7 +473,7 @@ static void json_append_string(lua_State *l, strbuf_t *json, int lindex)
         abort(); /* Overflow check */
     strbuf_ensure_empty_length(json, len + 2);
 
-    strbuf_append_char(json, '\"');
+    strbuf_append_char_unsafe(json, '\"');
     for (i = 0; i < len; i++) {
         escstr = char2escape[(unsigned char)str[i]];
         if (escstr)

--- a/deps/lua/src/lua_cjson.c
+++ b/deps/lua/src/lua_cjson.c
@@ -469,23 +469,19 @@ static void json_append_string(lua_State *l, strbuf_t *json, int lindex)
 
     str = lua_tolstring(l, lindex, &len);
 
-    /* Worst case is len * 6 (all unicode escapes).
-     * This buffer is reused constantly for small strings
-     * If there are any excess pages, they won't be hit anyway.
-     * This gains ~5% speedup. */
-    if (len > SIZE_MAX / 6 - 3)
+    if (len > SIZE_MAX - 3)
         abort(); /* Overflow check */
-    strbuf_ensure_empty_length(json, len * 6 + 2);
+    strbuf_ensure_empty_length(json, len + 2);
 
-    strbuf_append_char_unsafe(json, '\"');
+    strbuf_append_char(json, '\"');
     for (i = 0; i < len; i++) {
         escstr = char2escape[(unsigned char)str[i]];
         if (escstr)
             strbuf_append_string(json, escstr);
         else
-            strbuf_append_char_unsafe(json, str[i]);
+            strbuf_append_char(json, str[i]);
     }
-    strbuf_append_char_unsafe(json, '\"');
+    strbuf_append_char(json, '\"');
 }
 
 /* Find the size of the array on the top of the Lua stack


### PR DESCRIPTION
The Lua cjson library implements an optimization that pre-allocates a string buffer by estimating the maximum memory used if all characters in a string require to be represented as unicode escapes, which may take 6 bytes each. Therefore, if a string has `len` bytes, the pre-allocated buffer will have `len * 6` bytes.

This optimization can easily cause OOM errors, because if someone uses a string with a few gigabytes of size, the pre-allocator will require 6 times the size of that string, and when running the Lua script in a small instance with low memory, it will make the valkey-server process to abort.

I ran the following Lua script to check if there is a significant performance regression:

```
local s = string.rep("a", 1024 * 1024 * 1024)
return #cjson.encode(s..s..s)
```

The execution duration, in seconds, for 3 runs before and after this commit is the following:

Before: 46.309; 42.443; 42.242

After: 46.729; 42.969; 42.774