### PR TITLE
Update COPY and MOVE command description clearer in JSON file

### DIFF
--- a/src/commands/copy.json
+++ b/src/commands/copy.json
@@ -82,7 +82,7 @@
                     "const": 1
                 },
                 {
-                    "description": "Source was not copied.",
+                    "description": "Source was not copied when the destination key already exists",
                     "const": 0
                 }
             ]

--- a/src/commands/move.json
+++ b/src/commands/move.json
@@ -52,7 +52,7 @@
                     "const": 1
                 },
                 {
-                    "description": "Key wasn't moved.",
+                    "description": "When key already exists in the destination database, or it does not exist in the source database",
                     "const": 0
                 }
             ]

--- a/src/commands/move.json
+++ b/src/commands/move.json
@@ -52,7 +52,7 @@
                     "const": 1
                 },
                 {
-                    "description": "When key already exists in the destination database, or it does not exist in the source database",
+                    "description": "Key wasn't moved. When key already exists in the destination database, or it does not exist in the source database",
                     "const": 0
                 }
             ]


### PR DESCRIPTION
As I do the code review for PR https://github.com/valkey-io/valkey/pull/1671 (Add multi-database support to cluster mode), I find
the return value message of the command COPY and MOVE is not very clear to user. Thus I update them in this PR and valkey-doc repo as PR https://github.com/valkey-io/valkey-doc/pull/249

