### PR TITLE
Initialize child process pipe file descriptor to -1

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3546,7 +3546,7 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
     listNode *ln;
     listIter li;
     pid_t childpid;
-    int pipefds[2], rdb_pipe_write = 0, safe_to_exit_pipe = 0;
+    int pipefds[2], rdb_pipe_write = -1, safe_to_exit_pipe = -1;
     int dual_channel = (req & REPLICA_REQ_RDB_CHANNEL);
 
     if (hasActiveChildProcess()) return C_ERR;


### PR DESCRIPTION
This commit addresses an issue with the initialization of the child process pipe file descriptor. Previously, it was initialized to 0, which is a valid file descriptor (typically representing standard input). This could potentially lead to confusion and errors in file descriptor handling.

File descriptor 0 is a valid descriptor, which could cause unexpected behavior or conflicts in file operations. Using -1 as the initial value clearly indicates that the file descriptor is not yet set or is invalid. This change aligns with common practices in file descriptor handling, where -1 is often used to represent an uninitialized or invalid descriptor.