### PR TITLE
Fix engine crash on module client blocking during keyspace events

### DIFF
--- a/src/adlist.c
+++ b/src/adlist.c
@@ -53,6 +53,7 @@ list *listCreate(void) {
 
 /* Remove all the elements from the list without destroying the list itself. */
 void listEmpty(list *list) {
+    if (!list) return;
     unsigned long len;
     listNode *current, *next;
 
@@ -72,7 +73,6 @@ void listEmpty(list *list) {
  *
  * This function can't fail. */
 void listRelease(list *list) {
-    if (!list) return;
     listEmpty(list);
     zfree(list);
 }

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1253,6 +1253,7 @@ void bitfieldGeneric(client *c, int flags) {
         }
     }
 
+    initDeferredReplyBuffer(c);
     addReplyArrayLen(c, numops);
 
     /* Actually process the operations. */
@@ -1364,6 +1365,7 @@ void bitfieldGeneric(client *c, int flags) {
         notifyKeyspaceEvent(NOTIFY_STRING, "setbit", c->argv[1], c->db->id);
         server.dirty += changes;
     }
+    commitDeferredReplyBuffer(c);
     zfree(ops);
 }
 

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -1365,7 +1365,7 @@ void bitfieldGeneric(client *c, int flags) {
         notifyKeyspaceEvent(NOTIFY_STRING, "setbit", c->argv[1], c->db->id);
         server.dirty += changes;
     }
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
     zfree(ops);
 }
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -98,6 +98,7 @@ void freeClientBlockingState(client *c) {
     dictRelease(c->bstate->keys);
     zfree(c->bstate);
     c->bstate = NULL;
+    if (c->deferred_reply) commitDeferredReplyBuffer(c);
 }
 
 /* Block a client for the specific operation type. Once the CLIENT_BLOCKED

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -99,7 +99,7 @@ void freeClientBlockingState(client *c) {
     zfree(c->bstate);
     c->bstate = NULL;
 
-    debugServerAssert(!c->deferred_reply);
+    debugServerAssert(!isDeferredReplyEnabled(c));
     commitDeferredReplyBuffer(c, 0);
 }
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -98,7 +98,9 @@ void freeClientBlockingState(client *c) {
     dictRelease(c->bstate->keys);
     zfree(c->bstate);
     c->bstate = NULL;
-    if (c->deferred_reply) commitDeferredReplyBuffer(c);
+
+    serverAssert(!c->deferred_reply);
+    commitDeferredReplyBuffer(c, 0);
 }
 
 /* Block a client for the specific operation type. Once the CLIENT_BLOCKED

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -98,9 +98,6 @@ void freeClientBlockingState(client *c) {
     dictRelease(c->bstate->keys);
     zfree(c->bstate);
     c->bstate = NULL;
-
-    debugServerAssert(!isDeferredReplyEnabled(c));
-    commitDeferredReplyBuffer(c, 0);
 }
 
 /* Block a client for the specific operation type. Once the CLIENT_BLOCKED

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -99,7 +99,7 @@ void freeClientBlockingState(client *c) {
     zfree(c->bstate);
     c->bstate = NULL;
 
-    serverAssert(!c->deferred_reply);
+    debugServerAssert(!c->deferred_reply);
     commitDeferredReplyBuffer(c, 0);
 }
 

--- a/src/expire.c
+++ b/src/expire.c
@@ -682,6 +682,9 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         return;
     } else {
         obj = setExpire(c, c->db, key, when);
+        signalModifiedKey(c, c->db, key);
+        notifyKeyspaceEvent(NOTIFY_GENERIC, "expire", key, c->db->id);
+        server.dirty++;
         addReply(c, shared.cone);
         /* Propagate as PEXPIREAT millisecond-timestamp
          * Only rewrite the command arg if not already PEXPIREAT */
@@ -695,10 +698,6 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
             rewriteClientCommandArgument(c, 2, when_obj);
             decrRefCount(when_obj);
         }
-
-        signalModifiedKey(c, c->db, key);
-        notifyKeyspaceEvent(NOTIFY_GENERIC, "expire", key, c->db->id);
-        server.dirty++;
         return;
     }
 }

--- a/src/module.c
+++ b/src/module.c
@@ -198,8 +198,8 @@ typedef struct ValkeyModuleCtx ValkeyModuleCtx;
 #define VALKEYMODULE_CTX_NEW_CLIENT (1 << 7)  /* Free client object when the \
                                                  context is destroyed */
 #define VALKEYMODULE_CTX_CHANNELS_POS_REQUEST (1 << 8)
