### PR TITLE
Accept limited number of new cluster link connections per cycle

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1545,10 +1545,9 @@ static void clusterConnAcceptHandler(connection *conn) {
     connSetReadHandler(conn, clusterReadHandler);
 }
 
-#define MAX_CLUSTER_ACCEPTS_PER_CALL 1000
 void clusterAcceptHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
     int cport, cfd;
-    int max = MAX_CLUSTER_ACCEPTS_PER_CALL;
+    int max = server.tls_cluster ? server.max_new_tls_conns_per_cycle : server.max_new_conns_per_cycle;
     char cip[NET_IP_STR_LEN];
     int require_auth = TLS_CLIENT_AUTH_YES;
     UNUSED(el);


### PR DESCRIPTION
For large cluster accepting too many new cluster link connections in one cycle can cause increase in temporary memory usage as well as causes longer to accept all the connections. With this change, we utilize the same configuration introduced for clients with cluster link connections i.e. `10` for non TLS cluster and `1` for TLS cluster.

### Unstable
```
# Memory
used_memory:13495144
used_memory_human:12.87M
used_memory_rss:309686272
used_memory_rss_human:295.34M
used_memory_peak:110714488
used_memory_peak_human:105.59M
```

### With 1 accept per call  for TLS cluster
```
# Memory
used_memory:13495472
used_memory_human:12.87M
used_memory_rss:256172032
used_memory_rss_human:244.30M
used_memory_peak:59974584
used_memory_peak_human:57.20M
```

Summary: Peak memory is 46% lower for the best case observed during test experiments.

### Unstable
```
time ./valkey-cli --tls --cacert ca.crt --cert valkey-server.crt --key valkey-server.key --json info memory
# Memory
used_memory:45572952
used_memory_human:43.46M
...

real    0m9.466s
user    0m0.014s
sys    0m0.002s
```

### With 1 accept per call for TLS cluster
```
time ./valkey-cli --tls --cacert ca.crt --cert valkey-server.crt --key valkey-server.key --json info memory
# Memory
used_memory:10964872
used_memory_human:10.46M
...

real    0m4.005s
user    0m0.011s
sys    0m0.005s
```

Summary: Time to serve user traffic is 57% lower for the best case observed during test experiments. 
