### PR TITLE
Fixed build error with CMake

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -166,7 +166,7 @@ int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int 
             return C_ERR;
 
         ftval *= 1000.0; /* seconds => millisec */
-        if (ftval > LLONG_MAX) {
+        if (ftval > (long double)LLONG_MAX) {
             addReplyError(c, "timeout is out of range");
             return C_ERR;
         }


### PR DESCRIPTION
Explicitly cast `long long` -> `long double` to avoid build warnings. This issue manifests when using `clang 19`. Using the `Makefile` build, we only get a warning. This small PR fixes this.

Fixes #1805