### PR TITLE
Optimize saving cluster config file using sdscatfmt

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -344,7 +344,7 @@ int auxHumanNodenameSetter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxHumanNodenameGetter(clusterNode *n, sds s) {
-    return sdscatfmt(s, "%s", n->human_nodename);
+    return sdscat(s, n->human_nodename);
 }
 
 int auxHumanNodenamePresent(clusterNode *n) {
@@ -370,7 +370,7 @@ int auxAnnounceClientIpV4Setter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxAnnounceClientIpV4Getter(clusterNode *n, sds s) {
-    return sdscatfmt(s, "%s", n->announce_client_ipv4);
+    return sdscat(s, n->announce_client_ipv4);
 }
 
 int auxAnnounceClientIpV4Present(clusterNode *n) {
@@ -396,7 +396,7 @@ int auxAnnounceClientIpV6Setter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxAnnounceClientIpV6Getter(clusterNode *n, sds s) {
-    return sdscatfmt(s, "%s", n->announce_client_ipv6);
+    return sdscat(s, n->announce_client_ipv6);
 }
 
 int auxAnnounceClientIpV6Present(clusterNode *n) {

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -327,7 +327,7 @@ int auxShardIdSetter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxShardIdGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%.40s", n->shard_id);
+    return sdscatlen(s, n->shard_id, CLUSTER_NAMELEN);
 }
 
 int auxShardIdPresent(clusterNode *n) {
@@ -344,7 +344,7 @@ int auxHumanNodenameSetter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxHumanNodenameGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%s", n->human_nodename);
+    return sdscatfmt(s, "%s", n->human_nodename);
 }
 
 int auxHumanNodenamePresent(clusterNode *n) {
@@ -370,7 +370,7 @@ int auxAnnounceClientIpV4Setter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxAnnounceClientIpV4Getter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%s", n->announce_client_ipv4);
+    return sdscatfmt(s, "%s", n->announce_client_ipv4);
 }
 
 int auxAnnounceClientIpV4Present(clusterNode *n) {
@@ -396,7 +396,7 @@ int auxAnnounceClientIpV6Setter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxAnnounceClientIpV6Getter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%s", n->announce_client_ipv6);
+    return sdscatfmt(s, "%s", n->announce_client_ipv6);
 }
 
 int auxAnnounceClientIpV6Present(clusterNode *n) {
@@ -415,7 +415,7 @@ int auxTcpPortSetter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxTcpPortGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%d", n->tcp_port);
+    return sdscatfmt(s, "%i", n->tcp_port);
 }
 
 int auxTcpPortPresent(clusterNode *n) {
@@ -434,7 +434,7 @@ int auxTlsPortSetter(clusterNode *n, void *value, size_t length) {
 }
 
 sds auxTlsPortGetter(clusterNode *n, sds s) {
-    return sdscatprintf(s, "%d", n->tls_port);
+    return sdscatfmt(s, "%i", n->tls_port);
 }
 
 int auxTlsPortPresent(clusterNode *n) {
@@ -6095,17 +6095,15 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
      * we are migrating to other instances or importing from other
      * instances. */
     if (node->flags & CLUSTER_NODE_MYSELF) {
-        char nodename[CLUSTER_NAMELEN + 1];
-
         for (j = 0; j < CLUSTER_SLOTS; j++) {
             if (server.cluster->migrating_slots_to[j]) {
-                memcpy(nodename, server.cluster->migrating_slots_to[j]->name, CLUSTER_NAMELEN);
-                nodename[CLUSTER_NAMELEN] = '\0';
-                ci = sdscatfmt(ci, " [%i->-%s]", j, nodename);
+                ci = sdscatfmt(ci, " [%i->-", j);
+                ci = sdscatlen(ci, server.cluster->migrating_slots_to[j]->name, CLUSTER_NAMELEN);
+                ci = sdscat(ci, "]");
             } else if (server.cluster->importing_slots_from[j]) {
-                memcpy(nodename, server.cluster->importing_slots_from[j]->name, CLUSTER_NAMELEN);
-                nodename[CLUSTER_NAMELEN] = '\0';
-                ci = sdscatfmt(ci, " [%i-<-%s]", j, nodename);
+                ci = sdscatfmt(ci, " [%i-<-", j);
+                ci = sdscatlen(ci, server.cluster->importing_slots_from[j]->name, CLUSTER_NAMELEN);
+                ci = sdscat(ci, "]");
             }
         }
     }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6045,7 +6045,7 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
                 continue;
             }
             if (auxFieldHandlers[i].isPresent(node)) {
-                ci = sdscatprintf(ci, ",%s=", auxFieldHandlers[i].field);
+                ci = sdscatfmt(ci, ",%s=", auxFieldHandlers[i].field);
                 ci = auxFieldHandlers[i].getter(node, ci);
             }
         }
@@ -6095,11 +6095,17 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
      * we are migrating to other instances or importing from other
      * instances. */
     if (node->flags & CLUSTER_NODE_MYSELF) {
+        char nodename[CLUSTER_NAMELEN + 1];
+
         for (j = 0; j < CLUSTER_SLOTS; j++) {
             if (server.cluster->migrating_slots_to[j]) {
-                ci = sdscatprintf(ci, " [%d->-%.40s]", j, server.cluster->migrating_slots_to[j]->name);
+                memcpy(nodename, server.cluster->migrating_slots_to[j]->name, CLUSTER_NAMELEN);
+                nodename[CLUSTER_NAMELEN] = '\0';
+                ci = sdscatfmt(ci, " [%i->-%s]", j, nodename);
             } else if (server.cluster->importing_slots_from[j]) {
-                ci = sdscatprintf(ci, " [%d-<-%.40s]", j, server.cluster->importing_slots_from[j]->name);
+                memcpy(nodename, server.cluster->importing_slots_from[j]->name, CLUSTER_NAMELEN);
+                nodename[CLUSTER_NAMELEN] = '\0';
+                ci = sdscatfmt(ci, " [%i-<-%s]", j, nodename);
             }
         }
     }


### PR DESCRIPTION
Replace `sdscatprintf` with the faster variant `sdscatfmt` in the code for generating the cluster config file. This optimization also affects CLUSTER NODES which uses the same code.

When the cluster topology changes, such as during failovers, the cluster config file is written and at the same time the nodes may experience extra load due to failovers, redirects, full sync, etc.

In the profiles I am capturing for large scale clusters, I am observing decent compute cycles being utilized by `sdscatprintf`

Profile:
<img width="596" alt="Screenshot 2025-05-14 at 2 57 51 PM" src="https://github.com/user-attachments/assets/376837ec-cc57-4e63-b310-9274b57b90d9" />

This profile was captured when the engine CPU utilization was more than 90% during multiple primary node failures.