### PR TITLE
Add certificate rotation functionality to ValKey

### DIFF
--- a/runtest-rotation
+++ b/runtest-rotation
@@ -1,0 +1,31 @@
+#!/bin/sh
+TCL_VERSIONS="8.5 8.6"
+TCLSH=""
+
+export ASAN_OPTIONS=allocator_may_return_null=1  $ASAN_OPTIONS
+
+for VERSION in $TCL_VERSIONS; do
+	TCL=`which tclsh$VERSION 2>/dev/null` && TCLSH=$TCL
+done
+
+if [ -z $TCLSH ]
+then
+    echo "You need tcl 8.5 or newer in order to run the ValKey test"
+    exit 1
+fi
+if [ ! -r tests/tls ] || [ ! -r tests/tls_1 ] || [ ! -r tests/tls_2 ];
+then
+    echo "Generating neccessary certificates for TLS rotation testing."
+    rm -rf tests/tls tests/tls_1 tests/tls_2
+
+    utils/gen-test-certs.sh
+    mv tests/tls tests/tls_1
+    utils/gen-test-certs.sh
+    mv tests/tls tests/tls_2
+    utils/gen-test-certs.sh
+fi
+$TCLSH tests/test_helper.tcl \
+--single tls-rotation/tls-rotation \
+--tls \
+--config io-threads 3 \
+"${@}"

--- a/runtest-rotation
+++ b/runtest-rotation
@@ -15,7 +15,7 @@ then
 fi
 if [ ! -r tests/tls ] || [ ! -r tests/tls_1 ] || [ ! -r tests/tls_2 ];
 then
-    echo "Generating neccessary certificates for TLS rotation testing."
+    echo "Generating necessary certificates for TLS rotation testing."
     rm -rf tests/tls tests/tls_1 tests/tls_2
 
     utils/gen-test-certs.sh

