### PR TITLE
Add sentinel_total_tilt to sentinel INFO sentinel

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -259,6 +259,7 @@ struct sentinelState {
                                         Key is the instance name, value is the
                                         sentinelValkeyInstance structure pointer. */
     int tilt;                          /* Are we in TILT mode? */
+    int total_tilt;                    /* Number of tilt. */
     int running_scripts;               /* Number of scripts in execution right now. */
     mstime_t tilt_start_time;          /* When TITL started. */
     mstime_t previous_time;            /* Last time we ran the time handler. */
@@ -492,6 +493,7 @@ void initSentinel(void) {
     sentinel.primaries = dictCreate(&instancesDictType);
     sentinel.tilt = 0;
     sentinel.tilt_start_time = 0;
+    sentinel.total_tilt = 0;
     sentinel.previous_time = mstime();
     sentinel.running_scripts = 0;
     sentinel.scripts_queue = listCreate();
@@ -4091,11 +4093,12 @@ void sentinelInfoCommand(client *c) {
                             "sentinel_masters:%lu\r\n"
                             "sentinel_tilt:%d\r\n"
                             "sentinel_tilt_since_seconds:%jd\r\n"
+                            "sentinel_total_tilt:%d\r\n"
                             "sentinel_running_scripts:%d\r\n"
                             "sentinel_scripts_queue_length:%ld\r\n"
                             "sentinel_simulate_failure_flags:%lu\r\n",
                             dictSize(sentinel.primaries), sentinel.tilt,
-                            sentinel.tilt ? (intmax_t)((mstime() - sentinel.tilt_start_time) / 1000) : -1,
+                            sentinel.tilt ? (intmax_t)((mstime() - sentinel.tilt_start_time) / 1000) : -1, sentinel.total_tilt,
                             sentinel.running_scripts, listLength(sentinel.scripts_queue), sentinel.simfailure_flags);
 
         di = dictGetIterator(sentinel.primaries);
@@ -5186,6 +5189,7 @@ void sentinelCheckTiltCondition(void) {
     if (delta < 0 || delta > sentinel_tilt_trigger) {
         sentinel.tilt = 1;
         sentinel.tilt_start_time = mstime();
+        sentinel.total_tilt++;
         sentinelEvent(LL_WARNING, "+tilt", NULL, "#tilt mode entered");
     }
     sentinel.previous_time = mstime();

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4098,7 +4098,8 @@ void sentinelInfoCommand(client *c) {
                             "sentinel_scripts_queue_length:%ld\r\n"
                             "sentinel_simulate_failure_flags:%lu\r\n",
                             dictSize(sentinel.primaries), sentinel.tilt,
-                            sentinel.tilt ? (intmax_t)((mstime() - sentinel.tilt_start_time) / 1000) : -1, sentinel.total_tilt,
+                            sentinel.tilt ? (intmax_t)((mstime() - sentinel.tilt_start_time) / 1000) : -1,
+                            sentinel.total_tilt,
                             sentinel.running_scripts, listLength(sentinel.scripts_queue), sentinel.simfailure_flags);
 
         di = dictGetIterator(sentinel.primaries);


### PR DESCRIPTION
it will be a good idea to add total_tilt in info command to show total tilt count, in order to help admin to know sentinel tilt condition.