### PR TITLE
Fix RANDOMKEY infinite loop during CLIENT PAUSE

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -445,7 +445,7 @@ robj *dbRandomKey(serverDb *db) {
         sds key = objectGetKey(valkey);
         robj *keyobj = createStringObject(key, sdslen(key));
         if (objectIsExpired(valkey)) {
-            if (allvolatile && (server.primary_host || server.import_mode) && --maxtries == 0) {
+            if (allvolatile && (server.primary_host || server.import_mode || isPausedActions(PAUSE_ACTION_EXPIRE)) && --maxtries == 0) {
                 /* If the DB is composed only of keys with an expire set,
                  * it could happen that all the keys are already logically
                  * expired in the replica, so the function cannot stop because

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -417,11 +417,11 @@ start_server {tags {"pause network"}} {
         r flushall
 
         # then set a key with expire time
-        r set key value ex 3
+        r set key value px 3
 
         # set pause-write model and wait key expired
         r client pause 10000 write
-        after 5000
+        after 5
 
         wait_for_condition 50 100 {
             [r randomkey] == "key"
@@ -429,7 +429,7 @@ start_server {tags {"pause network"}} {
             fail "execute randomkey failed, caused by the infinite loop"
         }
 
-        after 6000
+        r client unpause
         assert_equal [r randomkey] {}
 
     }

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -412,6 +412,17 @@ start_server {tags {"pause network"}} {
         } {bar2}
     }
 
+    test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
+        r set key value ex 2
+        r client pause 5000 write
+        after 3000
+        wait_for_condition 30 100 {
+            [r randomkey] == {}
+        } else {
+            fail "randomkey cause the infinite loop"
+        }
+    }
+
     # Make sure we unpause at the end
     r client unpause
 }

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -413,14 +413,25 @@ start_server {tags {"pause network"}} {
     }
 
     test "Test the randomkey command will not cause the server to get into an infinite loop during the client pause write" {
-        r set key value ex 2
-        r client pause 5000 write
-        after 3000
-        wait_for_condition 30 100 {
-            [r randomkey] == {}
+        # first, clear the database to avoid interference from existing keys on the test results 
+        r flushall
+
+        # then set a key with expire time
+        r set key value ex 3
+
+        # set pause-write model and wait key expired
+        r client pause 10000 write
+        after 5000
+
+        wait_for_condition 50 100 {
+            [r randomkey] == "key"
         } else {
-            fail "randomkey cause the infinite loop"
+            fail "execute randomkey failed, caused by the infinite loop"
         }
+
+        after 6000
+        assert_equal [r randomkey] {}
+
     }
 
     # Make sure we unpause at the end


### PR DESCRIPTION
When the `client pause write` is set and all the keys in the server
are expired keys, executing the `randomkey` command will lead to an
infinite loop.

The reason is that expired keys are not deleted in this case. Limit
the number of tries and return an expired key after the max number
tries in this case.

Closes #1848.