### PR TITLE
Redundant Calculation of mstime()

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1674,10 +1674,11 @@ int clusterNodeAddFailureReport(clusterNode *failing, clusterNode *sender) {
     /* If a failure report from the same sender already exists, just update
      * the timestamp. */
     listRewind(l, &li);
+    mstime_t now = mstime();
     while ((ln = listNext(&li)) != NULL) {
         fr = ln->value;
         if (fr->node == sender) {
-            fr->time = mstime();
+            fr->time = now;
             return 0;
         }
     }
@@ -1685,7 +1686,7 @@ int clusterNodeAddFailureReport(clusterNode *failing, clusterNode *sender) {
     /* Otherwise create a new report. */
     fr = zmalloc(sizeof(*fr));
     fr->node = sender;
-    fr->time = mstime();
+    fr->time = now;
     listAddNodeTail(l, fr);
     return 1;
 }


### PR DESCRIPTION
This changes removes the redundant calls to mstime() within a same function. I believe this value should not change over the loop and can be reused.

