### PR TITLE
CI build-macos version from macOS 14 to macOS 15

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1130,7 +1130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1130,7 +1130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-13, macos-14,  macos-15]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1130,7 +1130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14,  macos-15]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
macOS 15 has been officially released for some time, our current `build-macos` workflow is still running on macOS 14. 
This PR upgrades the macOS version used in our CI to macOS 15 to keep up with the latest OS version and ensure long-term compatibility.

The `build-macos` CI workflow has successfully run on macOS 15: https://github.com/vitahlin/valkey/actions/runs/14640672882