### PR TITLE
Properly escape double quotes and backslash in sdscatrepr

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -952,9 +952,9 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
     s = sdsMakeRoomFor(s, len + 2);
     s = sdscatlen(s, "\"", 1);
     while (len) {
-        if (isprint(*p)) {
+        if (isprint(*p) && *p != '\\' && *p != '"') {
             const char *start = p;
-            while (len && isprint(*p)) {
+            while (len && isprint(*p) && *p != '\\' && *p != '"') {
                 len--;
                 p++;
             }

--- a/src/sds.c
+++ b/src/sds.c
@@ -952,6 +952,9 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
     s = sdsMakeRoomFor(s, len + 2);
     s = sdscatlen(s, "\"", 1);
     while (len) {
+        /* The condition here in combination with the loop inside ensures we're calling sdscatlen only once for an
+         * entire string chunk rather than calling it for every character. This reduces the amount of memcpy calls.
+         * \ and " are valid isprint characters but we need to handle them in the else block below to escape them. */
         if (isprint(*p) && *p != '\\' && *p != '"') {
             const char *start = p;
             while (len && isprint(*p) && *p != '\\' && *p != '"') {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -678,6 +678,15 @@ start_server {tags {"introspection"}} {
         set _ $res
     } {*"set" "foo"*"get" "foo"*}
 
+	test {MONITOR properly escapes special characters through sdscatrepr} {
+		set rd [valkey_deferring_client]
+		$rd monitor
+		assert_match {*OK*} [$rd read]
+		r echo "backslash\\quotes\"newline\ncarriagereturn\rtab\talert\abackspace\bhexnormal\x7Ahexspecial\x7F"
+		assert_match {*"echo" "backslash\\\\quotes\\"newline\\ncarriagereturn\\rtab\\talert\\abackspace\\bhexnormalzhexspecial\\x7f"*} [$rd read]
+		$rd close
+	}
+
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [valkey_deferring_client]
         $rd monitor

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -678,14 +678,14 @@ start_server {tags {"introspection"}} {
         set _ $res
     } {*"set" "foo"*"get" "foo"*}
 
-	test {MONITOR properly escapes special characters through sdscatrepr} {
-		set rd [valkey_deferring_client]
-		$rd monitor
-		assert_match {*OK*} [$rd read]
-		r echo "backslash\\quotes\"newline\ncarriagereturn\rtab\talert\abackspace\bhexnormal\x7Ahexspecial\x7F"
-		assert_match {*"echo" "backslash\\\\quotes\\"newline\\ncarriagereturn\\rtab\\talert\\abackspace\\bhexnormalzhexspecial\\x7f"*} [$rd read]
-		$rd close
-	}
+    test {MONITOR properly escapes special characters through sdscatrepr} {
+        set rd [valkey_deferring_client]
+        $rd monitor
+        assert_match {*OK*} [$rd read]
+        r echo "backslash\\quotes\"newline\ncarriagereturn\rtab\talert\abackspace\bhexnormal\x7Ahexspecial\x7F"
+        assert_match {*"echo" "backslash\\\\quotes\\"newline\\ncarriagereturn\\rtab\\talert\\abackspace\\bhexnormalzhexspecial\\x7f"*} [$rd read]
+        $rd close
+    }
 
     test {MONITOR can log commands issued by the scripting engine} {
         set rd [valkey_deferring_client]


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/2035, a bug introduced in https://github.com/valkey-io/valkey/pull/1342