### PR TITLE
Migrate binaries build to ARM github runners

### DIFF
--- a/.github/actions/generate-package-build-matrix/build-config.json
+++ b/.github/actions/generate-package-build-matrix/build-config.json
@@ -21,15 +21,15 @@
         },
         {
           "arch": "arm64",
-          "target": "ubuntu20.04",
+          "target": "ubuntu-22.04-arm",
           "type": "deb",
-          "platform": "focal"
+          "platform": "jammy"
         },
         {
           "arch": "arm64",
-          "target": "ubuntu22.04",
+          "target": "ubuntu-24.04-arm",
           "type": "deb",
-          "platform": "jammy"
+          "platform": "noble"
         }
       ]
 }

--- a/.github/workflows/call-build-linux-arm-packages.yml
+++ b/.github/workflows/call-build-linux-arm-packages.yml
@@ -35,7 +35,7 @@ jobs:
   build-valkey:
     # Capture source tarball and generate checksum for it
     name: Build package ${{ matrix.distro.target }} ${{ matrix.distro.arch }}
-    runs-on: "ubuntu-24.04-arm"
+    runs-on: ${{matrix.distro.target}}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.build_matrix) }}
@@ -51,13 +51,11 @@ jobs:
           aws-region: ${{ inputs.region }}
           role-to-assume: ${{ secrets.role_to_assume }}
 
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev libsystemd-dev
+
       - name: Make Valkey
-        uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: aarch64
-          distro: ${{matrix.distro.target}}
-          install: apt-get update && apt-get install -y build-essential libssl-dev libsystemd-dev
-          run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
+        run: make -C src all BUILD_TLS=yes USE_SYSTEMD=yes
 
       - name: Create Tarball and SHA256sums
         run: |


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/1720 https://github.com/valkey-io/valkey/issues/1740 https://github.com/valkey-io/valkey/pull/1742 

The issue was that we were previously using github action that emulated the arm build, the aim was to migrate the workflow to used github arm runners which were released for public in January.

This PR migrates the workflows to run on github hosted arm runners for each ubuntu version that is currently supported

Here is an example successful workflow run from my personal repository: https://github.com/roshkhatri/valkey/actions/runs/13557505302/job/37894541269

<img width="1287" alt="Screenshot 2025-02-26 at 6 32 00 PM" src="https://github.com/user-attachments/assets/623d5485-da5f-47cf-8373-9a75b32cfff8" />

It is much faster than what it used to take with emulation that is around 21 mins.

Now it takes approx 4-5 mins.