### PR TITLE
Update CloseKey module API documentation to avoid use-after-free behavior

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4199,7 +4199,7 @@ static void moduleCloseKey(ValkeyModuleKey *key) {
     decrRefCount(key->key);
 }
 
-/* Close a key handle. */
+/* Close a key handle. The key handle is freed and should not be accessed anymore */
 void VM_CloseKey(ValkeyModuleKey *key) {
     if (key == NULL) return;
     moduleCloseKey(key);

--- a/src/module.c
+++ b/src/module.c
@@ -4199,7 +4199,7 @@ static void moduleCloseKey(ValkeyModuleKey *key) {
     decrRefCount(key->key);
 }
 
-/* Close a key handle. The key handle is freed and should not be accessed anymore */
+/* Close a key handle. The key handle is freed and should not be accessed anymore. */
 void VM_CloseKey(ValkeyModuleKey *key) {
     if (key == NULL) return;
     moduleCloseKey(key);


### PR DESCRIPTION
### Issue: https://github.com/valkey-io/valkey/issues/1775

Without a clear comment, users might mistakenly attempt to access or close the same key object multiple times, leading to use-after-free errors, undefined behavior, or crashes due to double-free operations.
