### PR TITLE
Fix timing issue in the module propagate test

### DIFF
--- a/tests/unit/moduleapi/propagate.tcl
+++ b/tests/unit/moduleapi/propagate.tcl
@@ -597,11 +597,13 @@ tags "modules" {
 
                     assert_equal [$master get k1] 1
                     assert_equal [$master ttl k1] -1
+                    wait_for_ofs_sync $master $replica
                     assert_equal [$replica get k1] 1
                     assert_equal [$replica ttl k1] -1
                     # Validate that replicated commands were "obeyed" from primary.
                     assert_equal [$replica propagate-test.obeyed] 1
                     $master propagate-test.incr k1
+                    wait_for_ofs_sync $master $replica
                     assert_equal [$replica propagate-test.obeyed] 2
                 }
 


### PR DESCRIPTION
There is a timing issue in the test:
```
*** [err]: module RM_Call of expired key propagation in tests/unit/moduleapi/propagate.tcl
Expected '1' to be equal to '2' (context: type eval line 27 cmd {assert_equal [$replica propagate-test.obeyed] 2} proc ::test)
```

We should wait for sync, otherwise the replica may not be fully
synchronized before checking. The test was introduced in #1582.