### PR TITLE
Add output buffer limiting for unauthenticated clients

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -456,8 +456,7 @@ void ACLFreeUserAndKillClients(user *u) {
              * this may result in some security hole: it's much
              * more defensive to set the default user and put
              * it in non authenticated mode. */
-            c->user = DefaultUser;
-            c->authenticated = 0;
+            clientSetUser(c, DefaultUser, 0);
             /* We will write replies to this client later, so we can't
              * close it directly even if async. */
             if (c == server.current_client) {
@@ -1466,10 +1465,10 @@ void addAuthErrReply(client *c, robj *err) {
  * connection user reference is populated.
  *
  * The return value is AUTH_OK on success (valid username / password pair) & AUTH_ERR otherwise. */
-int checkPasswordBasedAuth(client *c, robj *username, robj *password) {
-    if (ACLCheckUserCredentials(username,password) == C_OK) {
-        c->authenticated = 1;
-        c->user = ACLGetUserByName(username->ptr,sdslen(username->ptr));
+static int checkPasswordBasedAuth(client *c, robj *username, robj *password) {
+    if (ACLCheckUserCredentials(username, password) == C_OK) {
+        user *user = ACLGetUserByName(username->ptr, sdslen(username->ptr));
+        clientSetUser(c, user, 1);
         moduleNotifyUserChanged(c);
         return AUTH_OK;
     } else {

--- a/src/debug.c
+++ b/src/debug.c
@@ -499,8 +499,8 @@ void debugCommand(client *c) {
 "CLUSTERLINK KILL <to|from|all> <node-id>",
 "    Kills the link based on the direction to/from (both) with the provided node." ,
 "CLIENT-ENFORCE-REPLY-LIST <0|1>",
-            "When set to 1, it enforces the use of the client reply list directly",
-            "    and avoids using the client's static buffer.",
+"    When set to 1, it enforces the use of the client reply list directly",
+"    and avoids using the client's static buffer.",
 NULL
         };
         addReplyHelp(c, help);

--- a/src/debug.c
+++ b/src/debug.c
@@ -498,6 +498,9 @@ void debugCommand(client *c) {
 "    Enable or disable the reply buffer resize cron job",
 "CLUSTERLINK KILL <to|from|all> <node-id>",
 "    Kills the link based on the direction to/from (both) with the provided node." ,
+"CLIENT-ENFORCE-REPLY-LIST <0|1>",
+            "When set to 1, it enforces the use of the client reply list directly",
+            "    and avoids using the client's static buffer.",
 NULL
         };
         addReplyHelp(c, help);
@@ -1048,6 +1051,9 @@ NULL
             addReplyErrorFormat(c, "Unknown direction %s", (char*) c->argv[3]->ptr);
         }
         addReply(c,shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "client-enforce-reply-list") && c->argc == 3) {
+        server.debug_client_enforce_reply_list = atoi(c->argv[2]->ptr);
+        addReply(c, shared.ok);
     } else {
         addReplySubcommandSyntaxError(c);
         return;

--- a/src/module.c
+++ b/src/module.c
@@ -9429,8 +9429,7 @@ void revokeClientAuthentication(client *c) {
      * is eventually freed we don't rely on the module to still exist. */
     moduleNotifyUserChanged(c);
 
-    c->user = DefaultUser;
-    c->authenticated = 0;
+    clientSetUser(c, DefaultUser, 0);
     /* We will write replies to this client later, so we can't close it
      * directly even if async. */
     if (c == server.current_client) {
@@ -9744,8 +9743,7 @@ static int authenticateClientWithUser(ValkeyModuleCtx *ctx, user *user, ValkeyMo
 
     moduleNotifyUserChanged(ctx->client);
 
-    ctx->client->user = user;
-    ctx->client->authenticated = 1;
+    clientSetUser(ctx->client, user, 1);
 
     if (clientHasModuleAuthInProgress(ctx->client)) {
         ctx->client->flags |= CLIENT_MODULE_AUTH_HAS_RESULT;

--- a/src/networking.c
+++ b/src/networking.c
@@ -102,9 +102,22 @@ void linkClient(client *c) {
 static void clientSetDefaultAuth(client *c) {
     /* If the default user does not require authentication, the user is
      * directly authenticated. */
-    c->user = DefaultUser;
-    c->authenticated = (c->user->flags & USER_FLAG_NOPASS) &&
-                       !(c->user->flags & USER_FLAG_DISABLED);
+    clientSetUser(c, DefaultUser, (DefaultUser->flags & USER_FLAG_NOPASS) && !(DefaultUser->flags & USER_FLAG_DISABLED));
+}
+
+/* Attach the user u to this client.
+ * Also, mark the client authentication state. In case the client is marked as authenticated,
+ * it will also set the ever_authenticated flag on the client in order to avoid low level
+ * limiting of the client output buffer.*/
+void clientSetUser(client *c, user *u, int authenticated) {
+    c->user = u;
+    c->authenticated = authenticated;
+    if (authenticated)
+        c->ever_authenticated = authenticated;
+}
+
+static int clientEverAuthenticated(client *c) {
+    return c->ever_authenticated;
 }
 
 int authRequired(client *c) {
@@ -329,7 +342,8 @@ int prepareClientToWrite(client *c) {
 REDIS_NO_SANITIZE("bounds")
 size_t _addReplyToBuffer(client *c, const char *s, size_t len) {
     size_t available = c->buf_usable_size - c->bufpos;
-
+    /* If the debug enforcing to use the reply list is enabled.*/
+    if (server.debug_client_enforce_reply_list) return 0;
     /* If there already are entries in the reply list, we cannot
      * add anything more to the static buffer. */
     if (listLength(c->reply) > 0) return 0;
@@ -3853,6 +3867,10 @@ char *getClientTypeName(int class) {
 int checkClientOutputBufferLimits(client *c) {
     int soft = 0, hard = 0, class;
     unsigned long used_mem = getClientOutputBufferMemoryUsage(c);
+
+    /* For unauthenticated clients which were also never authenticated before the output buffer is limited to prevent
+     * them from abusing it by not reading the replies */
+    if (used_mem > REPLY_BUFFER_SIZE_UNAUTHENTICATED_CLIENT && authRequired(c) && !clientEverAuthenticated(c)) return 1;
 
     class = getClientType(c);
     /* For the purpose of output buffer limiting, masters are handled

--- a/src/networking.c
+++ b/src/networking.c
@@ -183,6 +183,7 @@ client *createClient(connection *conn) {
     c->ctime = c->lastinteraction = server.unixtime;
     c->duration = 0;
     clientSetDefaultAuth(c);
+    c->ever_authenticated = 0;
     c->replstate = REPL_STATE_NONE;
     c->repl_start_cmd_stream_on_ack = 0;
     c->reploff = 0;

--- a/src/replication.c
+++ b/src/replication.c
@@ -1777,7 +1777,7 @@ void replicationCreateMasterClient(connection *conn, int dbid) {
      * connection. */
     server.master->flags |= CLIENT_MASTER;
 
-    server.master->authenticated = 1;
+    clientSetUser(server.master, NULL, 1);
     server.master->reploff = server.master_initial_offset;
     server.master->read_reploff = server.master->reploff;
     server.master->user = NULL; /* This client can do everything. */
@@ -3397,7 +3397,7 @@ void replicationResurrectCachedMaster(connection *conn) {
     server.master->conn = conn;
     connSetPrivateData(server.master->conn, server.master);
     server.master->flags &= ~(CLIENT_CLOSE_AFTER_REPLY|CLIENT_CLOSE_ASAP);
-    server.master->authenticated = 1;
+    clientSetUser(server.master, NULL, 1);
     server.master->lastinteraction = server.unixtime;
     server.repl_state = REPL_STATE_CONNECTED;
     server.repl_down_since = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -2607,6 +2607,7 @@ void initServer(void) {
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;
+    server.debug_client_enforce_reply_list = 0;
     resetReplicationBuffer();
 
     /* Make sure the locale is set on startup based on the config file. */

--- a/src/server.h
+++ b/src/server.h
@@ -182,6 +182,7 @@ struct hdr_histogram;
 #define REDIS_AUTOSYNC_BYTES (1024*1024*4) /* Sync file every 4MB. */
 
 #define REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME 5000 /* 5 seconds */
+#define REPLY_BUFFER_SIZE_UNAUTHENTICATED_CLIENT 1024 /* 1024 bytes */
 
 /* When configuring the server eventloop, we setup it so that the total number
  * of file descriptors we can handle are server.maxclients + RESERVED_FDS +
@@ -1191,6 +1192,7 @@ typedef struct client {
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
     time_t obuf_soft_limit_reached_time;
     int authenticated;      /* Needed when the default user requires auth. */
+    int ever_authenticated; /* Indicate a client was ever successfully authenticated during it's lifetime */
     int replstate;          /* Replication state if this is a slave. */
     int repl_start_cmd_stream_on_ack; /* Install slave write handler on first ACK. */
     int repldbfd;           /* Replication DB file descriptor. */
@@ -1628,6 +1630,7 @@ struct redisServer {
     int enable_protected_configs;    /* Enable the modification of protected configs, see PROTECTED_ACTION_ALLOWED_* */
     int enable_debug_cmd;            /* Enable DEBUG commands, see PROTECTED_ACTION_ALLOWED_* */
     int enable_module_cmd;           /* Enable MODULE commands, see PROTECTED_ACTION_ALLOWED_* */
+    int debug_client_enforce_reply_list;      /* Force client to always use the reply list */
 
     /* RDB / AOF loading information */
     volatile sig_atomic_t loading; /* We are loading data from disk if true */
@@ -2646,6 +2649,7 @@ void unprotectClient(client *c);
 void initThreadedIO(void);
 client *lookupClientByID(uint64_t id);
 int authRequired(client *c);
+void clientSetUser(client *c, user *u, int authenticated);
 void putClientInPendingWriteQueue(client *c);
 
 /* logreqres.c - logging of requests and responses */

--- a/tests/unit/auth.tcl
+++ b/tests/unit/auth.tcl
@@ -45,6 +45,58 @@ start_server {tags {"auth external:skip"} overrides {requirepass foobar}} {
         assert_match {*unauthenticated bulk length*} $e
         $rr close
     }
+
+    test {For unauthenticated clients output buffer is limited} {
+        set rr [redis [srv "host"] [srv "port"] 1 $::tls]
+        
+        # make sure the client is no longer authenticated
+        $rr SET x 5
+        catch {[$rr read]} e
+        assert_match {*NOAUTH Authentication required*} $e
+
+        # Force clients to use the reply list in order 
+        # to make them have a larger than 1K output buffer on any reply
+        assert_match "OK" [r debug client-enforce-reply-list 1]
+        
+        # Fill the output buffer without reading it and make
+        # sure the client disconnected.
+        $rr SET x 5
+        catch {[$rr read]} e
+        assert_match {I/O error reading reply} $e  
+
+        # Reset the debug
+        assert_match "OK" [r debug client-enforce-reply-list 0]
+    }  
+
+    test {For once authenticated clients output buffer is NOT limited} {
+        set rr [redis [srv "host"] [srv "port"] 1 $::tls]
+
+        # first time authenticate client
+        $rr auth foobar
+        assert_equal {OK} [$rr read]
+
+        # now reset the client so it is not authenticated
+        $rr reset
+        assert_equal {RESET} [$rr read]
+
+        # make sure the client is no longer authenticated
+        $rr SET x 5
+        catch {[$rr read]} e
+        assert_match {*NOAUTH Authentication required*} $e
+
+        # Force clients to use the reply list in order 
+        # to make them have a larger than 1K output buffer on any reply
+        assert_match "OK" [r debug client-enforce-reply-list 1]
+        
+        # Fill the output buffer without reading it and make
+        # sure the client was NOT disconnected.
+        $rr SET x 5
+        catch {[$rr read]} e
+        assert_match {*NOAUTH Authentication required*} $e
+
+        # Reset the debug
+        assert_match "OK" [r debug client-enforce-reply-list 0]
+    }  
 }
 
 start_server {tags {"auth_binary_password external:skip"}} {


### PR DESCRIPTION
This commit introduces a mechanism to track client authentication state with a new `ever_authenticated` flag. 
It refactors client authentication handling by adding a `clientSetUser` function that properly sets both the authenticated and `ever_authenticated` flags.

The implementation limits output buffer size for clients that have never been authenticated.

Added tests to verify the output buffer limiting behavior for unauthenticated clients.