### PR TITLE
Fix crash during TLS handshake with I/O threads

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -574,6 +574,7 @@ void trySendPollJobToIOThreads(void) {
 static void ioThreadAccept(void *data) {
     client *c = (client *)data;
     connAccept(c->conn, NULL);
+    atomic_thread_fence(memory_order_release);
     c->io_read_state = CLIENT_COMPLETED_IO;
 }
 


### PR DESCRIPTION
Fix https://github.com/valkey-io/valkey/issues/1883

The issue arises from a missing memory release fence, which can cause the main thread to see the updated client's IO read state (`CLIENT_COMPLETED_IO`) but not the updated connection flags. In this case, it crashes as the flags are not as expected.

Following @skolosov-snap instructions I was able to consistently reproduce the issue on ARM instances by generating sufficient load to invoke the IO threads while constantly creating new connections to trigger the accept flow. I've validated that no crashes occur with this fix.

I didn't write a regression test for the fix since reproduction is difficult and flaky.