### PR TITLE
Fix panic in primary when blocking shutdown after previous block with timeout

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -653,6 +653,8 @@ void blockPostponeClient(client *c) {
 
 /* Block client due to shutdown command */
 void blockClientShutdown(client *c) {
+    initClientBlockingState(c);
+    c->bstate->timeout = 0;
     blockClient(c, BLOCKED_SHUTDOWN);
 }
 


### PR DESCRIPTION
When previous timeout isn't zeroed out, shutdown will use the previously executed blocking commands timeout. Since shutdown is not expected to have timeouts, this causes a serverPanic.

Without this fix, this scenario leads to a server panic:

1. Call any command that uses blockClient with a timeout (this could be BLPOP or something that blocks implicitly like CLUSTER SETSLOT)
2. On the same client, call SHUTDOWN with some pending replication data, which will trigger shutdown to be blocked while we try to catch the replica up
