### PR TITLE
Make sure that the same point reports for geo comparisons

### DIFF
--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -46,8 +46,6 @@
 #define ECCENT (sqrt(1.0 - (RATIO * RATIO)))
 #define COM (0.5 * ECCENT)
 
-/// @brief The usual PI/180 constant
-const double DEG_TO_RAD = 0.017453292519943295769236907684886;
 /// @brief Earth's quadratic mean radius for WGS-84
 const double EARTH_RADIUS_IN_METERS = 6372797.560856;
 
@@ -233,8 +231,10 @@ double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d
     lon1r = deg_rad(lon1d);
     lon2r = deg_rad(lon2d);
     v = sin((lon2r - lon1r) / 2);
-    /* if v == 0 we can avoid doing expensive math when lons are practically the same */
-    if (v == 0.0) return geohashGetLatDistance(lat1d, lat2d);
+    /* Reflects about 6nm on earth for comparing longitudes. */
+    const double GEO_EPSILON = 1e-15;
+    /* if v == 0, or practically 0, we can avoid doing expensive math when lons are practically the same */
+    if (fabs(v) <= GEO_EPSILON) return geohashGetLatDistance(lat1d, lat2d);
     lat1r = deg_rad(lat1d);
     lat2r = deg_rad(lat2d);
     u = sin((lat2r - lat1r) / 2);

--- a/tests/unit/geo.tcl
+++ b/tests/unit/geo.tcl
@@ -550,6 +550,14 @@ start_server {tags {"geo"}} {
         assert_equal {{1 0.0001} {2 9.8182}} [r GEORADIUS points -122.407107 37.794300 30 mi ASC WITHDIST]
     }
 
+    test {GEOSEARCH with exact zero distances} {
+        r del points
+        # These are full precision coordinates, so the distance should 0.0000
+        r geoadd points -122.40710645914077759 37.79430076631935975 position
+        assert_equal {{position 0.0000}} [r GEOSEARCH points FROMMEMBER position BYRADIUS 0 mi ASC WITHDIST]
+        assert_equal {{position 0.0000}} [r GEOSEARCH points FROMLONLAT -122.40710645914077759 37.79430076631935975 BYRADIUS 0 mi ASC WITHDIST]
+    }
+
     foreach {type} {byradius bybox} {
     test "GEOSEARCH fuzzy test - $type" {
         if {$::accurate} { set attempt 300 } else { set attempt 30 }


### PR DESCRIPTION
Resolves https://github.com/valkey-io/valkey/issues/2051

We have an optimization where if the longitudes of two points are the same in a geospatial search, we can do a much simpler distance across the radius of the earth. This optimization was not being called for ARM with optimizations, since it was always accumulating a small amount of rounding error. This was also causing slightly divergent behavior between x86 and ARM.

The goal of this PR is to compare against a very small value instead of zero to avoid most of these rounding errors. There is a very simple test that worked on x86 but did not work on ARM.

Also deleted an extra constant.