### PR TITLE
Fix incorrect assertion in client list operations

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "adlist.h"
 
-#include "server.h"
+#include "serverassert.h"
 #include "zmalloc.h"
 
 /* Create a new list. The created list can be freed with

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -31,6 +31,8 @@
 
 #include <stdlib.h>
 #include "adlist.h"
+
+#include "server.h"
 #include "zmalloc.h"
 
 /* Create a new list. The created list can be freed with
@@ -187,6 +189,7 @@ void listDelNode(list *list, listNode *node) {
  * Remove the specified node from the list without freeing it.
  */
 void listUnlinkNode(list *list, listNode *node) {
+    serverAssert(list->len > 0);
     if (node->prev)
         node->prev->next = node->next;
     else

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -190,14 +190,22 @@ void listDelNode(list *list, listNode *node) {
  */
 void listUnlinkNode(list *list, listNode *node) {
     assert(list->len > 0);
-    if (node->prev)
+
+    if (node->prev) {
+        assert(node->prev->next == node);
         node->prev->next = node->next;
-    else
+    } else {
+        assert(list->head == node);
         list->head = node->next;
-    if (node->next)
+    }
+
+    if (node->next) {
+        assert(node->next->prev == node);
         node->next->prev = node->prev;
-    else
+    } else {
+        assert(list->tail == node);
         list->tail = node->prev;
+    }
 
     node->next = NULL;
     node->prev = NULL;

--- a/src/adlist.c
+++ b/src/adlist.c
@@ -189,7 +189,7 @@ void listDelNode(list *list, listNode *node) {
  * Remove the specified node from the list without freeing it.
  */
 void listUnlinkNode(list *list, listNode *node) {
-    serverAssert(list->len > 0);
+    assert(list->len > 0);
     if (node->prev)
         node->prev->next = node->next;
     else

--- a/src/networking.c
+++ b/src/networking.c
@@ -1584,10 +1584,8 @@ void unlinkClient(client *c) {
     /* Remove from the list of pending writes if needed. */
     if (c->flag.pending_write) {
         if (c->io_write_state == CLIENT_IDLE) {
-            debugServerAssert(listSearchKey(server.clients_pending_write, c) != NULL);
             listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         } else {
-            debugServerAssert(listSearchKey(server.clients_pending_io_write, c) != NULL);
             listUnlinkNode(server.clients_pending_io_write, &c->clients_pending_write_node);
         }
         c->flag.pending_write = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1584,10 +1584,10 @@ void unlinkClient(client *c) {
     /* Remove from the list of pending writes if needed. */
     if (c->flag.pending_write) {
         if (c->io_write_state == CLIENT_IDLE) {
-            serverAssert(listSearchKey(server.clients_pending_write, c) != NULL);
+            debugServerAssert(listSearchKey(server.clients_pending_write, c) != NULL);
             listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         } else {
-            serverAssert(listSearchKey(server.clients_pending_io_write, c) != NULL);
+            debugServerAssert(listSearchKey(server.clients_pending_io_write, c) != NULL);
             listUnlinkNode(server.clients_pending_io_write, &c->clients_pending_write_node);
         }
         c->flag.pending_write = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1583,10 +1583,11 @@ void unlinkClient(client *c) {
 
     /* Remove from the list of pending writes if needed. */
     if (c->flag.pending_write) {
-        serverAssert(&c->clients_pending_write_node.next != NULL || &c->clients_pending_write_node.prev != NULL);
         if (c->io_write_state == CLIENT_IDLE) {
+            serverAssert(listSearchKey(server.clients_pending_write, c) != NULL);
             listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         } else {
+            serverAssert(listSearchKey(server.clients_pending_io_write, c) != NULL);
             listUnlinkNode(server.clients_pending_io_write, &c->clients_pending_write_node);
         }
         c->flag.pending_write = 0;


### PR DESCRIPTION
The current assertion introduced in https://github.com/redis/redis/pull/11220/

```c
serverAssert(&c->clients_pending_write_node.next != NULL || &c->clients_pending_write_node.prev != NULL);
```

is incorrect for two reasons:

1. Using &pointer.next would always be non-NULL since it's the address of the field.
2. The check is incorrect even without the & because in a single-node list, both pointers can be NULL.

Fix:
1. Remove the always-true assertion
2. Add proper assertions in listUnlinkNode to ensure the node membership in the list to cover all list cases.