### PR TITLE
Consistent look and feel of licenses

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,7 @@
 # License 1
 
+SPDX-License-Identifier: BSD-3-Clause
+
 BSD 3-Clause License
 
 Copyright (c) 2024-present, Valkey contributors

--- a/deps/fast_float_c_interface/fast_float_strtod.cpp
+++ b/deps/fast_float_c_interface/fast_float_strtod.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "../fast_float/fast_float.h"

--- a/src/allocator_defrag.c
+++ b/src/allocator_defrag.c
@@ -1,8 +1,8 @@
-/* Copyright 2024- Valkey contributors
+/*
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
 /*
  * This file implements allocator-specific defragmentation logic used
  * within the Valkey engine. Below is the relationship between various

--- a/src/asciilogo.h
+++ b/src/asciilogo.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2009-2012, Redis Ltd.
- * Copyright (c) 2024, Valkey contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 const char *ascii_logo =
     "                .+^+.                                                \n"
     "            .+#########+.                                            \n"

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -26,9 +26,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- *
- * ---------------------------------------------------------------------------
- *
+ */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * API:
  *
  * blockClient() set the CLIENT_BLOCKED flag in the client, and set the

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -26,7 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 /*
  * cluster.c contains the common parts of a clustering
  * implementation, the parts that are shared between

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -26,7 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 /*
  * cluster_legacy.c contains the implementation of the cluster API that is
  * specific to the standard, cluster-bus based clustering mechanism.

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -1,9 +1,8 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
-
 #include "cluster_slot_stats.h"
 
 #define UNASSIGNED_SLOT 0

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 /* Commandlog implements a system that is able to remember the latest N
  * queries that took more than M microseconds to execute, or consumed
  * too much network bandwidth and memory for input/output buffers.
@@ -14,10 +20,6 @@
  * but is accessible thanks to the COMMANDLOG command.
  *
  * ----------------------------------------------------------------------------
- *
- * Copyright Valkey Contributors.
- * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
  */
 
 #include "commandlog.h"

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -32,6 +32,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include "hashtable.h"

--- a/src/dict.c
+++ b/src/dict.c
@@ -32,7 +32,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include "fmacros.h"
 
 #include <stddef.h>

--- a/src/eval.c
+++ b/src/eval.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 /*
  * This file initializes the global LUA object and registers functions to call Valkey API from within the LUA language.

--- a/src/expire.c
+++ b/src/expire.c
@@ -29,6 +29,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "functions.h"
 #include "sds.h"

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -28,6 +28,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include "intrinsics.h"

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -1,7 +1,7 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include "io_threads.h"

--- a/src/lua/engine_lua.c
+++ b/src/lua/engine_lua.c
@@ -1,5 +1,5 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -1,8 +1,9 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
- *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * This file utilizes prefetching keys and data for multiple commands in a batch,
  * to improve performance by amortizing memory access costs across multiple operations.
  */

--- a/src/module.c
+++ b/src/module.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 /* --------------------------------------------------------------------------
  * Modules API documentation information

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include "lzf.h" /* LZF compression library */

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -7,6 +7,11 @@
  * the top-level directory.
  * ==========================================================================
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #define VALKEYMODULE_CORE_MODULE
 #include "server.h"

--- a/src/replication.c
+++ b/src/replication.c
@@ -27,7 +27,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include "cluster.h"

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -1,5 +1,5 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/src/server.c
+++ b/src/server.c
@@ -26,7 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include "server.h"
 #include "monotonic.h"
 #include "cluster.h"

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include <math.h>

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include "hashtable.h"

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -26,6 +26,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 
 #include "server.h"
 #include <math.h> /* isnan(), isinf() */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -27,7 +27,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 /*-----------------------------------------------------------------------------
  * Sorted set API
  *----------------------------------------------------------------------------*/

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -1,7 +1,7 @@
 /*
- * Copyright Valkey contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <strings.h>

--- a/src/unit/test_valkey_strtod.c
+++ b/src/unit/test_valkey_strtod.c
@@ -1,9 +1,8 @@
 /*
- * Copyright Valkey Contributors.
+ * Copyright (c) Valkey Contributors
  * All rights reserved.
- * SPDX-License-Identifier: BSD 3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  */
-
 
 #include "../valkey_strtod.h"
 #include "errno.h"

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -27,7 +27,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include "fmacros.h"
 
 #include <stdio.h>


### PR DESCRIPTION
Use a consistent set of licenses for Valkey files. I took a look and applied sort of a "did we make a material change in this file?" and tried to be conservative in adding the trademark. We could also be liberal as well.

Resolves: https://github.com/valkey-io/valkey/issues/1692.

Included documentation about the licensing here: https://github.com/valkey-io/valkey/pull/1787.

Licenses are now also always explicitly first, even above documentation in files.