### PR TITLE
Fix defrag crash when using FLUSHDB ASYNC in cluster mode

### DIFF
--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -2,6 +2,7 @@
 #include "bio.h"
 #include "atomicvar.h"
 #include "functions.h"
+#include "cluster.h"
 
 static redisAtomic size_t lazyfree_objects = 0;
 static redisAtomic size_t lazyfreed_objects = 0;
@@ -177,6 +178,10 @@ void emptyDbAsync(redisDb *db) {
     dict *oldht1 = db->dict, *oldht2 = db->expires;
     db->dict = dictCreate(&dbDictType);
     db->expires = dictCreate(&dbExpiresDictType);
+    if (server.cluster_enabled) {
+         slotToKeyDestroy(db);
+         slotToKeyInit(db);
+    }
     atomicIncr(lazyfree_objects,dictSize(oldht1));
     bioCreateLazyFreeJob(lazyfreeFreeDatabase,2,oldht1,oldht2);
 }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -14,6 +14,7 @@ proc test_memory_efficiency {range} {
     for {set j 0} {$j < 10000} {incr j} {
         $rd read ; # Discard replies
     }
+    $rd close
 
     set current_mem [s used_memory]
     set used [expr {$current_mem-$base_mem}]
@@ -308,6 +309,8 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             }
             assert_equal [r dbsize] 250010
 
+            $rd close
+
             # start defrag
             after 120 ;# serverCron only updates the info once in 100ms
             set frag [s allocator_frag_ratio]
@@ -399,6 +402,8 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
                 $rd read ; # Discard replies
                 $rd read ; # Discard replies
             }
+
+            $rd close
 
             # create some fragmentation
             r del biglist2
@@ -519,6 +524,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
                 for {set j 0} {$j < $sent} {incr j} {
                     $rd read ; # Discard replies
                 }
+                $rd close
 
                 # create higher fragmentation in the first slab
                 for {set j 10} {$j < 32} {incr j} {
@@ -577,4 +583,63 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
         }
     }
 }
+
+start_cluster 1 0 {tags {"defrag external:skip"}} {
+    if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
+        test "Active defrag slot_to_keys crash when calling flush async in cluster mode" {
+            r flushdb async
+            r config set activedefrag no
+            r config set hz 100
+            r config set active-defrag-threshold-lower 1
+            r config set active-defrag-cycle-min 65
+            r config set active-defrag-cycle-max 75
+            r config set active-defrag-ignore-bytes 10b
+
+            catch {r config set activedefrag yes} e
+            if {[r config get activedefrag] eq "activedefrag yes"} {
+                set rd [redis_deferring_client]
+                set random_int [expr 1+[randomInt 10240]]
+
+                # Create keys
+                for {set j 0} {$j < 10000} {incr j} {
+                    set buf [string repeat "pl-$j" $random_int]
+                    $rd set $j $buf ex 10000
+                }
+                for {set j 0} {$j < 10000} {incr j} {
+                    $rd read ;# Discard replies
+                }
+
+                # wait for the active defrag to start
+                r flushdb async
+                wait_for_condition 50 100 {
+                    [s active_defrag_running] ne 0
+                } else {
+                    fail "defrag not started."
+                }
+
+                # Create keys
+                for {set j 0} {$j < 10000} {incr j} {
+                    set buf [string repeat "pl-$j" $random_int]
+                    $rd set $j $buf ex $random_int
+                }
+                for {set j 0} {$j < 10000} {incr j} {
+                    $rd read ; # Discard replies
+                }
+                $rd close
+
+                # wait for the active defrag to stop working
+                wait_for_condition 500 100 {
+                    [s active_defrag_running] eq 0
+                } else {
+                    after 120 ;# serverCron only updates the info once in 100ms
+                    puts [r info memory]
+                    puts [r memory malloc-stats]
+                    fail "defrag didn't stop."
+                }
+            }
+            r ping
+        }
+    }
+}
+
 } ;# run_solo

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -586,7 +586,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
 
 start_cluster 1 0 {tags {"defrag external:skip"}} {
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
-        test "Active defrag slot_to_keys crash when calling flush async in cluster mode" {
+        test "Active defrag with flush async performed in cluster mode" {
             r flushdb async
             r config set activedefrag no
             r config set hz 100


### PR DESCRIPTION
There is a crash report in #1872:
```
=== REDIS BUG REPORT START: Cut & paste starting from here ===
69308:M 22 Mar 2025 08:35:10.242 # valkey 7.2.8 crashed by signal: 11, si_code: 1
69308:M 22 Mar 2025 08:35:10.245 # Accessing address: 0x50
69308:M 22 Mar 2025 08:35:10.246 # Crashed running the instruction at: 0x109e82510

------ STACK TRACE ------
EIP:
0   valkey-server                       0x0000000109e82510 dbDictAfterReplaceEntry + 576

Backtrace:
0   libsystem_platform.dylib            0x00007ff801d12e1d _sigtramp + 29
1   ???                                 0x0000000000000000 0x0 + 0
2   valkey-server                       0x0000000109e81782 dictDefragBucket + 354
3   valkey-server                       0x0000000109e813ec dictScanDefrag + 732
4   valkey-server                       0x0000000109faa520 activeDefragCycle + 592
5   valkey-server                       0x0000000109e86b8e serverCron + 4974
6   valkey-server                       0x0000000109e7e466 aeProcessEvents + 1094
7   valkey-server                       0x0000000109ea29ad main + 24781
8   dyld                                0x00007ff80194d2cd start + 1805
```

The reason is that when doing FLUSHDB async, in emptyDbAsync, after we create
the new dict, we did not call slotToKeyInit to init the clusterDictMetadata.
And then in slotToKeyReplaceEntry we will get a wrong pointer and crash.

This issue only occurs under 7.2 since the code structure changed in unstable
branch. Fixes #1872.