### PR TITLE
Fix crash in VM_GetCurrentUserName when no valid user

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9763,7 +9763,8 @@ ValkeyModuleString *VM_GetModuleUserACLString(ValkeyModuleUser *user) {
  * The returned string must be released with ValkeyModule_FreeString() or by
  * enabling automatic memory management. */
 ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
-    if (ctx != NULL || ctx->client != NULL || ctx->client->user != NULL) {
+    if (ctx == NULL || ctx->client == NULL || ctx->client->user == NULL) {
+        errno = ENOTSUP;
         return NULL;
     }
     return VM_CreateString(ctx, ctx->client->user->name, sdslen(ctx->client->user->name));

--- a/src/module.c
+++ b/src/module.c
@@ -9770,7 +9770,6 @@ ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
         errno = EINVAL;
         return NULL;
     }
-    errno = 0;
     return VM_CreateString(ctx, ctx->client->user->name, sdslen(ctx->client->user->name));
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -9763,6 +9763,9 @@ ValkeyModuleString *VM_GetModuleUserACLString(ValkeyModuleUser *user) {
  * The returned string must be released with ValkeyModule_FreeString() or by
  * enabling automatic memory management. */
 ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
+    if (ctx != NULL || ctx->client != NULL || ctx->client->user != NULL) {
+        return NULL;
+    }
     return VM_CreateString(ctx, ctx->client->user->name, sdslen(ctx->client->user->name));
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -9763,8 +9763,8 @@ ValkeyModuleString *VM_GetModuleUserACLString(ValkeyModuleUser *user) {
  * The returned string must be released with ValkeyModule_FreeString() or by
  * enabling automatic memory management. */
 ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
-    if (ctx == NULL || ctx->client == NULL || ctx->client->user == NULL) {
-        errno = ENOTSUP;
+    if (ctx == NULL || ctx->client == NULL || ctx->client->user == NULL || ctx->client->user->name == NULL) {
+        errno = EINVAL;
         return NULL;
     }
     return VM_CreateString(ctx, ctx->client->user->name, sdslen(ctx->client->user->name));

--- a/src/module.c
+++ b/src/module.c
@@ -9761,7 +9761,10 @@ ValkeyModuleString *VM_GetModuleUserACLString(ValkeyModuleUser *user) {
  * See more information in VM_GetModuleUserFromUserName.
  *
  * The returned string must be released with ValkeyModule_FreeString() or by
- * enabling automatic memory management. */
+ * enabling automatic memory management.
+ *
+ * If the context is not associated with a client connection, NULL is returned
+ * and errno is set to EINVAL. */
 ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
     if (ctx == NULL || ctx->client == NULL || ctx->client->user == NULL || ctx->client->user->name == NULL) {
         errno = EINVAL;

--- a/src/module.c
+++ b/src/module.c
@@ -9770,6 +9770,7 @@ ValkeyModuleString *VM_GetCurrentUserName(ValkeyModuleCtx *ctx) {
         errno = EINVAL;
         return NULL;
     }
+    errno = 0;
     return VM_CreateString(ctx, ctx->client->user->name, sdslen(ctx->client->user->name));
 }
 


### PR DESCRIPTION
VM_GetCurrentUserName make the binary crash when it gets not fully structured ctx, when it doesn't have a valid ctx, client, user behind it. Rather than making the binary crash, safely return NULL