### PR TITLE
Fix clang build error in bitops.c

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -30,15 +30,10 @@
 
 #include "server.h"
 #ifdef HAVE_AVX2
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
+/* Define __MM_MALLOC_H to prevent importing the memory aligned
+ * allocation functions, which we don't use. */
+#define __MM_MALLOC_H
 #include <immintrin.h>
-
-#pragma clang diagnostic pop
-#pragma GCC diagnostic pop
 #endif
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -30,8 +30,15 @@
 
 #include "server.h"
 #ifdef HAVE_AVX2
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 #include <immintrin.h>
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 /* -----------------------------------------------------------------------------
  * Helpers and low level bit functions.

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -30,6 +30,7 @@
 
 #include "server.h"
 #ifdef HAVE_AVX2
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <immintrin.h>
 #endif
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
In a recent PR https://github.com/valkey-io/valkey/pull/1741 the new header `<immintrin.h>` was added, which transitively includes `<mm_malloc.h>` header, where a function called `_mm_malloc(...)` makes a call to the `malloc` function.

The Valkey server code explicitly sets the malloc function as a deprecated function in `server.h`:
```c
void *malloc(size_t size) __attribute__((deprecated));
```

The Valkey server code is then compiled with
`-Werror=deprecated-declarations` option to detect the uses of deprecated functions like `malloc`, and due to this, when the `bitops.c` file is compiled with Clang, fails with the following error:

```
In file included from bitops.c:33:
In file included from /usr/lib/llvm-18/lib/clang/18/include/immintrin.h:26:
In file included from /usr/lib/llvm-18/lib/clang/18/include/xmmintrin.h:31:
/usr/lib/llvm-18/lib/clang/18/include/mm_malloc.h:35:12: error: 'malloc' is deprecated [-Werror,-Wdeprecated-declarations]
   35 |     return malloc(__size);
      |            ^
./server.h:3874:42: note: 'malloc' has been explicitly marked deprecated here
 3874 | void *malloc(size_t size) __attribute__((deprecated));
```

There is a difference in behavior though, between GCC and Clang. The `bitops.c` file compiles successfully with GCC.

I don't know exactly why GCC does not issue a warning in this case. My best guess is that GCC does not issue warnings from code of the standard library.

To fix the build error in clang, we explicitly use `pragma` macro to tell clang to ignore deprecated declarations warnings in `bitops.c`.