### PR TITLE
Update valkey-benchmark parseURI function name and comment

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -308,7 +308,7 @@ static sds percentDecode(const char *pe, size_t len) {
  *   path:      ["/" [<db>]]
  *
  *  [1]: https://www.iana.org/assignments/uri-schemes/prov/redis */
-void parseRedisOrValkeyUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag) {
+void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag) {
 #ifdef USE_OPENSSL
     UNUSED(tool_name);
 #else

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -303,7 +303,7 @@ static sds percentDecode(const char *pe, size_t len) {
 /* Parse a URI and extract the server connection information.
  * URI scheme is based on the provisional specification[1] excluding support
  * for query parameters. Valid URIs are:
- *   scheme:    "valkey://", or "valkeys://", or "redis://", or "rediss://"
+ *   scheme:    "valkey://" or "valkeys://" or "redis://" or "rediss://"
  *   authority: [[<username> ":"] <password> "@"] [<hostname> [":" <port>]]
  *   path:      ["/" [<db>]]
  *

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -303,12 +303,12 @@ static sds percentDecode(const char *pe, size_t len) {
 /* Parse a URI and extract the server connection information.
  * URI scheme is based on the provisional specification[1] excluding support
  * for query parameters. Valid URIs are:
- *   scheme:    "valkey://"
+ *   scheme:    "valkey://", or "valkeys://", or "redis://", or "rediss://"
  *   authority: [[<username> ":"] <password> "@"] [<hostname> [":" <port>]]
  *   path:      ["/" [<db>]]
  *
  *  [1]: https://www.iana.org/assignments/uri-schemes/prov/redis */
-void parseRedisUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag) {
+void parseRedisOrValkeyUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag) {
 #ifdef USE_OPENSSL
     UNUSED(tool_name);
 #else

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -45,7 +45,7 @@ sds *getSdsArrayFromArgv(int argc, char **argv, int quoted);
 
 sds unquoteCString(char *str);
 
-void parseRedisOrValkeyUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag);
+void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag);
 
 void freeCliConnInfo(cliConnInfo connInfo);
 

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -45,7 +45,7 @@ sds *getSdsArrayFromArgv(int argc, char **argv, int quoted);
 
 sds unquoteCString(char *str);
 
-void parseRedisUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag);
+void parseRedisOrValkeyUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int *tls_flag);
 
 void freeCliConnInfo(cliConnInfo connInfo);
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1342,7 +1342,7 @@ int parseOptions(int argc, char **argv) {
             if (lastarg) goto invalid;
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
-            parseRedisOrValkeyUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
+            parseUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
                 fprintf(stderr, "Invalid server port.\n");
                 exit(1);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1342,7 +1342,7 @@ int parseOptions(int argc, char **argv) {
             if (lastarg) goto invalid;
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
-            parseRedisUri(argv[++i], "redis-benchmark", &config.conn_info, &config.tls);
+            parseRedisOrValkeyUri(argv[++i], "valkey-benchmark", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
                 fprintf(stderr, "Invalid server port.\n");
                 exit(1);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2608,7 +2608,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--user") && !lastarg) {
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
-            parseRedisOrValkeyUri(argv[++i], "valkey-cli", &config.conn_info, &config.tls);
+            parseUri(argv[++i], "valkey-cli", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
                 fprintf(stderr, "Invalid server port.\n");
                 exit(1);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2608,7 +2608,7 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--user") && !lastarg) {
             config.conn_info.user = sdsnew(argv[++i]);
         } else if (!strcmp(argv[i], "-u") && !lastarg) {
-            parseRedisUri(argv[++i], "valkey-cli", &config.conn_info, &config.tls);
+            parseRedisOrValkeyUri(argv[++i], "valkey-cli", &config.conn_info, &config.tls);
             if (config.conn_info.hostport < 0 || config.conn_info.hostport > 65535) {
                 fprintf(stderr, "Invalid server port.\n");
                 exit(1);


### PR DESCRIPTION
In Valkey, when user runs the valkey-benchmark tools, the command
**valkey-benchmark -u** could accept 4 schemes of server URI format:  
"valkey://", "valkeys://", "redis://", "rediss://"   

Thus, I add them in the function comment, and update the function name to parseRedisOrValkeyUri.

Finally, I fix one mistake for valkey-benchmark tool name for this command.
