### PR TITLE
Adds a memory leak check after running a unit test

### DIFF
--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -29,19 +29,18 @@ int runTestSuite(struct unitTestSuite *test, int argc, char **argv, int flags) {
     for (int id = 0; test->tests[id].proc != NULL; id++) {
         test_num++;
         int test_result = (test->tests[id].proc(argc, argv, flags) != 0);
-
-        /* Check if the test has cleaned up all the memory used. */
-        if (zmalloc_used_memory() > 0) {
-            printf("[" KRED "%s - %s" KRESET "] Memory leak detected of %zu bytes\n", test->tests[id].name, test->filename, zmalloc_used_memory());
-            test_result = 1;
-        }
-
         if (!test_result) {
             printf("[" KGRN "ok" KRESET "] - %s:%s\n", test->filename, test->tests[id].name);
         } else {
             printf("[" KRED "fail" KRESET "] - %s:%s\n", test->filename, test->tests[id].name);
             failed_tests++;
         }
+    }
+
+    /* Check if the test suite has cleaned up all the memory used. */
+    if (zmalloc_used_memory() > 0) {
+        printf("[" KRED "%s" KRESET "] Memory leak detected of %zu bytes\n", test->filename, zmalloc_used_memory());
+        failed_tests++;
     }
 
     printf("[" KBLUE "END" KRESET "] - %s: ", test->filename);

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -12,6 +12,7 @@
 #include "../util.h"
 #include "../mt19937-64.h"
 #include "../hashtable.h"
+#include "../zmalloc.h"
 
 /* We override the default assertion mechanism, so that it prints out info and then dies. */
 void _serverAssert(const char *estr, const char *file, int line) {
@@ -28,6 +29,13 @@ int runTestSuite(struct unitTestSuite *test, int argc, char **argv, int flags) {
     for (int id = 0; test->tests[id].proc != NULL; id++) {
         test_num++;
         int test_result = (test->tests[id].proc(argc, argv, flags) != 0);
+
+        /* Check if the test has cleaned up all the memory used. */
+        if (zmalloc_used_memory() > 0) {
+            printf("[" KRED "%s - %s" KRESET "] Memory leak detected of %lu bytes\n", test->tests[id].name, test->filename, zmalloc_used_memory());
+            test_result = 1;
+        }
+
         if (!test_result) {
             printf("[" KGRN "ok" KRESET "] - %s:%s\n", test->filename, test->tests[id].name);
         } else {

--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -32,7 +32,7 @@ int runTestSuite(struct unitTestSuite *test, int argc, char **argv, int flags) {
 
         /* Check if the test has cleaned up all the memory used. */
         if (zmalloc_used_memory() > 0) {
-            printf("[" KRED "%s - %s" KRESET "] Memory leak detected of %lu bytes\n", test->tests[id].name, test->filename, zmalloc_used_memory());
+            printf("[" KRED "%s - %s" KRESET "] Memory leak detected of %zu bytes\n", test->tests[id].name, test->filename, zmalloc_used_memory());
             test_result = 1;
         }
 


### PR DESCRIPTION
This commit adds check after each test function execution of a unit test, that checks if there is still memory allocated.

This check prevents situations where tests, which do these kind of checks, fail due to memory leaks caused by previous tests.