### PR TITLE
Fix variable scope confusion

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1900,8 +1900,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 return NULL;
             }
             dec = getDecodedObject(ele);
-            size_t len = sdslen(dec->ptr);
-            quicklistPushTail(o->ptr, dec->ptr, len);
+            quicklistPushTail(o->ptr, dec->ptr, sdslen(dec->ptr));
             decrRefCount(dec);
             decrRefCount(ele);
         }


### PR DESCRIPTION
Fix variable `len` scope confusion `declaration shadows a local variable`.
The variable len is defined at the very beginning, this change also saves
one line of code and makes the code more readable.