### PR TITLE
Compile with -Wundef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_EXAMPLE_MODULES "Build example modules" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 project("valkey")
+add_compile_options(-Wundef)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,7 @@ ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
 endif
 endif
-WARN=-Wall -W -Wno-missing-field-initializers -Werror=deprecated-declarations -Wstrict-prototypes
+WARN=-Wall -W -Wno-missing-field-initializers -Werror=deprecated-declarations -Wstrict-prototypes -Wundef
 OPT=$(OPTIMIZATION)
 
 # Detect if the compiler supports C11 _Atomic.

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,7 @@ ifneq (,$(findstring FreeBSD,$(uname_S)))
   STD+=-Wno-c11-extensions
 endif
 endif
-WARN=-Wall -W -Wno-missing-field-initializers -Werror=deprecated-declarations -Wstrict-prototypes -Wundef
+WARN=-Wall -W -Wno-missing-field-initializers -Werror=deprecated-declarations -Wstrict-prototypes -Werror=undef
 OPT=$(OPTIMIZATION)
 
 # Detect if the compiler supports C11 _Atomic.

--- a/src/config.h
+++ b/src/config.h
@@ -283,7 +283,10 @@ void setproctitle(const char *fmt, ...);
 #endif /* __aarch64__ && __APPLE__ */
 #endif /* CACHE_LINE_SIZE */
 
-#if (__i386 || __amd64 || __powerpc__) && __GNUC__
+#if ((defined(__i386) && __i386) || \
+     (defined(__amd64) && __amd64) || \
+     (defined(__powerpc__) && __powerpc__)) && \
+    defined(__GNUC__) && __GNUC__
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if defined(__clang__)
 #define HAVE_ATOMIC

--- a/src/config.h
+++ b/src/config.h
@@ -283,10 +283,10 @@ void setproctitle(const char *fmt, ...);
 #endif /* __aarch64__ && __APPLE__ */
 #endif /* CACHE_LINE_SIZE */
 
-#if ((defined(__i386) && __i386) || \
-     (defined(__amd64) && __amd64) || \
+#if ((defined(__i386) && __i386) ||            \
+     (defined(__amd64) && __amd64) ||          \
      (defined(__powerpc__) && __powerpc__)) && \
-    defined(__GNUC__) && __GNUC__
+    defined(__GNUC__)
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if defined(__clang__)
 #define HAVE_ATOMIC

--- a/src/config.h
+++ b/src/config.h
@@ -283,10 +283,7 @@ void setproctitle(const char *fmt, ...);
 #endif /* __aarch64__ && __APPLE__ */
 #endif /* CACHE_LINE_SIZE */
 
-#if ((defined(__i386) && __i386) ||            \
-     (defined(__amd64) && __amd64) ||          \
-     (defined(__powerpc__) && __powerpc__)) && \
-    defined(__GNUC__)
+#if (defined(__i386) || defined(__amd64) || defined(__powerpc__)) && defined(__GNUC__)
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if defined(__clang__)
 #define HAVE_ATOMIC

--- a/src/crcspeed.c
+++ b/src/crcspeed.c
@@ -61,7 +61,7 @@ void crcspeed64little_init(crcfn64 crcfn, uint64_t table[8][256]) {
             table[k][n] = crc;
         }
     }
