### PR TITLE
fix cluster slot stats assertion during promotion of replica

### DIFF
--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -148,10 +148,14 @@ static void clusterSlotStatsUpdateNetworkBytesOutForReplication(long long len) {
     client *c = server.current_client;
     if (c == NULL || !canAddNetworkBytesOut(c)) return;
 
+    /* We multiply the bytes len by the number of replicas to account for us broadcasting to multiple replicas at once. */
+    len *= (long long)listLength(server.replicas);
     serverAssert(c->slot >= 0 && c->slot < CLUSTER_SLOTS);
     serverAssert(nodeIsPrimary(server.cluster->myself));
-    if (len < 0) serverAssert(server.cluster->slot_stats[c->slot].network_bytes_out >= (uint64_t)llabs(len));
-    server.cluster->slot_stats[c->slot].network_bytes_out += (len * listLength(server.replicas));
+    /* We sometimes want to adjust the counter downwards (for example when we want to undo accounting for
+     * SELECT commands that don't belong to any slot) so let's make sure we don't underflow the counter. */
+    serverAssert(len >= 0 || server.cluster->slot_stats[c->slot].network_bytes_out >= (uint64_t)-len);
+    server.cluster->slot_stats[c->slot].network_bytes_out += len;
 }
 
 /* Increment network bytes out for replication stream. This method will increment `len` value times the active replica

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -253,7 +253,7 @@ proc start_cluster {masters replicas options code {slot_allocator continuous_slo
 
     # Configure the starting of multiple servers. Set cluster node timeout
     # aggressively since many tests depend on ping/pong messages. 
-    set cluster_options [list overrides [list cluster-enabled yes cluster-ping-interval 100 cluster-node-timeout 3000]]
+    set cluster_options [list overrides [list cluster-enabled yes cluster-ping-interval 100 cluster-node-timeout 3000 cluster-slot-stats-enabled yes]]
     set options [concat $cluster_options $options]
 
     # Cluster mode only supports a single database, so before executing the tests


### PR DESCRIPTION
This affects only the configuration `cluster-slot-stats-enabled yes`.

For the first command a newly promoted primary receives, we send a `SELECT` command to all replicas via `replicationFeedReplicas`. This calls a chain of functions (`feedReplicationBufferWithObject` -> `feedReplicationBuffer` -> `clusterSlotStatsIncrNetworkBytesOutForReplication` -> `clusterSlotStatsUpdateNetworkBytesOutForReplication`) that increments the per-slot `network_bytes_out` by `len * listLength(server.replicas)`. However, if the new primary receives a command before any replicas connected yet, `server.replicas` is still empty, causing the increment to add zero.

Right after, we call `clusterSlotStatsDecrNetworkBytesOutForReplication` to remove the `SELECT` overhead from the per-slot stats. The assert in `clusterSlotStatsUpdateNetworkBytesOutForReplication` was using (basically) `>= -len` instead of `>= -(len * listLength(server.replicas))`, so it could fail if the previous increment was zero because we never included the `server.replicas` length in the assertion.

This patch makes the addition and subtraction use the same computed value (`rlen = len * listLength(server.replicas)`) in both the stats update and the assert, ensuring the logic remains consistent when replicas are promoted.

Fixes #1912