### PR TITLE
Add DELIFEQ command

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -10459,6 +10459,31 @@ struct COMMAND_ARG DECRBY_Args[] = {
 {MAKE_ARG("decrement",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/********** DELIFEQ ********************/
+
+#ifndef SKIP_CMD_HISTORY_TABLE
+/* DELIFEQ history */
+#define DELIFEQ_History NULL
+#endif
+
+#ifndef SKIP_CMD_TIPS_TABLE
+/* DELIFEQ tips */
+#define DELIFEQ_Tips NULL
+#endif
+
+#ifndef SKIP_CMD_KEY_SPECS_TABLE
+/* DELIFEQ key specs */
+keySpec DELIFEQ_Keyspecs[1] = {
+{NULL,CMD_KEY_RM|CMD_KEY_ACCESS|CMD_KEY_DELETE,KSPEC_BS_INDEX,.bs.index={1},KSPEC_FK_RANGE,.fk.range={0,1,0}}
+};
+#endif
+
+/* DELIFEQ argument table */
+struct COMMAND_ARG DELIFEQ_Args[] = {
+{MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("value",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /********** GET ********************/
 
 #ifndef SKIP_CMD_HISTORY_TABLE
@@ -11316,6 +11341,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 {MAKE_CMD("append","Appends a string to the value of a key. Creates the key if it doesn't exist.","O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by the server will double the free space available on every reallocation.","2.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,APPEND_History,0,APPEND_Tips,0,appendCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,APPEND_Keyspecs,1,NULL,2),.args=APPEND_Args},
 {MAKE_CMD("decr","Decrements the integer value of a key by one. Uses 0 as initial value if the key doesn't exist.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DECR_History,0,DECR_Tips,0,decrCommand,2,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,DECR_Keyspecs,1,NULL,1),.args=DECR_Args},
 {MAKE_CMD("decrby","Decrements a number from the integer value of a key. Uses 0 as initial value if the key doesn't exist.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DECRBY_History,0,DECRBY_Tips,0,decrbyCommand,3,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_STRING,DECRBY_Keyspecs,1,NULL,2),.args=DECRBY_Args},
+{MAKE_CMD("delifeq","Delete key if value matches string.","O(1)","9.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,DELIFEQ_History,0,DELIFEQ_Tips,0,delifeqCommand,3,CMD_WRITE,ACL_CATEGORY_STRING,DELIFEQ_Keyspecs,1,NULL,2),.args=DELIFEQ_Args},
 {MAKE_CMD("get","Returns the string value of a key.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GET_History,0,GET_Tips,0,getCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_STRING,GET_Keyspecs,1,NULL,1),.args=GET_Args},
 {MAKE_CMD("getdel","Returns the string value of a key after deleting the key.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETDEL_History,0,GETDEL_Tips,0,getdelCommand,2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETDEL_Keyspecs,1,NULL,1),.args=GETDEL_Args},
 {MAKE_CMD("getex","Returns the string value of a key after setting its expiration time.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"string",COMMAND_GROUP_STRING,GETEX_History,0,GETEX_Tips,0,getexCommand,-2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_STRING,GETEX_Keyspecs,1,NULL,2),.args=GETEX_Args},

--- a/src/commands/delifeq.json
+++ b/src/commands/delifeq.json
@@ -1,0 +1,60 @@
+{
+    "DELIFEQ": {
+        "summary": "Delete key if value matches string.",
+        "complexity": "O(1)",
+        "group": "string",
+        "since": "9.0.0",
+        "arity": 3,
+        "function": "delifeqCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "STRING"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RM",
+                    "ACCESS",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The key was not deleted.",
+                    "const": 0
+                },
+                {
+                    "description": "The key was deleted.",
+                    "const": 1
+                }
+            ]
+        },
+        "arguments": [
+          {
+              "name": "key",
+              "type": "key",
+              "key_spec_index": 0
+          },
+          {
+              "name": "value",
+              "type": "string"
+          }
+        ]
+    }
+}

--- a/src/server.h
+++ b/src/server.h
@@ -3628,6 +3628,7 @@ void setCommand(client *c);
 void setnxCommand(client *c);
 void setexCommand(client *c);
 void psetexCommand(client *c);
+void delifeqCommand(client *c);
 void getCommand(client *c);
 void getexCommand(client *c);
 void getdelCommand(client *c);

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -384,6 +384,32 @@ void psetexCommand(client *c) {
     setGenericCommand(c, OBJ_PX | OBJ_ARGV3, c->argv[1], c->argv[3], c->argv[2], UNIT_MILLISECONDS, NULL, NULL, NULL);
 }
 
+void delifeqCommand(client *c) {
+    robj *existing_value = lookupKeyWrite(c->db, c->argv[1]);
+
+    if (existing_value == NULL) {
+        addReplyLongLong(c, 0);
+        return;
+    }
+
+    if (checkType(c, existing_value, OBJ_STRING)) {
+        /* Error reply already sent */
+        return;
+    }
+
+    if (compareStringObjects(existing_value, c->argv[2]) != 0) {
+        addReplyLongLong(c, 0);
+        return;
+    }
+
+    if (!dbSyncDelete(c->db, c->argv[1])) {
+        addReplyLongLong(c, 0);
+        return;
+    }
+
+    addReplyLongLong(c, 1);
+}
+
 int getGenericCommand(client *c) {
     robj *o;
 

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -756,6 +756,27 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
         lappend res [r get bar]
     } {12 12}
 
+    test {DELIFEQ non-existing key} {
+        r del foo
+        assert_equal 0 [r delifeq foo "test"]
+    }
+
+    test {DELIFEQ existing key, matching value} {
+        r set foo "test"
+        assert_equal 1 [r delifeq foo "test"]
+    }
+
+    test {DELIFEQ existing key, non-matching value} {
+        r set foo "nope"
+        assert_equal 0 [r delifeq foo "test"]
+    }
+
+    test {DELIFEQ existing key, non-string value} {
+        r del foo
+        r sadd foo "test"
+        assert_error "WRONGTYPE*" {r delifeq foo "test"}
+    }
+
 if {[string match {*jemalloc*} [s mem_allocator]]} {
     test {Memory usage of embedded string value} {
         # Check that we can fit 9 bytes of key + value into a 32 byte


### PR DESCRIPTION
Please also pick #2120.

This feature introduces a new command: `DELIFEQ key value`.

The command deletes the given key _only if_ its current value is equal to the provided `value`. It returns:

- 1 if the key was removed (i.e., it existed and matched the value),
- 0 otherwise (key did not exist, or the value did not match).

This command complements `SET key value IFEQ match-value`, added in #1324.

**The problem/use-case that the feature addresses**

A very common operation when synchronizing distributed locks is to remove a key, but only if the value matches a specific string. This pattern is frequently used in distributed locking algorithms like Redlock. The conditional delete prevents a client from inadvertently releasing a lock it doesn’t own—e.g., when a timeout or retry causes overlapping or stale attempts.

Today, this logic is typically implemented using a small Lua script like:

```lua
if redis.call("get",KEYS[1]) == ARGV[1] then
    return redis.call("del",KEYS[1])
else
    return 0
end
```

However, using scripts adds a layer of complexity and overhead. Having this logic as a built-in Redis command improves simplicity, reliability, and performance. It also complements `SET key IFEQ value` very nicely.

Example:

```redis
SET foo test
DELIFEQ foo test   # returns 1, key is deleted

SET foo nope
DELIFEQ foo test   # returns 0, key remains
```