### PR TITLE
Fix minor memory leak in valkey-cli when command table hint fails due to NOAUTH

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -432,7 +432,10 @@ static void cliLegacyIntegrateHelp(void) {
     if (cliConnect(CC_QUIET) == VALKEY_ERR) return;
 
     valkeyReply *reply = valkeyCommand(context, "COMMAND");
-    if (reply == NULL || reply->type != VALKEY_REPLY_ARRAY) return;
+    if (reply == NULL || reply->type != VALKEY_REPLY_ARRAY) {
+        freeReplyObject(reply);
+        return;
+    }
 
     /* Scan the array reported by COMMAND and fill only the entries that
      * don't already match what we have. */

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -879,4 +879,20 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
             assert_equal {PONG} [exec {*}$cmdline PING]
         }
     }
+
+    test "check whether valkey-cli memory leak when the server require auth" {
+        # enable auth of server
+        set fd [open_cli]
+        assert_equal "OK" [run_command $fd "CONFIG SET requirepass 12345"]
+
+        # Using another client to send a command (non-AUTH command), then closing the client
+        # Valgrind should not detect memory leaks
+        set fd_2 [open_cli]
+        run_command $fd_2 "ping"
+        close_cli $fd_2
+
+        # disable auth of server
+        assert_equal "OK" [run_command $fd "CONFIG SET requirepass \"\""]
+        close_cli $fd
+    }
 }

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -880,18 +880,17 @@ if {!$::tls} { ;# fake_redis_node doesn't support TLS
         }
     }
 
-    test "check whether valkey-cli memory leak when the server require auth" {
-        # enable auth of server
+    test "valkey-cli command table hint will not leak memory when COMMAND fails due to auth" {
+        # Enable auth of server.
         set fd [open_cli]
         assert_equal "OK" [run_command $fd "CONFIG SET requirepass 12345"]
 
-        # Using another client to send a command (non-AUTH command), then closing the client
-        # Valgrind should not detect memory leaks
-        set fd_2 [open_cli]
-        run_command $fd_2 "ping"
-        close_cli $fd_2
+        # Using another client to send a command (non-AUTH command), then closing the client.
+        set fd2 [open_cli]
+        assert_match "NOAUTH*" [run_command $fd2 "PING"]
+        close_cli $fd2
 
-        # disable auth of server
+        # Disable auth of server.
         assert_equal "OK" [run_command $fd "CONFIG SET requirepass \"\""]
         close_cli $fd
     }


### PR DESCRIPTION
Valkey-cli sends some commands when it connects, e.g. COMMAND and
COMMAND DOCS to init the command table hint. These return a NOAUTH
error when the client is unathenticated and there is a memory leak.

Close #2064.