### PR TITLE
Implement INFO KEYSIZES section

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -798,7 +798,18 @@ static void hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpac
 
 void hsetnxCommand(client *c) {
     robj *o;
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    long previous_element_number;
+    long current_element_number;
+
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
 
     if (hashTypeExists(o, c->argv[2]->ptr)) {
         addReply(c, shared.czero);
@@ -809,22 +820,37 @@ void hsetnxCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
         server.dirty++;
+        current_element_number = previous_element_number + 1;
+        /* TO DO: update INFO KEYSIZES  */
     }
 }
 
 void hsetCommand(client *c) {
     int i, created = 0;
     robj *o;
+    long previous_element_number;
+    long current_element_number;
 
     if ((c->argc % 2) == 1) {
         addReplyErrorArity(c);
         return;
     }
 
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
+
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
 
     for (i = 2; i < c->argc; i += 2) created += !hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, HASH_SET_COPY);
+    current_element_number = previous_element_number + created;
+    /* TO DO: update INFO KEYSIZES  */
 
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;
@@ -846,9 +872,19 @@ void hincrbyCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    long previous_element_number;
+    long current_element_number;
 
     if (getLongLongFromObjectOrReply(c, c->argv[3], &incr, NULL) != C_OK) return;
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
     if (hashTypeGetValue(o, c->argv[2]->ptr, &vstr, &vlen, &value) == C_OK) {
         if (vstr) {
             if (string2ll((char *)vstr, vlen, &value) == 0) {
@@ -873,6 +909,8 @@ void hincrbyCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrby", c->argv[1], c->db->id);
     server.dirty++;
+    current_element_number = hashTypeLength(o);
+    /* TO DO: update INFO KEYSIZES  */
 }
 
 void hincrbyfloatCommand(client *c) {
@@ -882,13 +920,24 @@ void hincrbyfloatCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    long previous_element_number;
+    long current_element_number;
 
     if (getLongDoubleFromObjectOrReply(c, c->argv[3], &incr, NULL) != C_OK) return;
     if (isnan(incr) || isinf(incr)) {
         addReplyError(c, "value is NaN or Infinity");
         return;
     }
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
+
     if (hashTypeGetValue(o, c->argv[2]->ptr, &vstr, &vlen, &ll) == C_OK) {
         if (vstr) {
             if (string2ld((char *)vstr, vlen, &value) == 0) {
@@ -916,6 +965,8 @@ void hincrbyfloatCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrbyfloat", c->argv[1], c->db->id);
     server.dirty++;
+    current_element_number = hashTypeLength(o);
+    /* TO DO: update INFO KEYSIZES  */
 
     /* Always replicate HINCRBYFLOAT as an HSET command with the final value
      * in order to make sure that differences in float precision or formatting
@@ -974,9 +1025,12 @@ void hmgetCommand(client *c) {
 void hdelCommand(client *c) {
     robj *o;
     int j, deleted = 0, keyremoved = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, o, OBJ_HASH)) return;
 
+    previous_element_number = hashTypeLength(o);
     for (j = 2; j < c->argc; j++) {
         if (hashTypeDelete(o, c->argv[j]->ptr)) {
             deleted++;
@@ -990,7 +1044,11 @@ void hdelCommand(client *c) {
     if (deleted) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_HASH, "hdel", c->argv[1], c->db->id);
-        if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        if (keyremoved) {
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        }
+        current_element_number = previous_element_number - deleted;
+        /* TO DO: update INFO KEYSIZES  */
         server.dirty += deleted;
     }
     addReplyLongLong(c, deleted);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -461,6 +461,8 @@ void listTypeDelRange(robj *subject, long start, long count) {
  * 'xx': push if key exists. */
 void pushGenericCommand(client *c, int where, int xx) {
     int j;
+    long previous_element_number;
+    long current_element_number;
 
     robj *lobj = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, lobj, OBJ_LIST)) return;
@@ -470,8 +472,11 @@ void pushGenericCommand(client *c, int where, int xx) {
             return;
         }
 
+        previous_element_number = 0;
         lobj = createListListpackObject();
         dbAdd(c->db, c->argv[1], &lobj);
+    } else {
+        previous_element_number = listTypeLength(lobj);
     }
 
     listTypeTryConversionAppend(lobj, c->argv, 2, c->argc - 1, NULL, NULL);
@@ -479,8 +484,9 @@ void pushGenericCommand(client *c, int where, int xx) {
         listTypePush(lobj, c->argv[j], where);
         server.dirty++;
     }
-
-    addReplyLongLong(c, listTypeLength(lobj));
+    current_element_number = listTypeLength(lobj);
+    /* TO DO: update INFO KEYSIZES  */
+    addReplyLongLong(c, current_element_number);
 
     char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     signalModifiedKey(c, c->db, c->argv[1]);
@@ -510,10 +516,12 @@ void rpushxCommand(client *c) {
 /* LINSERT <key> (BEFORE|AFTER) <pivot> <element> */
 void linsertCommand(client *c) {
     int where;
-    robj *subject;
+    robj *lobj;
     listTypeIterator *iter;
     listTypeEntry entry;
     int inserted = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if (strcasecmp(c->argv[2]->ptr, "after") == 0) {
         where = LIST_TAIL;
@@ -524,7 +532,7 @@ void linsertCommand(client *c) {
         return;
     }
 
-    if ((subject = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, subject, OBJ_LIST))
+    if ((lobj = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, lobj, OBJ_LIST))
         return;
 
     /* We're not sure if this value can be inserted yet, but we cannot
@@ -532,10 +540,11 @@ void linsertCommand(client *c) {
      * the list twice (once to see if the value can be inserted and once
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
-    listTypeTryConversionAppend(subject, c->argv, 4, 4, NULL, NULL);
+    previous_element_number = listTypeLength(lobj);
+    listTypeTryConversionAppend(lobj, c->argv, 4, 4, NULL, NULL);
 
     /* Seek pivot from head to tail */
-    iter = listTypeInitIterator(subject, 0, LIST_TAIL);
+    iter = listTypeInitIterator(lobj, 0, LIST_TAIL);
     while (listTypeNext(iter, &entry)) {
         if (listTypeEqual(&entry, c->argv[3])) {
             listTypeInsert(&entry, c->argv[4], where);
@@ -549,13 +558,15 @@ void linsertCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST, "linsert", c->argv[1], c->db->id);
         server.dirty++;
+        current_element_number = previous_element_number + 1;
+        /* TO DO: update INFO KEYSIZES  */
+        addReplyLongLong(c, current_element_number);
+        return;
     } else {
         /* Notify client of a failed insert */
         addReplyLongLong(c, -1);
         return;
     }
-
-    addReplyLongLong(c, listTypeLength(subject));
 }
 
 /* LLEN <key> */
@@ -756,6 +767,8 @@ void popGenericCommand(client *c, int where) {
     int hascount = (c->argc == 3);
     long count = 0;
     robj *value;
+    long previous_element_number;
+    long current_element_number;
 
     if (c->argc > 3) {
         addReplyErrorArity(c);
@@ -765,8 +778,8 @@ void popGenericCommand(client *c, int where) {
         if (getPositiveLongFromObjectOrReply(c, c->argv[2], &count, NULL) != C_OK) return;
     }
 
-    robj *o = lookupKeyWriteOrReply(c, c->argv[1], hascount ? shared.nullarray[c->resp] : shared.null[c->resp]);
-    if (o == NULL || checkType(c, o, OBJ_LIST)) return;
+    robj *lobj = lookupKeyWriteOrReply(c, c->argv[1], hascount ? shared.nullarray[c->resp] : shared.null[c->resp]);
+    if (lobj == NULL || checkType(c, lobj, OBJ_LIST)) return;
 
     if (hascount && !count) {
         /* Fast exit path. */
@@ -774,27 +787,31 @@ void popGenericCommand(client *c, int where) {
         return;
     }
 
+    previous_element_number = listTypeLength(lobj);
     if (!count) {
         /* Pop a single element. This is POP's original behavior that replies
          * with a bulk string. */
-        value = listTypePop(o, where);
+        value = listTypePop(lobj, where);
         serverAssert(value != NULL);
         addReplyBulk(c, value);
         decrRefCount(value);
-        listElementsRemoved(c, c->argv[1], where, o, 1, 1, NULL);
+        listElementsRemoved(c, c->argv[1], where, lobj, 1, 1, NULL);
+        current_element_number = previous_element_number - 1;
     } else {
         /* Pop a range of elements. An addition to the original POP command,
          *  which replies with a multi-bulk. */
-        long llen = listTypeLength(o);
+        long llen = previous_element_number;
         long rangelen = (count > llen) ? llen : count;
         long rangestart = (where == LIST_HEAD) ? 0 : -rangelen;
         long rangeend = (where == LIST_HEAD) ? rangelen - 1 : -1;
         int reverse = (where == LIST_HEAD) ? 0 : 1;
 
-        addListRangeReply(c, o, rangestart, rangeend, reverse);
-        listTypeDelRange(o, rangestart, rangelen);
-        listElementsRemoved(c, c->argv[1], where, o, rangelen, 1, NULL);
+        addListRangeReply(c, lobj, rangestart, rangeend, reverse);
+        listTypeDelRange(lobj, rangestart, rangelen);
+        listElementsRemoved(c, c->argv[1], where, lobj, rangelen, 1, NULL);
+        current_element_number = previous_element_number - rangelen;
     }
+    /* TO DO: update INFO KEYSIZES  */
 }
 
 /* Like popGenericCommand but work with multiple keys.
@@ -862,15 +879,19 @@ void lrangeCommand(client *c) {
 
 /* LTRIM <key> <start> <stop> */
 void ltrimCommand(client *c) {
-    robj *o;
+    robj *lobj;
     long start, end, llen, ltrim, rtrim;
+    long previous_element_number;
+    long current_element_number;
+
 
     if ((getLongFromObjectOrReply(c, c->argv[2], &start, NULL) != C_OK) ||
         (getLongFromObjectOrReply(c, c->argv[3], &end, NULL) != C_OK))
         return;
 
-    if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.ok)) == NULL || checkType(c, o, OBJ_LIST)) return;
-    llen = listTypeLength(o);
+    if ((lobj = lookupKeyWriteOrReply(c, c->argv[1], shared.ok)) == NULL || checkType(c, lobj, OBJ_LIST)) return;
+    llen = listTypeLength(lobj);
+    previous_element_number = llen;
 
     /* convert negative indexes */
     if (start < 0) start = llen + start;
@@ -890,23 +911,25 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklistDelRange(o->ptr, 0, ltrim);
-        quicklistDelRange(o->ptr, -rtrim, rtrim);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        o->ptr = lpDeleteRange(o->ptr, 0, ltrim);
-        o->ptr = lpDeleteRange(o->ptr, -rtrim, rtrim);
+    if (lobj->encoding == OBJ_ENCODING_QUICKLIST) {
+        quicklistDelRange(lobj->ptr, 0, ltrim);
+        quicklistDelRange(lobj->ptr, -rtrim, rtrim);
+    } else if (lobj->encoding == OBJ_ENCODING_LISTPACK) {
+        lobj->ptr = lpDeleteRange(lobj->ptr, 0, ltrim);
+        lobj->ptr = lpDeleteRange(lobj->ptr, -rtrim, rtrim);
     } else {
         serverPanic("Unknown list encoding");
     }
 
+    current_element_number = listTypeLength(lobj);
     notifyKeyspaceEvent(NOTIFY_LIST, "ltrim", c->argv[1], c->db->id);
-    if (listTypeLength(o) == 0) {
+    if (current_element_number == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     } else {
-        listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
+        listTypeTryConversion(lobj, LIST_CONV_SHRINKING, NULL, NULL);
     }
+    /* TO DO: update INFO KEYSIZES  */
     signalModifiedKey(c, c->db, c->argv[1]);
     server.dirty += (ltrim + rtrim);
     addReply(c, shared.ok);
@@ -1021,27 +1044,31 @@ void lposCommand(client *c) {
 
 /* LREM <key> <count> <element> */
 void lremCommand(client *c) {
-    robj *subject, *obj;
-    obj = c->argv[3];
+    robj *lobj, *element;
+    element = c->argv[3];
     long toremove;
     long removed = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &toremove, NULL) != C_OK) return;
 
-    subject = lookupKeyWriteOrReply(c, c->argv[1], shared.czero);
-    if (subject == NULL || checkType(c, subject, OBJ_LIST)) return;
+    lobj = lookupKeyWriteOrReply(c, c->argv[1], shared.czero);
+    if (lobj == NULL || checkType(c, lobj, OBJ_LIST)) return;
 
     listTypeIterator *li;
     if (toremove < 0) {
         toremove = -toremove;
-        li = listTypeInitIterator(subject, -1, LIST_HEAD);
+        li = listTypeInitIterator(lobj, -1, LIST_HEAD);
     } else {
-        li = listTypeInitIterator(subject, 0, LIST_TAIL);
+        li = listTypeInitIterator(lobj, 0, LIST_TAIL);
     }
 
+    previous_element_number = listTypeLength(lobj);
+    current_element_number = previous_element_number;
     listTypeEntry entry;
     while (listTypeNext(li, &entry)) {
-        if (listTypeEqual(&entry, obj)) {
+        if (listTypeEqual(&entry, element)) {
             listTypeDelete(li, &entry);
             server.dirty++;
             removed++;
@@ -1052,13 +1079,15 @@ void lremCommand(client *c) {
 
     if (removed) {
         notifyKeyspaceEvent(NOTIFY_LIST, "lrem", c->argv[1], c->db->id);
-        if (listTypeLength(subject) == 0) {
+        current_element_number = listTypeLength(lobj);
+        if (current_element_number == 0) {
             dbDelete(c->db, c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         } else {
-            listTypeTryConversion(subject, LIST_CONV_SHRINKING, NULL, NULL);
+            listTypeTryConversion(lobj, LIST_CONV_SHRINKING, NULL, NULL);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
+        /* TO DO: update INFO KEYSIZES  */
     }
 
     addReplyLongLong(c, removed);
@@ -1101,10 +1130,17 @@ robj *getStringObjectFromListPosition(int position) {
 
 void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
     robj *sobj, *value;
+    int *delete = NULL;
+    long sobj_previous_element_number;
+    long sobj_current_element_number;
+    long dobj_previous_element_number;
+    long dobj_current_element_number;
+
     if ((sobj = lookupKeyWriteOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, sobj, OBJ_LIST))
         return;
 
-    if (listTypeLength(sobj) == 0) {
+    sobj_previous_element_number = listTypeLength(sobj);
+    if (sobj_previous_element_number == 0) {
         /* This may only happen after loading very old RDB files. Recent
          * versions of the server delete keys of empty lists. */
         addReplyNull(c);
@@ -1113,19 +1149,29 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
         robj *touchedkey = c->argv[1];
 
         if (checkType(c, dobj, OBJ_LIST)) return;
+        if (!dobj) {
+            dobj_previous_element_number = 0;
+        }
         value = listTypePop(sobj, wherefrom);
         serverAssert(value); /* assertion for valgrind (avoid NPD) */
         lmoveHandlePush(c, c->argv[2], dobj, value, whereto);
-        listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, 1, NULL);
+        listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, 1, delete);
 
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
-
+        if (*delete == 1) {
+            sobj_current_element_number = 0;
+        } else {
+            // It will crash, Need to check
+            // sobj_current_element_number = listTypeLength(sobj);
+        }
         if (c->cmd->proc == blmoveCommand) {
             rewriteClientCommandVector(c, 5, shared.lmove, c->argv[1], c->argv[2], c->argv[3], c->argv[4]);
         } else if (c->cmd->proc == brpoplpushCommand) {
             rewriteClientCommandVector(c, 3, shared.rpoplpush, c->argv[1], c->argv[2]);
         }
+        // dobj_current_element_number = listTypeLength(dobj);
+        /* TO DO: update INFO KEYSIZES  */
     }
 }
 


### PR DESCRIPTION
It is related to the issue https://github.com/valkey-io/valkey/issues/1827#issuecomment-2775321800,  https://github.com/valkey-io/valkey/issues/1880, and https://github.com/valkey-io/valkey/pull/1151

Reference Redis latest feature in Version 8 as below:

127.0.0.1:6379> INFO keysizes
# Keysizes
db0_distrib_strings_sizes:1=19,2=655,4=3918,8=19,16=23,32=326,64=5,128=1,256=47,512=100899,1K=31,2K=29,4K=23,8K=16,16K=3,32K=2
db0_distrib_lists_items:1=5784492,2=151535,4=46670,8=20453,16=8637,32=3558,64=1047,128=676,256=533,512=218,4K=1,8K=42
db0_distrib_sets_items:1=7355615,2=207181,4=50612,8=21462,16=8864,32=2905,64=1365,128=974,256=773,512=675,1K=395,2K=292,4K=154,8K=89,16K=48,32K=21,64K=27,128K=16,256K=5,512K=4,1M=2
db0_distrib_hashes_items:2=1,4=544,8=746485,16=324174,32=141169,64=207329,128=4349,256=136226,1K=1