### PR TITLE
Update commandlog parameters conf text to mention special value settings

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -2073,6 +2073,7 @@ aof-timestamp-enabled no
 # The following time is expressed in microseconds, so 1000000 is equivalent to 1 second.
 # Note that -1 disables the slow log, while 0 forces logging of every command.
 commandlog-execution-slower-than 10000
+# Record the number of commands.
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the slow log with SLOWLOG RESET or COMMANDLOG RESET SLOW.
 commandlog-slow-execution-max-len 128
@@ -2084,8 +2085,11 @@ commandlog-slow-execution-max-len 128
 # bandwidth or query buffer space are recorded here.
 #
 # The threshold is measured in bytes.
+# Note that -1 disables the large request log, while 0 forces logging of every command.
 commandlog-request-larger-than 1048576
 # Record the number of commands.
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the large request log with COMMANDLOG RESET LARGE-REQUEST.
 commandlog-large-request-max-len 128
 #
 # LARGE_REPLY Command Logs
@@ -2094,8 +2098,12 @@ commandlog-large-request-max-len 128
 # like `KEYS` or `HGETALL` that return large datasets. Even a `GET` command may qualify if the value 
 # is substantial.
 #
-# The threshold is measured in bytes. 
+# The threshold is measured in bytes.
+# Note that -1 disables the large reply log, while 0 forces logging of every command.
 commandlog-reply-larger-than 1048576
+# Record the number of commands.
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the large reply log with COMMANDLOG RESET LARGE-REPLY.
 commandlog-large-reply-max-len 128
 
 ################################ LATENCY MONITOR ##############################

--- a/valkey.conf
+++ b/valkey.conf
@@ -2067,8 +2067,11 @@ aof-timestamp-enabled no
 #
 # The threshold is measured in microseconds.
 #
-# Backward Compatibility: The parameter `slowlog-log-slower-than` is still supported but 
-# deprecated in favor of `commandlog-slow-execution`.
+# Backward Compatibility: The parameters `slowlog-log-slower-than` and `slowlog-max-len`
+# are still supported but deprecated in favor of these commandlog parameters.
+#
+# The following time is expressed in microseconds, so 1000000 is equivalent to 1 second.
+# Note that -1 disables the slow log, while 0 forces logging of every command.
 commandlog-execution-slower-than 10000
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the slow log with SLOWLOG RESET or COMMANDLOG RESET SLOW.


### PR DESCRIPTION
Earlier we described the `slowlog-log-slower-than` configuration
option like this, we explicitly mentioned the special meaning of
negative numbers (actually -1) and 0.
```
The following time is expressed in microseconds, so 1000000 is equivalent
to one second. Note that a negative number disables the slow log, while
a value of zero forces the logging of every command.
slowlog-log-slower-than 10000
```

And after #1294 we lost this text, we need to mention these values,
we can mention the special number for all command log's configs,
also it seems we should also mention `slowlog-max-len`.