### PR TITLE
Fix memory leak in test_quicklist.c unit test

### DIFF
--- a/src/unit/test_quicklist.c
+++ b/src/unit/test_quicklist.c
@@ -2294,6 +2294,7 @@ int test_quicklistCompressAndDecomressQuicklistPlainNodeLargeThanUINT32MAX(int a
     zfree(node->next);
     zfree(node->entry);
     zfree(node);
+    zfree(s);
 
 #endif
     return 0;


### PR DESCRIPTION
In last daily run we had the following failure:

```
test — compress and decomress quicklist plain node large than UINT32_MAX
[test_quicklistCompressAndDecomressQuicklistPlainNodeLargeThanUINT32MAX - unit/test_quicklist.c:2288] Compress and decompress: 4096 MB in 39.27 seconds.

[ok] - test_quicklist.c:test_quicklistCompressAndDecomressQuicklistPlainNodeLargeThanUINT32MAX
[END] - test_quicklist.c: 58 tests, 58 passed, 0 failed
[START] - test_rax.c
[test_raxRandomWalk - unit/test_rax.c:548] Failed assertion: raxAllocSize(t) == zmalloc_used_memory()
[fail] - test_rax.c:test_raxRandomWalk
```

Job Link: https://github.com/valkey-io/valkey/actions/runs/13555915665/job/37890070586

Although the assert that failed was in a `test_rax.c` test function, the problem was in the last test function from the `test_quicklist.c` unit test that ran just before the test that failed.

The
`test_quicklistCompressAndDecomressQuicklistPlainNodeLargeThanUINT32MAX` test function was not freeing the string allocated in the beginning of the test.