### PR TITLE
Support MPTCP for valkey-cli and benchmark

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -430,7 +430,7 @@ sds cliVersion(void) {
 }
 
 /* This is a wrapper to call valkeyConnect or valkeyConnectWithTimeout. */
-valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock) {
+valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock, int multipath) {
     valkeyOptions options = {0};
 
     switch (ct) {
@@ -460,6 +460,11 @@ valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip
 
     if (nonblock) {
         options.options |= VALKEY_OPT_NONBLOCK;
+    }
+
+    if (multipath) {
+        assert(ct == VALKEY_CONN_TCP); /* caller should make sure multipath is available for TCP only */
+        options.options |= VALKEY_OPT_MPTCP;
     }
 
     return valkeyConnectWithOptions(&options);

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -53,6 +53,6 @@ sds escapeJsonString(sds s, const char *p, size_t len);
 
 sds cliVersion(void);
 
-valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock);
+valkeyContext *valkeyConnectWrapper(enum valkeyConnectionType ct, const char *ip_or_path, int port, const struct timeval tv, int nonblock, int multipath);
 
 #endif /* __CLICOMMON_H */


### PR DESCRIPTION
Add '--mptcp' for both valkey-cli and valkey-benchmark to enable MPTCP.

MPTCP is supported by both valkey and libvalkey.

Doc: https://github.com/valkey-io/valkey-doc/pull/274

Cc @matttbe @geliangtang