### PR TITLE
Adding json support for log-format config

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -395,28 +395,6 @@ void freeCliConnInfo(cliConnInfo connInfo) {
     if (connInfo.user) sdsfree(connInfo.user);
 }
 
-/*
- * Escape a Unicode string for JSON output (--json), following RFC 7159:
- * https://datatracker.ietf.org/doc/html/rfc7159#section-7
- */
-sds escapeJsonString(sds s, const char *p, size_t len) {
-    s = sdscatlen(s, "\"", 1);
-    while (len--) {
-        switch (*p) {
-        case '\\':
-        case '"': s = sdscatprintf(s, "\\%c", *p); break;
-        case '\n': s = sdscatlen(s, "\\n", 2); break;
-        case '\f': s = sdscatlen(s, "\\f", 2); break;
-        case '\r': s = sdscatlen(s, "\\r", 2); break;
-        case '\t': s = sdscatlen(s, "\\t", 2); break;
-        case '\b': s = sdscatlen(s, "\\b", 2); break;
-        default: s = sdscatprintf(s, *(unsigned char *)p <= 0x1f ? "\\u%04x" : "%c", *p);
-        }
-        p++;
-    }
-    return sdscatlen(s, "\"", 1);
-}
-
 sds cliVersion(void) {
     sds version = sdscatprintf(sdsempty(), "%s", VALKEY_VERSION);
 

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -49,8 +49,6 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
 
 void freeCliConnInfo(cliConnInfo connInfo);
 
-sds escapeJsonString(sds s, const char *p, size_t len);
-
 sds cliVersion(void);
 
 valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock, int multipath);

--- a/src/config.c
+++ b/src/config.c
@@ -165,7 +165,7 @@ configEnum propagation_error_behavior_enum[] = {
     {"panic-on-replicas", PROPAGATION_ERR_BEHAVIOR_PANIC_ON_REPLICAS},
     {NULL, 0}};
 
