### PR TITLE
Fix flaky shutdown tests caused by timing issue

### DIFF
--- a/tests/integration/shutdown.tcl
+++ b/tests/integration/shutdown.tcl
@@ -269,9 +269,12 @@ test "Shutting down primary wait for replica after previous block" {
             # Call shutdown.
             $primary_deferring shutdown
 
-            set info_clients [$primary info clients]
-            assert_match "*connected_clients:2*" $info_clients
-            assert_match "*blocked_clients:1*" $info_clients
+            wait_for_condition 100 100 {
+                [string match "*connected_clients:2*" [$primary info clients]] && [string match "*blocked_clients:1*" [$primary info clients]]
+            } else {
+                set client_info [$primary info clients]
+                fail "Shutdown did not trigger block. Current INFO CLIENTS output: $client_info"
+            }
 
             # Wake up replica, causing primary to continue shutting down.
             resume_process $replica_pid


### PR DESCRIPTION
This started failing after https://github.com/valkey-io/valkey/commit/ee9a305b5bc7b0cc4495d3ee8d212269e91675a0, since processing of SHUTDOWN might happen after the CLIENT INFO is retrieved. Now we use wait_for_condition to make sure CLIENT INFO is retried in the case that SHUTDOWN is not processed yet.