-#define VALKEYMODULE_CTX_COMMAND (1 << 9) /* Context created to serve a command from call() or AOF (which calls cmd->proc directly) */
-
+#define VALKEYMODULE_CTX_COMMAND (1 << 9)                /* Context created to serve a command from call() or AOF (which calls cmd->proc directly) */
+#define VALKEYMODULE_CTX_KEYSPACE_NOTIFICATION (1 << 10) /* Context created a keyspace notification event */
 
 /* This represents a key opened with VM_OpenKey(). */
 struct ValkeyModuleKey {
@@ -7795,6 +7795,8 @@ void unblockClientFromModule(client *c) {
  * in that case the privdata argument is disregarded, because we pass the
  * reply callback the privdata that is set here while blocking.
  *
+ * For details on return values and error codes, see the comment block for
+ * VM_BlockClient.
  */
 ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
                                              ValkeyModuleCmdFunc reply_callback,
@@ -7807,8 +7809,27 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
                                              void *privdata,
                                              int flags) {
     client *c = ctx->client;
+    if (c->flag.blocked || getClientType(c) != CLIENT_TYPE_NORMAL || c->flag.deny_blocking) {
+        /* Early return if duplicate block attempt or client is not normal or
+         * client is set to deny blocking. */
+        errno = ENOTSUP;
+        return NULL;
+    }
+
+    if (ctx->flags & (VALKEYMODULE_CTX_TEMP_CLIENT | VALKEYMODULE_CTX_NEW_CLIENT)) {
+        /* Temporary clients can't be blocked */
+        errno = EINVAL;
+        return NULL;
+    }
+    int is_keyspace_notification = ctx->flags & (VALKEYMODULE_CTX_KEYSPACE_NOTIFICATION);
     int islua = scriptIsRunning();
     int ismulti = server.in_exec;
+    if ((islua || ismulti) && is_keyspace_notification) {
+        /* Avoid blocking within transactions when context initiated by
+         * keyspace notification. */
+        errno = EINVAL;
+        return NULL;
+    }
     initClientBlockingState(c);
 
     c->bstate->module_blocked_handle = zmalloc(sizeof(ValkeyModuleBlockedClient));
@@ -7863,6 +7884,11 @@ ValkeyModuleBlockedClient *moduleBlockClient(ValkeyModuleCtx *ctx,
         } else {
             c->bstate->timeout = timeout;
             blockClient(c, BLOCKED_MODULE);
+        }
+        /* Defer response until after being unblocked for a context originated from
+         * keyspace notification events */
+        if (is_keyspace_notification) {
+            initDeferredReplyBuffer(c);
         }
     }
     return bc;
@@ -8091,14 +8117,27 @@ int moduleTryServeClientBlockedOnKey(client *c, robj *key) {
  *     free_privdata:    called in order to free the private data that is passed
  *                       by ValkeyModule_UnblockClient() call.
  *
- * Note: ValkeyModule_UnblockClient should be called for every blocked client,
- *       even if client was killed, timed-out or disconnected. Failing to do so
- *       will result in memory leaks.
+ * Notes:
+ * 1. ValkeyModule_UnblockClient should be called for every blocked client,
+ * even if client was killed, timed-out or disconnected. Failing to do so
+ * will result in memory leaks.
+ * 2. Attempting to block the client on keyspace event notification in versions
+ *    prior to 8.1.1 leads to a crash.
  *
  * There are some cases where ValkeyModule_BlockClient() cannot be used:
  *
  * 1. If the client is a Lua script.
  * 2. If the client is executing a MULTI block.
+ * 3. If the client is a temporary module client.
+ * 4. If the client is already blocked.
+ *
+ * In cases 1 and 2, a call to ValkeyModule_BlockClient() will **not** block the
+ * client, but instead produce a specific error reply. Note that if the
+ * BlockClient call originated from within a keyspace notification, no error
+ * reply is generated but nullptr is returned while the errno is set to EINVAL.
+ *
+ * In case 3 and 4, a call to ValkeyModule_BlockClient() are no-op, returning
+ * nullptr. errno is set to EINVAL for case 3 while ENOTSUP for case 4.
  *
  * In these cases, a call to ValkeyModule_BlockClient() will **not** block the
  * client, but instead produce a specific error reply.
@@ -8290,6 +8329,12 @@ int moduleClientIsBlockedOnKeys(client *c) {
  * needs to be passed to the client, included but not limited some slow
  * to compute reply or some reply obtained via networking.
  *
+ * Returns VALKEYMODULE_OK on success. On failure, VALKEYMODULE_ERR is returned
+ * and `errno` is set as follows:
+ *
+ * - EINVAL if bc is NULL.
+ * - ENOTSUP if bc contains `blocked on keys` but its timeout callback is NULL.
+ *
  * Note 1: this function can be called from threads spawned by the module.
  *
  * Note 2: when we unblock a client that is blocked for keys using the API
@@ -8300,10 +8345,17 @@ int moduleClientIsBlockedOnKeys(client *c) {
  * ValkeyModule_BlockClientOnKeys() is accessible from the timeout
  * callback via VM_GetBlockedClientPrivateData). */
 int VM_UnblockClient(ValkeyModuleBlockedClient *bc, void *privdata) {
+    if (!bc) {
+        errno = EINVAL;
+        return VALKEYMODULE_ERR;
+    }
     if (bc->blocked_on_keys) {
         /* In theory the user should always pass the timeout handler as an
          * argument, but better to be safe than sorry. */
-        if (bc->timeout_callback == NULL) return VALKEYMODULE_ERR;
+        if (bc->timeout_callback == NULL) {
+            errno = ENOTSUP;
+            return VALKEYMODULE_ERR;
+        }
         if (bc->unblocked) return VALKEYMODULE_OK;
         if (bc->client) moduleBlockedClientTimedOut(bc->client, 1);
     }
@@ -8392,11 +8444,17 @@ void moduleHandleBlockedClients(void) {
             moduleInvokeFreePrivDataCallback(c, bc);
         }
 
-        /* It is possible that this blocked client object accumulated
-         * replies to send to the client in a thread safe context.
-         * We need to glue such replies to the client output buffer and
-         * free the temporary client we just used for the replies. */
-        if (c) AddReplyFromClient(c, bc->reply_client);
+        if (c) {
+            /* Replies which were added after the client is blocked by a module
+             * are accumulated separately. We need to transmit those replies
+             * to the client. */
+            commitDeferredReplyBuffer(c);
+            /* It is possible that this blocked client object accumulated
+             * replies to send to the client in a thread safe context.
+             * We need to glue such replies to the client output buffer and
+             * free the temporary client we just used for the replies. */
+            AddReplyFromClient(c, bc->reply_client);
+        }
         moduleReleaseTempClient(bc->reply_client);
         moduleReleaseTempClient(bc->thread_safe_ctx_client);
 
@@ -8492,9 +8550,10 @@ void moduleBlockedClientTimedOut(client *c, int from_module) {
 
     moduleFreeContext(&ctx);
 
-    if (!from_module)
+    if (!from_module) {
         updateStatsOnUnblock(c, bc->background_duration, 0,
                              ((server.stat_total_error_replies != prev_error_replies) ? ERROR_COMMAND_FAILED : 0));
+    }
 
     /* For timeout events, we do not want to call the disconnect callback,
      * because the blocked client will be automatically disconnected in
@@ -8880,8 +8939,14 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
         if ((sub->event_mask & type) &&
             (sub->active == 0 || (sub->module->options & VALKEYMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS))) {
             ValkeyModuleCtx ctx;
-            moduleCreateContext(&ctx, sub->module, VALKEYMODULE_CTX_TEMP_CLIENT);
+            if (server.executing_client == NULL) {
+                moduleCreateContext(&ctx, sub->module, VALKEYMODULE_CTX_TEMP_CLIENT);
+            } else {
+                moduleCreateContext(&ctx, sub->module, VALKEYMODULE_CTX_NONE);
+                ctx.client = server.executing_client;
+            }
             selectDb(ctx.client, dbid);
+            ctx.flags |= VALKEYMODULE_CTX_KEYSPACE_NOTIFICATION;
 
             /* mark the handler as active to avoid reentrant loops.
              * If the subscriber performs an action triggering itself,

--- a/src/module.c
+++ b/src/module.c
@@ -8899,12 +8899,16 @@ int VM_NotifyKeyspaceEvent(ValkeyModuleCtx *ctx, int type, const char *event, Va
     return VALKEYMODULE_OK;
 }
 
+unsigned long moduleNotifyKeyspaceSubscribersCnt(void) {
+    return listLength(moduleKeyspaceSubscribers);
+}
+
 /* Dispatcher for keyspace notifications to module subscriber functions.
  * This gets called  only if at least one module requested to be notified on
  * keyspace notifications */
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid) {
     /* Don't do anything if there aren't any subscribers */
-    if (listLength(moduleKeyspaceSubscribers) == 0) return;
+    if (moduleNotifyKeyspaceSubscribersCnt() == 0) return;
 
     /* Ugly hack to handle modules which use write commands from within
      * notify_callback, which they should NOT do!

--- a/src/module.c
+++ b/src/module.c
@@ -8448,7 +8448,7 @@ void moduleHandleBlockedClients(void) {
             /* Replies which were added after the client is blocked by a module
              * are accumulated separately. We need to transmit those replies
              * to the client. */
-            commitDeferredReplyBuffer(c);
+            commitDeferredReplyBuffer(c, 0);
             /* It is possible that this blocked client object accumulated
              * replies to send to the client in a thread safe context.
              * We need to glue such replies to the client output buffer and

--- a/src/module.h
+++ b/src/module.h
@@ -203,6 +203,7 @@ void moduleAcquireGIL(void);
 int moduleTryAcquireGIL(void);
 void moduleReleaseGIL(void);
 void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid);
+unsigned long moduleNotifyKeyspaceSubscribersCnt(void);
 void firePostExecutionUnitJobs(void);
 void moduleCallCommandFilters(client *c);
 void modulePostExecutionUnitOperations(void);

--- a/src/networking.c
+++ b/src/networking.c
@@ -149,6 +149,12 @@ static inline int isReplicaReadyForReplData(client *replica) {
            !(replica->flag.close_asap);
 }
 
+static void resetDeferredReplyBuffer(client *c) {
+    listRelease(c->deferred_reply);
+    c->deferred_reply = NULL;
+    c->deferred_reply_bytes = 0;
+}
+
 client *createClient(connection *conn) {
     client *c = zmalloc(sizeof(client));
 
@@ -203,8 +209,10 @@ client *createClient(connection *conn) {
     c->duration = 0;
     clientSetDefaultAuth(c);
     c->reply = listCreate();
+    c->deferred_reply = NULL;
     c->deferred_reply_errors = NULL;
     c->reply_bytes = 0;
+    c->deferred_reply_bytes = 0;
     c->obuf_soft_limit_reached_time = 0;
     listSetFreeMethod(c->reply, freeClientReplyValue);
     listSetDupMethod(c->reply, dupClientReplyValue);
@@ -277,7 +285,6 @@ void putClientInPendingWriteQueue(client *c) {
         listLinkNodeHead(server.clients_pending_write, &c->clients_pending_write_node);
     }
 }
-
 /* This function is called every time we are going to transmit new data
  * to the client. The behavior is the following:
  *
@@ -326,6 +333,7 @@ int prepareClientToWrite(client *c) {
      * it should already be setup to do so (it has already pending data). */
     if (!clientHasPendingReplies(c)) putClientInPendingWriteQueue(c);
 
+    if (c->deferred_reply == NULL) c->flag.buffered_reply = 1;
     /* Authorize the caller to queue in the output buffer of this client. */
     return C_OK;
 }
@@ -425,13 +433,15 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
          * least PROTO_REPLY_CHUNK_BYTES */
         size_t usable_size;
         size_t size = len < PROTO_REPLY_CHUNK_BYTES ? PROTO_REPLY_CHUNK_BYTES : len;
+        if (c->deferred_reply) size = len;
         tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
         /* take over the allocation's internal fragmentation */
         tail->size = usable_size - sizeof(clientReplyBlock);
         tail->used = len;
         memcpy(tail->buf, s, len);
         listAddNodeTail(reply_list, tail);
-        c->reply_bytes += tail->size;
+        unsigned long long *reply_bytes = (c->deferred_reply) ? &c->deferred_reply_bytes : &c->reply_bytes;
+        *reply_bytes += tail->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
     }
@@ -462,6 +472,11 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     c->net_output_bytes_curr_cmd += len;
 
+    if (c->deferred_reply) {
+        _addReplyProtoToList(c, c->deferred_reply, s, len);
+        return;
+    }
+
     /* We call it here because this function may affect the reply
      * buffer offset (see function comment) */
     reqresSaveClientReplyOffset(c);
@@ -477,7 +492,6 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
         _addReplyProtoToList(c, server.pending_push_messages, s, len);
         return;
     }
-
     size_t reply_len = _addReplyToBuffer(c, s, len);
     if (len > reply_len) _addReplyProtoToList(c, c->reply, s + reply_len, len - reply_len);
 }
@@ -564,6 +578,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         return;
     }
 
