### PR TITLE
[cluster] Add node id to log statement for closing link on first message as lightweight

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3214,7 +3214,7 @@ int clusterProcessPacket(clusterLink *link) {
             serverLog(
                 LL_NOTICE,
                 "Closing link for node %.40s that sent a lightweight message of type %s as its first message on the link",
-                (getNodeFromLinkAndMsg(link, hdr))->name,
+                hdr->sender,
                 clusterGetMessageTypeString(type));
             return 0;
         }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3213,7 +3213,8 @@ int clusterProcessPacket(clusterLink *link) {
             freeClusterLink(link);
             serverLog(
                 LL_NOTICE,
-                "Closing link for node that sent a lightweight message of type %s as its first message on the link",
+                "Closing link for node %.40s that sent a lightweight message of type %s as its first message on the link",
+                (getNodeFromLinkAndMsg(link, hdr))->name,
                 clusterGetMessageTypeString(type));
             return 0;
         }


### PR DESCRIPTION
I was playing around and was sending lightweight message before the cluster link had stabilized and the link was getting disconnected. I'm unsure how it happens in the current scenario. However, if it happens at all it will be good to capture the node name from which the message had originated. 