### PR TITLE
Allow scripts to support null characters again

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -411,6 +411,7 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
         scriptingEngineCallCompileCode(engine,
                                        VMSE_EVAL,
                                        (sds)body->ptr + shebang_len,
+                                       sdslen(body->ptr) - shebang_len,
                                        0,
                                        &num_compiled_functions,
                                        &_err);

--- a/src/functions.c
+++ b/src/functions.c
@@ -1012,6 +1012,7 @@ sds functionsCreateWithLibraryCtx(sds code, int replace, sds *err, functionsLibC
         scriptingEngineCallCompileCode(engine,
                                        VMSE_FUNCTION,
                                        md.code,
+                                       sdslen(md.code),
                                        timeout,
                                        &num_compiled_functions,
                                        &compile_error);

--- a/src/lua/engine_lua.c
+++ b/src/lua/engine_lua.c
@@ -195,6 +195,7 @@ static compiledFunction **luaEngineCompileCode(ValkeyModuleCtx *module_ctx,
                                                engineCtx *engine_ctx,
                                                subsystemType type,
                                                const char *code,
+                                               size_t code_len,
                                                size_t timeout,
                                                size_t *out_num_compiled_functions,
                                                robj **err) {
@@ -207,7 +208,7 @@ static compiledFunction **luaEngineCompileCode(ValkeyModuleCtx *module_ctx,
     if (type == VMSE_EVAL) {
         lua_State *lua = lua_engine_ctx->eval_lua;
 
-        if (luaL_loadbuffer(lua, code, strlen(code), "@user_script")) {
+        if (luaL_loadbuffer(lua, code, code_len, "@user_script")) {
             sds error = sdscatfmt(sdsempty(), "Error compiling script (new function): %s", lua_tostring(lua, -1));
             *err = createObject(OBJ_STRING, error);
             lua_pop(lua, 1);

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -217,6 +217,7 @@ static void engineTeardownModuleCtx(scriptingEngine *e) {
 compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
                                                   subsystemType type,
                                                   const char *code,
+                                                  size_t code_len,
                                                   size_t timeout,
                                                   size_t *out_num_compiled_functions,
                                                   robj **err) {
@@ -229,6 +230,7 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
         engine->impl.ctx,
         type,
         code,
+        code_len,
         timeout,
         out_num_compiled_functions,
         err);

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -222,7 +222,7 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
                                                   size_t *out_num_compiled_functions,
                                                   robj **err) {
     serverAssert(type == VMSE_EVAL || type == VMSE_FUNCTION);
-    compiledFunction **functions= NULL;
+    compiledFunction **functions = NULL;
     engineSetupModuleCtx(engine, NULL);
     if (engine->impl.methods.version == 1) {
         functions = engine->impl.methods.compile_code_v1(

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -222,18 +222,30 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
                                                   size_t *out_num_compiled_functions,
                                                   robj **err) {
     serverAssert(type == VMSE_EVAL || type == VMSE_FUNCTION);
-
+    compiledFunction **functions= NULL;
     engineSetupModuleCtx(engine, NULL);
+    if (engine->impl.methods.version == 1) {
+        functions = engine->impl.methods.compile_code_v1(
+            engine->module_ctx,
+            engine->impl.ctx,
+            type,
+            code,
+            timeout,
+            out_num_compiled_functions,
+            err);
+    } else {
+        /* Assume versions greater than 1 use updated interface. */
+        functions = engine->impl.methods.compile_code(
+            engine->module_ctx,
+            engine->impl.ctx,
+            type,
+            code,
+            code_len,
+            timeout,
+            out_num_compiled_functions,
+            err);
+    }
 
-    compiledFunction **functions = engine->impl.methods.compile_code(
-        engine->module_ctx,
-        engine->impl.ctx,
-        type,
-        code,
-        code_len,
-        timeout,
-        out_num_compiled_functions,
-        err);
 
     engineTeardownModuleCtx(engine);
 

--- a/src/scripting_engine.h
+++ b/src/scripting_engine.h
@@ -55,6 +55,7 @@ ValkeyModule *scriptingEngineGetModule(scriptingEngine *engine);
 compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
                                                   subsystemType type,
                                                   const char *code,
+                                                  size_t code_len,
                                                   size_t timeout,
                                                   size_t *out_num_compiled_functions,
                                                   robj **err);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -900,8 +900,8 @@ typedef ValkeyModuleScriptingEngineCompiledFunction **(*ValkeyModuleScriptingEng
     size_t *out_num_compiled_functions,
     ValkeyModuleString **err);
 
-/* Version one of code compilation, which may not safely handle
- * binary data. */
+/* Version one of source code compilation interface. This API does not allow the compiler to
+ * safely handle binary data. You should use a newer version of the API if possible.
 typedef ValkeyModuleScriptingEngineCompiledFunctionV1 **(*ValkeyModuleScriptingEngineCompileCodeFuncV1)(
     ValkeyModuleCtx *module_ctx,
     ValkeyModuleScriptingEngineCtx *engine_ctx,

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -878,6 +878,8 @@ typedef struct ValkeyModuleScriptingEngineCallableLazyEvalReset {
  *
  * - `code`: string pointer to the source code.
  *
+ * - `code_len`: The length of the code string.
+ *
  * - `timeout`: timeout for the library creation (0 for no timeout).
  *
  * - `out_num_compiled_functions`: out param with the number of objects
@@ -894,6 +896,17 @@ typedef ValkeyModuleScriptingEngineCompiledFunction **(*ValkeyModuleScriptingEng
     ValkeyModuleScriptingEngineSubsystemType type,
     const char *code,
     size_t code_len,
+    size_t timeout,
+    size_t *out_num_compiled_functions,
+    ValkeyModuleString **err);
+
+/* Version one of code compilation, which may not safely handle
+ * binary data. */
+typedef ValkeyModuleScriptingEngineCompiledFunctionV1 **(*ValkeyModuleScriptingEngineCompileCodeFuncV1)(
+    ValkeyModuleCtx *module_ctx,
+    ValkeyModuleScriptingEngineCtx *engine_ctx,
+    ValkeyModuleScriptingEngineSubsystemType type,
+    const char *code,
     size_t timeout,
     size_t *out_num_compiled_functions,
     ValkeyModuleString **err);
@@ -986,7 +999,7 @@ typedef ValkeyModuleScriptingEngineMemoryInfo (*ValkeyModuleScriptingEngineGetMe
     ValkeyModuleScriptingEngineSubsystemType type);
 
 /* Current ABI version for scripting engine modules. */
-#define VALKEYMODULE_SCRIPTING_ENGINE_ABI_VERSION 1UL
+#define VALKEYMODULE_SCRIPTING_ENGINE_ABI_VERSION 2UL
 
 typedef struct ValkeyModuleScriptingEngineMethods {
     uint64_t version; /* Version of this structure for ABI compat. */
@@ -994,8 +1007,10 @@ typedef struct ValkeyModuleScriptingEngineMethods {
     /* Compile code function callback. When a new script is loaded, this
      * callback will be called with the script code, compiles it, and returns a
      * list of `ValkeyModuleScriptingEngineCompiledFunc` objects. */
-    ValkeyModuleScriptingEngineCompileCodeFunc compile_code;
-
+    union {
+        ValkeyModuleScriptingEngineCompileCodeFuncV1 compile_code_v1;
+        ValkeyModuleScriptingEngineCompileCodeFunc compile_code;
+    };
     /* Function callback to free the memory of a registered engine function. */
     ValkeyModuleScriptingEngineFreeFunctionFunc free_function;
 
@@ -1013,9 +1028,9 @@ typedef struct ValkeyModuleScriptingEngineMethods {
     /* Function callback to get the used memory by the engine. */
     ValkeyModuleScriptingEngineGetMemoryInfoFunc get_memory_info;
 
-} ValkeyModuleScriptingEngineMethodsV1;
+} ValkeyModuleScriptingEngineMethodsV2;
 
-#define ValkeyModuleScriptingEngineMethods ValkeyModuleScriptingEngineMethodsV1
+#define ValkeyModuleScriptingEngineMethods ValkeyModuleScriptingEngineMethodsV2
 
 /* ------------------------- End of common defines ------------------------ */
 

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -893,6 +893,7 @@ typedef ValkeyModuleScriptingEngineCompiledFunction **(*ValkeyModuleScriptingEng
     ValkeyModuleScriptingEngineCtx *engine_ctx,
     ValkeyModuleScriptingEngineSubsystemType type,
     const char *code,
+    size_t code_len,
     size_t timeout,
     size_t *out_num_compiled_functions,
     ValkeyModuleString **err);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -901,7 +901,7 @@ typedef ValkeyModuleScriptingEngineCompiledFunction **(*ValkeyModuleScriptingEng
     ValkeyModuleString **err);
 
 /* Version one of source code compilation interface. This API does not allow the compiler to
- * safely handle binary data. You should use a newer version of the API if possible.
+ * safely handle binary data. You should use a newer version of the API if possible. */
 typedef ValkeyModuleScriptingEngineCompiledFunctionV1 **(*ValkeyModuleScriptingEngineCompileCodeFuncV1)(
     ValkeyModuleCtx *module_ctx,
     ValkeyModuleScriptingEngineCtx *engine_ctx,

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1028,9 +1028,9 @@ typedef struct ValkeyModuleScriptingEngineMethods {
     /* Function callback to get the used memory by the engine. */
     ValkeyModuleScriptingEngineGetMemoryInfoFunc get_memory_info;
 
-} ValkeyModuleScriptingEngineMethodsV2;
+} ValkeyModuleScriptingEngineMethodsV1;
 
-#define ValkeyModuleScriptingEngineMethods ValkeyModuleScriptingEngineMethodsV2
+#define ValkeyModuleScriptingEngineMethods ValkeyModuleScriptingEngineMethodsV1
 
 /* ------------------------- End of common defines ------------------------ */
 

--- a/tests/modules/helloscripting.c
+++ b/tests/modules/helloscripting.c
@@ -349,10 +349,12 @@ static ValkeyModuleScriptingEngineCompiledFunction **createHelloLangEngine(Valke
                                                                            ValkeyModuleScriptingEngineCtx *engine_ctx,
                                                                            ValkeyModuleScriptingEngineSubsystemType type,
                                                                            const char *code,
+                                                                           size_t code_len,
                                                                            size_t timeout,
                                                                            size_t *out_num_compiled_functions,
                                                                            ValkeyModuleString **err) {
     VALKEYMODULE_NOT_USED(module_ctx);
+    VALKEYMODULE_NOT_USED(code_len);
     VALKEYMODULE_NOT_USED(type);
     VALKEYMODULE_NOT_USED(timeout);
     VALKEYMODULE_NOT_USED(err);

--- a/tests/modules/helloscripting.c
+++ b/tests/modules/helloscripting.c
@@ -349,12 +349,10 @@ static ValkeyModuleScriptingEngineCompiledFunction **createHelloLangEngine(Valke
                                                                            ValkeyModuleScriptingEngineCtx *engine_ctx,
                                                                            ValkeyModuleScriptingEngineSubsystemType type,
                                                                            const char *code,
-                                                                           size_t code_len,
                                                                            size_t timeout,
                                                                            size_t *out_num_compiled_functions,
                                                                            ValkeyModuleString **err) {
     VALKEYMODULE_NOT_USED(module_ctx);
-    VALKEYMODULE_NOT_USED(code_len);
     VALKEYMODULE_NOT_USED(type);
     VALKEYMODULE_NOT_USED(timeout);
     VALKEYMODULE_NOT_USED(err);

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2458,4 +2458,10 @@ start_server {tags {"scripting"}} {
             assert { [r memory usage foo] <= $expected_memory};
         }
     }
+
+    test {EVAL - Scripts support NULL byte} {
+        assert_equal [r eval "return \"\x00\";" 0] "\x00"
+        # Using a null byte never seemed to work with functions, so
+        # we don't have a test for that case.
+    }
 }


### PR DESCRIPTION
We made a change during the refactoring of the engine changes that used a strlen on an SDS string. SDS are resizable, but they are binary safe and support NULL characters, which means we are truncating the string at the null character.

This is a breaking change for modules, so wanted to raise it for the upcoming patch.

An alternative is we could expose the script code as a server object, which would require some construction of the object in the function pathway and freeing. I opted to keep the code flow as similar as possible for the patch.

There is a test which only passes now.

For some reasons, functions don't support binary data. So as of right now this patch doesn't fix that case.

Resolves https://github.com/valkey-io/valkey/issues/1942