### PR TITLE
Further improve performance of sdssplitargs

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -1143,7 +1143,8 @@ static int sdsparsearg(const char *arg, unsigned int *len, char *dst) {
  */
 sds *sdssplitargs(const char *line, int *argc) {
     const char *p = line;
-    char **vector = NULL;
+    size_t cap = 0;
+    sds *vector = NULL;
 
     *argc = 0;
     while (*p) {
@@ -1158,9 +1159,11 @@ sds *sdssplitargs(const char *line, int *argc) {
             p += parsedlen;
 
             /* add the token to the vector */
-            vector = s_realloc(vector, ((*argc) + 1) * sizeof(char *));
-            vector[*argc] = current;
-            (*argc)++;
+            if ((size_t)*argc == cap) {
+                cap = cap == 0 ? 8 : (cap * 2);
+                vector = s_realloc(vector, sizeof(sds) * cap);
+            }
+            vector[(*argc)++] = current;
             current = NULL;
         } else {
             while ((*argc)--) sdsfree(vector[*argc]);


### PR DESCRIPTION
This reduces the amount of `s_realloc` calls we do for multi-argument inline commands by pre-allocating enough for 8 arguments and doubling the capacity when growing instead of increasing the size linearly:

![image](https://github.com/user-attachments/assets/3ae48068-fcbd-4bde-bf5a-f21598ab2452)
