### PR TITLE
Fix bug where invalidation messages were getting sent to closing clients

### DIFF
--- a/src/tracking.c
+++ b/src/tracking.c
@@ -280,7 +280,7 @@ void sendTrackingMessage(client *c, char *keyname, size_t keylen, int proto) {
     int using_redirection = 0;
     if (c->pubsub_data->client_tracking_redirection) {
         client *redir = lookupClientByID(c->pubsub_data->client_tracking_redirection);
-        if (!redir) {
+        if (!redir || redir->flag.close_after_reply || redir->flag.close_asap) {
             c->flag.tracking_broken_redir = 1;
             /* We need to signal to the original connection that we
              * are unable to send invalidation messages to the redirected

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -243,8 +243,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1
-        $rd_redirection QUIT
-        assert_equal OK [$rd_redirection read]
+        r CLIENT KILL ID $redir_id
         $rd_redirection close
         $rd_sg SET key1 2
 
@@ -261,7 +260,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         } else {
             fail "Failed to get redirect broken indication"
         }
-         # Consume PING reply
+        # Consume PING reply
         assert_equal PONG [r read]
     }
 
@@ -718,8 +717,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1
-        $rd_redirection QUIT
-        assert_equal OK [$rd_redirection read]
+        r CLIENT KILL ID $redir_id
         $rd_sg SET key1 2
         set res [lsearch -exact [r read] "tracking-redir-broken"]
         assert {$res >= 0}

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -243,7 +243,8 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1
-        r CLIENT KILL ID $redir_id
+        $rd_redirection QUIT
+        assert_equal OK [$rd_redirection read]
         $rd_redirection close
         $rd_sg SET key1 2
 
@@ -717,7 +718,8 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1
-        r CLIENT KILL ID $redir_id
+        $rd_redirection QUIT
+        assert_equal OK [$rd_redirection read]
         $rd_sg SET key1 2
         set res [lsearch -exact [r read] "tracking-redir-broken"]
         assert {$res >= 0}

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -241,6 +241,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         # make sure r is working resp 3
         r HELLO 3
         r CLIENT TRACKING on REDIRECT $redir_id
+        set redir_error "tracking-redir-broken $redir_id"
         $rd_sg SET key1 1
         r GET key1
         $rd_redirection QUIT
@@ -257,10 +258,11 @@ start_server {tags {"tracking network logreqres:skip"}} {
 
         # Wait to read the tracking-redir-broken
         wait_for_condition 1000 50 {
-            [lsearch -exact [r PING] "tracking-redir-broken"]
+            [set response [r PING]] != "PONG"
         } else {
             fail "Failed to get redirect broken indication"
         }
+        assert_equal $redir_error $response
         # Consume PING reply
         assert_equal PONG [r read]
     }


### PR DESCRIPTION
So I think we were seeing [these timeouts](https://github.com/valkey-io/valkey/actions/runs/13688155322/job/38276139543#step:6:839) because QUIT behaves differently between IO threading and non-IO Threading. In both cases, `QUIT` is a close after reply command. Once the client has written out the results, it gets added to the queue to that gets cleaned up at the end of the event loop. Normally this is fine, as before we circle around to the next event loop this client is definitely killed.

For IO threads, we need to process the pending IO commands to add the client to the kill queue. This may not happen immediately, which means we might go down and process that `SET` command *before* we free the client that is supposedly already quit. This is very sensitive to timing, so it's not very likely, but still possible. Once the `SET` has been executed, the invariants in the tests are off since it will get a correct invalidation.

The fix is to also mark a client as broken if it's being closed. 

The test was also hanging because of a test issue, because the conditional `lsearch` check was returning 1 or 0 strings, which are both valid exit criteria for the wait_for.

```
./runtest --io-threads --accurate --verbose --tags network --dump-logs --single unit/tracking --loops 500 --clients 25
```

Fixes #1647 (I believe this now!)