### PR TITLE
Add node pfail and fail count to cluster info metrics

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6400,7 +6400,8 @@ sds genClusterInfoString(void) {
 
     if (nodes_pfail + nodes_fail > dictSize(server.cluster->nodes)) {
         serverLog(LL_WARNING, "Aggregated count of nodes marked as PFAIL and FAIL exceeds the total count of nodes."
-                  "PFAIL nodes: %u, FAIL nodes: %u", nodes_pfail, nodes_fail);
+                              "PFAIL nodes: %u, FAIL nodes: %u",
+                  nodes_pfail, nodes_fail);
     }
 
     info = sdscatprintf(info,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6384,18 +6384,39 @@ sds genClusterInfoString(void) {
         }
     }
 
+    dictIterator *di = dictGetIterator(server.cluster->nodes);
+    dictEntry *de;
+    u_int nodes_pfail = 0, nodes_fail = 0;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (nodeTimedOut(node)) {
+            nodes_pfail++;
+        }
+        if (nodeFailed(node)) {
+            nodes_fail++;
+        }
+    }
+    dictReleaseIterator(di);
+
+    if (nodes_pfail + nodes_fail > dictSize(server.cluster->nodes)) {
+        serverLog(LL_WARNING, "Aggregated count of nodes marked as PFAIL and FAIL exceeds the total count of nodes."
+                  "PFAIL nodes: %u, FAIL nodes: %u", nodes_pfail, nodes_fail);
+    }
+
     info = sdscatprintf(info,
                         "cluster_state:%s\r\n"
                         "cluster_slots_assigned:%d\r\n"
                         "cluster_slots_ok:%d\r\n"
                         "cluster_slots_pfail:%d\r\n"
                         "cluster_slots_fail:%d\r\n"
+                        "cluster_nodes_pfail:%u\r\n"
+                        "cluster_nodes_fail:%u\r\n"
                         "cluster_known_nodes:%lu\r\n"
                         "cluster_size:%d\r\n"
                         "cluster_current_epoch:%llu\r\n"
                         "cluster_my_epoch:%llu\r\n",
                         statestr[server.cluster->state], slots_assigned, slots_ok, slots_pfail, slots_fail,
-                        dictSize(server.cluster->nodes), server.cluster->size,
+                        nodes_pfail, nodes_fail, dictSize(server.cluster->nodes), server.cluster->size,
                         (unsigned long long)server.cluster->currentEpoch, (unsigned long long)nodeEpoch(myself));
 
     /* Show stats about messages sent and received. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6386,7 +6386,7 @@ sds genClusterInfoString(void) {
 
     dictIterator *di = dictGetIterator(server.cluster->nodes);
     dictEntry *de;
-    u_int nodes_pfail = 0, nodes_fail = 0;
+    unsigned nodes_pfail = 0, nodes_fail = 0;
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (nodeTimedOut(node)) {
@@ -6398,10 +6398,11 @@ sds genClusterInfoString(void) {
     }
     dictReleaseIterator(di);
 
-    if (nodes_pfail + nodes_fail > dictSize(server.cluster->nodes)) {
+    if (nodes_pfail + nodes_fail > dictSize(server.cluster->nodes) && !server.crashed) {
         serverLog(LL_WARNING, "Aggregated count of nodes marked as PFAIL and FAIL exceeds the total count of nodes."
-                              "PFAIL nodes: %u, FAIL nodes: %u",
-                  nodes_pfail, nodes_fail);
+                              "PFAIL nodes: %u, FAIL nodes: %u, total nodes: %lu",
+                  nodes_pfail, nodes_fail, dictSize(server.cluster->nodes));
+        serverAssert(0);
     }
 
     info = sdscatprintf(info,

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6404,13 +6404,6 @@ sds genClusterInfoString(void) {
     }
     dictReleaseIterator(di);
 
-    if (nodes_pfail + nodes_fail > dictSize(server.cluster->nodes) && !server.crashed) {
-        serverLog(LL_WARNING, "Aggregated count of nodes marked as PFAIL and FAIL exceeds the total count of nodes."
-                              "PFAIL nodes: %u, FAIL nodes: %u, total nodes: %lu",
-                  nodes_pfail, nodes_fail, dictSize(server.cluster->nodes));
-        serverAssert(0);
-    }
-
     info = sdscatprintf(info,
                         "cluster_state:%s\r\n"
                         "cluster_slots_assigned:%d\r\n"

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6386,14 +6386,20 @@ sds genClusterInfoString(void) {
 
     dictIterator *di = dictGetIterator(server.cluster->nodes);
     dictEntry *de;
-    unsigned nodes_pfail = 0, nodes_fail = 0;
+    unsigned nodes_pfail = 0, nodes_fail = 0, voting_nodes_pfail = 0, voting_nodes_fail = 0;
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (nodeTimedOut(node)) {
             nodes_pfail++;
+            if (clusterNodeIsVotingPrimary(node)) {
+                voting_nodes_pfail++;
+            }
         }
         if (nodeFailed(node)) {
             nodes_fail++;
+            if (clusterNodeIsVotingPrimary(node)) {
+                voting_nodes_fail++;
+            }
         }
     }
     dictReleaseIterator(di);
@@ -6413,12 +6419,14 @@ sds genClusterInfoString(void) {
                         "cluster_slots_fail:%d\r\n"
                         "cluster_nodes_pfail:%u\r\n"
                         "cluster_nodes_fail:%u\r\n"
+                        "cluster_voting_nodes_pfail:%u\r\n"
+                        "cluster_voting_nodes_fail:%u\r\n"
                         "cluster_known_nodes:%lu\r\n"
                         "cluster_size:%d\r\n"
                         "cluster_current_epoch:%llu\r\n"
                         "cluster_my_epoch:%llu\r\n",
                         statestr[server.cluster->state], slots_assigned, slots_ok, slots_pfail, slots_fail,
-                        nodes_pfail, nodes_fail, dictSize(server.cluster->nodes), server.cluster->size,
+                        nodes_pfail, nodes_fail, voting_nodes_pfail, voting_nodes_fail, dictSize(server.cluster->nodes), server.cluster->size,
                         (unsigned long long)server.cluster->currentEpoch, (unsigned long long)nodeEpoch(myself));
 
     /* Show stats about messages sent and received. */

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -64,3 +64,32 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
         wait_for_cluster_state ok
     }
 }
