### PR TITLE
Fix VALKEYCLI_AUTH env variable fallback to REDISCLI_AUTH mistake

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2908,7 +2908,7 @@ static int parseOptions(int argc, char **argv) {
 static void parseEnv(void) {
     /* Set auth from env, but do not overwrite CLI arguments if passed */
     char *auth = getenv(CLI_AUTH_ENV);
-    if (auth != NULL) {
+    if (auth == NULL) {
         auth = getenv(OLD_CLI_AUTH_ENV);
     }
     if (auth != NULL && config.conn_info.auth == NULL) {


### PR DESCRIPTION
Fix flipped-logic mistake introduced in #1995.

Signed-off-by: Hiranmoy Das Chowdhury <hiranmoy.das70@gmail.com>