### PR TITLE
Reuse RDB file as AOF preamble on replica after disk-based full sync

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1097,7 +1097,7 @@ int restartAOFWithSyncRdb(void) {
 
     serverLog(LL_NOTICE, "Reused RDB file from primary sync as AOF base file: %s", new_base_filename);
     ret = C_OK;
-    goto done;
+    return ret;
 
 cleanup:
     if (rdbfile_renamed) {
@@ -1127,8 +1127,6 @@ cleanup:
     }
     if (temp_am) aofManifestFree(temp_am);
     if (new_base_filepath) sdsfree(new_base_filepath);
-
-done:
     return ret;
 }
 

--- a/src/aof.c
+++ b/src/aof.c
@@ -1005,6 +1005,133 @@ int startAppendOnly(void) {
     return C_OK;
 }
 
+/* Try to restart AOF after replica full sync by adopting `server.rdb_filename`
+ * as the new BASE file (RDB preamble mode), avoiding a redundant AOFRW.
+ * Returns C_OK on success; on C_ERR caller should fallback to
+ * restartAOFAfterSYNC(). */
+int restartAOFWithSyncRdb(void) {
+    serverAssert(server.aof_state == AOF_OFF);
+
+    int ret = C_ERR;
+    int newfd = -1, rdbfile_renamed = 0;
+    sds new_base_filename = NULL;
+    sds new_base_filepath = NULL;
+    sds new_incr_filename = NULL;
+    sds new_incr_filepath = NULL;
+    aofManifest *temp_am = NULL;
+
+    if (dirCreateIfMissing(server.aof_dirname) == -1) {
+        serverLog(LL_WARNING, "Can't open or create append-only dir %s: %s", server.aof_dirname, strerror(errno));
+        goto cleanup;
+    }
+
+    serverAssert(server.aof_manifest != NULL);
+    temp_am = aofManifestDup(server.aof_manifest);
+
+    new_base_filename = getNewBaseFileNameAndMarkPreAsHistory(temp_am, server.aof_use_rdb_preamble);
+    serverAssert(new_base_filename != NULL);
+    new_base_filepath = makePath(server.aof_dirname, new_base_filename);
+
+    if (rename(server.rdb_filename, new_base_filepath) == -1) {
+        serverLog(LL_WARNING, "Error trying to rename the RDB file %s into %s: %s", server.rdb_filename,
+                  new_base_filepath, strerror(errno));
+        goto cleanup;
+    }
+    rdbfile_renamed = 1;
+
+    /* Mark existing incr AOF files as history BEFORE creating the new one,
+     * so the new incr entry is not inadvertently moved to history. */
+    markRewrittenIncrAofAsHistory(temp_am);
+
+    new_incr_filename = getNewIncrAofName(temp_am);
+    new_incr_filepath = makePath(server.aof_dirname, new_incr_filename);
+    newfd = open(new_incr_filepath, O_WRONLY | O_TRUNC | O_CREAT, 0666);
+    if (newfd == -1) {
+        serverLog(LL_WARNING, "Can't open the append-only file %s: %s", new_incr_filename, strerror(errno));
+        goto cleanup;
+    }
+
+    if (persistAofManifest(temp_am) == C_ERR) {
+        goto cleanup;
+    }
+
+    aofManifestFreeAndUpdate(temp_am);
+    temp_am = NULL;
+
+    aofDelHistoryFiles();
+
+    sdsfree(new_base_filepath);
+    new_base_filepath = NULL;
+    sdsfree(new_incr_filepath);
+    new_incr_filepath = NULL;
+
+    /* Drain pending fsync jobs from the previous AOF before publishing the new
+     * fsynced offset to avoid races on fsynced_reploff_pending. */
+    bioDrainWorker(BIO_AOF_FSYNC);
+    atomic_store_explicit(&server.fsynced_reploff_pending, server.primary_repl_offset, memory_order_relaxed);
+    server.fsynced_reploff =
+        atomic_load_explicit(&server.fsynced_reploff_pending, memory_order_relaxed);
+
+    int aof_bio_fsync_status = atomic_load_explicit(&server.aof_bio_fsync_status, memory_order_relaxed);
+    if (aof_bio_fsync_status == C_ERR) {
+        serverLog(LL_WARNING, "AOF reopen, just ignore the AOF fsync error in bio job");
+        atomic_store_explicit(&server.aof_bio_fsync_status, C_OK, memory_order_relaxed);
+    }
+
+    if (server.aof_last_write_status == C_ERR) {
+        serverLog(LL_WARNING, "AOF reopen, just ignore the last error.");
+        server.aof_last_write_status = C_OK;
+    }
+
+    server.aof_lastbgrewrite_status = C_OK;
+    server.stat_aofrw_consecutive_failures = 0;
+
+    server.aof_last_fsync = server.mstime;
+    server.aof_last_incr_size = 0;
+    server.aof_last_incr_fsync_offset = 0;
+    server.aof_rewrite_base_size = getAppendOnlyFileSize(new_base_filename, NULL);
+    server.aof_current_size = server.aof_rewrite_base_size;
+
+    server.aof_fd = newfd;
+    server.aof_state = AOF_ON;
+
+    serverLog(LL_NOTICE, "Reused RDB file from primary sync as AOF base file: %s", new_base_filename);
+    ret = C_OK;
+    goto done;
+
+cleanup:
+    if (rdbfile_renamed) {
+        if (rename(new_base_filepath, server.rdb_filename) == -1) {
+            serverLog(LL_WARNING,
+                      "Failed to rename AOF base back to RDB file %s: %s. "
+                      "Orphan file may remain at %s",
+                      server.rdb_filename, strerror(errno), new_base_filepath);
+        } else {
+            rdbfile_renamed = 0;
+        }
+    }
+    if (server.rdb_del_sync_files && allPersistenceDisabled()) {
+        serverLog(LL_NOTICE, "Removing the RDB file obtained from "
+                             "the primary. This replica has persistence "
+                             "disabled");
+        if (rdbfile_renamed) {
+            bg_unlink(new_base_filepath);
+        } else {
+            bg_unlink(server.rdb_filename);
+        }
+    }
+    if (newfd != -1) close(newfd);
+    if (new_incr_filepath) {
+        bg_unlink(new_incr_filepath);
+        sdsfree(new_incr_filepath);
+    }
+    if (temp_am) aofManifestFree(temp_am);
+    if (new_base_filepath) sdsfree(new_base_filepath);
+
+done:
+    return ret;
+}
+
 /* This is a wrapper to the write syscall in order to retry on short writes
  * or if the syscall gets interrupted. It could look strange that we retry
  * on short writes given that we are writing to a block device: normally if

--- a/src/replication.c
+++ b/src/replication.c
@@ -2340,7 +2340,7 @@ void replicaBeforeLoadPrimaryRDB(connection *conn, int use_diskless_load) {
     connSetReadHandler(conn, NULL);
 }
 
-void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi) {
+void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi, int disk_based_sync) {
     /* Final setup of the connected replica <- primary link */
     if (conn == server.repl_rdb_transfer_s) {
         dualChannelSyncHandleRdbLoadCompletion();
@@ -2375,10 +2375,18 @@ void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi) {
                                  "in read-write mode.\n");
     }
 
