### PR TITLE
Remove TLSCONN_DEBUG dead code in tls.c

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -415,12 +415,6 @@ error:
     return C_ERR;
 }
 
-#ifdef TLS_DEBUGGING
-#define TLSCONN_DEBUG(fmt, ...) serverLog(LL_DEBUG, "TLSCONN: " fmt, __VA_ARGS__)
-#else
-#define TLSCONN_DEBUG(fmt, ...)
-#endif
-
 static ConnectionType CT_TLS;
 
 /* Normal socket connections have a simple events/handler correlation.
@@ -696,9 +690,6 @@ static void TLSAccept(void *_conn) {
 
 static void tlsHandleEvent(tls_connection *conn, int mask) {
     int ret, conn_error;
-
-    TLSCONN_DEBUG("tlsEventHandler(): fd=%d, state=%d, mask=%d, r=%d, w=%d, flags=%d", fd, conn->c.state, mask,
-                  conn->c.read_handler != NULL, conn->c.write_handler != NULL, conn->flags);
 
     switch (conn->c.state) {
     case CONN_STATE_CONNECTING:


### PR DESCRIPTION
This code is a dead code, there is also a undefined fd error in it.
Obviously this will not compile if this kind of debugging is enabled.

This seems to be broken ever since 5a477946065bcf05b335ededd6b794e82882ab73
which was done in 2019. It's dead code that we never test and never use.

Fixes #1887