### PR TITLE
Make test cases independent of each other in the moduleapi/scan suite

### DIFF
--- a/tests/unit/moduleapi/scan.tcl
+++ b/tests/unit/moduleapi/scan.tcl
@@ -39,9 +39,9 @@ start_server {tags {"modules"}} {
 
     test {Module scan zset skiplist} {
         r config set zset-max-ziplist-entries 2
-        r zadd zz 3 f3
-        assert_encoding skiplist zz
-        lsort [r scan.scan_key zz]
+        r zadd zz1 1 f1 2 f2 3 f3
+        assert_encoding skiplist zz1
+        lsort [r scan.scan_key zz1]
     } {{f1 1} {f2 2} {f3 3}}
 
     test {Module scan set intset} {
@@ -52,9 +52,9 @@ start_server {tags {"modules"}} {
 
     test {Module scan set dict} {
         r config set set-max-intset-entries 2
-        r sadd ss 3
-        assert_encoding hashtable ss
-        lsort [r scan.scan_key ss]
+        r sadd ssa 1 2 3
+        assert_encoding hashtable ssa
+        lsort [r scan.scan_key ssa]
     } {{1 {}} {2 {}} {3 {}}}
 
     test {Module scan set listpack} {

--- a/tests/unit/moduleapi/scan.tcl
+++ b/tests/unit/moduleapi/scan.tcl
@@ -52,7 +52,8 @@ start_server {tags {"modules"}} {
 
     test {Module scan set dict} {
         r config set set-max-intset-entries 2
-        r sadd ssa 1 2 3
+        r sadd ssa 1 2 ; # Created as intset
+        r sadd ssa 3   ; # Converted to hashtable
         assert_encoding hashtable ssa
         lsort [r scan.scan_key ssa]
     } {{1 {}} {2 {}} {3 {}}}

--- a/tests/unit/moduleapi/scan.tcl
+++ b/tests/unit/moduleapi/scan.tcl
@@ -45,12 +45,14 @@ start_server {tags {"modules"}} {
     } {{f1 1} {f2 2} {f3 3}}
 
     test {Module scan set intset} {
+        r del ss
         r sadd ss 1 2
         assert_encoding intset ss
         lsort [r scan.scan_key ss]
     } {{1 {}} {2 {}}}
 
     test {Module scan set dict} {
+        r del ssa
         r config set set-max-intset-entries 2
         r sadd ssa 1 2 ; # Created as intset
         r sadd ssa 3   ; # Converted to hashtable
@@ -59,6 +61,7 @@ start_server {tags {"modules"}} {
     } {{1 {}} {2 {}} {3 {}}}
 
     test {Module scan set listpack} {
+        r del ss1
         r sadd ss1 a b c
         assert_encoding listpack ss1
         lsort [r scan.scan_key ss1]

--- a/tests/unit/moduleapi/scan.tcl
+++ b/tests/unit/moduleapi/scan.tcl
@@ -26,9 +26,9 @@ start_server {tags {"modules"}} {
 
     test {Module scan hash dict} {
         r config set hash-max-ziplist-entries 2
-        r hmset hh f3 v3
-        assert_encoding hashtable hh
-        lsort [r scan.scan_key hh]
+        r hmset hh3 f1 v1 f2 v2 f3 v3
+        assert_encoding hashtable hh3
+        lsort [r scan.scan_key hh3]
     } {{f1 v1} {f2 v2} {f3 v3}}
 
     test {Module scan zset listpack} {


### PR DESCRIPTION
I try to running moduleapi test and this command may test failed:
```shell
./runtest-moduleapi --single "unit/moduleapi/scan" --only "Module scan hash dict"
```

I found that the test `Module scan hash dict` and `Module scan hash listpack` use the same key `hh`:
https://github.com/valkey-io/valkey/blob/41a93a2a77c1e5ce5c90d616f0fc14f406bfa87b/tests/unit/moduleapi/scan.tcl#L15-L19

https://github.com/valkey-io/valkey/blob/41a93a2a77c1e5ce5c90d616f0fc14f406bfa87b/tests/unit/moduleapi/scan.tcl#L27-L32

From what I’ve seen in other tests, when the same key is used, it’s typically deleted or reset to avoid side effects between tests.
Maybe we should adjust these tests to make them independent of each other?


