### PR TITLE
Replaced the use of sdsReplyDictType and hashDictType.

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1162,14 +1162,6 @@ void addReplyBulkSds(client *c, sds s) {
     _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
-void addWritePreparedReplyBulkSds(writePreparedClient *wpc, sds s) {
-    client *c = (client *)wpc;
-    _addReplyLongLongWithPrefix(c, sdslen(s), '$');
-    _addReplyToBufferOrList(c, s, sdslen(s));
-    sdsfree(s);
-    _addReplyToBufferOrList(c, "\r\n", 2);
-}
-
 /* Set sds to a deferred reply (for symmetry with addReplyBulkSds it also frees the sds) */
 void setDeferredReplyBulkSds(client *c, void *node, sds s) {
     sds reply = sdscatprintf(sdsempty(), "$%d\r\n%s\r\n", (unsigned)sdslen(s), s);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1162,6 +1162,14 @@ void addReplyBulkSds(client *c, sds s) {
     _addReplyToBufferOrList(c, "\r\n", 2);
 }
 
+void addWritePreparedReplyBulkSds(writePreparedClient *wpc, sds s) {
+    client *c = (client *)wpc;
+    _addReplyLongLongWithPrefix(c, sdslen(s), '$');
+    _addReplyToBufferOrList(c, s, sdslen(s));
+    sdsfree(s);
+    _addReplyToBufferOrList(c, "\r\n", 2);
+}
+
 /* Set sds to a deferred reply (for symmetry with addReplyBulkSds it also frees the sds) */
 void setDeferredReplyBulkSds(client *c, void *node, sds s) {
     sds reply = sdscatprintf(sdsempty(), "$%d\r\n%s\r\n", (unsigned)sdslen(s), s);

--- a/src/server.c
+++ b/src/server.c
@@ -678,16 +678,6 @@ dictType hashDictType = {
     NULL,              /* allow to expand */
 };
 
-/* Dict type without destructor */
-dictType sdsReplyDictType = {
-    dictSdsHash,       /* hash function */
-    NULL,              /* key dup */
-    dictSdsKeyCompare, /* key compare */
-    NULL,              /* key destructor */
-    NULL,              /* val destructor */
-    NULL               /* allow to expand */
-};
-
 /* Hashtable type without destructor */
 hashtableType sdsReplyHashtableType = {
     .hashFunction = dictSdsCaseHash,

--- a/src/server.c
+++ b/src/server.c
@@ -668,16 +668,6 @@ hashtableType hashHashtableType = {
     .entryDestructor = hashHashtableTypeDestructor,
 };
 
-/* Hash type hash table (note that small hashes are represented with listpacks) */
-dictType hashDictType = {
-    dictSdsHash,       /* hash function */
-    NULL,              /* key dup */
-    dictSdsKeyCompare, /* key compare */
-    dictSdsDestructor, /* key destructor */
-    dictSdsDestructor, /* val destructor */
-    NULL,              /* allow to expand */
-};
-
 /* Hashtable type without destructor */
 hashtableType sdsReplyHashtableType = {
     .hashFunction = dictSdsCaseHash,

--- a/src/server.h
+++ b/src/server.h
@@ -2569,7 +2569,6 @@ extern dictType clientDictType;
 extern dictType objToDictDictType;
 extern hashtableType kvstoreChannelHashtableType;
 extern dictType modulesDictType;
-extern dictType sdsReplyDictType;
 extern hashtableType sdsReplyHashtableType;
 extern dictType keylistDictType;
 extern dict *modules;

--- a/src/server.h
+++ b/src/server.h
@@ -2671,6 +2671,7 @@ void addReply(client *c, robj *obj);
 void addReplyStatusLength(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
 void addReplyBulkSds(client *c, sds s);
+void addWritePreparedReplyBulkSds(writePreparedClient *c, sds s);
 void setDeferredReplyBulkSds(client *c, void *node, sds s);
 void addReplyErrorObject(client *c, robj *err);
 void addReplyOrErrorObject(client *c, robj *reply);

--- a/src/server.h
+++ b/src/server.h
@@ -2560,7 +2560,6 @@ extern hashtableType zsetHashtableType;
 extern hashtableType kvstoreKeysHashtableType;
 extern hashtableType kvstoreExpiresHashtableType;
 extern double R_Zero, R_PosInf, R_NegInf, R_Nan;
-extern dictType hashDictType;
 extern hashtableType hashHashtableType;
 extern dictType stringSetDictType;
 extern dictType externalStringType;

--- a/src/server.h
+++ b/src/server.h
@@ -2671,7 +2671,6 @@ void addReply(client *c, robj *obj);
 void addReplyStatusLength(client *c, const char *s, size_t len);
 void addReplySds(client *c, sds s);
 void addReplyBulkSds(client *c, sds s);
-void addWritePreparedReplyBulkSds(writePreparedClient *c, sds s);
 void setDeferredReplyBulkSds(client *c, void *node, sds s);
 void addReplyErrorObject(client *c, robj *err);
 void addReplyOrErrorObject(client *c, robj *reply);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1272,7 +1272,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             addWritePreparedReplyBulkSds(wpc, sdsdup(field));
             if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));
         }
-        
+
         hashtableResetIterator(&iter);
         hashtableRelease(ht);
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1239,50 +1239,50 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * used into CASE 4 is highly inefficient. */
     if (count * HRANDFIELD_SUB_STRATEGY_MUL > size) {
         /* Hashtable encoding (generic implementation) */
-        dict *d = dictCreate(&sdsReplyDictType);
-        dictExpand(d, size);
+        hashtable *ht = hashtableCreate(&hashHashtableType);
+        hashtableExpand(ht, size);
         hashTypeIterator hi;
         hashTypeInitIterator(hash, &hi);
 
-        /* Add all the elements into the temporary dictionary. */
-        while ((hashTypeNext(&hi)) != C_ERR) {
-            int ret = DICT_ERR;
+        /* Add all the elements into the temporary hashtable. */
+        while (hashTypeNext(&hi) != C_ERR) {
+            int ret = 0;
             sds field, value = NULL;
 
             field = hashTypeCurrentObjectNewSds(&hi, OBJ_HASH_FIELD);
             if (withvalues) value = hashTypeCurrentObjectNewSds(&hi, OBJ_HASH_VALUE);
-            ret = dictAdd(d, field, value);
-
-            serverAssert(ret == DICT_OK);
+            hashTypeEntry *entry = hashTypeCreateEntry(field, value);
+            sdsfree(field);
+            ret = hashtableAdd(ht, entry);
+            serverAssert(ret);
         }
-        serverAssert(dictSize(d) == size);
+        serverAssert(hashtableSize(ht) == size);
         hashTypeResetIterator(&hi);
 
         /* Remove random elements to reach the right count. */
         while (size > count) {
-            dictEntry *de;
-            de = dictGetFairRandomKey(d);
-            dictUnlink(d, dictGetKey(de));
-            sdsfree(dictGetKey(de));
-            sdsfree(dictGetVal(de));
-            dictFreeUnlinkedEntry(d, de);
+            void *element;
+            hashtableFairRandomEntry(ht, &element);
+            sds field = hashTypeEntryGetField((hashTypeEntry*)element);
+            hashtableDelete(ht, field);
             size--;
         }
 
-        /* Reply with what's in the dict and release memory */
-        dictIterator *di;
-        dictEntry *de;
-        di = dictGetIterator(d);
-        while ((de = dictNext(di)) != NULL) {
-            sds field = dictGetKey(de);
-            sds value = dictGetVal(de);
+        /* Reply with what's in the temporary hashtable and release memory */
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, ht, 0);
+        void *next;
+        while (hashtableNext(&iter, &next)) {
+            hashTypeEntry* entry = (hashTypeEntry*)next;
+            sds field = hashTypeEntryGetField(entry);
+            sds value = hashTypeEntryGetValue(entry);
             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-            addWritePreparedReplyBulkSds(wpc, field);
-            if (withvalues) addWritePreparedReplyBulkSds(wpc, value);
+            addWritePreparedReplyBulkSds(wpc, sdsdup(field));
+            if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));
         }
-
-        dictReleaseIterator(di);
-        dictRelease(d);
+        
+        hashtableResetIterator(&iter);
+        hashtableRelease(ht);
     }
 
     /* CASE 4: We have a big hash compared to the requested number of elements.
@@ -1293,16 +1293,16 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
         listpackEntry field, value;
-        dict *d = dictCreate(&hashDictType);
-        dictExpand(d, count);
+        hashtable *ht = hashtableCreate(&setHashtableType);
+        hashtableExpand(ht, count);
         while (added < count) {
             hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL);
 
-            /* Try to add the object to the dictionary. If it already exists
+            /* Try to add the object to the hashtable. If it already exists
              * free it, otherwise increment the number of objects we have
-             * in the result dictionary. */
+             * in the result hashtable. */
             sds sfield = hashSdsFromListpackEntry(&field);
-            if (dictAdd(d, sfield, NULL) != DICT_OK) {
+            if (!hashtableAdd(ht, sfield)) {
                 sdsfree(sfield);
                 continue;
             }
@@ -1315,7 +1315,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         }
 
         /* Release memory */
-        dictRelease(d);
+        hashtableRelease(ht);
     }
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1246,9 +1246,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
 
         /* Add all the elements into the temporary hashtable. */
         while (hashTypeNext(&hi) != C_ERR) {
-            int ret = 0;
-            ret = hashtableAdd(ht, (&hi)->next);
-            serverAssert(ret);
+            serverAssert(hashtableAdd(ht, (&hi)->next));
         }
         serverAssert(hashtableSize(ht) == size);
         hashTypeResetIterator(&hi);
@@ -1269,8 +1267,10 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             sds field = hashTypeEntryGetField(next);
             sds value = hashTypeEntryGetValue(next);
             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-            addWritePreparedReplyBulkSds(wpc, sdsdup(field));
-            if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));
+            addReplyBulkCBuffer(c, field, sdslen(field));
+            // addWritePreparedReplyBulkSds(wpc, sdsdup(field));
+            if (withvalues) addReplyBulkCBuffer(c, value, sdslen(value));
+            // if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));
         }
 
         hashtableResetIterator(&iter);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1267,8 +1267,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             sds field = hashTypeEntryGetField(next);
             sds value = hashTypeEntryGetValue(next);
             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-            addReplyBulkCBuffer(c, field, sdslen(field));
