### PR TITLE
Restore omitted singledb config in tests

### DIFF
--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -535,3 +535,5 @@ start_multiple_servers 3 [list overrides $base_conf] {
 }
 
 }
+
+set ::singledb $old_singledb


### PR DESCRIPTION
Re-adds a statement to restore the `singledb` config that was accidentally removed in PR #1671.

Fixes https://github.com/valkey-io/valkey/issues/2049