+    commitDeferredReplyBuffer(c);
     if (!(flags & ERR_REPLY_FLAG_NO_STATS_UPDATE)) {
         /* Increment the global error counter */
         server.stat_total_error_replies++;
@@ -1283,6 +1298,32 @@ void addReplySubcommandSyntaxError(client *c) {
     sdsfree(cmd);
 }
 
+void initDeferredReplyBuffer(client *c) {
+    if (c->deferred_reply == NULL) {
+        c->deferred_reply = listCreate();
+    }
+}
+
+/* Move the client deferred reply buffer into the client reply buffer and put the client
+ * in the pending write queue. */
+void commitDeferredReplyBuffer(client *c) {
+    if (c->deferred_reply == NULL || listLength(c->deferred_reply) == 0) {
+        resetDeferredReplyBuffer(c);
+        return;
+    }
+
+    listJoin(c->reply, c->deferred_reply);
+    c->reply_bytes += c->deferred_reply_bytes;
+
+    resetDeferredReplyBuffer(c);
+    if (prepareClientToWrite(c) != C_OK) {
+        return;
+    }
+    /* We call it here because this function may affect the reply
+     * buffer offset (see function comment) */
+    reqresSaveClientReplyOffset(c);
+}
+
 /* Append 'src' client output buffers into 'dst' client output buffers.
  * This function clears the output buffers of 'src' */
 void AddReplyFromClient(client *dst, client *src) {
@@ -1299,6 +1340,7 @@ void AddReplyFromClient(client *dst, client *src) {
         return;
     }
 
+
     /* First add the static buffer (either into the static buffer or reply list) */
     addReplyProto(dst, src->buf, src->bufpos);
 
@@ -1310,6 +1352,7 @@ void AddReplyFromClient(client *dst, client *src) {
      * checks in it. */
     if (dst->flag.close_after_reply) return;
 
+    commitDeferredReplyBuffer(src);
     /* Concatenate the reply list into the dest */
     if (listLength(src->reply)) listJoin(dst->reply, src->reply);
     dst->reply_bytes += src->reply_bytes;
@@ -1737,6 +1780,7 @@ void freeClient(client *c) {
     c->reply = NULL;
     zfree_with_size(c->buf, c->buf_usable_size);
     c->buf = NULL;
+    resetDeferredReplyBuffer(c);
 
     freeClientArgv(c);
     freeClientOriginalArgv(c);
@@ -2579,6 +2623,8 @@ void resetClient(client *c) {
     c->slot = -1;
     c->flag.executing_command = 0;
     c->flag.replication_done = 0;
+    c->flag.buffered_reply = 0;
+    c->flag.keyspace_notified = 0;
     c->net_output_bytes_curr_cmd = 0;
 
     /* Make sure the duration has been recorded to some command. */
@@ -2589,6 +2635,7 @@ void resetClient(client *c) {
 
     if (c->deferred_reply_errors) listRelease(c->deferred_reply_errors);
     c->deferred_reply_errors = NULL;
+    commitDeferredReplyBuffer(c);
 
     /* We clear the ASKING flag as well if we are not inside a MULTI, and
      * if what we just executed is not the ASKING command itself. */
@@ -4478,10 +4525,10 @@ void rewriteClientCommandVector(client *c, int argc, ...) {
 
 /* Completely replace the client command vector with the provided one. */
 void replaceClientCommandVector(client *c, int argc, robj **argv) {
-    int j;
     backupAndUpdateClientArgv(c, argc, argv);
     c->argv_len_sum = 0;
-    for (j = 0; j < c->argc; j++)
+    c->flag.buffered_reply = 0;
+    for (int j = 0; j < c->argc; j++)
         if (c->argv[j]) c->argv_len_sum += getStringObjectLen(c->argv[j]);
     c->cmd = lookupCommandOrOriginal(c->argv, c->argc);
     serverAssertWithInfo(c, NULL, c->cmd != NULL);
@@ -4512,6 +4559,7 @@ void rewriteClientCommandArgument(client *c, int i, robj *newval) {
 
     /* If this is the command name make sure to fix c->cmd. */
     if (i == 0) {
+        c->flag.buffered_reply = 0;
         c->cmd = lookupCommandOrOriginal(c->argv, c->argc);
         serverAssertWithInfo(c, NULL, c->cmd != NULL);
     }
@@ -4535,10 +4583,15 @@ size_t getClientOutputBufferMemoryUsage(client *c) {
             repl_node_num = last->id - cur->id + 1;
         }
         return repl_buf_size + (repl_node_size * repl_node_num);
-    } else {
-        size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
-        return c->reply_bytes + (list_item_size * listLength(c->reply));
     }
+
+    size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
+    size_t usage = c->reply_bytes + (list_item_size * listLength(c->reply));
+    if (c->deferred_reply) {
+        usage += c->deferred_reply_bytes +
+                 (list_item_size * listLength(c->deferred_reply));
+    }
+    return usage;
 }
 
 /* Returns the total client's memory usage.

--- a/src/networking.c
+++ b/src/networking.c
@@ -1782,7 +1782,7 @@ void freeClient(client *c) {
     c->reply = NULL;
     zfree_with_size(c->buf, c->buf_usable_size);
     c->buf = NULL;
-    resetDeferredReplyBuffer(c);
+    listRelease(c->deferred_reply);
 
     freeClientArgv(c);
     freeClientOriginalArgv(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1342,7 +1342,6 @@ void AddReplyFromClient(client *dst, client *src) {
         return;
     }
 
-
     /* First add the static buffer (either into the static buffer or reply list) */
     addReplyProto(dst, src->buf, src->bufpos);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -473,7 +473,7 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
      * The check for executing_client also avoids affecting push messages that are part of eviction.
      * Check CLIENT_PUSHING first to avoid race conditions, as it's absent in module's fake client. */
     int defer_push_message = c->flag.pushing && c == server.current_client && server.executing_client &&
-        !cmdHasPushAsReply(server.executing_client->cmd);
+                             !cmdHasPushAsReply(server.executing_client->cmd);
     if (defer_push_message == 0 && isDeferredReplyEnabled(c)) {
         _addReplyProtoToList(c, c->deferred_reply, s, len);
         return;

--- a/src/networking.c
+++ b/src/networking.c
@@ -466,23 +466,23 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     c->net_output_bytes_curr_cmd += len;
 
-    if (isDeferredReplyEnabled(c)) {
-        _addReplyProtoToList(c, c->deferred_reply, s, len);
-        return;
-    }
-
-    /* We call it here because this function may affect the reply
-     * buffer offset (see function comment) */
-    reqresSaveClientReplyOffset(c);
-
     /* If we're processing a push message into the current client (i.e. executing PUBLISH
      * to a channel which we are subscribed to, then we wanna postpone that message to be added
      * after the command's reply (specifically important during multi-exec). the exception is
      * the SUBSCRIBE command family, which (currently) have a push message instead of a proper reply.
      * The check for executing_client also avoids affecting push messages that are part of eviction.
      * Check CLIENT_PUSHING first to avoid race conditions, as it's absent in module's fake client. */
-    if (c->flag.pushing && c == server.current_client && server.executing_client &&
-        !cmdHasPushAsReply(server.executing_client->cmd)) {
+    int defer_push_message = c->flag.pushing && c == server.current_client && server.executing_client &&
+        !cmdHasPushAsReply(server.executing_client->cmd);
+    if (defer_push_message == 0 && isDeferredReplyEnabled(c)) {
+        _addReplyProtoToList(c, c->deferred_reply, s, len);
+        return;
+    }
+    /* We call it here because this function may affect the reply
+     * buffer offset (see function comment) */
+    reqresSaveClientReplyOffset(c);
+
+    if (defer_push_message) {
         _addReplyProtoToList(c, server.pending_push_messages, s, len);
         return;
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -578,7 +578,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         return;
     }
 
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
     if (!(flags & ERR_REPLY_FLAG_NO_STATS_UPDATE)) {
         /* Increment the global error counter */
         server.stat_total_error_replies++;
@@ -1306,7 +1306,9 @@ void initDeferredReplyBuffer(client *c) {
 
 /* Move the client deferred reply buffer into the client reply buffer and put the client
  * in the pending write queue. */
-void commitDeferredReplyBuffer(client *c) {
+void commitDeferredReplyBuffer(client *c, int skip_if_blocked) {
+    if (skip_if_blocked && c->flag.blocked) return;
+
     if (c->deferred_reply == NULL || listLength(c->deferred_reply) == 0) {
         resetDeferredReplyBuffer(c);
         return;
@@ -1352,7 +1354,6 @@ void AddReplyFromClient(client *dst, client *src) {
      * checks in it. */
     if (dst->flag.close_after_reply) return;
 
-    commitDeferredReplyBuffer(src);
     /* Concatenate the reply list into the dest */
     if (listLength(src->reply)) listJoin(dst->reply, src->reply);
     dst->reply_bytes += src->reply_bytes;
@@ -2635,7 +2636,7 @@ void resetClient(client *c) {
 
     if (c->deferred_reply_errors) listRelease(c->deferred_reply_errors);
     c->deferred_reply_errors = NULL;
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
 
     /* We clear the ASKING flag as well if we are not inside a MULTI, and
      * if what we just executed is not the ASKING command itself. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1296,6 +1296,12 @@ inline int isDeferredReplyEnabled(client *c) {
     return c->deferred_reply_bytes != ULLONG_MAX;
 }
 
+/* Commands that generate replies before triggering keyspace notifications must
+ * use a deferred reply buffer. This allows postponing the actual transmission
+ * of the reply until after the client is unblocked, in case it was blocked by
+ * a keyspace notification. This is necessary because modules subscribed to
+ * keyspace notifications can block the client from within the notification
+ * callback. */
 void initDeferredReplyBuffer(client *c) {
     if (moduleNotifyKeyspaceSubscribersCnt() == 0) return;
     if (c->deferred_reply == NULL) c->deferred_reply = listCreate();

--- a/src/networking.c
+++ b/src/networking.c
@@ -149,12 +149,6 @@ static inline int isReplicaReadyForReplData(client *replica) {
            !(replica->flag.close_asap);
 }
 
-static void resetDeferredReplyBuffer(client *c) {
-    listRelease(c->deferred_reply);
-    c->deferred_reply = NULL;
-    c->deferred_reply_bytes = 0;
-}
-
 client *createClient(connection *conn) {
     client *c = zmalloc(sizeof(client));
 
@@ -212,7 +206,7 @@ client *createClient(connection *conn) {
     c->deferred_reply = NULL;
     c->deferred_reply_errors = NULL;
     c->reply_bytes = 0;
-    c->deferred_reply_bytes = 0;
+    c->deferred_reply_bytes = ULLONG_MAX;
     c->obuf_soft_limit_reached_time = 0;
     listSetFreeMethod(c->reply, freeClientReplyValue);
     listSetDupMethod(c->reply, dupClientReplyValue);
@@ -333,7 +327,7 @@ int prepareClientToWrite(client *c) {
      * it should already be setup to do so (it has already pending data). */
     if (!clientHasPendingReplies(c)) putClientInPendingWriteQueue(c);
 
-    if (c->deferred_reply == NULL) c->flag.buffered_reply = 1;
+    if (!isDeferredReplyEnabled(c)) c->flag.buffered_reply = 1;
     /* Authorize the caller to queue in the output buffer of this client. */
     return C_OK;
 }
@@ -433,14 +427,14 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
          * least PROTO_REPLY_CHUNK_BYTES */
         size_t usable_size;
         size_t size = len < PROTO_REPLY_CHUNK_BYTES ? PROTO_REPLY_CHUNK_BYTES : len;
-        if (c->deferred_reply) size = len;
+        if (isDeferredReplyEnabled(c)) size = len;
         tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
         /* take over the allocation's internal fragmentation */
         tail->size = usable_size - sizeof(clientReplyBlock);
         tail->used = len;
         memcpy(tail->buf, s, len);
         listAddNodeTail(reply_list, tail);
-        unsigned long long *reply_bytes = (c->deferred_reply) ? &c->deferred_reply_bytes : &c->reply_bytes;
+        unsigned long long *reply_bytes = (isDeferredReplyEnabled(c)) ? &c->deferred_reply_bytes : &c->reply_bytes;
         *reply_bytes += tail->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
@@ -472,7 +466,7 @@ void _addReplyToBufferOrList(client *c, const char *s, size_t len) {
 
     c->net_output_bytes_curr_cmd += len;
 
-    if (c->deferred_reply) {
+    if (isDeferredReplyEnabled(c)) {
         _addReplyProtoToList(c, c->deferred_reply, s, len);
         return;
     }
@@ -1298,10 +1292,18 @@ void addReplySubcommandSyntaxError(client *c) {
     sdsfree(cmd);
 }
 
+inline int isDeferredReplyEnabled(client *c) {
+    return c->deferred_reply_bytes != ULLONG_MAX;
+}
+
 void initDeferredReplyBuffer(client *c) {
-    if (c->deferred_reply == NULL) {
-        c->deferred_reply = listCreate();
-    }
+    if (c->deferred_reply == NULL) c->deferred_reply = listCreate();
+    if (!isDeferredReplyEnabled(c)) c->deferred_reply_bytes = 0;
+}
+
+static void resetDeferredReplyBuffer(client *c) {
+    listEmpty(c->deferred_reply);
+    c->deferred_reply_bytes = ULLONG_MAX;
 }
 
 /* Move the client deferred reply buffer into the client reply buffer and put the client
@@ -1309,7 +1311,7 @@ void initDeferredReplyBuffer(client *c) {
 void commitDeferredReplyBuffer(client *c, int skip_if_blocked) {
     if (skip_if_blocked && c->flag.blocked) return;
 
-    if (c->deferred_reply == NULL || listLength(c->deferred_reply) == 0) {
+    if (!isDeferredReplyEnabled(c) || (c->deferred_reply && listLength(c->deferred_reply) == 0)) {
         resetDeferredReplyBuffer(c);
         return;
     }
@@ -4587,7 +4589,7 @@ size_t getClientOutputBufferMemoryUsage(client *c) {
 
     size_t list_item_size = sizeof(listNode) + sizeof(clientReplyBlock);
     size_t usage = c->reply_bytes + (list_item_size * listLength(c->reply));
-    if (c->deferred_reply) {
+    if (isDeferredReplyEnabled(c)) {
         usage += c->deferred_reply_bytes +
                  (list_item_size * listLength(c->deferred_reply));
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -426,8 +426,8 @@ void _addReplyProtoToList(client *c, list *reply_list, const char *s, size_t len
         /* Create a new node, make sure it is allocated to at
          * least PROTO_REPLY_CHUNK_BYTES */
         size_t usable_size;
-        size_t size = len < PROTO_REPLY_CHUNK_BYTES ? PROTO_REPLY_CHUNK_BYTES : len;
-        if (isDeferredReplyEnabled(c)) size = len;
+        size_t min_reply_size = isDeferredReplyEnabled(c) ? PROTO_REPLY_MIN_BYTES : PROTO_REPLY_CHUNK_BYTES;
+        size_t size = len < min_reply_size ? min_reply_size : len;
         tail = zmalloc_usable(size + sizeof(clientReplyBlock), &usable_size);
         /* take over the allocation's internal fragmentation */
         tail->size = usable_size - sizeof(clientReplyBlock);
@@ -1297,6 +1297,7 @@ inline int isDeferredReplyEnabled(client *c) {
 }
 
 void initDeferredReplyBuffer(client *c) {
+    if (moduleNotifyKeyspaceSubscribersCnt() == 0) return;
     if (c->deferred_reply == NULL) c->deferred_reply = listCreate();
     if (!isDeferredReplyEnabled(c)) c->deferred_reply_bytes = 0;
 }

--- a/src/notify.c
+++ b/src/notify.c
@@ -108,7 +108,8 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     int len = -1;
     char buf[24];
     client *c = server.executing_client;
-    debugServerAssert((type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
+    debugServerAssert(moduleNotifyKeyspaceSubscribersCnt() == 0 ||
+                      (type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
                       c == NULL ||
                       c->cmd == NULL ||
                       (c->cmd->flags & CMD_WRITE) == 0 ||

--- a/src/notify.c
+++ b/src/notify.c
@@ -109,13 +109,13 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     char buf[24];
     client *c = server.executing_client;
     debugServerAssert((type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
-                 c == NULL ||
-                 c->cmd == NULL ||
-                 (c->cmd->flags & CMD_WRITE) == 0 ||
-                 c->flag.buffered_reply == 0 ||
-                 c->flag.keyspace_notified == 1 ||
-                 c->id == UINT64_MAX || // AOF client
-                 getClientType(c) != CLIENT_TYPE_NORMAL);
+                      c == NULL ||
+                      c->cmd == NULL ||
+                      (c->cmd->flags & CMD_WRITE) == 0 ||
+                      c->flag.buffered_reply == 0 ||
+                      c->flag.keyspace_notified == 1 ||
+                      c->id == UINT64_MAX || // AOF client
+                      getClientType(c) != CLIENT_TYPE_NORMAL);
     /* If any modules are interested in events, notify the module system now.
      * This bypasses the notifications configuration, but the module engine
      * will only call event subscribers if the event type matches the types

--- a/src/notify.c
+++ b/src/notify.c
@@ -108,7 +108,7 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     int len = -1;
     char buf[24];
     client *c = server.executing_client;
-    serverAssert((type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
+    debugServerAssert((type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
                  c == NULL ||
                  c->cmd == NULL ||
                  (c->cmd->flags & CMD_WRITE) == 0 ||

--- a/src/notify.c
+++ b/src/notify.c
@@ -123,9 +123,7 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     moduleNotifyKeyspaceEvent(type, event, key, dbid);
     if (c) {
         c->flag.keyspace_notified = 1;
-        if (c->bstate == NULL && c->deferred_reply) {
-            commitDeferredReplyBuffer(c);
-        }
+        commitDeferredReplyBuffer(c, 1);
     }
 
     /* If notifications for this class of events are off, return ASAP. */

--- a/src/notify.c
+++ b/src/notify.c
@@ -107,12 +107,26 @@ void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid) {
     robj *chanobj, *eventobj;
     int len = -1;
     char buf[24];
-
+    client *c = server.executing_client;
+    serverAssert((type & (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_STREAM)) == 0 ||
+                 c == NULL ||
+                 c->cmd == NULL ||
+                 (c->cmd->flags & CMD_WRITE) == 0 ||
+                 c->flag.buffered_reply == 0 ||
+                 c->flag.keyspace_notified == 1 ||
+                 c->id == UINT64_MAX || // AOF client
+                 getClientType(c) != CLIENT_TYPE_NORMAL);
     /* If any modules are interested in events, notify the module system now.
      * This bypasses the notifications configuration, but the module engine
      * will only call event subscribers if the event type matches the types
      * they are interested in. */
     moduleNotifyKeyspaceEvent(type, event, key, dbid);
+    if (c) {
+        c->flag.keyspace_notified = 1;
+        if (c->bstate == NULL && c->deferred_reply) {
+            commitDeferredReplyBuffer(c);
+        }
+    }
 
     /* If notifications for this class of events are off, return ASAP. */
     if (!(server.notify_keyspace_events & type)) return;

--- a/src/server.c
+++ b/src/server.c
@@ -3745,7 +3745,7 @@ void call(client *c, int flags) {
 
     exitExecutionUnit();
 
-    if (c->bstate == NULL && c->deferred_reply) commitDeferredReplyBuffer(c);
+    if (c->bstate == NULL && c->deferred_reply) commitDeferredReplyBuffer(c, 1);
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3745,7 +3745,6 @@ void call(client *c, int flags) {
 
     exitExecutionUnit();
 
-    commitDeferredReplyBuffer(c, 1);
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3745,7 +3745,7 @@ void call(client *c, int flags) {
 
     exitExecutionUnit();
 
-    if (c->bstate == NULL && c->deferred_reply) commitDeferredReplyBuffer(c, 1);
+    commitDeferredReplyBuffer(c, 1);
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3728,6 +3728,8 @@ void call(client *c, int flags) {
      * re-processing and unblock the client.*/
     c->flag.executing_command = 1;
 
+    c->flag.buffered_reply = 0;
+    c->flag.keyspace_notified = 0;
     /* Setting the CLIENT_REPROCESSING_COMMAND flag so that during the actual
      * processing of the command proc, the client is aware that it is being
      * re-processed. */
@@ -3743,6 +3745,7 @@ void call(client *c, int flags) {
 
     exitExecutionUnit();
 
+    if (c->bstate == NULL && c->deferred_reply) commitDeferredReplyBuffer(c);
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;
@@ -4067,6 +4070,7 @@ int processCommand(client *c) {
             }
         }
         c->cmd = c->lastcmd = c->realcmd = cmd;
+        c->flag.buffered_reply = 0;
         sds err;
         if (!commandCheckExistence(c, &err)) {
             rejectCommandSds(c, err);

--- a/src/server.h
+++ b/src/server.h
@@ -2669,7 +2669,7 @@ void addReplyBool(client *c, int b);
 void addReplyVerbatim(client *c, const char *s, size_t len, const char *ext);
 void addReplyProto(client *c, const char *s, size_t len);
 void AddReplyFromClient(client *c, client *src);
-void commitDeferredReplyBuffer(client *c);
+void commitDeferredReplyBuffer(client *c, int skip_if_blocked);
 void addReplyBulk(client *c, robj *obj);
 void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);

--- a/src/server.h
+++ b/src/server.h
@@ -1108,7 +1108,11 @@ typedef struct ClientFlags {
                                             * flag, we won't cache the primary in freeClient. */
     uint64_t fake : 1;                     /* This is a fake client without a real connection. */
     uint64_t import_source : 1;            /* This client is importing data to server and can visit expired key. */
-    uint64_t reserved : 4;                 /* Reserved for future use */
+    uint64_t buffered_reply : 1;           /* Indicates the reply for the current command was buffered, either in client::reply
+                                              or client::buf. */
+    uint64_t keyspace_notified : 1;        /* Indicates that a keyspace notification was triggered during the execution of the
+                                              current command. */
+    uint64_t reserved : 2;                 /* Reserved for future use */
 } ClientFlags;
 
 typedef struct ClientPubSubData {
@@ -1259,13 +1263,16 @@ typedef struct client {
     dictEntry *cur_script;             /* Cached pointer to the dictEntry of the script being executed. */
     user *user;                        /* User associated with this connection */
     time_t obuf_soft_limit_reached_time;
-    list *deferred_reply_errors; /* Used for module thread safe contexts. */
-    robj *name;                  /* As set by CLIENT SETNAME. */
-    robj *lib_name;              /* The client library name as set by CLIENT SETINFO. */
-    robj *lib_ver;               /* The client library version as set by CLIENT SETINFO. */
-    sds peerid;                  /* Cached peer ID. */
-    sds sockname;                /* Cached connection target address. */
-    time_t ctime;                /* Client creation time. */
+    list *deferred_reply_errors;             /* Used for module thread safe contexts. */
+    robj *name;                              /* As set by CLIENT SETNAME. */
+    robj *lib_name;                          /* The client library name as set by CLIENT SETINFO. */
+    robj *lib_ver;                           /* The client library version as set by CLIENT SETINFO. */
+    sds peerid;                              /* Cached peer ID. */
+    sds sockname;                            /* Cached connection target address. */
+    time_t ctime;                            /* Client creation time. */
+    list *deferred_reply;                    /* List of reply objects to be sent to the client, typically after
+                                                the client has been unblocked. */
+    unsigned long long deferred_reply_bytes; /* Total bytes of objects in the blocked client pending list.*/
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
@@ -2644,6 +2651,7 @@ void resetClientIOState(client *c);
 void freeClientOriginalArgv(client *c);
 void freeClientArgv(client *c);
 void sendReplyToClient(connection *conn);
+void initDeferredReplyBuffer(client *c);
 void *addReplyDeferredLen(client *c);
 void setDeferredArrayLen(client *c, void *node, long length);
 void setDeferredMapLen(client *c, void *node, long length);
@@ -2661,6 +2669,7 @@ void addReplyBool(client *c, int b);
 void addReplyVerbatim(client *c, const char *s, size_t len, const char *ext);
 void addReplyProto(client *c, const char *s, size_t len);
 void AddReplyFromClient(client *c, client *src);
+void commitDeferredReplyBuffer(client *c);
 void addReplyBulk(client *c, robj *obj);
 void addReplyBulkCString(client *c, const char *s);
 void addReplyBulkCBuffer(client *c, const void *p, size_t len);
@@ -2815,7 +2824,7 @@ void listTypeDelete(listTypeIterator *iter, listTypeEntry *entry);
 robj *listTypeDup(robj *o);
 void listTypeDelRange(robj *o, long start, long stop);
 void popGenericCommand(client *c, int where);
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int signal, int *deleted);
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int *deleted);
 typedef enum {
     LIST_CONV_AUTO,
     LIST_CONV_GROWING,
@@ -3525,6 +3534,7 @@ int isInsideYieldingLongCommand(void);
 void processUnblockedClients(void);
 void initClientBlockingState(client *c);
 void freeClientBlockingState(client *c);
+void resetBlockedClientPendingReply(client *c);
 void blockClient(client *c, int btype);
 void unblockClient(client *c, int queue_for_reprocessing);
 void unblockClientOnTimeout(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -2651,6 +2651,7 @@ void resetClientIOState(client *c);
 void freeClientOriginalArgv(client *c);
 void freeClientArgv(client *c);
 void sendReplyToClient(connection *conn);
+int isDeferredReplyEnabled(client *c);
 void initDeferredReplyBuffer(client *c);
 void *addReplyDeferredLen(client *c);
 void setDeferredArrayLen(client *c, void *node, long length);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -480,11 +480,11 @@ void pushGenericCommand(client *c, int where, int xx) {
         server.dirty++;
     }
 
-    addReplyLongLong(c, listTypeLength(lobj));
-
-    char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     signalModifiedKey(c, c->db, c->argv[1]);
+    char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     notifyKeyspaceEvent(NOTIFY_LIST, event, c->argv[1], c->db->id);
+
+    addReplyLongLong(c, listTypeLength(lobj));
 }
 
 /* LPUSH <key> <element> [<element> ...] */
@@ -608,10 +608,10 @@ void lsetCommand(client *c) {
          * already handled the growing case in listTypeTryConversionAppend()
          * above, so here we just need to try the conversion for shrinking. */
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
-        addReply(c, shared.ok);
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST, "lset", c->argv[1], c->db->id);
         server.dirty++;
+        addReply(c, shared.ok);
     } else {
         addReplyErrorObject(c, shared.outofrangeerr);
     }
@@ -628,13 +628,14 @@ void lsetCommand(client *c) {
  *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function. */
-void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long count, int signal, int *deleted) {
+void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long count, int *deleted) {
     long llen = listTypeLength(o);
     long rangelen = (count > llen) ? llen : count;
     long rangestart = (where == LIST_HEAD) ? 0 : -rangelen;
     long rangeend = (where == LIST_HEAD) ? rangelen - 1 : -1;
     int reverse = (where == LIST_HEAD) ? 0 : 1;
 
+    initDeferredReplyBuffer(c);
     /* We return key-name just once, and an array of elements */
     addReplyArrayLen(c, 2);
     addReplyBulk(c, key);
@@ -643,7 +644,8 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
     /* Pop these elements. */
     listTypeDelRange(o, rangestart, rangelen);
     /* Maintain the notifications and dirty. */
-    listElementsRemoved(c, key, where, o, rangelen, signal, deleted);
+    listElementsRemoved(c, key, where, o, rangelen, deleted);
+    commitDeferredReplyBuffer(c);
 }
 
 /* Extracted from `addListRangeReply()` to reply with a quicklist list.
@@ -727,11 +729,9 @@ void addListRangeReply(client *c, robj *o, long start, long end, int reverse) {
 
 /* A housekeeping helper for list elements popping tasks.
  *
- * If 'signal' is 0, skip calling signalModifiedKey().
- *
  * 'deleted' is an optional output argument to get an indication
  * if the key got deleted by this function. */
-void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int signal, int *deleted) {
+void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, int *deleted) {
     char *event = (where == LIST_HEAD) ? "lpop" : "rpop";
 
     notifyKeyspaceEvent(NOTIFY_LIST, event, key, c->db->id);
@@ -744,7 +744,7 @@ void listElementsRemoved(client *c, robj *key, int where, robj *o, long count, i
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
         if (deleted) *deleted = 0;
     }
-    if (signal) signalModifiedKey(c, c->db, key);
+    signalModifiedKey(c, c->db, key);
     server.dirty += count;
 }
 
@@ -778,10 +778,10 @@ void popGenericCommand(client *c, int where) {
         /* Pop a single element. This is POP's original behavior that replies
          * with a bulk string. */
         value = listTypePop(o, where);
+        listElementsRemoved(c, c->argv[1], where, o, 1, NULL);
         serverAssert(value != NULL);
         addReplyBulk(c, value);
         decrRefCount(value);
-        listElementsRemoved(c, c->argv[1], where, o, 1, 1, NULL);
     } else {
         /* Pop a range of elements. An addition to the original POP command,
          *  which replies with a multi-bulk. */
@@ -791,9 +791,11 @@ void popGenericCommand(client *c, int where) {
         long rangeend = (where == LIST_HEAD) ? rangelen - 1 : -1;
         int reverse = (where == LIST_HEAD) ? 0 : 1;
 
+        initDeferredReplyBuffer(c);
         addListRangeReply(c, o, rangestart, rangeend, reverse);
         listTypeDelRange(o, rangestart, rangelen);
-        listElementsRemoved(c, c->argv[1], where, o, rangelen, 1, NULL);
+        listElementsRemoved(c, c->argv[1], where, o, rangelen, NULL);
+        commitDeferredReplyBuffer(c);
     }
 }
 
@@ -823,7 +825,7 @@ void mpopGenericCommand(client *c, robj **keys, int numkeys, int where, long cou
         if (llen == 0) continue;
 
         /* Pop a range of elements in a nested arrays way. */
-        listPopRangeAndReplyWithKey(c, o, key, where, count, 1, NULL);
+        listPopRangeAndReplyWithKey(c, o, key, where, count, NULL);
 
         /* Replicate it as [LR]POP COUNT. */
         robj *count_obj = createStringObjectFromLongLong((count > llen) ? llen : count);
@@ -1116,7 +1118,7 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
         value = listTypePop(sobj, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
         lmoveHandlePush(c, c->argv[2], dobj, value, whereto);
-        listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, 1, NULL);
+        listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, NULL);
 
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
@@ -1190,7 +1192,7 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
         if (count != -1) {
             /* BLMPOP, non empty list, like a normal [LR]POP with count option.
              * The difference here we pop a range of elements in a nested arrays way. */
-            listPopRangeAndReplyWithKey(c, o, key, where, count, 1, NULL);
+            listPopRangeAndReplyWithKey(c, o, key, where, count, NULL);
 
             /* Replicate it as [LR]POP COUNT. */
             robj *count_obj = createStringObjectFromLongLong((count > llen) ? llen : count);
@@ -1203,12 +1205,11 @@ void blockingPopGenericCommand(client *c, robj **keys, int numkeys, int where, i
         robj *value = listTypePop(o, where);
         serverAssert(value != NULL);
 
+        listElementsRemoved(c, key, where, o, 1, NULL);
         addReplyArrayLen(c, 2);
         addReplyBulk(c, key);
         addReplyBulk(c, value);
         decrRefCount(value);
-        listElementsRemoved(c, key, where, o, 1, 1, NULL);
-
         /* Replicate it as an [LR]POP instead of B[LR]POP. */
         rewriteClientCommandVector(c, 2, (where == LIST_HEAD) ? shared.lpop : shared.rpop, key);
         return;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -645,7 +645,7 @@ void listPopRangeAndReplyWithKey(client *c, robj *o, robj *key, int where, long 
     listTypeDelRange(o, rangestart, rangelen);
     /* Maintain the notifications and dirty. */
     listElementsRemoved(c, key, where, o, rangelen, deleted);
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
 }
 
 /* Extracted from `addListRangeReply()` to reply with a quicklist list.
@@ -795,7 +795,7 @@ void popGenericCommand(client *c, int where) {
         addListRangeReply(c, o, rangestart, rangeend, reverse);
         listTypeDelRange(o, rangestart, rangelen);
         listElementsRemoved(c, c->argv[1], where, o, rangelen, NULL);
-        commitDeferredReplyBuffer(c);
+        commitDeferredReplyBuffer(c, 1);
     }
 }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -903,7 +903,6 @@ void spopWithCountCommand(client *c) {
                 setTypeRemoveAux(set, str, len, llele, encoding == OBJ_ENCODING_HASHTABLE);
             }
         }
-
         /* Transfer the old set to the client. */
         setTypeIterator *si;
         si = setTypeInitIterator(set);
@@ -1387,16 +1386,16 @@ void sinterGenericCommand(client *c,
                 dstset->ptr = lpShrinkToFit(dstset->ptr);
             }
             setKey(c, c->db, dstkey, &dstset, 0);
-            addReplyLongLong(c, setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET, "sinterstore", dstkey, c->db->id);
             server.dirty++;
+            addReplyLongLong(c, setTypeSize(dstset));
         } else {
-            addReply(c, shared.czero);
             if (dbDelete(c->db, dstkey)) {
                 server.dirty++;
                 signalModifiedKey(c, c->db, dstkey);
                 notifyKeyspaceEvent(NOTIFY_GENERIC, "del", dstkey, c->db->id);
             }
+            addReply(c, shared.czero);
             decrRefCount(dstset);
         }
     } else {
@@ -1611,16 +1610,16 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
          * create this key with the result set inside */
         if (setTypeSize(dstset) > 0) {
             setKey(c, c->db, dstkey, &dstset, 0);
-            addReplyLongLong(c, setTypeSize(dstset));
             notifyKeyspaceEvent(NOTIFY_SET, op == SET_OP_UNION ? "sunionstore" : "sdiffstore", dstkey, c->db->id);
             server.dirty++;
+            addReplyLongLong(c, setTypeSize(dstset));
         } else {
-            addReply(c, shared.czero);
             if (dbDelete(c->db, dstkey)) {
                 server.dirty++;
                 signalModifiedKey(c, c->db, dstkey);
                 notifyKeyspaceEvent(NOTIFY_GENERIC, "del", dstkey, c->db->id);
             }
+            addReply(c, shared.czero);
             decrRefCount(dstset);
         }
     }

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -2027,10 +2027,10 @@ void xaddCommand(client *c) {
         return;
     }
     sds replyid = createStreamIDString(&id);
-    addReplyBulkCBuffer(c, replyid, sdslen(replyid));
 
     notifyKeyspaceEvent(NOTIFY_STREAM, "xadd", c->argv[1], c->db->id);
     server.dirty++;
+    addReplyBulkCBuffer(c, replyid, sdslen(replyid));
 
     /* Trim if needed. */
     if (parsed_args.trim_strategy != TRIM_STRATEGY_NONE) {
@@ -2663,9 +2663,9 @@ void xgroupCommand(client *c) {
 
         streamCG *cg = streamCreateCG(s, grpname, sdslen(grpname), &id, entries_read);
         if (cg) {
-            addReply(c, shared.ok);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM, "xgroup-create", c->argv[2], c->db->id);
+            addReply(c, shared.ok);
         } else {
             addReplyError(c, "-BUSYGROUP Consumer Group name already exists");
         }
@@ -2678,16 +2678,16 @@ void xgroupCommand(client *c) {
         }
         cg->last_id = id;
         cg->entries_read = entries_read;
-        addReply(c, shared.ok);
         server.dirty++;
         notifyKeyspaceEvent(NOTIFY_STREAM, "xgroup-setid", c->argv[2], c->db->id);
+        addReply(c, shared.ok);
     } else if (!strcasecmp(opt, "DESTROY") && c->argc == 4) {
         if (cg) {
             raxRemove(s->cgroups, (unsigned char *)grpname, sdslen(grpname), NULL);
             streamFreeCG(cg);
-            addReply(c, shared.cone);
             server.dirty++;
             notifyKeyspaceEvent(NOTIFY_STREAM, "xgroup-destroy", c->argv[2], c->db->id);
+            addReply(c, shared.cone);
             /* We want to unblock any XREADGROUP consumers with -NOGROUP. */
             signalKeyAsReady(c->db, c->argv[2], OBJ_STREAM);
         } else {
@@ -2780,9 +2780,9 @@ void xsetidCommand(client *c) {
     s->last_id = id;
     if (entries_added != -1) s->entries_added = entries_added;
     if (!streamIDEqZero(&max_xdel_id)) s->max_deleted_entry_id = max_xdel_id;
-    addReply(c, shared.ok);
     server.dirty++;
     notifyKeyspaceEvent(NOTIFY_STREAM, "xsetid", c->argv[1], c->db->id);
+    addReply(c, shared.ok);
 }
 
 /* XACK <key> <group> <id> <id> ... <id>

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -198,7 +198,7 @@ void setGenericCommand(client *c,
     }
 
 cleanup:
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
 }
 
 /*
@@ -474,7 +474,7 @@ void getexCommand(client *c) {
             server.dirty++;
         }
     }
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
 }
 
 void getdelCommand(client *c) {
@@ -487,7 +487,7 @@ void getdelCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty++;
     }
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
 }
 
 void getsetCommand(client *c) {
@@ -499,7 +499,7 @@ void getsetCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STRING, "set", c->argv[1], c->db->id);
     server.dirty++;
 
-    commitDeferredReplyBuffer(c);
+    commitDeferredReplyBuffer(c, 1);
     /* Propagate as SET command */
     rewriteClientCommandArgument(c, 0, shared.set);
 }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -106,7 +106,8 @@ void setGenericCommand(client *c,
     }
 
     if (flags & OBJ_SET_GET) {
-        if (getGenericCommand(c) == C_ERR) return;
+        initDeferredReplyBuffer(c);
+        if (getGenericCommand(c) == C_ERR) goto cleanup;
     }
 
     robj *existing_value = lookupKeyWrite(c->db, key);
@@ -115,27 +116,27 @@ void setGenericCommand(client *c,
     /* Handle the IFEQ conditional check */
     if (flags & OBJ_SET_IFEQ && found) {
         if (!(flags & OBJ_SET_GET) && checkType(c, existing_value, OBJ_STRING)) {
-            return;
+            goto cleanup;
         }
 
         if (compareStringObjects(existing_value, comparison) != 0) {
             if (!(flags & OBJ_SET_GET)) {
                 addReply(c, abort_reply ? abort_reply : shared.null[c->resp]);
             }
-            return;
+            goto cleanup;
         }
     } else if (flags & OBJ_SET_IFEQ && !found) {
         if (!(flags & OBJ_SET_GET)) {
             addReply(c, abort_reply ? abort_reply : shared.null[c->resp]);
         }
-        return;
+        goto cleanup;
     }
 
     if ((flags & OBJ_SET_NX && found) || (flags & OBJ_SET_XX && !found)) {
         if (!(flags & OBJ_SET_GET)) {
             addReply(c, abort_reply ? abort_reply : shared.null[c->resp]);
         }
-        return;
+        goto cleanup;
     }
 
     /* If the `milliseconds` have expired, then we don't need to set it into the
@@ -144,7 +145,7 @@ void setGenericCommand(client *c,
     if (expire && checkAlreadyExpired(milliseconds)) {
         if (found) deleteExpiredKeyFromOverwriteAndPropagate(c, key);
         if (!(flags & OBJ_SET_GET)) addReply(c, shared.ok);
-        return;
+        goto cleanup;
     }
 
     /* When expire is not NULL, we avoid deleting the TTL so it can be updated later instead of being deleted and then
@@ -195,6 +196,9 @@ void setGenericCommand(client *c,
         }
         replaceClientCommandVector(c, argc, argv);
     }
+
+cleanup:
+    commitDeferredReplyBuffer(c);
 }
 
 /*
@@ -442,6 +446,7 @@ void getexCommand(client *c) {
         return;
     }
 
+    initDeferredReplyBuffer(c);
     /* We need to do this before we expire the key or delete it */
     addReplyBulk(c, o);
 
@@ -469,9 +474,11 @@ void getexCommand(client *c) {
             server.dirty++;
         }
     }
+    commitDeferredReplyBuffer(c);
 }
 
 void getdelCommand(client *c) {
+    initDeferredReplyBuffer(c);
     if (getGenericCommand(c) == C_ERR) return;
     if (dbSyncDelete(c->db, c->argv[1])) {
         /* Propagate as DEL command */
@@ -480,9 +487,11 @@ void getdelCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty++;
     }
+    commitDeferredReplyBuffer(c);
 }
 
 void getsetCommand(client *c) {
+    initDeferredReplyBuffer(c);
     if (getGenericCommand(c) == C_ERR) return;
     c->argv[2] = tryObjectEncoding(c->argv[2]);
     setKey(c, c->db, c->argv[1], &c->argv[2], 0);
@@ -490,6 +499,7 @@ void getsetCommand(client *c) {
     notifyKeyspaceEvent(NOTIFY_STRING, "set", c->argv[1], c->db->id);
     server.dirty++;
 
+    commitDeferredReplyBuffer(c);
     /* Propagate as SET command */
     rewriteClientCommandArgument(c, 0, shared.set);
 }

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -39,6 +39,7 @@ TEST_MODULES = \
     datatype2.so \
     auth.so \
     keyspace_events.so \
+    block_keyspace_notification.so \
     blockedclient.so \
     getkeys.so \
     getchannels.so \

--- a/tests/modules/auth.c
+++ b/tests/modules/auth.c
@@ -187,15 +187,11 @@ void AuthBlock_FreeData(ValkeyModuleCtx *ctx, void *privdata) {
  * of blocking module auth.
  */
 int blocking_auth_cb(ValkeyModuleCtx *ctx, ValkeyModuleString *username, ValkeyModuleString *password, ValkeyModuleString **err) {
-    VALKEYMODULE_NOT_USED(username);
-    VALKEYMODULE_NOT_USED(password);
     VALKEYMODULE_NOT_USED(err);
     /* Block the client from the Module. */
     ValkeyModuleBlockedClient *bc = ValkeyModule_BlockClientOnAuth(ctx, AuthBlock_Reply, AuthBlock_FreeData);
-    int ctx_flags = ValkeyModule_GetContextFlags(ctx);
-    if (ctx_flags & VALKEYMODULE_CTX_FLAGS_MULTI || ctx_flags & VALKEYMODULE_CTX_FLAGS_LUA) {
-        /* Clean up by using ValkeyModule_UnblockClient since we attempted blocking the client. */
-        ValkeyModule_UnblockClient(bc, NULL);
+    if (bc == NULL) {
+        ValkeyModule_ReplyWithError(ctx, "ERR Blocking module command called from transaction");
         return VALKEYMODULE_AUTH_HANDLED;
     }
     ValkeyModule_BlockedClientMeasureTimeStart(bc);

--- a/tests/modules/block_keyspace_notification.c
+++ b/tests/modules/block_keyspace_notification.c
@@ -1,0 +1,169 @@
+/* This module is used to test blocking the client during a keyspace event. */
+#define _BSD_SOURCE
+#define _DEFAULT_SOURCE /* For usleep */
+
+#include "valkeymodule.h"
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+
+#define EVENT_LOG_MAX_SIZE 1024
+
+static pthread_mutex_t event_log_mutex = PTHREAD_MUTEX_INITIALIZER;
+typedef struct KeyspaceEventData {
+    ValkeyModuleString *key;
+    ValkeyModuleString *event;
+} KeyspaceEventData;
+
+typedef struct KeyspaceEventLog {
+    KeyspaceEventData *log[EVENT_LOG_MAX_SIZE];
+    size_t next_index;
+} KeyspaceEventLog;
+
+KeyspaceEventLog *event_log = NULL;
+int unloaded = 0;
+
+typedef struct BackgroundThreadData {
+    KeyspaceEventData *event;
+    ValkeyModuleBlockedClient *bc;
+} BackgroundThreadData;
+
+static void *GenericEvent_BackgroundWork(void *arg) {
+    BackgroundThreadData *data = (BackgroundThreadData *)arg;
+    // Sleep for 1 second
+    sleep(1);
+    pthread_mutex_lock(&event_log_mutex);
+    if (!unloaded && event_log->next_index < EVENT_LOG_MAX_SIZE) {
+        event_log->log[event_log->next_index] = data->event;
+        event_log->next_index++;
+    }
+    pthread_mutex_unlock(&event_log_mutex);
+    if (data->bc) {
+        ValkeyModule_UnblockClient(data->bc, NULL);
+    }
+    ValkeyModule_Free(data);
+    pthread_exit(NULL);
+}
+
+static int KeySpace_NotificationGeneric(ValkeyModuleCtx *ctx, int type,
+                                        const char *event,
+                                        ValkeyModuleString *key) {
+    VALKEYMODULE_NOT_USED(ctx);
+    VALKEYMODULE_NOT_USED(type);
+    ValkeyModuleString *retained_key = ValkeyModule_HoldString(ctx, key);
+    ValkeyModuleBlockedClient *bc =
+        ValkeyModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+    if (bc == NULL) {
+        ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_NOTICE,
+                         "Failed to block for event %s on %s!", event,
+                         ValkeyModule_StringPtrLen(key, NULL));
+    }
+    BackgroundThreadData *data =
+        ValkeyModule_Alloc(sizeof(BackgroundThreadData));
+    data->bc = bc;
+    KeyspaceEventData *event_data =
+        ValkeyModule_Alloc(sizeof(KeyspaceEventData));
+    event_data->key = retained_key;
+    event_data->event = ValkeyModule_CreateString(ctx, event, strlen(event));
+    data->event = event_data;
+    pthread_t tid;
+    pthread_create(&tid, NULL, GenericEvent_BackgroundWork, (void *)data);
+    return VALKEYMODULE_OK;
+}
+
+static int cmdGetEvents(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                        int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    pthread_mutex_lock(&event_log_mutex);
+    ValkeyModule_ReplyWithArray(ctx, event_log->next_index);
+    for (size_t i = 0; i < event_log->next_index; i++) {
+        ValkeyModule_ReplyWithArray(ctx, 4);
+        ValkeyModule_ReplyWithStringBuffer(ctx, "event", 5);
+        ValkeyModule_ReplyWithString(ctx, event_log->log[i]->event);
+        ValkeyModule_ReplyWithStringBuffer(ctx, "key", 3);
+        ValkeyModule_ReplyWithString(ctx, event_log->log[i]->key);
+    }
+    pthread_mutex_unlock(&event_log_mutex);
+    return VALKEYMODULE_OK;
+}
+
+static int cmdClearEvents(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                          int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    pthread_mutex_lock(&event_log_mutex);
+    for (size_t i = 0; i < event_log->next_index; i++) {
+        KeyspaceEventData *data = event_log->log[i];
+        ValkeyModule_FreeString(ctx, data->event);
+        ValkeyModule_FreeString(ctx, data->key);
+        ValkeyModule_Free(data);
+    }
+    event_log->next_index = 0;
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    pthread_mutex_unlock(&event_log_mutex);
+    return VALKEYMODULE_OK;
+}
+
+/* This function must be present on each Valkey module. It is used in order to
+ * register the commands into the Valkey server. */
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                        int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    if (ValkeyModule_Init(ctx, "testblockingkeyspacenotif", 1,
+                          VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+    event_log = ValkeyModule_Alloc(sizeof(KeyspaceEventLog));
+    event_log->next_index = 0;
+    int keySpaceAll = ValkeyModule_GetKeyspaceNotificationFlagsAll();
+    if (!(keySpaceAll & VALKEYMODULE_NOTIFY_LOADED)) {
+        // VALKEYMODULE_NOTIFY_LOADED event are not supported we can not start
+        return VALKEYMODULE_ERR;
+    }
+    if (ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_LOADED,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_GENERIC,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_EXPIRED,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_MODULE,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(
+            ctx, VALKEYMODULE_NOTIFY_KEY_MISS, KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_STRING,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_HASH,
+                                               KeySpace_NotificationGeneric) !=
+            VALKEYMODULE_OK ||
+        ValkeyModule_CreateCommand(ctx, "b_keyspace.events", cmdGetEvents, "",
+                                   0, 0, 0) == VALKEYMODULE_ERR ||
+        ValkeyModule_CreateCommand(ctx, "b_keyspace.clear", cmdClearEvents, "",
+                                   0, 0, 0) == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+    return VALKEYMODULE_OK;
+}
+
+int ValkeyModule_OnUnload(ValkeyModuleCtx *ctx) {
+    pthread_mutex_lock(&event_log_mutex);
+    unloaded = 1;
+    for (size_t i = 0; i < event_log->next_index; i++) {
+        KeyspaceEventData *data = event_log->log[i];
+        ValkeyModule_FreeString(ctx, data->event);
+        ValkeyModule_FreeString(ctx, data->key);
+        ValkeyModule_Free(data);
+    }
+    ValkeyModule_Free(event_log);
+    pthread_mutex_unlock(&event_log_mutex);
+    return VALKEYMODULE_OK;
+}

--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -1,0 +1,126 @@
+
+set testmodule [file normalize tests/modules/block_keyspace_notification.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+    test {Blocking keyspace notification one} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        assert_equal "1" [r hset a b c]
+        assert_equal "{event hset key a}" [r b_keyspace.events]
+    }
+    test {Blocking keyspace notification two} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        set rd1 [valkey_deferring_client]
+        $rd1 hset b c d
+        after 500
+        set rd2 [valkey_deferring_client]
+        $rd2 hset c d e
+        wait_for_blocked_clients_count 2
+        assert_equal "" [r b_keyspace.events]
+        wait_for_blocked_clients_count 1
+        assert_equal "{event hset key b}" [r b_keyspace.events]
+        wait_for_blocked_clients_count 0
+        assert_equal "{event hset key b} {event hset key c}" [r b_keyspace.events]
+    }
+    test {Blocking keyspace notification with pipelining hset after hget} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        set rd1 [valkey_deferring_client]
+        $rd1 hset key_10 field_10 value_10
+        wait_for_blocked_clients_count 0
+        assert_equal "1" [$rd1 read]
+        pause_process [srv 0 pid]
+        # Queue up three commands
+        $rd1 hget key_10 field_10
+        $rd1 hset key_10 value_10 ss
+        $rd1 hget key_10 field_10
+        set start [clock milliseconds]; # Record time before unblocking
+        resume_process [srv 0 pid]
+        assert_equal "value_10" [$rd1 read]
+        set first_hget [expr [clock milliseconds] - $start];
+        assert_equal "1" [$rd1 read]
+        set first_hset [expr [clock milliseconds] - $start];
+        assert_equal "value_10" [$rd1 read]
+        set second_hget [expr [clock milliseconds] - $start];
+        assert {[expr {$first_hget * 10 < $first_hset}]}
+        assert {[expr {$second_hget - $first_hset <= 50}]}
+        wait_for_blocked_clients_count 0
+    }
+    test {Blocking keyspace notification with pipelining hget after hset} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        set rd1 [valkey_deferring_client]
+        pause_process [srv 0 pid]
+        $rd1 hset key_2 field_1 value_1
+        $rd1 hget key_2 field_1
+        resume_process [srv 0 pid]
+        wait_for_blocked_clients_count 1
+        assert_equal "" [r b_keyspace.events]
+        wait_for_blocked_clients_count 0
+        assert_equal "{event hset key key_2}" [r b_keyspace.events]
+        assert_equal "1" [$rd1 read]
+        assert_equal "value_1" [$rd1 read]
+    }
+    test {Blocking keyspace notif during multi} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        r multi
+        r hset d e f
+        r hset e f g
+        assert_equal "1 1" [r exec]
+        # Nothing should be blocked inside the transaction
+        assert_equal [s 0 blocked_clients] 0
+        assert_equal [r b_keyspace.events] ""
+        # In the background, the work should still occur
+        wait_for_condition 1000 50 {
+            [string match "{event hset key *} {event hset key *}" [set latest [r b_keyspace.events]]]
+        } else {
+            fail "Keyspace event not propagated within 5 seconds"
+        }
+    }
+    test {Event that fires twice} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        r hset f g h
+        wait_for_blocked_clients_count 0
+        assert_equal "OK" [r b_keyspace.clear]
+        set rd1 [valkey_deferring_client]
+        $rd1 RENAME f g
+        # Only one blocked client
+        assert_equal [s 0 blocked_clients] 1
+        assert_equal "" [r b_keyspace.events]
+        # We should still see async processing for both events, which could be processed in either order
+        wait_for_condition 1000 50 {
+            [string match "{event rename_* key *} {event rename_* key *}" [set latest [r b_keyspace.events]]]
+        } else {
+            fail "Rename event not propagated within 5 seconds: latest value ${latest}"
+        }
+    }
+    test {Server-created keyspace notification} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        assert_equal "1" [r hset h i j]
+        assert_equal "1" [r expire h 1]
+        assert_equal [s 0 blocked_clients] 0
+        # Expire will proceed processing in the background as we haven't
+        # enabled blocking for the command yet.
+        wait_for_condition 1000 50 {
+            [r b_keyspace.events] eq "{event hset key h} {event expire key h}"
+        } else {
+            fail "Expire event not propagated within 5 seconds"
+        }
+        assert_equal "OK" [r b_keyspace.clear]
+        # Expiration should happen in the background
+        wait_for_condition 1000 50 {
+            [r b_keyspace.events] eq "{event expired key h}"
+        } else {
+            fail "Expired event not propagated within 5 seconds"
+        }
+    }
+    test "Unload the module - testblockingkeyspacenotif" {
+        assert_equal {OK} [r module unload testblockingkeyspacenotif]
+    }
+}
+


### PR DESCRIPTION
This change enhances user experience and consistency by allowing a module to block a client on keyspace event notifications. Consistency is improved by allowing that reads after writes on the same connection yield expected results. For example, in ValkeySearch, mutations processed earlier on the same connection will be available for search.

The implementation extends `VM_BlockClient` to support blocking clients on keyspace event notifications. Internal clients, LUA clients, clients issueing multi exec and those with the `deny_blocking` flag set are not blocked. Once blocked, a client’s reply is withheld until it is explicitly unblocked.