### PR TITLE
CI rename build-macos to build-old-version-macos

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1126,7 +1126,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
         run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  build-old-version-macos:
+  build-old-macos-versions:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1343,7 +1343,7 @@ jobs:
       - test-macos-latest
       - test-macos-latest-sentinel
       - test-macos-latest-cluster
-      - build-macos
+      - build-old-macos-versions
       - test-freebsd
       - test-alpine-jemalloc
       - test-alpine-libc-malloc

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1126,11 +1126,11 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
         run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
 
-  build-macos:
+  build-old-version-macos:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     if: |
       (github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
This is a follow-up adjustment based on the previous PR: https://github.com/valkey-io/valkey/pull/2000
@hwware @madolson 
Apologies again for the extra review work this may have caused — I really appreciate your time and feedback.