### PR TITLE
Stop running large memory test for address santizer

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -705,10 +705,10 @@ jobs:
           sudo apt-get install tcl8.6 tclx -y
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest --accurate --verbose --dump-logs --large-memory ${{github.event.inputs.test_args}}
+        run: ./runtest --accurate --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
-        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --dump-logs --large-memory ${{github.event.inputs.test_args}}
+        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --dump-logs ${{github.event.inputs.test_args}}
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
         run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}


### PR DESCRIPTION
After this change, https://github.com/valkey-io/valkey/pull/1767/files, the address sanitizer test seems to be causing the test process to just die, possibly from OOM: https://github.com/valkey-io/valkey/actions/runs/13620692597/job/38069694391#step:6:4755. 

If we switch the large memory tests to be sequential on ASAN, it might resolve it, but I wanted to open this to propose reverting it to get the tests passing again.