-    /* Restart the AOF subsystem now that we finished the sync. This
-     * will trigger an AOF rewrite, and when done will start appending
-     * to the new file. */
-    if (server.aof_enabled) restartAOFAfterSYNC();
+    /* Restart the AOF subsystem now that we finished the sync.
+     *
+     * When disk-based sync was used and aof-use-rdb-preamble is enabled,
+     * reuse the RDB file received from the primary as the AOF base file
+     * directly, avoiding a redundant bgrewriteaof. Otherwise (diskless
+     * sync or rdb-preamble disabled), fall back to bgrewriteaof. */
+    if (server.aof_enabled) {
+        if (disk_based_sync && server.aof_use_rdb_preamble && server.aof_state == AOF_OFF) {
+            restartAOFWithSyncRdb();
+        }
+        if (server.aof_state == AOF_OFF) restartAOFAfterSYNC();
+    }
 
     /* In case of dual channel replication sync we want to close the RDB connection
      * once the connection is established */
@@ -2581,8 +2589,11 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    /* Cleanup. */
-    if (server.rdb_del_sync_files && allPersistenceDisabled()) {
+    /* Cleanup. When aof-use-rdb-preamble is enabled and AOF is on, keep the
+     * RDB file so it can be reused as the AOF base file, avoiding a redundant
+     * bgrewriteaof that would produce an almost identical snapshot. */
+    if (!(server.aof_enabled && server.aof_use_rdb_preamble) &&
+        server.rdb_del_sync_files && allPersistenceDisabled()) {
         serverLog(LL_NOTICE, "Removing the RDB file obtained from "
                              "the primary. This replica has persistence "
                              "disabled");
@@ -2642,7 +2653,7 @@ read_from_socket:
         cancelReplicationHandshake(1);
         return;
     }
-    replicaAfterLoadPrimaryRDB(conn, &rsi);
+    replicaAfterLoadPrimaryRDB(conn, &rsi, 0);
 }
 
 int tryReadBulkPayload(connection *conn, char *buf, int usemark, ssize_t *nread_out) {
@@ -5196,7 +5207,7 @@ void handleBioThreadFinishedRDBDownload(void) {
         cancelReplicationHandshake(1);
         return;
     }
-    replicaAfterLoadPrimaryRDB(conn, &rsi);
+    replicaAfterLoadPrimaryRDB(conn, &rsi, 1);
     server.repl_transfer_size = bio_repl_transfer_size;
     server.repl_transfer_read = bio_repl_transfer_read;
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -2382,10 +2382,13 @@ void replicaAfterLoadPrimaryRDB(connection *conn, rdbSaveInfo *rsi, int disk_bas
      * directly, avoiding a redundant bgrewriteaof. Otherwise (diskless
      * sync or rdb-preamble disabled), fall back to bgrewriteaof. */
     if (server.aof_enabled) {
-        if (disk_based_sync && server.aof_use_rdb_preamble && server.aof_state == AOF_OFF) {
-            restartAOFWithSyncRdb();
+        if (disk_based_sync && server.aof_use_rdb_preamble) {
+            if (restartAOFWithSyncRdb() == C_ERR) {
+                restartAOFAfterSYNC();
+            }
+        } else {
+            restartAOFAfterSYNC();
         }
-        if (server.aof_state == AOF_OFF) restartAOFAfterSYNC();
     }
 
     /* In case of dual channel replication sync we want to close the RDB connection

--- a/src/server.h
+++ b/src/server.h
@@ -3253,6 +3253,7 @@ int rewriteAppendOnlyFileBackground(void);
 int loadAppendOnlyFiles(aofManifest *am);
 void stopAppendOnly(void);
 int startAppendOnly(void);
+int restartAOFWithSyncRdb(void);
 void backgroundRewriteDoneHandler(int exitcode, int bysignal);
 void killAppendOnlyChild(void);
 void restartAOFAfterSYNC(void);

--- a/tests/integration/replication-aof-sync.tcl
+++ b/tests/integration/replication-aof-sync.tcl
@@ -1,0 +1,304 @@
+source tests/support/aofmanifest.tcl
+
+proc log_file_matches {log pattern} {
+    set fp [open $log r]
+    set content [read $fp]
+    close $fp
+    string match $pattern $content
+}
+
+# Test that reuses the RDB file from full sync as the AOF base file
+# when aof-use-rdb-preamble is enabled and disk-based replication is used.
+
+proc get_aof_manifest_path {r} {
+    set dir [lindex [$r config get dir] 1]
+    set appenddirname [lindex [$r config get appenddirname] 1]
+    set appendfilename [lindex [$r config get appendfilename] 1]
+    return [file join $dir $appenddirname $appendfilename$::manifest_suffix]
+}
+
+tags {"repl external:skip"} {
+
+    # Test 1: Disk-based full sync with aof-use-rdb-preamble yes should
+    # reuse the RDB file as AOF base file
+    test "Reuse RDB from disk-based full sync as AOF base file" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 100} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+            waitForBgrewriteaof $primary
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                # Start replication
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                # Check AOF state is ON (not WAIT_REWRITE)
+                wait_for_condition 50 100 {
+                    [string match "*aof_rewrite_in_progress:0*" [$replica info persistence]]
+                } else {
+                    fail "AOF rewrite still in progress"
+                }
+
+                # Verify the log message about reusing RDB
+                wait_for_condition 50 100 {
+                    [log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]
+                } else {
+                    fail "Expected log message about reusing RDB file not found"
+                }
+
+                # Verify AOF base file exists and is RDB format
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+                assert {[string match "*.rdb" $base_name]}
+
+                # Verify data integrity
+                assert_equal 100 [$replica dbsize]
+                for {set i 0} {$i < 100} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+            }
+        }
+    }
+
+    # Test 2: After sync, new writes should go to AOF incr file
+    test "New writes after RDB-reuse sync go to AOF incr file" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 50} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+            waitForBgrewriteaof $primary
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                wait_for_condition 50 100 {
+                    [log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]
+                } else {
+                    fail "Expected log message not found"
+                }
+
+                # Write new data to primary after sync
+                for {set i 50} {$i < 100} {incr i} {
+                    $primary set "key:$i" "value:$i"
+                }
+
+                # Wait for replication to propagate
+                wait_for_ofs_sync $primary $replica
+
+                # Verify incr AOF file exists
+                set manifest_path [get_aof_manifest_path $replica]
+                set incr_name [get_last_incr_aof_name $manifest_path]
+                assert {$incr_name ne ""}
+
+                # Verify all data is present
+                assert_equal 100 [$replica dbsize]
+                for {set i 0} {$i < 100} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+            }
+        }
+    }
+
+    # Test 3: Replica restart should load AOF correctly after RDB-reuse sync
+    test "Replica restart loads AOF correctly after RDB-reuse sync" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 50} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+            waitForBgrewriteaof $primary
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync no save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                wait_for_condition 50 100 {
+                    [log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]
+                } else {
+                    fail "Expected log message not found"
+                }
+
+                # Write more data
+                for {set i 50} {$i < 80} {incr i} {
+                    $primary set "key:$i" "value:$i"
+                }
+                wait_for_ofs_sync $primary $replica
+
+                # Stop replica and disconnect from primary
+                $replica replicaof no one
+
+                # Restart replica (this tests AOF loading)
+                restart_server 0 true false
+                set replica [srv 0 client]
+                wait_done_loading $replica
+
+                # Verify data integrity after restart
+                assert_equal 80 [$replica dbsize]
+                for {set i 0} {$i < 80} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+            }
+        }
+    }
+
+    # Test 4: aof-use-rdb-preamble no should fall back to bgrewriteaof
+    test "Disk-based sync with aof-use-rdb-preamble no uses bgrewriteaof" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble no repl-diskless-sync no save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 50} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble no repl-diskless-sync no save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                # Should NOT see the RDB reuse log message
+                after 1000
+                assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
+
+                # Structural assertion: AOF base exists (produced by bgrewriteaof)
+                # and uses .aof suffix (not .rdb) since rdb-preamble is off.
+                waitForBgrewriteaof $replica
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+                assert {[string match "*.aof" $base_name]}
+
+                assert_equal 50 [$replica dbsize]
+                for {set i 0} {$i < 50} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+            }
+        }
+    }
+
+    # Test 5: Diskless sync with aof-use-rdb-preamble yes should fall back
+    # to bgrewriteaof (no RDB file on disk to reuse)
+    test "Diskless sync with aof-use-rdb-preamble yes uses bgrewriteaof fallback" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync yes repl-diskless-sync-delay 0 save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 50} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-load flush-before-load save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                after 1000
+                assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
+
+                # Structural assertion: bgrewriteaof should produce an AOF base
+                # file with .rdb suffix (since rdb-preamble is yes).
+                waitForBgrewriteaof $replica
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+                assert {[string match "*.rdb" $base_name]}
+
+                assert_equal 50 [$replica dbsize]
+                for {set i 0} {$i < 50} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+            }
+        }
+    }
+
+    # Test 6: Diskless sync with a stale local RDB must NOT reuse it.
+    # This verifies that disk_based_sync=0 prevents the optimization even
+    # when a leftover dump.rdb exists on the replica.
+    test "Diskless sync with stale local RDB does not reuse it as AOF base" {
+        start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-sync yes repl-diskless-sync-delay 0 save ""}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+
+            for {set i 0} {$i < 50} {incr i} {
+                $primary set "key:$i" "value:$i"
+            }
+
+            start_server {overrides {appendonly yes aof-use-rdb-preamble yes repl-diskless-load flush-before-load save ""}} {
+                set replica [srv 0 client]
+                set replica_log [srv 0 stdout]
+
+                # Create stale data and persist it as a local RDB so that
+                # dump.rdb exists when the diskless sync completes.
+                $replica set stale_key stale_value
+                $replica bgsave
+                waitForBgsave $replica
+
+                # Now do a diskless full sync
+                $replica replicaof $primary_host $primary_port
+                wait_for_sync $replica
+
+                # The stale RDB must NOT have been reused
+                after 1000
+                assert {![log_file_matches $replica_log "*Reused RDB file from primary sync as AOF base file*"]}
+
+                # Structural assertion: bgrewriteaof produced the base file
+                waitForBgrewriteaof $replica
+                set manifest_path [get_aof_manifest_path $replica]
+                set base_name [get_cur_base_aof_name $manifest_path]
+                assert {$base_name ne ""}
+
+                # Data must come from the primary, not the stale RDB
+                assert_equal 50 [$replica dbsize]
+                for {set i 0} {$i < 50} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+                assert_equal "" [$replica get stale_key]
+
+                # Restart replica and verify data again. This catches the regression
+                # where a stale dump.rdb was incorrectly reused as AOF base: at
+                # runtime memory is correct (from socket), but after restart the
+                # wrong AOF base would load stale data.
+                $replica replicaof no one
+                restart_server 0 true false
+                set replica [srv 0 client]
+                wait_done_loading $replica
+
+                assert_equal 50 [$replica dbsize]
+                for {set i 0} {$i < 50} {incr i} {
+                    assert_equal "value:$i" [$replica get "key:$i"]
+                }
+                assert_equal "" [$replica get stale_key]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When a replica finishes a **disk-based** full sync and both `appendonly yes` and
`aof-use-rdb-preamble yes` are enabled, this PR reuses the received `dump.rdb`
as the new AOF base file, instead of triggering `BGREWRITEAOF`.

This avoids generating an almost identical base snapshot and removes redundant CPU/IO work.

### Before
1. Replica receives RDB via disk-based full sync
2. Replica loads RDB into memory
3. Replica may delete synced RDB (`rdb-del-sync-files`)
4. `BGREWRITEAOF` runs and generates a new base snapshot
5. New snapshot becomes AOF base

### After
1. Replica receives RDB via disk-based full sync
2. Replica loads RDB into memory
3. Synced RDB is renamed to the new AOF base file
4. A new incremental AOF is created
5. No `BGREWRITEAOF` is needed

### Tests
- [x] Disk-based sync + preamble on: RDB reused as AOF base
- [x] New writes after sync: incr AOF works correctly
- [x] Replica restart: reused AOF loads correctly
- [x] Disk-based sync + preamble off: fallback to `BGREWRITEAOF`
- [x] Diskless sync + preamble on: fallback to `BGREWRITEAOF`
- [x] Diskless sync with stale local `dump.rdb`: stale file is not reused