-configEnum log_format_enum[] = {{"legacy", LOG_FORMAT_LEGACY}, {"logfmt", LOG_FORMAT_LOGFMT}, {NULL, 0}};
+configEnum log_format_enum[] = {{"legacy", LOG_FORMAT_LEGACY}, {"logfmt", LOG_FORMAT_LOGFMT}, {"json", LOG_FORMAT_JSON}, {NULL, 0}};
 
 configEnum log_timestamp_format_enum[] = {{"legacy", LOG_TIMESTAMP_LEGACY},
                                           {"iso8601", LOG_TIMESTAMP_ISO8601},

--- a/src/server.c
+++ b/src/server.c
@@ -50,6 +50,7 @@
 #include "sds.h"
 #include "module.h"
 #include "scripting_engine.h"
+#include "util.h"
 
 #include "eval.h"
 

--- a/src/server.c
+++ b/src/server.c
@@ -182,7 +182,6 @@ void serverLogRaw(int level, const char *msg) {
     const char *verbose_level[] = {"debug", "info", "notice", "warning"};
     const char *roles[] = {"sentinel", "RDB/AOF", "replica", "primary"};
     const char *role_chars = "XCSM";
-    const char *json_format = "{\"pid\":%d,\"role\":\"%s\",\"timestamp\":\"%s\",\"level\":\"%s\",\"message\":\"%s\"}\n";
     const char *logfmt_format = "pid=%d role=%s timestamp=\"%s\" level=%s message=\"%s\"\n";
     FILE *fp;
     char buf[64];
@@ -236,17 +235,22 @@ void serverLogRaw(int level, const char *msg) {
         }
         switch (server.log_format) {
         case LOG_FORMAT_LOGFMT:
-        case LOG_FORMAT_JSON:
             if (hasInvalidLogfmtChar(msg)) {
                 char safemsg[LOG_MAX_LEN];
                 filterInvalidLogfmtChar(safemsg, LOG_MAX_LEN, msg);
-                fprintf(fp, server.log_format == LOG_FORMAT_LOGFMT ? logfmt_format : json_format, (int)getpid(), roles[role_index],
-                        buf, verbose_level[level], safemsg);
+                fprintf(fp, logfmt_format, (int)getpid(), roles[role_index], buf, verbose_level[level], safemsg);
             } else {
-                fprintf(fp, server.log_format == LOG_FORMAT_LOGFMT ? logfmt_format : json_format, (int)getpid(), roles[role_index],
-                        buf, verbose_level[level], msg);
+                fprintf(fp, logfmt_format, (int)getpid(), roles[role_index], buf, verbose_level[level], msg);
             }
             break;
+
+        case LOG_FORMAT_JSON: {
+            sds jsonmsg = escapeJsonString(sdsempty(), msg, strlen(msg));
+            fprintf(fp, "{\"pid\":%d,\"role\":\"%s\",\"timestamp\":\"%s\",\"level\":\"%s\",\"message\":%s}\n",
+                    (int)getpid(), roles[role_index], buf, verbose_level[level], jsonmsg);
+            sdsfree(jsonmsg);
+            break;
+        }
 
         case LOG_FORMAT_LEGACY:
             fprintf(fp, "%d:%c %s %c %s\n", (int)getpid(), role_chars[role_index], buf, c[level], msg);

--- a/src/server.c
+++ b/src/server.c
@@ -182,6 +182,8 @@ void serverLogRaw(int level, const char *msg) {
     const char *verbose_level[] = {"debug", "info", "notice", "warning"};
     const char *roles[] = {"sentinel", "RDB/AOF", "replica", "primary"};
     const char *role_chars = "XCSM";
+    const char *json_format = "{\"pid\":%d,\"role\":\"%s\",\"timestamp\":\"%s\",\"level\":\"%s\",\"message\":\"%s\"}\n";
+    const char *logfmt_format = "pid=%d role=%s timestamp=\"%s\" level=%s message=\"%s\"\n";
     FILE *fp;
     char buf[64];
     int rawmode = (level & LL_RAW);
@@ -234,13 +236,14 @@ void serverLogRaw(int level, const char *msg) {
         }
         switch (server.log_format) {
         case LOG_FORMAT_LOGFMT:
+        case LOG_FORMAT_JSON:
             if (hasInvalidLogfmtChar(msg)) {
                 char safemsg[LOG_MAX_LEN];
                 filterInvalidLogfmtChar(safemsg, LOG_MAX_LEN, msg);
-                fprintf(fp, "pid=%d role=%s timestamp=\"%s\" level=%s message=\"%s\"\n", (int)getpid(), roles[role_index],
+                fprintf(fp, server.log_format == LOG_FORMAT_LOGFMT ? logfmt_format : json_format, (int)getpid(), roles[role_index],
                         buf, verbose_level[level], safemsg);
             } else {
-                fprintf(fp, "pid=%d role=%s timestamp=\"%s\" level=%s message=\"%s\"\n", (int)getpid(), roles[role_index],
+                fprintf(fp, server.log_format == LOG_FORMAT_LOGFMT ? logfmt_format : json_format, (int)getpid(), roles[role_index],
                         buf, verbose_level[level], msg);
             }
             break;

--- a/src/server.h
+++ b/src/server.h
@@ -625,7 +625,8 @@ typedef enum {
 
 /* Sets log format */
 typedef enum { LOG_FORMAT_LEGACY = 0,
-               LOG_FORMAT_LOGFMT } log_format_type;
+               LOG_FORMAT_LOGFMT,
+               LOG_FORMAT_JSON } log_format_type;
 
 /* Sets log timestamp format */
 typedef enum { LOG_TIMESTAMP_LEGACY = 0,

--- a/src/util.c
+++ b/src/util.c
@@ -1621,3 +1621,25 @@ void writePointerWithPadding(unsigned char *buf, const void *ptr) {
     /* if it is 32-bit system, pad the remaining 4 bytes with zero */
     if (ptr_size == 4) memset(buf + ptr_size, 0, ptr_size);
 }
+
+/*
+ * Escape a Unicode string for JSON output, following RFC 7159:
+ * https://datatracker.ietf.org/doc/html/rfc7159#section-7
+ */
+sds escapeJsonString(sds s, const char *p, size_t len) {
+    s = sdscatlen(s, "\"", 1);
+    while (len--) {
+        switch (*p) {
+        case '\\':
+        case '"': s = sdscatprintf(s, "\\%c", *p); break;
+        case '\n': s = sdscatlen(s, "\\n", 2); break;
+        case '\f': s = sdscatlen(s, "\\f", 2); break;
+        case '\r': s = sdscatlen(s, "\\r", 2); break;
+        case '\t': s = sdscatlen(s, "\\t", 2); break;
+        case '\b': s = sdscatlen(s, "\\b", 2); break;
+        default: s = sdscatprintf(s, *(unsigned char *)p <= 0x1f ? "\\u%04x" : "%c", *p);
+        }
+        p++;
+    }
+    return sdscatlen(s, "\"", 1);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -122,5 +122,6 @@ void getRandomBytes(unsigned char *p, size_t len);
 long long ustime(void);
 mstime_t mstime(void);
 void writePointerWithPadding(unsigned char *buf, const void *ptr);
+sds escapeJsonString(sds s, const char *p, size_t len);
 
 #endif

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -68,6 +68,7 @@
 #include "ae.h"
 #include "connection.h"
 #include "cli_common.h"
+#include "util.h"
 #include "mt19937-64.h"
 #include "cli_commands.h"
 
@@ -315,20 +316,6 @@ size_t valkey_strlcpy(char *dst, const char *src, size_t dsize);
 static void cliPushHandler(void *, void *);
 
 uint16_t crc16(const char *buf, int len);
-
-static long long ustime(void) {
-    struct timeval tv;
-    long long ust;
-
-    gettimeofday(&tv, NULL);
-    ust = ((long long)tv.tv_sec) * 1000000;
-    ust += tv.tv_usec;
-    return ust;
-}
-
-static long long mstime(void) {
-    return ustime() / 1000;
-}
 
 static void cliRefreshPrompt(void) {
     if (config.eval_ldb) return;

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -146,11 +146,34 @@ if {$backtrace_supported} {
 
 # test JSON log format with special characters
 start_server {overrides {log-format json}} {
-    test {JSON log format properly escapes special characters} {
+    test {JSON log format escapes backslash and double quote} {
         set log_lines [count_log_lines 0]
+        r debug log "Test \"quotes\" and \\backslash\\"
+        verify_log_message 0 {*"message":"DEBUG LOG: Test \\"quotes\\" and \\\\backslash\\\\"*} $log_lines
+    }
 
-        r debug log "Test \"quotes\" and \\backslash\\ and newline"
-        verify_log_message 0 {*\"message\":\"DEBUG LOG: Test \\"quotes\\" and \\\\backslash\\\\*} $log_lines
+    test {JSON log format escapes tab character} {
+        set log_lines [count_log_lines 0]
+        r debug log "Test\ttab"
+        verify_log_message 0 {*"message":"DEBUG LOG: Test\\ttab"*} $log_lines
+    }
+
+    test {JSON log format escapes carriage return} {
+        set log_lines [count_log_lines 0]
+        r debug log "Test\rcarriage"
+        verify_log_message 0 {*"message":"DEBUG LOG: Test\\rcarriage"*} $log_lines
+    }
+
+    test {JSON log format escapes form feed} {
+        set log_lines [count_log_lines 0]
+        r debug log "Test\fformfeed"
+        verify_log_message 0 {*"message":"DEBUG LOG: Test\\fformfeed"*} $log_lines
+    }
+
+    test {JSON log format escapes backspace} {
+        set log_lines [count_log_lines 0]
+        r debug log "Test\bbackspace"
+        verify_log_message 0 {*"message":"DEBUG LOG: Test\\bbackspace"*} $log_lines
     }
 }
 

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -53,7 +53,7 @@ if {$backtrace_supported} {
         test "Server is able to generate a stack trace on selected systems" {
             r config set watchdog-period 200
             r debug sleep 1
-            
+
             check_log_backtrace_for_debug "*WATCHDOG TIMER EXPIRED*"
             # make sure the server is still alive
             assert_equal "PONG" [r ping]
@@ -65,7 +65,7 @@ if {$backtrace_supported} {
 if {!$::valgrind} {
     if {$backtrace_supported} {
         set check_cb check_log_backtrace_for_debug
-    } else {  
+    } else {
         set check_cb check_crash_log
     }
 
@@ -141,6 +141,16 @@ if {$backtrace_supported} {
             catch {r debug assert}
             check_log_backtrace_for_debug "*ASSERTION FAILED*"
         }
+    }
+}
+
+# test JSON log format with special characters
+start_server {overrides {log-format json}} {
+    test {JSON log format properly escapes special characters} {
+        set log_lines [count_log_lines 0]
+
+        r debug log "Test \"quotes\" and \\backslash\\ and newline"
+        verify_log_message 0 {*\"message\":\"DEBUG LOG: Test \\"quotes\\" and \\\\backslash\\\\*} $log_lines
     }
 }
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -425,7 +425,7 @@ loglevel notice
 #
 # - legacy: the default, traditional log format
 # - logfmt: a structured log format; see https://www.brandur.org/logfmt
-# - json: a structured log format; see https://json.org/
+# - json: a structured log format
 #
 # log-format legacy
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -425,6 +425,7 @@ loglevel notice
 #
 # - legacy: the default, traditional log format
 # - logfmt: a structured log format; see https://www.brandur.org/logfmt
+# - json: a structured log format; see https://json.org/
 #
 # log-format legacy
 


### PR DESCRIPTION
Introduce a json log format that can be invoked by passing `log-format json` in your config.

We also refactor `escapeJsonString` to `util` since it is now a shared function.

Closes: https://github.com/valkey-io/valkey/issues/1006
