### PR TITLE
Only enable defrag for vendored jemalloc

### DIFF
--- a/deps/jemalloc/include/jemalloc/jemalloc.sh
+++ b/deps/jemalloc/include/jemalloc/jemalloc.sh
@@ -5,6 +5,9 @@ objroot=$1
 cat <<EOF
 #ifndef JEMALLOC_H_
 #define JEMALLOC_H_
+
+#define VALKEY_VENDORED_JEMALLOC yes
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/deps/jemalloc/include/jemalloc/jemalloc.sh
+++ b/deps/jemalloc/include/jemalloc/jemalloc.sh
@@ -8,7 +8,7 @@ cat <<EOF
 
 /* A macro that is used to indicate that this the jemalloc vendored with the project
  * and has been tested with active defragmentation. */
-#define VALKEY_VENDORED_JEMALLOC yes
+#define VALKEY_VENDORED_JEMALLOC 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/deps/jemalloc/include/jemalloc/jemalloc.sh
+++ b/deps/jemalloc/include/jemalloc/jemalloc.sh
@@ -6,6 +6,8 @@ cat <<EOF
 #ifndef JEMALLOC_H_
 #define JEMALLOC_H_
 
+/* A macro that is used to indicate that this the jemalloc vendored with the project
+ * and has been tested with active defragmentation. */
 #define VALKEY_VENDORED_JEMALLOC yes
 
 #ifdef __cplusplus

--- a/src/allocator_defrag.h
+++ b/src/allocator_defrag.h
@@ -5,7 +5,7 @@
 #include <jemalloc/jemalloc.h>
 /* We can enable the server defrag capabilities only if we are using Jemalloc
  * and the version that has the experimental.utilization namespace in mallctl . */
-#if (defined(JEMALLOC_VERSION_MAJOR) &&                                                                 \
+#if (defined(VALKEY_VENDORED_JEMALLOC) && defined(JEMALLOC_VERSION_MAJOR) &&                                                                 \
      (JEMALLOC_VERSION_MAJOR > 5 ||                                                                     \
       (JEMALLOC_VERSION_MAJOR == 5 && JEMALLOC_VERSION_MINOR > 2) ||                                    \
       (JEMALLOC_VERSION_MAJOR == 5 && JEMALLOC_VERSION_MINOR == 2 && JEMALLOC_VERSION_BUGFIX >= 1))) || \

--- a/src/allocator_defrag.h
+++ b/src/allocator_defrag.h
@@ -5,7 +5,7 @@
 #include <jemalloc/jemalloc.h>
 /* We can enable the server defrag capabilities only if we are using Jemalloc
  * and the version that has the experimental.utilization namespace in mallctl . */
-#if (defined(VALKEY_VENDORED_JEMALLOC) && defined(JEMALLOC_VERSION_MAJOR) &&                                                                 \
+#if (defined(VALKEY_VENDORED_JEMALLOC) && defined(JEMALLOC_VERSION_MAJOR) &&                            \
      (JEMALLOC_VERSION_MAJOR > 5 ||                                                                     \
       (JEMALLOC_VERSION_MAJOR == 5 && JEMALLOC_VERSION_MINOR > 2) ||                                    \
       (JEMALLOC_VERSION_MAJOR == 5 && JEMALLOC_VERSION_MINOR == 2 && JEMALLOC_VERSION_BUGFIX >= 1))) || \


### PR DESCRIPTION
Only enable defrag for vendored jemalloc. 

Resolves a point of discussion from https://github.com/valkey-io/valkey/issues/1585, although not the overall issue. This change should be reverted when we properly validate using system jemalloc as part of https://github.com/valkey-io/valkey/issues/1882.