### PR TITLE
Optimize findBucket performance using SIMD

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -382,9 +382,11 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 #if HAVE_X86_SIMD
+#define ATTRIBUTE_TARGET_SSE2 __attribute__((target("sse2")))
 #define ATTRIBUTE_TARGET_AVX2 __attribute__((target("avx2")))
 #define ATTRIBUTE_TARGET_AVX512 __attribute__((target("avx512f,avx512bw,avx512vl")))
 #else
+#define ATTRIBUTE_TARGET_SSE2
 #define ATTRIBUTE_TARGET_AVX2
 #define ATTRIBUTE_TARGET_AVX512
 #endif

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -678,7 +678,7 @@ static int expand(hashtable *ht, size_t size, int *malloc_failed) {
  * entry at that position matches the provided key. If a match is found, it
  * updates the position and table index pointers and returns 1. Otherwise,
  * it returns 0. */
-static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, int *pos_in_bucket, int *table_index, int table) {
+static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, int table, int *pos_in_bucket, int *table_index) {
     /* It's a candidate. */
     void *entry = b->entries[pos];
     const void *elem_key = entryGetKey(ht, entry);
@@ -694,7 +694,7 @@ static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, cons
 
 #if HAVE_X86_SIMD
 ATTRIBUTE_TARGET_SSE2
-static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int *pos_in_bucket, int *table_index, int table) {
+static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
     /* Get the bucket's presence mask - indicates which positions are filled. */
     BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
     __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
@@ -709,7 +709,7 @@ static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void 
     newmask &= presence_mask;
     while (newmask > 0) {
         int pos = __builtin_ctz(newmask);
-        if (checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return 1;
+        if (checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index)) return 1;
         /* Clear the processed bit and continue with next match. */
         newmask &= ~(1 << pos);
     }
@@ -743,12 +743,12 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
         do {
 #if HAVE_X86_SIMD
             /* All x86-64 CPUs have SSE2. */
-            if (findKeyInBucketSSE2(ht, b, h2, key, pos_in_bucket, table_index, table)) return b;
+            if (findKeyInBucketSSE2(ht, b, h2, key, table, pos_in_bucket, table_index)) return b;
 #else
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {
                 if (isPositionFilled(b, pos) && b->hashes[pos] == h2 &&
-                    checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return b;
+                    checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index)) return b;
             }
 #endif
             b = getChildBucket(b);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -675,7 +675,7 @@ static int expand(hashtable *ht, size_t size, int *malloc_failed) {
  *
  * If 'table_index' is provided, it is set to the index of the table (0 or 1)
  * the returned bucket belongs to. */
-#ifdef HAVE_X86_SIMD
+#if HAVE_X86_SIMD
 #include <immintrin.h>
 ATTRIBUTE_TARGET_SSE2
 #endif

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -672,6 +672,12 @@ static int expand(hashtable *ht, size_t size, int *malloc_failed) {
     return resize(ht, size, malloc_failed);
 }
 
+/* Checks if a candidate entry in a bucket matches the given key.
+ *
+ * This function examines a specific position in a bucket to determine if the
+ * entry at that position matches the provided key. If a match is found, it
+ * updates the position and table index pointers and returns 1. Otherwise,
+ * it returns 0. */
 static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, int *pos_in_bucket, int *table_index, int table) {
     /* It's a candidate. */
     void *entry = b->entries[pos];
@@ -687,7 +693,8 @@ static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, cons
 }
 
 #if HAVE_X86_SIMD
-ATTRIBUTE_TARGET_SSE2 static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int *pos_in_bucket, int *table_index, int table) {
+ATTRIBUTE_TARGET_SSE2
+static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int *pos_in_bucket, int *table_index, int table) {
     /* Get the bucket's presence mask - indicates which positions are filled. */
     BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
     __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
@@ -740,9 +747,8 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
 #else
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {
-                if (isPositionFilled(b, pos) && b->hashes[pos] == h2) {
-                    if (checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return b;
-                }
+                if (isPositionFilled(b, pos) && b->hashes[pos] == h2 &&
+                    checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return b;
             }
 #endif
             b = getChildBucket(b);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -675,6 +675,10 @@ static int expand(hashtable *ht, size_t size, int *malloc_failed) {
  *
  * If 'table_index' is provided, it is set to the index of the table (0 or 1)
  * the returned bucket belongs to. */
+#ifdef HAVE_X86_SIMD
+#include <immintrin.h>
+ATTRIBUTE_TARGET_SSE2
+#endif
 static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *pos_in_bucket, int *table_index) {
     if (hashtableSize(ht) == 0) return 0;
     uint8_t h2 = highBits(hash);
@@ -693,6 +697,39 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
         }
         bucket *b = &ht->tables[table][bucket_idx];
         do {
+#if HAVE_X86_SIMD
+            if (__builtin_cpu_supports("sse2")) {
+                /* Get the bucket's presence mask - indicates which positions are filled. */
+                BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
+                __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
+                __m128i h2_vector = _mm_set1_epi8(h2);
+                /* Compare all hash values against the target hash simultaneously.
+                 * The result is a vector of 16 bytes, where each byte is 0xFF if
+                 * the corresponding hash matches the target hash, and 0x00 if it
+                 * doesn't. */
+                __m128i result = _mm_cmpeq_epi8(hash_vector, h2_vector);
+                BUCKET_BITS_TYPE newmask = _mm_movemask_epi8(result);
+                /* Only consider positions that are both filled (presence) and match the hash (newmask). */
+                newmask &= presence_mask;
+                while (newmask > 0) {
+                    int pos = __builtin_ctz(newmask);
+                    /* It's a candidate. */
+                    void *entry = b->entries[pos];
+                    const void *elem_key = entryGetKey(ht, entry);
+                    if (compareKeys(ht, key, elem_key) == 0) {
+                        /* It's a match. */
+                        assert(pos_in_bucket != NULL);
+                        *pos_in_bucket = pos;
+                        if (table_index) *table_index = table;
+                        return b;
+                    }
+                    /* Clear the processed bit and continue with next match. */
+                    newmask &= ~(1 << pos);
+                }
+                b = getChildBucket(b);
+                continue;
+            }
+#endif
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {
                 if (isPositionFilled(b, pos) && b->hashes[pos] == h2) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -57,6 +57,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#if HAVE_X86_SIMD
+#include <immintrin.h>
+#endif
 
 /* The default hashing function uses the SipHash implementation in siphash.c. */
 
@@ -669,16 +672,50 @@ static int expand(hashtable *ht, size_t size, int *malloc_failed) {
     return resize(ht, size, malloc_failed);
 }
 
+static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, int *pos_in_bucket, int *table_index, int table) {
+    /* It's a candidate. */
+    void *entry = b->entries[pos];
+    const void *elem_key = entryGetKey(ht, entry);
+    if (compareKeys(ht, key, elem_key) == 0) {
+        /* It's a match. */
+        assert(pos_in_bucket != NULL);
+        *pos_in_bucket = pos;
+        if (table_index) *table_index = table;
+        return 1;
+    }
+    return 0;
+}
+
+#if HAVE_X86_SIMD
+ATTRIBUTE_TARGET_SSE2 static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int *pos_in_bucket, int *table_index, int table) {
+    /* Get the bucket's presence mask - indicates which positions are filled. */
+    BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
+    __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
+    __m128i h2_vector = _mm_set1_epi8(h2);
+    /* Compare all hash values against the target hash simultaneously.
+     * The result is a vector of 16 bytes, where each byte is 0xFF if
+     * the corresponding hash matches the target hash, and 0x00 if it
+     * doesn't. */
+    __m128i result = _mm_cmpeq_epi8(hash_vector, h2_vector);
+    BUCKET_BITS_TYPE newmask = _mm_movemask_epi8(result);
+    /* Only consider positions that are both filled (presence) and match the hash (newmask). */
+    newmask &= presence_mask;
+    while (newmask > 0) {
+        int pos = __builtin_ctz(newmask);
+        if (checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return 1;
+        /* Clear the processed bit and continue with next match. */
+        newmask &= ~(1 << pos);
+    }
+    return 0;
+}
+#endif
+
 /* Finds an entry matching the key. If a match is found, returns a pointer to
  * the bucket containing the matching entry and points 'pos_in_bucket' to the
  * index within the bucket. Returns NULL if no matching entry was found.
  *
  * If 'table_index' is provided, it is set to the index of the table (0 or 1)
  * the returned bucket belongs to. */
-#if HAVE_X86_SIMD
-#include <immintrin.h>
-ATTRIBUTE_TARGET_SSE2
-#endif
 static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *pos_in_bucket, int *table_index) {
     if (hashtableSize(ht) == 0) return 0;
     uint8_t h2 = highBits(hash);
@@ -698,53 +735,16 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
         bucket *b = &ht->tables[table][bucket_idx];
         do {
 #if HAVE_X86_SIMD
-            if (__builtin_cpu_supports("sse2")) {
-                /* Get the bucket's presence mask - indicates which positions are filled. */
-                BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
-                __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
-                __m128i h2_vector = _mm_set1_epi8(h2);
-                /* Compare all hash values against the target hash simultaneously.
-                 * The result is a vector of 16 bytes, where each byte is 0xFF if
-                 * the corresponding hash matches the target hash, and 0x00 if it
-                 * doesn't. */
-                __m128i result = _mm_cmpeq_epi8(hash_vector, h2_vector);
-                BUCKET_BITS_TYPE newmask = _mm_movemask_epi8(result);
-                /* Only consider positions that are both filled (presence) and match the hash (newmask). */
-                newmask &= presence_mask;
-                while (newmask > 0) {
-                    int pos = __builtin_ctz(newmask);
-                    /* It's a candidate. */
-                    void *entry = b->entries[pos];
-                    const void *elem_key = entryGetKey(ht, entry);
-                    if (compareKeys(ht, key, elem_key) == 0) {
-                        /* It's a match. */
-                        assert(pos_in_bucket != NULL);
-                        *pos_in_bucket = pos;
-                        if (table_index) *table_index = table;
-                        return b;
-                    }
-                    /* Clear the processed bit and continue with next match. */
-                    newmask &= ~(1 << pos);
-                }
-                b = getChildBucket(b);
-                continue;
-            }
-#endif
+            /* All x86-64 CPUs have SSE2. */
+            if (findKeyInBucketSSE2(ht, b, h2, key, pos_in_bucket, table_index, table)) return b;
+#else
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {
                 if (isPositionFilled(b, pos) && b->hashes[pos] == h2) {
-                    /* It's a candidate. */
-                    void *entry = b->entries[pos];
-                    const void *elem_key = entryGetKey(ht, entry);
-                    if (compareKeys(ht, key, elem_key) == 0) {
-                        /* It's a match. */
-                        assert(pos_in_bucket != NULL);
-                        *pos_in_bucket = pos;
-                        if (table_index) *table_index = table;
-                        return b;
-                    }
+                    if (checkCandidateInBucket(ht, b, pos, key, pos_in_bucket, table_index, table)) return b;
                 }
             }
+#endif
             b = getChildBucket(b);
         } while (b != NULL);
     }


### PR DESCRIPTION
### Description

This PR introduces an optimization for the `findBucket` function utilizing SSE2 instructions. The `findBucket` function is widely be used in hashtable data structure, particularly in **SET** and **GET** related commands, but also for looking up a command by its name and many other things.

The core optimization happens with `_mm_cmpeq_epi8()`, which performs 16 bytes (with 7 bytes being valid) comparisons in parallel. The `_mm_movemask_epi8()` function then converts this vector of byte comparisons into a bit mask where each bit represents whether a comparison was successful.

This implementation demonstrates sophisticated use of SIMD instructions to accelerate hash table lookups by performing multiple hash comparisons in parallel.

### Performance Boost

The corresponding **GET** and **SET** commands can gain up to **~2% - ~6%** performance improvement especially with pipeline enabled.  Below test scenarios showed they are benefit for this optimization. 

|Benchmark|Performance Boost|
|-|-|
|[memtier_benchmark-10Mkeys-string-get-10B-pipeline-100-nokeyprefix](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-10Mkeys-string-get-10B-pipeline-100-nokeyprefix.yml) |**4%**|
|[memtier_benchmark-1Mkeys-string-get-10B-pipeline-50](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-50.yml) |**4%**|
|[memtier_benchmark-1Mkeys-string-get-10B-pipeline-100](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-100.yml) |**4%**|
|[memtier_benchmark-1Mkeys-string-get-10B-pipeline-100-nokeyprefix](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-100-nokeyprefix.yml) |**2%**|
|[memtier_benchmark-1Mkeys-string-get-10B-pipeline-500](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-string-get-10B-pipeline-500.yml) |**6%**|
|[memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-500](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-500.yml) |**4%**|
|[memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-100](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-100.yml) |**3%**|
|[memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-100-nokeyprefix](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1Mkeys-load-string-with-10B-values-pipeline-100-nokeyprefix.yml) |**3%**|


#### Test Env
- OS: CentOS Stream 9
- Platform: Intel Xeon 6980P
- Server and Client in same socket

#### Valkey-server configuration
```
taskset -c 0 ~/valkey/src/valkey-server ~/tmp_valkey.conf
port 9001
bind * -::*
daemonize no
protected-mode no
save
```