+
+start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 1000}} {
+    test "node partially failure count" {
+        pause_process [srv 0 pid]
+        wait_for_condition 500 10 {
+            [CI 1 cluster_nodes_pfail] eq 1 &&
+            [CI 2 cluster_nodes_pfail] eq 1 &&
+            [CI 1 cluster_nodes_fail] eq 0 &&
+            [CI 2 cluster_nodes_fail] eq 0
+        } else {
+            puts [R 1 CLUSTER INFO]
+            puts [R 2 CLUSTER INFO]
+            fail "Node 0 never timed out"
+        }
+    }
+
+    test "node complete failure count" {
+        # After reaching quorum about failure,
+        # node 0 should be marked as FAIL across all nodes in the cluster
+        wait_for_condition 100 100 {
+            [CI 1 cluster_nodes_fail] eq 1 &&
+            [CI 2 cluster_nodes_fail] eq 1 &&
+            [CI 1 cluster_nodes_pfail] eq 0 &&
+            [CI 2 cluster_nodes_pfail] eq 0
+        } else {
+            fail "Node 0 never completely failed"
+        }
+    }
+}

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -73,7 +73,9 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test "count - node partial failure" {
         wait_for_condition 500 10 {
             [CI 2 cluster_nodes_pfail] eq 2 &&
-            [CI 2 cluster_nodes_fail] eq 0
+            [CI 2 cluster_nodes_fail] eq 0 &&
+            [CI 2 cluster_voting_nodes_pfail] eq 2 &&
+            [CI 2 cluster_voting_nodes_fail] eq 0
         } else {
             puts [R 2 CLUSTER INFO]
             fail "Node 0/1 never timed out"
@@ -90,7 +92,10 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
             [CI 1 cluster_nodes_fail] eq 1 &&
             [CI 2 cluster_nodes_fail] eq 1 &&
             [CI 1 cluster_nodes_pfail] eq 0 &&
-            [CI 2 cluster_nodes_pfail] eq 0
+            [CI 2 cluster_nodes_pfail] eq 0 &&
+            [CI 1 cluster_voting_nodes_fail] eq 1 &&
+            [CI 2 cluster_voting_nodes_fail] eq 1
+
         } else {
             fail "Node 0 never completely failed"
         }

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -66,20 +66,22 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
 }
 
 start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 1000}} {
+    # Kill two primaries to observe partial failure on the remaining one.
     pause_process [srv 0 pid]
+    pause_process [srv -1 pid]
 
     test "count - node partial failure" {
         wait_for_condition 500 10 {
-            [CI 1 cluster_nodes_pfail] eq 1 &&
-            [CI 2 cluster_nodes_pfail] eq 1 &&
-            [CI 1 cluster_nodes_fail] eq 0 &&
+            [CI 2 cluster_nodes_pfail] eq 2 &&
             [CI 2 cluster_nodes_fail] eq 0
         } else {
-            puts [R 1 CLUSTER INFO]
             puts [R 2 CLUSTER INFO]
-            fail "Node 0 never timed out"
+            fail "Node 0/1 never timed out"
         }
     }
+
+    # Enable one more primary to reach quorum about node 0 failure
+    resume_process [srv -1 pid]
 
     test "count - node complete failure" {
         # After reaching quorum about failure,

--- a/tests/unit/cluster/info.tcl
+++ b/tests/unit/cluster/info.tcl
@@ -66,8 +66,9 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
 }
 
 start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 1000}} {
-    test "node partially failure count" {
-        pause_process [srv 0 pid]
+    pause_process [srv 0 pid]
+
+    test "count - node partial failure" {
         wait_for_condition 500 10 {
             [CI 1 cluster_nodes_pfail] eq 1 &&
             [CI 2 cluster_nodes_pfail] eq 1 &&
@@ -80,7 +81,7 @@ start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
         }
     }
 
-    test "node complete failure count" {
+    test "count - node complete failure" {
         # After reaching quorum about failure,
         # node 0 should be marked as FAIL across all nodes in the cluster
         wait_for_condition 100 100 {


### PR DESCRIPTION
New fields in CLUSTER INFO:

* `cluster_nodes_pfail`
* `cluster_nodes_fail`
* `cluster_voting_nodes_pfail`
* `cluster_voting_nodes_fail`

I'm running few tests and trying to capture partially failed and completely failed count. Slot partially failed / completely failed stats exists but is more difficult to assess the node failure count with that.

New output:

```
> CLUSTER INFO
cluster_state:fail
cluster_slots_assigned:0
cluster_slots_ok:0
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_nodes_pfail:1
cluster_nodes_fail:0
cluster_voting_nodes_pfail:1
cluster_voting_nodes_fail:0
cluster_known_nodes:3
cluster_size:0
cluster_current_epoch:1
cluster_my_epoch:1
cluster_stats_messages_ping_sent:2104
cluster_stats_messages_pong_sent:1906
cluster_stats_messages_meet_sent:1
cluster_stats_messages_sent:4011
cluster_stats_messages_ping_received:1906
cluster_stats_messages_pong_received:1964
cluster_stats_messages_received:3870
total_cluster_links_buffer_limit_exceeded:0
```
