### PR TITLE
Fix flaky randomkey test, key may expire before CLIENT PAUSE

### DIFF
--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -416,11 +416,14 @@ start_server {tags {"pause network"}} {
         # first, clear the database to avoid interference from existing keys on the test results 
         r flushall
 
+        r multi
         # then set a key with expire time
         r set key value px 3
 
         # set pause-write model and wait key expired
         r client pause 10000 write
+        r exec
+
         after 5
 
         wait_for_condition 50 100 {


### PR DESCRIPTION
Due to the very short TTL (3 ms), it was possible for the key
to expire and be deleted before the pause took effect, especially
under slowing environments. This caused [r randomkey] to return {}
instead of "key".

Wrap the commands in a MULTI/EXEC block to ensure that the key is
set and the pause is applied within the same transaction, reducing
the likelihood of premature expiration.

Test was introduced in #1850.
