### PR TITLE
INFO KEYSIZES section feature

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -880,6 +880,61 @@ void trackInstantaneousMetric(int metric, long long current_value, long long cur
     server.inst_metric[metric].last_sample_value = current_value;
 }
 
+void displayUpdate(int pre_value, int current_value) {
+    serverLog(LL_WARNING, "This is for testing, previous item number is %d, and current item number is %d", pre_value, current_value);
+}
+
+void displayDataTypeArray(keysizeInfo *keysize_array, int length) {
+    serverLog(LL_WARNING, "Current array length is %d", length);
+    for (int i = 0; i < length; i++) {
+        serverLog(LL_WARNING, "Item %ld and value is %ld", keysize_array[i].element_size, keysize_array[i].num);
+    }
+}
+
+void decreaseDataTypeArrayPreviousValue(keysizeInfo *keysize_array, int low, int high, int value) {
+    if (keysize_array[low].element_size == value) {
+        keysize_array[low].num--;
+    } else if (keysize_array[high].element_size == value) {
+        keysize_array[high].num--;
+    } else {
+        while (low + 1 < high) {
+            int mid = low + (high - low) / 2;
+            if (value > keysize_array[mid].element_size) {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        if (value == keysize_array[high].element_size) {
+            keysize_array[high].num--;
+        } else {
+            keysize_array[low].num--;
+        }
+    }
+}
+
+void increaseDataTypeArrayCurrentValue(keysizeInfo *keysize_array, int low, int high, int value) {
+    if (keysize_array[low].element_size == value) {
+        keysize_array[low].num++;
+    } else if (keysize_array[high].element_size == value) {
+        keysize_array[high].num++;
+    } else {
+        while (low + 1 < high) {
+            int mid = low + (high - low) / 2;
+            if (value > keysize_array[mid].element_size) {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        if (value == keysize_array[high].element_size) {
+            keysize_array[high].num++;
+        } else {
+            keysize_array[low].num++;
+        }
+    }
+}
+
 /* Return the mean of all the samples. */
 long long getInstantaneousMetric(int metric) {
     int j;
@@ -2731,6 +2786,7 @@ void makeThreadKillable(void) {
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 }
 
+#define INIT_ARRAY_SIZE 5
 void initServer(void) {
     int j;
 
@@ -2822,6 +2878,35 @@ void initServer(void) {
         server.db[j].watched_keys = dictCreate(&keylistDictType);
         server.db[j].id = j;
         server.db[j].avg_ttl = 0;
+        server.db[j].lists_array_length = INIT_ARRAY_SIZE;
+        server.db[j].lists_number_of_elements = 0;
+        server.db[j].lists_array = zmalloc(sizeof(keysizeInfo) * INIT_ARRAY_SIZE);
+        server.db[j].sets_array_length = INIT_ARRAY_SIZE;
+        server.db[j].sets_number_of_elements = 0;
+        server.db[j].sets_array = zmalloc(sizeof(keysizeInfo) * INIT_ARRAY_SIZE);
+        server.db[j].hashes_array_length = INIT_ARRAY_SIZE;
+        server.db[j].hashes_number_of_elements = 0;
+        server.db[j].hashes_array = zmalloc(sizeof(keysizeInfo) * INIT_ARRAY_SIZE);
+        server.db[j].zsets_array_length = INIT_ARRAY_SIZE;
+        server.db[j].zsets_number_of_elements = 0;
+        server.db[j].zsets_array = zmalloc(sizeof(keysizeInfo) * INIT_ARRAY_SIZE);
+        server.db[j].strings_array_length = INIT_ARRAY_SIZE;
+        server.db[j].strings_number_of_elements = 0;
+        server.db[j].strings_array = zmalloc(sizeof(keysizeInfo) * INIT_ARRAY_SIZE);
+        int i = 1;
+        for (int count = 0; count < INIT_ARRAY_SIZE; count++) {
+            server.db[j].lists_array[count].element_size = i;
+            server.db[j].lists_array[count].num = 0;
+            server.db[j].sets_array[count].element_size = i;
+            server.db[j].sets_array[count].num = 0;
+            server.db[j].hashes_array[count].element_size = i;
+            server.db[j].hashes_array[count].num = 0;
+            server.db[j].zsets_array[count].element_size = i;
+            server.db[j].zsets_array[count].num = 0;
+            server.db[j].strings_array[count].element_size = i;
+            server.db[j].strings_array[count].num = 0;
+            i *= 2;
+        }
     }
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     /* Note that server.pubsub_channels was chosen to be a kvstore (with only one dict, which
@@ -5553,6 +5638,7 @@ dict *genInfoSectionDict(robj **argv, int argc, char **defaults, int *out_all, i
         "errorstats",
         "cluster",
         "keyspace",
+        "keysizes",
         NULL,
     };
     if (!defaults) defaults = default_sections;
@@ -6203,6 +6289,41 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
             if (keys || vkeys) {
                 info = sdscatprintf(info, "db%d:keys=%lld,expires=%lld,avg_ttl=%lld\r\n", j, keys, vkeys,
                                     server.db[j].avg_ttl);
+            }
+        }
+    }
+
+    /* Key size distribution*/
+    if (all_sections || (dictFind(section_dict, "keysizes") != NULL)) {
+        if (sections++) info = sdscat(info, "\r\n");
+        info = sdscatprintf(info, "# Keysizes\r\n");
+        for (j = 0; j < server.dbnum; j++) {
+            if (server.db[j].lists_number_of_elements != 0) {
+                info = sdscatprintf(info, "db%d_distrib_strings_sizes:", j);
+                for (int l = 0; l < server.db[j].strings_array_length; l++) {
+                    info = sdscatprintf(info, "%ld=%ld,", server.db[j].strings_array[l].element_size, server.db[j].strings_array[l].num);
+                }
+                info = sdscatprintf(info, "\r\n");
+                info = sdscatprintf(info, "db%d_distrib_lists_items:", j);
+                for (int l = 0; l < server.db[j].lists_array_length; l++) {
+                    info = sdscatprintf(info, "%ld=%ld,", server.db[j].lists_array[l].element_size, server.db[j].lists_array[l].num);
+                }
+                info = sdscatprintf(info, "\r\n");
+                info = sdscatprintf(info, "db%d_distrib_sets_items:", j);
+                for (int l = 0; l < server.db[j].sets_array_length; l++) {
+                    info = sdscatprintf(info, "%ld=%ld,", server.db[j].sets_array[l].element_size, server.db[j].sets_array[l].num);
+                }
+                info = sdscatprintf(info, "\r\n");
+                info = sdscatprintf(info, "db%d_distrib_hashes_items:", j);
+                for (int l = 0; l < server.db[j].hashes_array_length; l++) {
+                    info = sdscatprintf(info, "%ld=%ld,", server.db[j].hashes_array[l].element_size, server.db[j].hashes_array[l].num);
+                }
+                info = sdscatprintf(info, "\r\n");
+                info = sdscatprintf(info, "db%d_distrib_zsets_items:", j);
+                for (int l = 0; l < server.db[j].zsets_array_length; l++) {
+                    info = sdscatprintf(info, "%ld=%ld,", server.db[j].zsets_array[l].element_size, server.db[j].zsets_array[l].num);
+                }
+                info = sdscatprintf(info, "\r\n");
             }
         }
     }

--- a/src/server.h
+++ b/src/server.h
@@ -818,6 +818,11 @@ typedef struct replBufBlock {
     char buf[];
 } replBufBlock;
 
+typedef struct keysizeInfo {
+    long element_size;
+    long num;
+} keysizeInfo;
+
 /* Database representation. There are multiple databases identified
  * by integers from 0 (the default database) up to the max configured
  * database. The database number is the 'id' field in the structure. */
@@ -833,6 +838,21 @@ typedef struct serverDb {
     int id;                               /* Database ID */
     long long avg_ttl;                    /* Average TTL, just for stats */
     unsigned long expires_cursor;         /* Cursor of the active expire cycle. */
+    keysizeInfo *lists_array;
+    int lists_array_length;
+    unsigned long long lists_number_of_elements;
+    keysizeInfo *sets_array;
+    int sets_array_length;
+    unsigned long long sets_number_of_elements;
+    keysizeInfo *hashes_array;
+    int hashes_array_length;
+    unsigned long long hashes_number_of_elements;
+    keysizeInfo *zsets_array;
+    int zsets_array_length;
+    unsigned long long zsets_number_of_elements;
+    keysizeInfo *strings_array;
+    int strings_array_length;
+    unsigned long long strings_number_of_elements;
 } serverDb;
 
 /* forward declaration for functions ctx */
@@ -3212,6 +3232,10 @@ void *activeDefragAlloc(void *ptr);
 robj *activeDefragStringOb(robj *ob);
 void dismissSds(sds s);
 void dismissMemoryInChild(void);
+void displayUpdate(int pre_value, int current_value);
+void displayDataTypeArray(keysizeInfo *keysize_array, int length);
+void decreaseDataTypeArrayPreviousValue(keysizeInfo *keysize_array, int low, int high, int value);
+void increaseDataTypeArrayCurrentValue(keysizeInfo *keysize_array, int low, int high, int value);
 
 #define RESTART_SERVER_NONE 0
 #define RESTART_SERVER_GRACEFULLY (1 << 0)     /* Do proper shutdown. */
@@ -3518,6 +3542,7 @@ unsigned long evalScriptsMemory(void);
 uint64_t evalGetCommandFlags(client *c, uint64_t orig_flags);
 uint64_t fcallGetCommandFlags(client *c, uint64_t orig_flags);
 int isInsideYieldingLongCommand(void);
+void displayUpdate(int pre_value, int current_value);
 
 /* Cache of recently used small arguments to avoid malloc calls. */
 #define LUA_CMD_OBJCACHE_SIZE 32

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -791,6 +791,46 @@ static void hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpac
     }
 }
 
+void scaleHashKeySizeArray(client *c, long value) {
+    int length = c->db->hashes_array_length;
+    int high_bound = c->db->hashes_array[length - 1].element_size;
+    int base = high_bound;
+    int count = 0;
+    while (high_bound < value) {
+        count++;
+        high_bound = high_bound * 2;
+    }
+    keysizeInfo *new_array = zmalloc(sizeof(keysizeInfo) * (count + length));
+    for (int i = 0; i < length; i++) {
+        new_array[i].element_size = c->db->hashes_array[i].element_size;
+        new_array[i].num = c->db->hashes_array[i].num;
+    }
+    for (int i = length; i < (count + length); i++) {
+        base *= 2;
+        new_array[i].element_size = base;
+        new_array[i].num = 0;
+    }
+    keysizeInfo *old_array = c->db->hashes_array;
+    zfree(old_array);
+    c->db->hashes_array = new_array;
+    c->db->hashes_array_length = count + length;
+}
+
+void updateHashKeySizeArray(client *c, long previous, long curr) {
+    int low = 0;
+    int high = c->db->hashes_array_length - 1;
+    if (curr > c->db->hashes_array[high].element_size) {
+        scaleHashKeySizeArray(c, curr);
+    }
+
+    high = c->db->hashes_array_length - 1;
+    if (previous != 0) {
+        decreaseDataTypeArrayPreviousValue(c->db->hashes_array, low, high, previous);
+    }
+    if (curr != 0) {
+        increaseDataTypeArrayCurrentValue(c->db->hashes_array, low, high, curr);
+    }
+}
 
 /*-----------------------------------------------------------------------------
  * Hash type commands
@@ -798,7 +838,18 @@ static void hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpac
 
 void hsetnxCommand(client *c) {
     robj *o;
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    long previous_element_number;
+    long current_element_number;
+
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
 
     if (hashTypeExists(o, c->argv[2]->ptr)) {
         addReply(c, shared.czero);
@@ -809,23 +860,39 @@ void hsetnxCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
         server.dirty++;
+        current_element_number = previous_element_number + 1;
+        /* TO DO: update INFO KEYSIZES  */
+	updateHashKeySizeArray(c, previous_element_number, current_element_number);
     }
 }
 
 void hsetCommand(client *c) {
     int i, created = 0;
     robj *o;
+    long previous_element_number;
+    long current_element_number;
 
     if ((c->argc % 2) == 1) {
         addReplyErrorArity(c);
         return;
     }
 
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+        c->db->hashes_number_of_elements++;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
 
     for (i = 2; i < c->argc; i += 2) created += !hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, HASH_SET_COPY);
 
+    current_element_number = previous_element_number + created;
+    updateHashKeySizeArray(c, previous_element_number, current_element_number);
     /* HMSET (deprecated) and HSET return value is different. */
     char *cmdname = c->argv[0]->ptr;
     if (cmdname[1] == 's' || cmdname[1] == 'S') {
@@ -846,9 +913,19 @@ void hincrbyCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    long previous_element_number;
+    long current_element_number;
 
     if (getLongLongFromObjectOrReply(c, c->argv[3], &incr, NULL) != C_OK) return;
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
     if (hashTypeGetValue(o, c->argv[2]->ptr, &vstr, &vlen, &value) == C_OK) {
         if (vstr) {
             if (string2ll((char *)vstr, vlen, &value) == 0) {
@@ -873,6 +950,9 @@ void hincrbyCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrby", c->argv[1], c->db->id);
     server.dirty++;
+    current_element_number = hashTypeLength(o);
+    /* TO DO: update INFO KEYSIZES  */
+    updateHashKeySizeArray(c, previous_element_number, current_element_number);
 }
 
 void hincrbyfloatCommand(client *c) {
@@ -882,13 +962,24 @@ void hincrbyfloatCommand(client *c) {
     sds new;
     unsigned char *vstr;
     unsigned int vlen;
+    long previous_element_number;
+    long current_element_number;
 
     if (getLongDoubleFromObjectOrReply(c, c->argv[3], &incr, NULL) != C_OK) return;
     if (isnan(incr) || isinf(incr)) {
         addReplyError(c, "value is NaN or Infinity");
         return;
     }
-    if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
+    o = lookupKeyWrite(c->db, c->argv[1]);
+    if (checkType(c, o, OBJ_HASH)) return;
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+        previous_element_number = 0;
+    } else {
+        previous_element_number = hashTypeLength(o);
+    }
+
     if (hashTypeGetValue(o, c->argv[2]->ptr, &vstr, &vlen, &ll) == C_OK) {
         if (vstr) {
             if (string2ld((char *)vstr, vlen, &value) == 0) {
@@ -916,6 +1007,9 @@ void hincrbyfloatCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrbyfloat", c->argv[1], c->db->id);
     server.dirty++;
+    current_element_number = hashTypeLength(o);
+    /* TO DO: update INFO KEYSIZES  */
+    updateHashKeySizeArray(c, previous_element_number, current_element_number);
 
     /* Always replicate HINCRBYFLOAT as an HSET command with the final value
      * in order to make sure that differences in float precision or formatting
@@ -974,9 +1068,12 @@ void hmgetCommand(client *c) {
 void hdelCommand(client *c) {
     robj *o;
     int j, deleted = 0, keyremoved = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, o, OBJ_HASH)) return;
 
+    previous_element_number = hashTypeLength(o);
     for (j = 2; j < c->argc; j++) {
         if (hashTypeDelete(o, c->argv[j]->ptr)) {
             deleted++;
@@ -990,7 +1087,12 @@ void hdelCommand(client *c) {
     if (deleted) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_HASH, "hdel", c->argv[1], c->db->id);
-        if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        if (keyremoved) {
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
+        }
+        current_element_number = previous_element_number - deleted;
+        /* TO DO: update INFO KEYSIZES  */
+	updateHashKeySizeArray(c, previous_element_number, current_element_number);
         server.dirty += deleted;
     }
     addReplyLongLong(c, deleted);

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -453,6 +453,47 @@ void listTypeDelRange(robj *subject, long start, long count) {
     }
 }
 
+void scaleListKeySizeArray(client *c, long value) {
+    int length = c->db->lists_array_length;
+    int high_bound = c->db->lists_array[length - 1].element_size;
+    int base = high_bound;
+    int count = 0;
+    while (high_bound < value) {
+        count++;
+        high_bound = high_bound * 2;
+    }
+    keysizeInfo *new_array = zmalloc(sizeof(keysizeInfo) * (count + length));
+    for (int i = 0; i < length; i++) {
+        new_array[i].element_size = c->db->lists_array[i].element_size;
+        new_array[i].num = c->db->lists_array[i].num;
+    }
+    for (int i = length; i < (count + length); i++) {
+        base *= 2;
+        new_array[i].element_size = base;
+        new_array[i].num = 0;
+    }
+    keysizeInfo *old_array = c->db->lists_array;
+    zfree(old_array);
+    c->db->lists_array = new_array;
+    c->db->lists_array_length = count + length;
+}
+
+void updateiListKeySizeArray(client *c, long previous, long curr) {
+    int low = 0;
+    int high = c->db->lists_array_length - 1;
+    if (curr > c->db->lists_array[high].element_size) {
+        scaleListKeySizeArray(c, curr);
+    }
+
+    high = c->db->lists_array_length - 1;
+    if (previous != 0) {
+        decreaseDataTypeArrayPreviousValue(c->db->lists_array, low, high, previous);
+    }
+    if (curr != 0) {
+        increaseDataTypeArrayCurrentValue(c->db->lists_array, low, high, curr);
+    }
+}
+
 /*-----------------------------------------------------------------------------
  * List Commands
  *----------------------------------------------------------------------------*/
@@ -461,6 +502,8 @@ void listTypeDelRange(robj *subject, long start, long count) {
  * 'xx': push if key exists. */
 void pushGenericCommand(client *c, int where, int xx) {
     int j;
+    long previous_element_number;
+    long current_element_number;
 
     robj *lobj = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, lobj, OBJ_LIST)) return;
@@ -470,8 +513,12 @@ void pushGenericCommand(client *c, int where, int xx) {
             return;
         }
 
+        previous_element_number = 0;
         lobj = createListListpackObject();
         dbAdd(c->db, c->argv[1], &lobj);
+        c->db->lists_number_of_elements++;
+    } else {
+        previous_element_number = listTypeLength(lobj);
     }
 
     listTypeTryConversionAppend(lobj, c->argv, 2, c->argc - 1, NULL, NULL);
@@ -481,6 +528,9 @@ void pushGenericCommand(client *c, int where, int xx) {
     }
 
     addReplyLongLong(c, listTypeLength(lobj));
+    current_element_number = listTypeLength(lobj);
+    //    displayUpdate(previous_element_number, current_element_number);
+    updateiListKeySizeArray(c, previous_element_number, current_element_number);
 
     char *event = (where == LIST_HEAD) ? "lpush" : "rpush";
     signalModifiedKey(c, c->db, c->argv[1]);
@@ -510,10 +560,12 @@ void rpushxCommand(client *c) {
 /* LINSERT <key> (BEFORE|AFTER) <pivot> <element> */
 void linsertCommand(client *c) {
     int where;
-    robj *subject;
+    robj *lobj;
     listTypeIterator *iter;
     listTypeEntry entry;
     int inserted = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if (strcasecmp(c->argv[2]->ptr, "after") == 0) {
         where = LIST_TAIL;
@@ -524,7 +576,7 @@ void linsertCommand(client *c) {
         return;
     }
 
-    if ((subject = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, subject, OBJ_LIST))
+    if ((lobj = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, lobj, OBJ_LIST))
         return;
 
     /* We're not sure if this value can be inserted yet, but we cannot
@@ -532,10 +584,12 @@ void linsertCommand(client *c) {
      * the list twice (once to see if the value can be inserted and once
      * to do the actual insert), so we assume this value can be inserted
      * and convert the listpack to a regular list if necessary. */
-    listTypeTryConversionAppend(subject, c->argv, 4, 4, NULL, NULL);
+    previous_element_number = listTypeLength(lobj);
+    listTypeTryConversionAppend(lobj, c->argv, 4, 4, NULL, NULL);
+
 
     /* Seek pivot from head to tail */
-    iter = listTypeInitIterator(subject, 0, LIST_TAIL);
+    iter = listTypeInitIterator(lobj, 0, LIST_TAIL);
     while (listTypeNext(iter, &entry)) {
         if (listTypeEqual(&entry, c->argv[3])) {
             listTypeInsert(&entry, c->argv[4], where);
@@ -549,13 +603,13 @@ void linsertCommand(client *c) {
         signalModifiedKey(c, c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_LIST, "linsert", c->argv[1], c->db->id);
         server.dirty++;
+        current_element_number = previous_element_number + 1;
+        updateiListKeySizeArray(c, previous_element_number, current_element_number);
     } else {
         /* Notify client of a failed insert */
         addReplyLongLong(c, -1);
         return;
     }
-
-    addReplyLongLong(c, listTypeLength(subject));
 }
 
 /* LLEN <key> */
@@ -756,6 +810,8 @@ void popGenericCommand(client *c, int where) {
     int hascount = (c->argc == 3);
     long count = 0;
     robj *value;
+    long previous_element_number;
+    long current_element_number;
 
     if (c->argc > 3) {
         addReplyErrorArity(c);
@@ -765,8 +821,8 @@ void popGenericCommand(client *c, int where) {
         if (getPositiveLongFromObjectOrReply(c, c->argv[2], &count, NULL) != C_OK) return;
     }
 
-    robj *o = lookupKeyWriteOrReply(c, c->argv[1], hascount ? shared.nullarray[c->resp] : shared.null[c->resp]);
-    if (o == NULL || checkType(c, o, OBJ_LIST)) return;
+    robj *lobj = lookupKeyWriteOrReply(c, c->argv[1], hascount ? shared.nullarray[c->resp] : shared.null[c->resp]);
+    if (lobj == NULL || checkType(c, lobj, OBJ_LIST)) return;
 
     if (hascount && !count) {
         /* Fast exit path. */
@@ -774,27 +830,31 @@ void popGenericCommand(client *c, int where) {
         return;
     }
 
+    previous_element_number = listTypeLength(lobj);
     if (!count) {
         /* Pop a single element. This is POP's original behavior that replies
          * with a bulk string. */
-        value = listTypePop(o, where);
+        value = listTypePop(lobj, where);
         serverAssert(value != NULL);
         addReplyBulk(c, value);
         decrRefCount(value);
-        listElementsRemoved(c, c->argv[1], where, o, 1, 1, NULL);
+        listElementsRemoved(c, c->argv[1], where, lobj, 1, 1, NULL);
+        current_element_number = previous_element_number - 1;
     } else {
         /* Pop a range of elements. An addition to the original POP command,
          *  which replies with a multi-bulk. */
-        long llen = listTypeLength(o);
+        long llen = previous_element_number;
         long rangelen = (count > llen) ? llen : count;
         long rangestart = (where == LIST_HEAD) ? 0 : -rangelen;
         long rangeend = (where == LIST_HEAD) ? rangelen - 1 : -1;
         int reverse = (where == LIST_HEAD) ? 0 : 1;
 
-        addListRangeReply(c, o, rangestart, rangeend, reverse);
-        listTypeDelRange(o, rangestart, rangelen);
-        listElementsRemoved(c, c->argv[1], where, o, rangelen, 1, NULL);
+        addListRangeReply(c, lobj, rangestart, rangeend, reverse);
+        listTypeDelRange(lobj, rangestart, rangelen);
+        listElementsRemoved(c, c->argv[1], where, lobj, rangelen, 1, NULL);
+        current_element_number = previous_element_number - rangelen;
     }
+    updateiListKeySizeArray(c, previous_element_number, current_element_number);
 }
 
 /* Like popGenericCommand but work with multiple keys.
@@ -862,15 +922,18 @@ void lrangeCommand(client *c) {
 
 /* LTRIM <key> <start> <stop> */
 void ltrimCommand(client *c) {
-    robj *o;
+    robj *lobj;
     long start, end, llen, ltrim, rtrim;
+    long previous_element_number;
+    long current_element_number;
 
     if ((getLongFromObjectOrReply(c, c->argv[2], &start, NULL) != C_OK) ||
         (getLongFromObjectOrReply(c, c->argv[3], &end, NULL) != C_OK))
         return;
 
-    if ((o = lookupKeyWriteOrReply(c, c->argv[1], shared.ok)) == NULL || checkType(c, o, OBJ_LIST)) return;
-    llen = listTypeLength(o);
+    if ((lobj = lookupKeyWriteOrReply(c, c->argv[1], shared.ok)) == NULL || checkType(c, lobj, OBJ_LIST)) return;
+    llen = listTypeLength(lobj);
+    previous_element_number = llen;
 
     /* convert negative indexes */
     if (start < 0) start = llen + start;
@@ -890,23 +953,25 @@ void ltrimCommand(client *c) {
     }
 
     /* Remove list elements to perform the trim */
-    if (o->encoding == OBJ_ENCODING_QUICKLIST) {
-        quicklistDelRange(o->ptr, 0, ltrim);
-        quicklistDelRange(o->ptr, -rtrim, rtrim);
-    } else if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        o->ptr = lpDeleteRange(o->ptr, 0, ltrim);
-        o->ptr = lpDeleteRange(o->ptr, -rtrim, rtrim);
+    if (lobj->encoding == OBJ_ENCODING_QUICKLIST) {
+        quicklistDelRange(lobj->ptr, 0, ltrim);
+        quicklistDelRange(lobj->ptr, -rtrim, rtrim);
+    } else if (lobj->encoding == OBJ_ENCODING_LISTPACK) {
+        lobj->ptr = lpDeleteRange(lobj->ptr, 0, ltrim);
+        lobj->ptr = lpDeleteRange(lobj->ptr, -rtrim, rtrim);
     } else {
         serverPanic("Unknown list encoding");
     }
 
+    current_element_number = listTypeLength(lobj);
     notifyKeyspaceEvent(NOTIFY_LIST, "ltrim", c->argv[1], c->db->id);
-    if (listTypeLength(o) == 0) {
+    if (current_element_number == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     } else {
-        listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
+        listTypeTryConversion(lobj, LIST_CONV_SHRINKING, NULL, NULL);
     }
+    updateiListKeySizeArray(c, previous_element_number, current_element_number);
     signalModifiedKey(c, c->db, c->argv[1]);
     server.dirty += (ltrim + rtrim);
     addReply(c, shared.ok);
@@ -1025,6 +1090,8 @@ void lremCommand(client *c) {
     obj = c->argv[3];
     long toremove;
     long removed = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &toremove, NULL) != C_OK) return;
 
@@ -1039,6 +1106,8 @@ void lremCommand(client *c) {
         li = listTypeInitIterator(subject, 0, LIST_TAIL);
     }
 
+    previous_element_number = listTypeLength(subject);
+    current_element_number = previous_element_number;
     listTypeEntry entry;
     while (listTypeNext(li, &entry)) {
         if (listTypeEqual(&entry, obj)) {
@@ -1052,13 +1121,15 @@ void lremCommand(client *c) {
 
     if (removed) {
         notifyKeyspaceEvent(NOTIFY_LIST, "lrem", c->argv[1], c->db->id);
-        if (listTypeLength(subject) == 0) {
+        current_element_number = listTypeLength(subject);
+        if (current_element_number == 0) {
             dbDelete(c->db, c->argv[1]);
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         } else {
             listTypeTryConversion(subject, LIST_CONV_SHRINKING, NULL, NULL);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
+        updateiListKeySizeArray(c, previous_element_number, current_element_number);
     }
 
     addReplyLongLong(c, removed);
@@ -1101,9 +1172,16 @@ robj *getStringObjectFromListPosition(int position) {
 
 void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
     robj *sobj, *value;
+    // int *delete = NULL;
+    // long sobj_previous_element_number;
+    // long sobj_current_element_number;
+    // long dobj_previous_element_number;
+    // long dobj_current_element_number;
+
     if ((sobj = lookupKeyWriteOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, sobj, OBJ_LIST))
         return;
 
+    // sobj_previous_element_number = listTypeLength(sobj);
     if (listTypeLength(sobj) == 0) {
         /* This may only happen after loading very old RDB files. Recent
          * versions of the server delete keys of empty lists. */
@@ -1120,12 +1198,23 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
 
         /* listTypePop returns an object with its refcount incremented */
         decrRefCount(value);
-
+        /*
+            if (*delete == 1) {
+                sobj_current_element_number = 0;
+            } else {
+                // It will crash, Need to check
+                // sobj_current_element_number = listTypeLength(sobj);
+            }
+        */
         if (c->cmd->proc == blmoveCommand) {
             rewriteClientCommandVector(c, 5, shared.lmove, c->argv[1], c->argv[2], c->argv[3], c->argv[4]);
         } else if (c->cmd->proc == brpoplpushCommand) {
             rewriteClientCommandVector(c, 3, shared.rpoplpush, c->argv[1], c->argv[2]);
         }
+        // dobj_current_element_number = listTypeLength(dobj);
+        /* TO DO: update INFO KEYSIZES  */
+        // displayUpdate(sobj_previous_element_number, sobj_current_element_number);
+        // displayUpdate(dobj_previous_element_number, dobj_current_element_number);
     }
 }
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -110,6 +110,47 @@ static void maybeConvertToIntset(robj *set) {
     set->encoding = OBJ_ENCODING_INTSET;
 }
 
+void scaleSetKeySizeArray(client *c, long value) {
+    int length = c->db->lists_array_length;
+    int high_bound = c->db->sets_array[length - 1].element_size;
+    int base = high_bound;
+    int count = 0;
+    while (high_bound < value) {
+        count++;
+        high_bound = high_bound * 2;
+    }
+    keysizeInfo *new_array = zmalloc(sizeof(keysizeInfo) * (count + length));
+    for (int i = 0; i < length; i++) {
+        new_array[i].element_size = c->db->sets_array[i].element_size;
+        new_array[i].num = c->db->sets_array[i].num;
+    }
+    for (int i = length; i < (count + length); i++) {
+        base *= 2;
+        new_array[i].element_size = base;
+        new_array[i].num = 0;
+    }
+    keysizeInfo *old_array = c->db->sets_array;
+    zfree(old_array);
+    c->db->sets_array = new_array;
+    c->db->sets_array_length = count + length;
+}
+
+void updateSetKeySizeArray(client *c, long previous, long curr) {
+    int low = 0;
+    int high = c->db->sets_array_length - 1;
+    if (curr > c->db->sets_array[high].element_size) {
+        scaleSetKeySizeArray(c, curr);
+    }
+
+    high = c->db->sets_array_length - 1;
+    if (previous != 0) {
+        decreaseDataTypeArrayPreviousValue(c->db->sets_array, low, high, previous);
+    }
+    if (curr != 0) {
+        increaseDataTypeArrayCurrentValue(c->db->sets_array, low, high, curr);
+    }
+}
+
 /* Add the specified sds value into a set.
  *
  * If the value was already member of the set, nothing is done and 0 is
@@ -622,9 +663,12 @@ void saddCommand(client *c) {
 void sremCommand(client *c) {
     robj *set;
     int j, deleted = 0, keyremoved = 0;
+    long previous_element_number;
+    long current_element_number;
 
     if ((set = lookupKeyWriteOrReply(c, c->argv[1], shared.czero)) == NULL || checkType(c, set, OBJ_SET)) return;
 
+    previous_element_number = setTypeSize(set);
     for (j = 2; j < c->argc; j++) {
         if (setTypeRemove(set, c->argv[j]->ptr)) {
             deleted++;
@@ -641,6 +685,9 @@ void sremCommand(client *c) {
         if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty += deleted;
     }
+    current_element_number = previous_element_number - deleted;
+    /* TO DO: update INFO KEYSIZES  */
+    updateSetKeySizeArray(c, previous_element_number, current_element_number);
     addReplyLongLong(c, deleted);
 }
 
@@ -747,6 +794,8 @@ void spopWithCountCommand(client *c) {
     long l;
     unsigned long count, size;
     robj *set;
+    long previous_element_number;
+    long current_element_number;
 
     /* Get the count argument */
     if (getPositiveLongFromObjectOrReply(c, c->argv[2], &l, NULL) != C_OK) return;
@@ -765,6 +814,7 @@ void spopWithCountCommand(client *c) {
     }
 
     size = setTypeSize(set);
+    previous_element_number = size;
 
     /* Generate an SPOP keyspace notification */
     notifyKeyspaceEvent(NOTIFY_SET, "spop", c->argv[1], c->db->id);
@@ -787,6 +837,9 @@ void spopWithCountCommand(client *c) {
         robj *aux = server.lazyfree_lazy_server_del ? shared.unlink : shared.del;
         rewriteClientCommandVector(c, 2, aux, c->argv[1]);
         signalModifiedKey(c, c->db, c->argv[1]);
+        current_element_number = 0;
+        /* TO DO: update INFO KEYSIZES  */
+	updateSetKeySizeArray(c, previous_element_number, current_element_number);
         return;
     }
 
@@ -805,6 +858,9 @@ void spopWithCountCommand(client *c) {
     size_t len;
     int64_t llele;
     unsigned long remaining = size - count; /* Elements left after SPOP. */
+    current_element_number = remaining;
+    /* TO DO: update INFO KEYSIZES  */
+    updateSetKeySizeArray(c, previous_element_number, current_element_number);
 
     /* If we are here, the number of requested elements is less than the
      * number of elements inside the set. Also we are sure that count < size.
@@ -950,6 +1006,8 @@ void spopWithCountCommand(client *c) {
 
 void spopCommand(client *c) {
     robj *set, *ele;
+    long previous_element_number;
+    long current_element_number;
 
     if (c->argc == 3) {
         spopWithCountCommand(c);
@@ -964,8 +1022,12 @@ void spopCommand(client *c) {
     if ((set = lookupKeyWriteOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, set, OBJ_SET))
         return;
 
+    previous_element_number = setTypeSize(set);
     /* Pop a random element from the set */
     ele = setTypePopRandom(set);
+    current_element_number = setTypeSize(set);
+    /* TO DO: update INFO KEYSIZES  */
+    updateSetKeySizeArray(c, previous_element_number, current_element_number);
 
     notifyKeyspaceEvent(NOTIFY_SET, "spop", c->argv[1], c->db->id);
 
@@ -977,7 +1039,7 @@ void spopCommand(client *c) {
     decrRefCount(ele);
 
     /* Delete the set if it's empty */
-    if (setTypeSize(set) == 0) {
+    if (current_element_number == 0) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -236,6 +236,47 @@ static int getExpireMillisecondsOrReply(client *c, robj *expire, int flags, int 
     return C_OK;
 }
 
+void scaleStringKeySizeArray(client *c, long value) {
+    int length = c->db->strings_array_length;
+    int high_bound = c->db->strings_array[length - 1].element_size;
+    int base = high_bound;
+    int count = 0;
+    while (high_bound < value) {
+        count++;
+        high_bound = high_bound * 2;
+    }
+    keysizeInfo *new_array = zmalloc(sizeof(keysizeInfo) * (count + length));
+    for (int i = 0; i < length; i++) {
+        new_array[i].element_size = c->db->strings_array[i].element_size;
+        new_array[i].num = c->db->strings_array[i].num;
+    }
+    for (int i = length; i < (count + length); i++) {
+        base *= 2;
+        new_array[i].element_size = base;
+        new_array[i].num = 0;
+    }
+    keysizeInfo *old_array = c->db->strings_array;
+    zfree(old_array);
+    c->db->strings_array = new_array;
+    c->db->strings_array_length = count + length;
+}
+
+void updateStringKeySizeArray(client *c, long previous, long curr) {
+    int low = 0;
+    int high = c->db->strings_array_length - 1;
+    if (curr > c->db->strings_array[high].element_size) {
+        scaleStringKeySizeArray(c, curr);
+    }
+
+    high = c->db->strings_array_length - 1;
+    if (previous != 0) {
+        decreaseDataTypeArrayPreviousValue(c->db->strings_array, low, high, previous);
+    }
+    if (curr != 0) {
+        increaseDataTypeArrayCurrentValue(c->db->strings_array, low, high, curr);
+    }
+}
+
 #define COMMAND_GET 0
 #define COMMAND_SET 1
 /*
@@ -498,6 +539,8 @@ void setrangeCommand(client *c) {
     robj *o;
     long offset;
     sds value = c->argv[3]->ptr;
+    long previous_str_len;
+    long curr_str_len;
 
     if (getLongFromObjectOrReply(c, c->argv[2], &offset, NULL) != C_OK)
         return;
@@ -519,6 +562,7 @@ void setrangeCommand(client *c) {
         if (checkStringLength(c, offset, sdslen(value)) != C_OK)
             return;
 
+        previous_str_len = 0;
         o = createObject(OBJ_STRING, sdsnewlen(NULL, offset + sdslen(value)));
         dbAdd(c->db, c->argv[1], &o);
     } else {
@@ -534,6 +578,7 @@ void setrangeCommand(client *c) {
             addReplyLongLong(c, olen);
             return;
         }
+        previous_str_len = olen;
 
         /* Return when the resulting string exceeds allowed size */
         if (checkStringLength(c, offset, sdslen(value)) != C_OK)
@@ -551,6 +596,9 @@ void setrangeCommand(client *c) {
                             "setrange", c->argv[1], c->db->id);
         server.dirty++;
     }
+    curr_str_len = sdslen(o->ptr);
+    /* TO DO: update INFO KEYSIZES */
+    updateStringKeySizeArray(c, previous_str_len,  curr_str_len);
     addReplyLongLong(c, sdslen(o->ptr));
 }
 
@@ -752,6 +800,8 @@ void incrbyfloatCommand(client *c) {
 void appendCommand(client *c) {
     size_t totlen;
     robj *o, *append;
+    long previous_str_len;
+    long curr_str_len;
 
     o = lookupKeyWrite(c->db, c->argv[1]);
     if (o == NULL) {
@@ -760,6 +810,7 @@ void appendCommand(client *c) {
         dbAdd(c->db, c->argv[1], &c->argv[2]);
         incrRefCount(c->argv[2]);
         totlen = stringObjectLen(c->argv[2]);
+        previous_str_len = 0;
     } else {
         /* Key exists, check type */
         if (checkType(c, o, OBJ_STRING))
@@ -770,6 +821,7 @@ void appendCommand(client *c) {
         if (checkStringLength(c, stringObjectLen(o), sdslen(append->ptr)) != C_OK)
             return;
 
+        previous_str_len = stringObjectLen(o);
         /* Append the value */
         o = dbUnshareStringValue(c->db, c->argv[1], o);
         o->ptr = sdscatlen(o->ptr, append->ptr, sdslen(append->ptr));
@@ -778,6 +830,9 @@ void appendCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_STRING, "append", c->argv[1], c->db->id);
     server.dirty++;
+    curr_str_len = totlen;
+    /* TO DO: update INFO KEYSIZES  */
+    updateStringKeySizeArray(c, previous_str_len, curr_str_len);
     addReplyLongLong(c, totlen);
 }
 

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1744,6 +1744,47 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
     }
 }
 
+void scaleZsetKeySizeArray(client *c, long value) {
+    int length = c->db->zsets_array_length;
+    int high_bound = c->db->zsets_array[length - 1].element_size;
+    int base = high_bound;
+    int count = 0;
+    while (high_bound < value) {
+        count++;
+        high_bound = high_bound * 2;
+    }
+    keysizeInfo *new_array = zmalloc(sizeof(keysizeInfo) * (count + length));
+    for (int i = 0; i < length; i++) {
+        new_array[i].element_size = c->db->zsets_array[i].element_size;
+        new_array[i].num = c->db->zsets_array[i].num;
+    }
+    for (int i = length; i < (count + length); i++) {
+        base *= 2;
+        new_array[i].element_size = base;
+        new_array[i].num = 0;
+    }
+    keysizeInfo *old_array = c->db->zsets_array;
+    zfree(old_array);
+    c->db->zsets_array = new_array;
+    c->db->zsets_array_length = count + length;
+}
+
+void updateZsetKeySizeArray(client *c, long previous, long curr) {
+    int low = 0;
+    int high = c->db->zsets_array_length - 1;
+    if (curr > c->db->zsets_array[high].element_size) {
+        scaleZsetKeySizeArray(c, curr);
+    }
+
+    high = c->db->lists_array_length - 1;
+    if (previous != 0) {
+        decreaseDataTypeArrayPreviousValue(c->db->zsets_array, low, high, previous);
+    }
+    if (curr != 0) {
+        increaseDataTypeArrayCurrentValue(c->db->zsets_array, low, high, curr);
+    }
+}
+
 /*-----------------------------------------------------------------------------
  * Sorted set commands
  *----------------------------------------------------------------------------*/
@@ -1754,6 +1795,8 @@ static void zaddGenericCommand(client *c, int flags) {
     robj *key = c->argv[1];
     robj *zobj;
     sds ele;
+    long previous_element_number;
+    long current_element_number;
     double score = 0, *scores = NULL;
     int j, elements, ch = 0;
     size_t maxelelen = 0;
@@ -1839,8 +1882,10 @@ static void zaddGenericCommand(client *c, int flags) {
         if (xx) goto reply_to_client; /* No key + XX option: nothing to do. */
         zobj = zsetTypeCreate(elements, maxelelen);
         dbAdd(c->db, key, &zobj);
+        previous_element_number = 0;
     } else {
         zsetTypeMaybeConvert(zobj, elements, maxelelen);
+        previous_element_number = zsetLength(zobj);
     }
 
     for (j = 0; j < elements; j++) {
@@ -1860,6 +1905,9 @@ static void zaddGenericCommand(client *c, int flags) {
         score = newscore;
     }
     server.dirty += (added + updated);
+    current_element_number = zsetLength(zobj);
+    /* TO DO: update INFO KEYSIZES  */
+    updateZsetKeySizeArray(c, previous_element_number, current_element_number);
 
 reply_to_client:
     if (incr) { /* ZINCRBY or INCR option. */
@@ -1891,9 +1939,12 @@ void zremCommand(client *c) {
     robj *key = c->argv[1];
     robj *zobj;
     int deleted = 0, keyremoved = 0, j;
+    long previous_element_number;
+    long current_element_number;
 
     if ((zobj = lookupKeyWriteOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) return;
 
+    previous_element_number = zsetLength(zobj);
     for (j = 2; j < c->argc; j++) {
         if (zsetDel(zobj, c->argv[j]->ptr)) deleted++;
         if (zsetLength(zobj) == 0) {
@@ -1909,6 +1960,9 @@ void zremCommand(client *c) {
         signalModifiedKey(c, c->db, key);
         server.dirty += deleted;
     }
+    current_element_number = previous_element_number - deleted;
+    /* TO DO: update INFO KEYSIZES  */
+    updateZsetKeySizeArray(c, previous_element_number, current_element_number);
     addReplyLongLong(c, deleted);
 }
 
@@ -1929,6 +1983,8 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     zlexrangespec lexrange;
     long start, end, llen;
     char *notify_type = NULL;
+    long previous_element_number;
+    long current_element_number;
 
     /* Step 1: Parse the range. */
     if (rangetype == ZRANGE_RANK) {
@@ -1955,6 +2011,7 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
     /* Step 2: Lookup & range sanity checks if needed. */
     if ((zobj = lookupKeyWriteOrReply(c, key, shared.czero)) == NULL || checkType(c, zobj, OBJ_ZSET)) goto cleanup;
 
+    previous_element_number = zsetLength(zobj);
     if (rangetype == ZRANGE_RANK) {
         /* Sanitize indexes. */
         llen = zsetLength(zobj);
@@ -2008,6 +2065,9 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     }
     server.dirty += deleted;
+    current_element_number = previous_element_number - deleted;
+    /* TO DO: update INFO KEYSIZES  */
+    updateZsetKeySizeArray(c, previous_element_number, current_element_number);
     addReplyLongLong(c, deleted);
 
 cleanup:
@@ -3811,6 +3871,9 @@ void genericZpopCommand(client *c,
     robj *zobj = NULL;
     sds ele;
     double score;
+    long previous_element_number;
+    long current_element_number;
+    long need_to_delete;
 
     if (deleted) *deleted = 0;
 
@@ -3846,7 +3909,9 @@ void genericZpopCommand(client *c,
     if (count == -1) count = 1;
 
     long llen = zsetLength(zobj);
+    previous_element_number = llen;
     long rangelen = (count > llen) ? llen : count;
+    need_to_delete = rangelen;
 
     if (!use_nested_array && !emitkey) {
         /* ZPOPMIN/ZPOPMAX with or without COUNT option in RESP2. */
@@ -3928,6 +3993,9 @@ void genericZpopCommand(client *c,
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", key, c->db->id);
     }
     signalModifiedKey(c, c->db, key);
+    current_element_number = previous_element_number - need_to_delete;
+    /* TO DO: update INFO KEYSIZES */
+    updateZsetKeySizeArray(c, previous_element_number, current_element_number);
 
     if (c->cmd->proc == zmpopCommand) {
         /* Always replicate it as ZPOP[MIN|MAX] with COUNT option instead of ZMPOP. */


### PR DESCRIPTION
It is related to the issue https://github.com/valkey-io/valkey/issues/1827#issuecomment-2775321800, https://github.com/valkey-io/valkey/issues/1880, and https://github.com/valkey-io/valkey/pull/1151

Reference Redis latest feature in Version 8 as below:

127.0.0.1:6379> INFO keysizes

Keysizes
db0_distrib_strings_sizes:1=19,2=655,4=3918,8=19,16=23,32=326,64=5,128=1,256=47,512=100899,1K=31,2K=29,4K=23,8K=16,16K=3,32K=2
db0_distrib_lists_items:1=5784492,2=151535,4=46670,8=20453,16=8637,32=3558,64=1047,128=676,256=533,512=218,4K=1,8K=42
db0_distrib_sets_items:1=7355615,2=207181,4=50612,8=21462,16=8864,32=2905,64=1365,128=974,256=773,512=675,1K=395,2K=292,4K=154,8K=89,16K=48,32K=21,64K=27,128K=16,256K=5,512K=4,1M=2
db0_distrib_hashes_items:2=1,4=544,8=746485,16=324174,32=141169,64=207329,128=4349,256=136226,1K=1