### PR TITLE
valkey-cli: remove RESP version assertion from getDatabases()

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -8736,7 +8736,6 @@ static int getDatabases(valkeyContext *ctx) {
         fprintf(stderr, "%s fails: %s, use default value %d instead\n",
                 config.cluster_mode ? cluster : standalone, reply->str, dbnum);
     } else {
-        assert(reply->type == (config.current_resp3 ? VALKEY_REPLY_MAP : VALKEY_REPLY_ARRAY));
         assert(reply->elements == 2);
         dbnum = atoi(reply->element[1]->str);
     }


### PR DESCRIPTION
The assertion fails in cluster manager mode, where the config doesn't apply. Fixes test failures when RESP3 is enforced and the cli runs in cluster mode.

fixes https://github.com/valkey-io/valkey/issues/2053