### PR TITLE
Redact protocol error log when hide-user-data-from-log enabled

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2760,17 +2760,8 @@ void processInlineBuffer(client *c) {
 static void setProtocolError(const char *errstr, client *c) {
     if (server.verbosity <= LL_VERBOSE || c->flag.primary) {
         sds client = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
-
-        /* Sample some protocol to given an idea about what was inside. */
         char buf[256];
         buf[0] = '\0';
-        if (c->querybuf && sdslen(c->querybuf) - c->qb_pos < PROTO_DUMP_LEN) {
-            snprintf(buf, sizeof(buf), "Query buffer during protocol error: '%s'", c->querybuf + c->qb_pos);
-        } else if (c->querybuf) {
-            snprintf(buf, sizeof(buf), "Query buffer during protocol error: '%.*s' (... more %zu bytes ...) '%.*s'",
-                     PROTO_DUMP_LEN / 2, c->querybuf + c->qb_pos, sdslen(c->querybuf) - c->qb_pos - PROTO_DUMP_LEN,
-                     PROTO_DUMP_LEN / 2, c->querybuf + sdslen(c->querybuf) - PROTO_DUMP_LEN / 2);
-        }
 
         /* Remove non printable chars. */
         char *p = buf;
@@ -2781,7 +2772,8 @@ static void setProtocolError(const char *errstr, client *c) {
 
         /* Log all the client and protocol info. */
         int loglevel = (c->flag.primary) ? LL_WARNING : LL_VERBOSE;
-        serverLog(loglevel, "Protocol error (%s) from client: %s. %s", errstr, client, buf);
+        serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client,
+                  server.hide_user_data_from_log ? "*redacted*" : buf);
         sdsfree(client);
     }
     c->flag.close_after_reply = 1;

--- a/src/networking.c
+++ b/src/networking.c
@@ -2760,20 +2760,31 @@ void processInlineBuffer(client *c) {
 static void setProtocolError(const char *errstr, client *c) {
     if (server.verbosity <= LL_VERBOSE || c->flag.primary) {
         sds client = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
+
+        /* Sample some protocol to given an idea about what was inside. */
         char buf[256];
         buf[0] = '\0';
+        if (server.hide_user_data_from_log) {
+            snprintf(buf, sizeof(buf), "*redacted*");
+        } else {
+            if (c->querybuf && sdslen(c->querybuf) - c->qb_pos < PROTO_DUMP_LEN) {
+                snprintf(buf, sizeof(buf), "'%s'", c->querybuf + c->qb_pos);
+            } else if (c->querybuf) {
+                snprintf(buf, sizeof(buf), "'%.*s' (... more %zu bytes ...) '%.*s'",
+                         PROTO_DUMP_LEN / 2, c->querybuf + c->qb_pos, sdslen(c->querybuf) - c->qb_pos - PROTO_DUMP_LEN,
+                         PROTO_DUMP_LEN / 2, c->querybuf + sdslen(c->querybuf) - PROTO_DUMP_LEN / 2);
+            }
 
-        /* Remove non printable chars. */
-        char *p = buf;
-        while (*p != '\0') {
-            if (!isprint(*p)) *p = '.';
-            p++;
+            /* Remove non printable chars. */
+            char *p = buf;
+            while (*p != '\0') {
+                if (!isprint(*p)) *p = '.';
+                p++;
+            }
         }
-
         /* Log all the client and protocol info. */
         int loglevel = (c->flag.primary) ? LL_WARNING : LL_VERBOSE;
-        serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client,
-                  server.hide_user_data_from_log ? "*redacted*" : buf);
+        serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client, buf);
         sdsfree(client);
     }
     c->flag.close_after_reply = 1;

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -117,7 +117,7 @@ if {!$::valgrind} {
             r write "*3\r\n\$3\r\nSET\r\n\$1\r\nx\r\n\$blabla\r\n"
             r flush
             catch {r debug segfault}
-            verify_no_log_message 0 "*redacted*" 0
+            wait_for_log_messages 0 {"*Query buffer: *\$blabla*"} 0 10 1000
         }
     }
 
@@ -127,7 +127,7 @@ if {!$::valgrind} {
             r write "*3\r\n\$3\r\nSET\r\n\$1\r\nx\r\n\$blabla\r\n"
             r flush
             catch {r debug segfault}
-            $check_cb "*Query buffer: *redacted*"
+            wait_for_log_messages 0 {"*Query buffer: *redacted*"} 0 10 1000
         }
     }
 }

--- a/tests/integration/logging.tcl
+++ b/tests/integration/logging.tcl
@@ -109,6 +109,27 @@ if {!$::valgrind} {
             assert_equal "PONG" [r ping]
         }
     }
+
+    # test hide-user-data-from-log
+    set server_path [tmpdir server5.log]
+    start_server [list overrides [list dir $server_path crash-memcheck-enabled no hide-user-data-from-log no]] {
+        test "Config hide-user-data-from-log is off" {
+            r write "*3\r\n\$3\r\nSET\r\n\$1\r\nx\r\n\$blabla\r\n"
+            r flush
+            catch {r debug segfault}
+            verify_no_log_message 0 "*redacted*" 0
+        }
+    }
+
+    set server_path [tmpdir server6.log]
+    start_server [list overrides [list dir $server_path crash-memcheck-enabled no hide-user-data-from-log yes]] {
+        test "Config hide-user-data-from-log is on" {
+            r write "*3\r\n\$3\r\nSET\r\n\$1\r\nx\r\n\$blabla\r\n"
+            r flush
+            catch {r debug segfault}
+            $check_cb "*Query buffer: *redacted*"
+        }
+    }
 }
 
 # test DEBUG ASSERT


### PR DESCRIPTION
In this code logic: https://github.com/valkey-io/valkey/blob/unstable/src/networking.c#L2767-L2773, `c->querybuf + c->qb_pos` may also include user data.  
Update the log message when config `hide-user-data-from-log` is enabled.