--- a/src/config.c
+++ b/src/config.c
@@ -3360,6 +3360,7 @@ standardConfig static_configs[] = {
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-session-caching", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.session_caching, 1, NULL, applyTlsCfg),
+    createBoolConfig("tls-rotation", NULL, MODIFIABLE_CONFIG, server.tls_rotation, 0, NULL, applyTlsCfg),
     createStringConfig("tls-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file_pass, NULL, NULL, applyTlsCfg),

--- a/src/server.c
+++ b/src/server.c
@@ -1670,10 +1670,10 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
         migrateCloseTimedoutSockets();
     }
 
-    /* Reload the TLS cert if neccessary. This effectively rotates the 
+    /* Reload the TLS cert if necessary. This effectively rotates the
      * cert if a change has been made on disk, but the ValKey server hasn't
      * been notified. */
-    run_with_period(1000){
+    run_with_period(1000) {
         tlsReload();
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1670,6 +1670,13 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
         migrateCloseTimedoutSockets();
     }
 
+    /* Reload the TLS cert if neccessary. This effectively rotates the 
+     * cert if a change has been made on disk, but the ValKey server hasn't
+     * been notified. */
+    run_with_period(1000){
+        tlsReload();
+    }
+
     /* Resize tracking keys table if needed. This is also done at every
      * command execution, but we want to be sure that if the last command
      * executed changes the value via CONFIG SET, the server will perform

--- a/src/server.h
+++ b/src/server.h
@@ -1485,6 +1485,12 @@ typedef struct serverTLSContextConfig {
     int session_caching;
     int session_cache_size;
     int session_cache_timeout;
+    time_t cert_file_last_modified;
+    time_t key_file_last_modified;
+    time_t client_cert_file_last_modified;
+    time_t client_key_file_last_modified;
+    time_t ca_cert_file_last_modified;
+    time_t ca_cert_dir_last_modified;
 } serverTLSContextConfig;
 
 /*-----------------------------------------------------------------------------
@@ -2119,6 +2125,7 @@ struct valkeyServer {
     int tls_cluster;
     int tls_replication;
     int tls_auth_clients;
+    int tls_rotation;
     serverTLSContextConfig tls_ctx_config;
     serverUnixContextConfig unix_ctx_config;
     serverRdmaContextConfig rdma_ctx_config;
@@ -2593,6 +2600,7 @@ int validateProcTitleTemplate(const char *template);
 int serverCommunicateSystemd(const char *sd_notify_msg);
 void serverSetCpuAffinity(const char *cpulist);
 void dictVanillaFree(void *val);
+void tlsReload(void);
 
 /* ERROR STATS constants */
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -47,6 +47,7 @@
 #include <sys/uio.h>
 #include <arpa/inet.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 
 #define REDIS_TLS_PROTO_TLSv1 (1 << 0)
 #define REDIS_TLS_PROTO_TLSv1_1 (1 << 1)
@@ -282,7 +283,7 @@ error:
 }
 
 /* Given a path to a file, return the last time it was accessed (in seconds) */
-static time_t getLastModifiedTime(const char* path){
+static time_t getLastModifiedTime(const char* path) {
     struct stat path_stat;
     stat(path, &path_stat);
 
@@ -1170,8 +1171,7 @@ static int tlsProcessPendingData(void) {
 /* Reload TLS certificate from disk, effectively rotating it */
 void tlsReload(void) {
     /* We will only bother checking keys and certs if TLS is enabled, otherwise we would be calling 'stat' for no reason */
-    if (server.tls_rotation && (server.tls_port || server.tls_replication || server.tls_cluster)){
-
+    if (server.tls_rotation && (server.tls_port || server.tls_replication || server.tls_cluster)) {
         bool cert_file_modified = getLastModifiedTime(server.tls_ctx_config.cert_file) != server.tls_ctx_config.cert_file_last_modified;
         bool key_file_modified = getLastModifiedTime(server.tls_ctx_config.key_file) != server.tls_ctx_config.key_file_last_modified;
 
@@ -1181,7 +1181,7 @@ void tlsReload(void) {
         bool ca_cert_file_modified = server.tls_ctx_config.ca_cert_file != NULL && getLastModifiedTime(server.tls_ctx_config.ca_cert_file) != server.tls_ctx_config.ca_cert_file_last_modified;
         bool ca_cert_dir_modified = server.tls_ctx_config.ca_cert_dir != NULL && getLastModifiedTime(server.tls_ctx_config.ca_cert_dir) != server.tls_ctx_config.ca_cert_dir_last_modified;
 
-        if (cert_file_modified || key_file_modified || ca_cert_file_modified || ca_cert_dir_modified || client_cert_file_modified || client_key_file_modified){
+        if (cert_file_modified || key_file_modified || ca_cert_file_modified || ca_cert_dir_modified || client_cert_file_modified || client_key_file_modified) {
             serverLog(LL_NOTICE, "TLS certificates changed on disk, attempting to rotate.");
             if (tlsConfigure(&server.tls_ctx_config, true) == C_ERR) {
                 serverLog(LL_NOTICE, "Error trying to rotate TLS certificates, TLS credentials remain unchanged.");
@@ -1279,7 +1279,8 @@ int RedisRegisterConnectionTypeTLS(void) {
     return C_ERR;
 }
 
-void tlsReload(void) {}
+void tlsReload(void) {
+}
 
 #endif
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -283,7 +283,7 @@ error:
 }
 
 /* Given a path to a file, return the last time it was accessed (in seconds) */
-static time_t getLastModifiedTime(const char* path) {
+static time_t getLastModifiedTime(const char *path) {
     struct stat path_stat;
     stat(path, &path_stat);
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -46,6 +46,7 @@
 #endif
 #include <sys/uio.h>
 #include <arpa/inet.h>
+#include <sys/stat.h>
 
 #define REDIS_TLS_PROTO_TLSv1 (1 << 0)
 #define REDIS_TLS_PROTO_TLSv1_1 (1 << 1)
@@ -280,6 +281,18 @@ error:
     return NULL;
 }
 
+/* Given a path to a file, return the last time it was accessed (in seconds) */
+static time_t getLastModifiedTime(const char* path){
+    struct stat path_stat;
+    stat(path, &path_stat);
+
+#ifdef __APPLE__
+    return path_stat.st_mtimespec.tv_sec;
+#else
+    return path_stat.st_mtime;
+#endif
+}
+
 /* Attempt to configure/reconfigure TLS. This operation is atomic and will
  * leave the SSL_CTX unchanged if fails.
  * @priv: config of serverTLSContextConfig.
@@ -312,6 +325,14 @@ static int tlsConfigure(void *priv, int reconfigure) {
                               "tls-replication or tls-auth-clients are enabled!");
         goto error;
     }
+
+    /* Update the last modified times for the TLS elements */
+    ctx_config->key_file_last_modified = getLastModifiedTime(ctx_config->key_file);
+    ctx_config->cert_file_last_modified = getLastModifiedTime(ctx_config->cert_file);
+    ctx_config->client_cert_file_last_modified = getLastModifiedTime(ctx_config->client_cert_file);
+    ctx_config->client_key_file_last_modified = getLastModifiedTime(ctx_config->client_key_file);
+    ctx_config->ca_cert_dir_last_modified = getLastModifiedTime(ctx_config->ca_cert_dir);
+    ctx_config->ca_cert_file_last_modified = getLastModifiedTime(ctx_config->ca_cert_file);
 
     int protocols = parseProtocolsConfig(ctx_config->protocols);
     if (protocols == -1) goto error;
@@ -1146,6 +1167,31 @@ static int tlsProcessPendingData(void) {
     return processed;
 }
 
+/* Reload TLS certificate from disk, effectively rotating it */
+void tlsReload(void) {
+    /* We will only bother checking keys and certs if TLS is enabled, otherwise we would be calling 'stat' for no reason */
+    if (server.tls_rotation && (server.tls_port || server.tls_replication || server.tls_cluster)){
+
+        bool cert_file_modified = getLastModifiedTime(server.tls_ctx_config.cert_file) != server.tls_ctx_config.cert_file_last_modified;
+        bool key_file_modified = getLastModifiedTime(server.tls_ctx_config.key_file) != server.tls_ctx_config.key_file_last_modified;
+
+        bool client_cert_file_modified = server.tls_ctx_config.client_cert_file != NULL && getLastModifiedTime(server.tls_ctx_config.client_cert_file) != server.tls_ctx_config.client_cert_file_last_modified;
+        bool client_key_file_modified = server.tls_ctx_config.client_key_file != NULL && getLastModifiedTime(server.tls_ctx_config.client_key_file) != server.tls_ctx_config.client_key_file_last_modified;
+
+        bool ca_cert_file_modified = server.tls_ctx_config.ca_cert_file != NULL && getLastModifiedTime(server.tls_ctx_config.ca_cert_file) != server.tls_ctx_config.ca_cert_file_last_modified;
+        bool ca_cert_dir_modified = server.tls_ctx_config.ca_cert_dir != NULL && getLastModifiedTime(server.tls_ctx_config.ca_cert_dir) != server.tls_ctx_config.ca_cert_dir_last_modified;
+
+        if (cert_file_modified || key_file_modified || ca_cert_file_modified || ca_cert_dir_modified || client_cert_file_modified || client_key_file_modified){
+            serverLog(LL_NOTICE, "TLS certificates changed on disk, attempting to rotate.");
+            if (tlsConfigure(&server.tls_ctx_config, true) == C_ERR) {
+                serverLog(LL_NOTICE, "Error trying to rotate TLS certificates, TLS credentials remain unchanged.");
+            } else {
+                serverLog(LL_NOTICE, "TLS certificates rotated successfully.");
+            }
+        }
+    }
+}
+
 /* Fetch the peer certificate used for authentication on the specified
  * connection and return it as a PEM-encoded sds.
  */
@@ -1232,6 +1278,8 @@ int RedisRegisterConnectionTypeTLS(void) {
     serverLog(LL_VERBOSE, "Connection type %s not builtin", CONN_TYPE_TLS);
     return C_ERR;
 }
+
+void tlsReload(void) {}
 
 #endif
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -249,6 +249,26 @@ proc valkey_client_by_addr {host port} {
     return $client
 }
 
+proc valkey_client_tls {args} {
+    set level 0
+    if {[llength $args] > 0 && [string is integer [lindex $args 0]]} {
+        set level [lindex $args 0]
+        set args [lrange $args 1 end]
+    }
+
+    set tlsoptions ""
+    if {[llength $args] > 0 && ![string is integer [lindex $args 0]]} {
+        set tlsoptions [lrange $args 0 end]
+    }
+
+    # create client that takes in custom tls options
+    set client [redis [srv $level "host"] [srv $level "port"] 0 $::tls $tlsoptions]
+
+    # # select the right db and read the response (OK)
+    $client select 9
+    return $client
+}
+
 # Provide easy access to INFO properties. Same semantic as "proc r".
 proc s {args} {
     set level 0

--- a/tests/tls-rotation/tls-rotation.tcl
+++ b/tests/tls-rotation/tls-rotation.tcl
@@ -1,0 +1,109 @@
+start_server {tags {"tls-rotation"} overrides {tls-rotation yes}} {
+    if {$::tls} {
+        package require tls
+
+        test {TLS: Create temporary location for certificate rotation} {
+            set rootdir [tmpdir tlscerts]
+
+            file copy "tests/tls" $rootdir
+            file copy "tests/tls_1" $rootdir
+            file copy "tests/tls_2" $rootdir
+
+            set serverdir [format "%s/$rootdir/tls" [pwd]]
+            set clientdir1 [format "%s/$rootdir/tls_1" [pwd]]
+            set clientdir2 [format "%s/$rootdir/tls_2" [pwd]]
+        }
+
+        test {TLS: Update server config to point to temporary location } {
+            r config set tls-key-file "$serverdir/server.key"
+            r config set tls-cert-file "$serverdir/server.crt"
+            r config set tls-ca-cert-file "$serverdir/ca.crt"
+        }
+
+        test {TLS: Connect client to server} {
+            set r2 [valkey_client_tls -keyfile "$serverdir/client.key" -certfile "$serverdir/client.crt" -require 1 -cafile "$serverdir/ca.crt"]
+            $r2 set x 50
+            assert_equal {50} [$r2 get x]
+        }
+
+        test {TLS: Rotate all TLS certificates} {
+            file delete -force -- $serverdir 
+            file copy $clientdir1 $serverdir
+            after 1000
+        }
+
+        test {TLS: Already connected clients do not lose connection post certificate rotation} {
+            $r2 incrby x 50
+            assert_equal {100} [$r2 get x]
+        }
+
+        test {TLS: Clients with outdated credentials cannot connect} {
+            catch {set r2 [valkey_client_tls -keyfile "$clientdir2/client.key" -certfile "$clientdir2/client.crt" -require 1 -cafile "$clientdir2/ca.crt"]} e
+            assert_no_match {*::redis::redisHandle*} $e
+        }
+
+        test {TLS: Clients with correct certifcates can cannect to server post rotation} {
+            set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir1/ca.crt"]
+            $r2 incrby x 50
+            assert_equal {150} [$r2 get x]
+        }
+
+        test {TLS: Rotate only server key causing key/cert mismatch} {
+            file copy -force -- "$clientdir2/server.key" $serverdir
+            after 1000
+        }
+
+        test {TLS: Already connected clients do not lose connection despite mismatch} {
+            $r2 incrby x 50
+            assert_equal {200} [$r2 get x]
+        }
+
+        test {TLS: Clients with old credentials can still connect} {
+            set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir1/ca.crt"]
+            $r2 incrby x 50
+            assert_equal {250} [$r2 get x]
+        }
+
+        test {TLS: Rotate corresponding cert fixing key/cert mismatch} {
+            file copy -force -- "$clientdir2/server.crt" $serverdir
+            after 1000
+        }
+
+        test {TLS: Check that old client is still connected post rotation} {
+            $r2 incrby x 50
+            assert_equal {300} [$r2 get x]
+        }
+
+        test {TLS: Clients with outdated credentials cannot connect} {
+            catch {set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir1/ca.crt"]} e
+            assert_no_match {*::redis::redisHandle*} $e
+        }
+
+        test {TLS: Clients with correct certifcates can cannect to server post rotation} {
+            set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir2/ca.crt"]
+            $r2 incrby x 50
+            assert_equal {350} [$r2 get x]
+        }
+
+        test {TLS: Rotate only CA cert} {
+            file copy -force -- "$clientdir2/ca.crt" $serverdir
+            after 1000
+        }
+
+        test {TLS: Check that old client is still connected} {
+            $r2 incrby x 50
+            assert_equal {400} [$r2 get x]
+        }
+
+        test {TLS: Check that client with old credentials won't connect} {
+            catch {set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir2/ca.crt"]} e
+            assert_no_match {*::redis::redisHandle*} $e
+        }
+
+        test {TLS: Check that client with updated credentials will connect} {
+            catch {set r2 [valkey_client_tls -keyfile "$clientdir2/client.key" -certfile "$clientdir2/client.crt" -require 1 -cafile "$clientdir2/ca.crt"]} e
+            $r2 incrby x 50
+            assert_equal {450} [$r2 get x]
+        }
+    }
+}

--- a/tests/tls-rotation/tls-rotation.tcl
+++ b/tests/tls-rotation/tls-rotation.tcl
@@ -42,7 +42,7 @@ start_server {tags {"tls-rotation"} overrides {tls-rotation yes}} {
             assert_no_match {*::redis::redisHandle*} $e
         }
 
-        test {TLS: Clients with correct certifcates can cannect to server post rotation} {
+        test {TLS: Clients with correct certificates can cannect to server post rotation} {
             set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir1/ca.crt"]
             $r2 incrby x 50
             assert_equal {150} [$r2 get x]
@@ -79,7 +79,7 @@ start_server {tags {"tls-rotation"} overrides {tls-rotation yes}} {
             assert_no_match {*::redis::redisHandle*} $e
         }
 
-        test {TLS: Clients with correct certifcates can cannect to server post rotation} {
+        test {TLS: Clients with correct certificates can cannect to server post rotation} {
             set r2 [valkey_client_tls -keyfile "$clientdir1/client.key" -certfile "$clientdir1/client.crt" -require 1 -cafile "$clientdir2/ca.crt"]
             $r2 incrby x 50
             assert_equal {350} [$r2 get x]

--- a/valkey.conf
+++ b/valkey.conf
@@ -300,6 +300,11 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
+# Allow the server to monitor the filesystem and rotate out TLS certificates if 
+# they change on disk, defaults to no.
+# 
+# tls-rotation no
+
 ################################### RDMA ######################################
 
 # Valkey Over RDMA is experimental, it may be changed or be removed in any minor or major version.


### PR DESCRIPTION
This PR adds the capability of certificate rotation to ValKey by reloading the certificates from disk if it changes. The feature is disabled out of box and is only enabled if `tls-rotation` config is true.