-            if (withvalues) addReplyBulkCBuffer(c, value, sdslen(value));
+            addWritePreparedReplyBulkCBuffer(wpc, field, sdslen(field));
+            if (withvalues) addWritePreparedReplyBulkCBuffer(wpc, value, sdslen(value));
         }
 
         hashtableResetIterator(&iter);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1241,15 +1241,17 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         /* Hashtable encoding (generic implementation) */
         hashtable *ht = hashtableCreate(&sdsReplyHashtableType);
         hashtableExpand(ht, size);
-        hashTypeIterator hi;
-        hashTypeInitIterator(hash, &hi);
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, hash->ptr, 0);
+        void *entry;
 
         /* Add all the elements into the temporary hashtable. */
-        while (hashTypeNext(&hi) != C_ERR) {
-            serverAssert(hashtableAdd(ht, (&hi)->next));
+        while (hashtableNext(&iter, &entry)) {
+            int res = hashtableAdd(ht, entry);
+            serverAssert(res);
         }
         serverAssert(hashtableSize(ht) == size);
-        hashTypeResetIterator(&hi);
+        hashtableResetIterator(&iter);
 
         /* Remove random elements to reach the right count. */
         while (size > count) {
@@ -1260,7 +1262,6 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         }
 
         /* Reply with what's in the temporary hashtable and release memory */
-        hashtableIterator iter;
         hashtableInitIterator(&iter, ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1239,7 +1239,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * used into CASE 4 is highly inefficient. */
     if (count * HRANDFIELD_SUB_STRATEGY_MUL > size) {
         /* Hashtable encoding (generic implementation) */
-        hashtable *ht = hashtableCreate(&hashHashtableType);
+        hashtable *ht = hashtableCreate(&sdsReplyHashtableType);
         hashtableExpand(ht, size);
         hashTypeIterator hi;
         hashTypeInitIterator(hash, &hi);
@@ -1247,13 +1247,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         /* Add all the elements into the temporary hashtable. */
         while (hashTypeNext(&hi) != C_ERR) {
             int ret = 0;
-            sds field, value = NULL;
-
-            field = hashTypeCurrentObjectNewSds(&hi, OBJ_HASH_FIELD);
-            if (withvalues) value = hashTypeCurrentObjectNewSds(&hi, OBJ_HASH_VALUE);
-            hashTypeEntry *entry = hashTypeCreateEntry(field, value);
-            sdsfree(field);
-            ret = hashtableAdd(ht, entry);
+            ret = hashtableAdd(ht, (&hi)->next);
             serverAssert(ret);
         }
         serverAssert(hashtableSize(ht) == size);
@@ -1263,8 +1257,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         while (size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            sds field = hashTypeEntryGetField((hashTypeEntry*)element);
-            hashtableDelete(ht, field);
+            hashtableDelete(ht, element);
             size--;
         }
 
@@ -1273,9 +1266,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         hashtableInitIterator(&iter, ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {
-            hashTypeEntry* entry = (hashTypeEntry*)next;
-            sds field = hashTypeEntryGetField(entry);
-            sds value = hashTypeEntryGetValue(entry);
+            sds field = hashTypeEntryGetField(next);
+            sds value = hashTypeEntryGetValue(next);
             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
             addWritePreparedReplyBulkSds(wpc, sdsdup(field));
             if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1268,9 +1268,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             sds value = hashTypeEntryGetValue(next);
             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
             addReplyBulkCBuffer(c, field, sdslen(field));
-            // addWritePreparedReplyBulkSds(wpc, sdsdup(field));
             if (withvalues) addReplyBulkCBuffer(c, value, sdslen(value));
-            // if (withvalues) addWritePreparedReplyBulkSds(wpc, sdsdup(value));
         }
 
         hashtableResetIterator(&iter);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4180,7 +4180,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     /* CASE 3:
      * The number of elements inside the zset is not greater than
      * ZRANDMEMBER_SUB_STRATEGY_MUL times the number of requested elements.
-     * In this case we create a dict from scratch with all the elements, and
+     * In this case we create a hashtable from scratch with all the elements, and
      * subtract random elements to reach the requested number of elements.
      *
      * This is done because if the number of requested elements is just
@@ -4188,39 +4188,41 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * used into CASE 4 is highly inefficient. */
     if (count * ZRANDMEMBER_SUB_STRATEGY_MUL > size) {
         /* Hashtable encoding (generic implementation) */
-        dict *d = dictCreate(&sdsReplyDictType);
-        dictExpand(d, size);
-        /* Add all the elements into the temporary dictionary. */
-        while (zuiNext(&src, &zval)) {
-            sds key = zuiNewSdsFromValue(&zval);
-            dictEntry *de = dictAddRaw(d, key, NULL);
-            serverAssert(de);
-            if (withscores) dictSetDoubleVal(de, zval.score);
+        hashtable *ht = hashtableCreate(&zsetHashtableType);
+        hashtableExpand(ht, size);
+        zset *zs = src.subject->ptr;
+        hashtableIterator iter;
+        hashtableInitIterator(&iter, zs->ht, 0);
+        void* entry;
+        /* Add all the elements into the temporary hashtable. */
+        while (hashtableNext(&iter, &entry)) {
+            int res = hashtableAdd(ht, entry);
+            serverAssert(res);
         }
-        serverAssert(dictSize(d) == size);
+        serverAssert(hashtableSize(ht) == size);
 
         /* Remove random elements to reach the right count. */
         while (size > count) {
-            dictEntry *de;
-            de = dictGetFairRandomKey(d);
-            dictUnlink(d, dictGetKey(de));
-            sdsfree(dictGetKey(de));
-            dictFreeUnlinkedEntry(d, de);
+            void *element;
+            hashtableFairRandomEntry(ht, &element);
+            hashtableDelete(ht, ((zskiplistNode*)element)->ele);
             size--;
         }
+        hashtableResetIterator(&iter);
 
-        /* Reply with what's in the dict and release memory */
-        dictIterator *di;
-        dictEntry *de;
-        di = dictGetIterator(d);
-        while ((de = dictNext(di)) != NULL) {
+        /* Reply with what's in the temporary hashtable and release memory */
+        hashtableInitIterator(&iter, ht, 0);
+        void *next;
+        while (hashtableNext(&iter, &next)) {
+            zskiplistNode* node = (zskiplistNode*)next;
+            sds key = node->ele;
             if (withscores && c->resp > 2) addReplyArrayLen(c, 2);
-            addReplyBulkSds(c, dictGetKey(de));
-            if (withscores) addReplyDouble(c, dictGetDoubleVal(de));
+            addReplyBulkCBuffer(c, key, sdslen(key));
+            if (withscores) addReplyDouble(c, node->score);
         }
 
-        dictReleaseIterator(di);
-        dictRelease(d);
+        hashtableResetIterator(&iter);
+        hashtableRelease(ht);
     }
 
     /* CASE 4: We have a big zset compared to the requested number of elements.
@@ -4230,19 +4232,19 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
     else {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
-        dict *d = dictCreate(&hashDictType);
-        dictExpand(d, count);
+        hashtable *ht = hashtableCreate(&setHashtableType);
+        hashtableExpand(ht, count);
 
         while (added < count) {
             listpackEntry key;
             double score;
             zsetTypeRandomElement(zsetobj, size, &key, withscores ? &score : NULL);
 
-            /* Try to add the object to the dictionary. If it already exists
+            /* Try to add the object to the hashtable. If it already exists
              * free it, otherwise increment the number of objects we have
-             * in the result dictionary. */
+             * in the result hashtable. */
             sds skey = zsetSdsFromListpackEntry(&key);
-            if (dictAdd(d, skey, NULL) != DICT_OK) {
+            if (!hashtableAdd(ht, skey)) {
                 sdsfree(skey);
                 continue;
             }
@@ -4254,7 +4256,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         }
 
         /* Release memory */
-        dictRelease(d);
+        hashtableRelease(ht);
     }
     zuiClearIterator(&src);
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4193,7 +4193,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         zset *zs = src.subject->ptr;
         hashtableIterator iter;
         hashtableInitIterator(&iter, zs->ht, 0);
-        void* entry;
+        void *entry;
         /* Add all the elements into the temporary hashtable. */
         while (hashtableNext(&iter, &entry)) {
             int res = hashtableAdd(ht, entry);
@@ -4205,7 +4205,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         while (size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            hashtableDelete(ht, ((zskiplistNode*)element)->ele);
+            hashtableDelete(ht, ((zskiplistNode *)element)->ele);
             size--;
         }
         hashtableResetIterator(&iter);
@@ -4214,7 +4214,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         hashtableInitIterator(&iter, ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {
-            zskiplistNode* node = (zskiplistNode*)next;
+            zskiplistNode *node = (zskiplistNode *)next;
             sds key = node->ele;
             if (withscores && c->resp > 2) addReplyArrayLen(c, 2);
             addReplyBulkCBuffer(c, key, sdslen(key));


### PR DESCRIPTION
This PR resolves #1550 by replacing the use of temporary dict structures with hashtable for random elements selection. 

hrandfieldWithCountCommand:

CASE 3: Replaced sdsReplyDictType with sdsReplyHashtableType to store a pointer to the entry. 
CASE 4: Replaced hashDictType with setHashtableType, as only the field needs to be stored.

zrandmemberWithCountCommand:
used similar logic to replace the use of hashDictType and sdsReplyDictType in CASE 3.

RDB load skiplist field duplication validation logic:
Replace use of dict for storing listpack/hash loaded fields when detecting duplications.  