-#if USE_STATIC_COMBINE_CACHE
+#if defined(USE_STATIC_COMBINE_CACHE) && USE_STATIC_COMBINE_CACHE
     /* initialize combine cache for CRC stapling for slice-by 16/24+ */
     init_combine_cache(CRC64_REVERSED_POLY, 64);
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -1098,7 +1098,7 @@ void serverLogObjectDebugInfo(const robj *o) {
     serverLog(LL_WARNING, "Object type: %u", o->type);
     serverLog(LL_WARNING, "Object encoding: %u", o->encoding);
     serverLog(LL_WARNING, "Object refcount: %d", o->refcount);
-#if UNSAFE_CRASH_REPORT
+#if defined(UNSAFE_CRASH_REPORT) && UNSAFE_CRASH_REPORT
     /* This code is now disabled. o->ptr may be unreliable to print. in some
      * cases a ziplist could have already been freed by realloc, but not yet
      * updated to o->ptr. in other cases the call to ziplistLen may need to

--- a/src/lzfP.h
+++ b/src/lzfP.h
@@ -133,6 +133,11 @@
  * not being able to store offset above UINT32_MAX in 64bit. */
 #define LZF_USE_OFFSETS 0
 
+/* Use assemly "rep movsb". Small win on amd, big loss on intel. */
+#ifndef USE_REP_MOVSB
+# define USE_REP_MOVSB 0
+#endif
+
 /*****************************************************************************/
 /* nothing should be changed below */
 

--- a/src/lzfP.h
+++ b/src/lzfP.h
@@ -133,7 +133,7 @@
  * not being able to store offset above UINT32_MAX in 64bit. */
 #define LZF_USE_OFFSETS 0
 
-/* Use assemly "rep movsb". Small win on amd, big loss on intel. */
+/* Use assembly "rep movsb". Small win on amd, big loss on intel. */
 #ifndef USE_REP_MOVSB
 # define USE_REP_MOVSB 0
 #endif

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -18,7 +18,8 @@
 #include "connection.h"
 
 #if defined __linux__ && defined USE_RDMA /* currently RDMA is only supported on Linux */
-#if (USE_RDMA == 1 /* BUILD_YES */) || ((USE_RDMA == 2 /* BUILD_MODULE */) && (BUILD_RDMA_MODULE == 2))
+#if (USE_RDMA == 1 /* BUILD_YES */) || \
+    ((USE_RDMA == 2 /* BUILD_MODULE */) && defined(BUILD_RDMA_MODULE) && (BUILD_RDMA_MODULE == 2))
 #include "connhelpers.h"
 
 #include <assert.h>

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -17,7 +17,7 @@
 #include "server.h"
 #include "connection.h"
 
-#if defined __linux__ /* currently RDMA is only supported on Linux */
+#if defined __linux__ && defined USE_RDMA /* currently RDMA is only supported on Linux */
 #if (USE_RDMA == 1 /* BUILD_YES */) || ((USE_RDMA == 2 /* BUILD_MODULE */) && (BUILD_RDMA_MODULE == 2))
 #include "connhelpers.h"
 

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1884,7 +1884,7 @@ int RegisterConnectionTypeRdma(void) {
 
 #endif
 
-#if BUILD_RDMA_MODULE == 2 /* BUILD_MODULE */
+#if defined(BUILD_RDMA_MODULE) && BUILD_RDMA_MODULE == 2 /* BUILD_MODULE */
 
 #include "release.h"
 

--- a/src/rio.c
+++ b/src/rio.c
@@ -131,7 +131,7 @@ static size_t rioFileWrite(rio *r, const void *buf, size_t len) {
             serverAssert(processed % r->io.file.autosync == 0);
             serverAssert(r->io.file.buffered == r->io.file.autosync);
 
-#if HAVE_SYNC_FILE_RANGE
+#if defined(HAVE_SYNC_FILE_RANGE) && HAVE_SYNC_FILE_RANGE
             /* Start writeout asynchronously. */
             if (sync_file_range(fileno(r->io.file.fp), processed - r->io.file.autosync, r->io.file.autosync,
                                 SYNC_FILE_RANGE_WRITE) == -1)

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -30,7 +30,7 @@
 
 #include "server.h"
 #include "hiredis.h"
-#if USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 #include "openssl/ssl.h"
 #include "hiredis_ssl.h"
 #endif
@@ -44,7 +44,7 @@
 
 extern char **environ;
 
-#if USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 extern SSL_CTX *valkey_tls_ctx;
 extern SSL_CTX *valkey_tls_client_ctx;
 #endif
@@ -2296,7 +2296,7 @@ void sentinelSetClientName(sentinelValkeyInstance *ri, redisAsyncContext *c, cha
 }
 
 static int instanceLinkNegotiateTLS(redisAsyncContext *context) {
-#if USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     if (!valkey_tls_ctx) return C_ERR;
     SSL *ssl = SSL_new(valkey_tls_client_ctx ? valkey_tls_client_ctx : valkey_tls_ctx);
     if (!ssl) return C_ERR;

--- a/src/setproctitle.c
+++ b/src/setproctitle.c
@@ -232,7 +232,7 @@ void spt_init(int argc, char *argv[]) {
 	if (!(SPT.arg0 = strdup(argv[0])))
 		goto syerr;
 
-#if __linux__
+#if defined __linux__
 	if (!(tmp = strdup(program_invocation_name)))
 		goto syerr;
 
@@ -242,7 +242,7 @@ void spt_init(int argc, char *argv[]) {
 		goto syerr;
 
 	program_invocation_short_name = tmp;
-#elif __APPLE__
+#elif defined __APPLE__
 	if (!(tmp = strdup(getprogname())))
 		goto syerr;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -34,7 +34,10 @@
 #include "adlist.h"
 #include "io_threads.h"
 
-#if (USE_OPENSSL == 1 /* BUILD_YES */) || ((USE_OPENSSL == 2 /* BUILD_MODULE */) && (BUILD_TLS_MODULE == 2))
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
 
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
@@ -1227,7 +1230,7 @@ int RedisRegisterConnectionTypeTLS(void) {
 
 #endif
 
-#if BUILD_TLS_MODULE == 2 /* BUILD_MODULE */
+#if defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2 /* BUILD_MODULE */
 
 #include "release.h"
 


### PR DESCRIPTION
This catches spelling errors in macros, like `#if MACCRO`.