### PR TITLE
Fix undefined behaviour in bitops unit test

### DIFF
--- a/src/unit/test_bitops.c
+++ b/src/unit/test_bitops.c
@@ -25,7 +25,8 @@ static long long bitcount(void *s, long count) {
 }
 
 static int test_case(const char *msg, int size) {
-    uint8_t buf[size];
+    size_t bufsize = size > 0 ? size : 1;
+    uint8_t buf[bufsize];
     int fuzzing = 1000;
     for (int y = 0; y < fuzzing; y += 1) {
         for (int z = 0; z < size; z += 1) {


### PR DESCRIPTION
The unit test was added in #1741. It fails when compiled with UBSAN. Using a local array like `char buf[size]` is undefined behaviour when `size == 0`. This fix just makes it size 1 in this case.

The failure I get locally:

    unit/test_bitops.c:28:13: runtime error: variable length array bound evaluates to non-positive value 0
