### PR TITLE
Allow mixing quoted and unquoted inline args

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -1068,10 +1068,7 @@ static int sdsparsearg(const char *arg, unsigned int *len, char *dst) {
                 default: new_char = *p; break;
                 }
             } else if (*p == '"') {
-                /* closing quote must be followed by a space or
-                 * nothing at all. */
-                if (*(p + 1) && !isspace(*(p + 1))) return 0;
-                done = 1;
+                inq = 0;
             } else if (!*p) {
                 /* unterminated quotes */
                 return 0;
@@ -1083,10 +1080,7 @@ static int sdsparsearg(const char *arg, unsigned int *len, char *dst) {
                 p++;
                 new_char = *p;
             } else if (*p == '\'') {
-                /* closing quote must be followed by a space or
-                 * nothing at all. */
-                if (*(p + 1) && !isspace(*(p + 1))) return 0;
-                done = 1;
+                insq = 0;
             } else if (!*p) {
                 /* unterminated quotes */
                 return 0;

--- a/src/unit/test_sds.c
+++ b/src/unit/test_sds.c
@@ -380,10 +380,10 @@ int test_sdssplitargs(int argc, char **argv, int flags) {
     TEST_ASSERT(!strcmp("", sargv[2]));
     sdsfreesplitres(sargv, len);
 
-    sargv = sdssplitargs("\"deeply\\\"quoted\" string", &len);
+    sargv = sdssplitargs("\"deeply\\\"quoted\" 's\\'t\\\"r'ing", &len);
     TEST_ASSERT(2 == len);
     TEST_ASSERT(!strcmp("deeply\"quoted", sargv[0]));
-    TEST_ASSERT(!strcmp("string", sargv[1]));
+    TEST_ASSERT(!strcmp("s't\\\"ring", sargv[1]));
     sdsfreesplitres(sargv, len);
 
     sargv = sdssplitargs("unquoted\" \"with' 'quotes string", &len);

--- a/src/unit/test_sds.c
+++ b/src/unit/test_sds.c
@@ -351,7 +351,7 @@ int test_sdssplitargs(int argc, char **argv, int flags) {
     TEST_ASSERT(sargv != NULL);
     sdsfreesplitres(sargv, len);
 
-    sargv = sdssplitargs("\"Testing split strings\" \'Another split string\'", &len);
+    sargv = sdssplitargs("\"Testing split strings\" 'Another split string'", &len);
     TEST_ASSERT(2 == len);
     TEST_ASSERT(!strcmp("Testing split strings", sargv[0]));
     TEST_ASSERT(!strcmp("Another split string", sargv[1]));
@@ -365,8 +365,51 @@ int test_sdssplitargs(int argc, char **argv, int flags) {
     char *binary_string = "\"\\x73\\x75\\x70\\x65\\x72\\x20\\x00\\x73\\x65\\x63\\x72\\x65\\x74\\x20\\x70\\x61\\x73\\x73\\x77\\x6f\\x72\\x64\"";
     sargv = sdssplitargs(binary_string, &len);
     TEST_ASSERT(1 == len);
-    TEST_ASSERT(22 == sdslen(sargv[0]));
+    TEST_ASSERT(!strcmp("super \x00secret password", sargv[0]));
     sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("unquoted", &len);
+    TEST_ASSERT(1 == len);
+    TEST_ASSERT(!strcmp("unquoted", sargv[0]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("empty string \"\"", &len);
+    TEST_ASSERT(3 == len);
+    TEST_ASSERT(!strcmp("empty", sargv[0]));
+    TEST_ASSERT(!strcmp("string", sargv[1]));
+    TEST_ASSERT(!strcmp("", sargv[2]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("\"deeply\\\"quoted\" string", &len);
+    TEST_ASSERT(2 == len);
+    TEST_ASSERT(!strcmp("deeply\"quoted", sargv[0]));
+    TEST_ASSERT(!strcmp("string", sargv[1]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("unquoted\" \"with' 'quotes string", &len);
+    TEST_ASSERT(2 == len);
+    TEST_ASSERT(!strcmp("unquoted with quotes", sargv[0]));
+    TEST_ASSERT(!strcmp("string", sargv[1]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("\"quoted\"' another 'quoted string", &len);
+    TEST_ASSERT(2 == len);
+    TEST_ASSERT(!strcmp("quoted another quoted", sargv[0]));
+    TEST_ASSERT(!strcmp("string", sargv[1]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("\"shell-like \"'\"'\"'\"' quote-escaping '", &len);
+    TEST_ASSERT(1 == len);
+    TEST_ASSERT(!strcmp("shell-like \"' quote-escaping ", sargv[0]));
+    sdsfreesplitres(sargv, len);
+
+    sargv = sdssplitargs("\"unterminated \"'single quotes", &len);
+    TEST_ASSERT(0 == len);
+    TEST_ASSERT(sargv == NULL);
+
+    sargv = sdssplitargs("'unterminated '\"double quotes", &len);
+    TEST_ASSERT(0 == len);
+    TEST_ASSERT(sargv == NULL);
 
     return 0;
 }

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -184,12 +184,7 @@ start_server {tags {"cli logreqres:skip"}} {
         assert_equal "\"bar\"" [r get key]
         assert_equal "OK" [run_command $fd "set key \"\tbar\t\""]
         assert_equal "\tbar\t" [r get key]
-
-        # invalid quotation
-        assert_equal "Invalid argument(s)" [run_command $fd "get \"\"key"]
-        assert_equal "Invalid argument(s)" [run_command $fd "get \"key\"x"]
-
-        # quotes after the argument are weird, but should be allowed
+        assert_equal "\"\\tbar\\t\"" [run_command $fd "get \"\"k'e'\"y\""]
         assert_equal "OK" [run_command $fd "set key\"\" bar"]
         assert_equal "bar" [r get key]
     }

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -69,6 +69,22 @@ start_server {tags {"protocol network"}} {
         assert_equal "test-value" [r read]
     }
 
+    test "Unbalanced single quotes" {
+        reconnect
+        r write "set foo 'b'a'r\r\n"
+        r write "ping\r\n"
+        r flush
+        assert_error "*unbalanced*" {r read}
+    }
+
+    test "Unbalanced double quotes" {
+        reconnect
+        r write "set foo \"b\"a\"r\r\n"
+        r write "ping\r\n"
+        r flush
+        assert_error "*unbalanced*" {r read}
+    }
+
     set c 0
     foreach seq [list "\x00" "*\x00" "$\x00" "*1\r\n$\x00"] {
         incr c

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -60,12 +60,13 @@ start_server {tags {"protocol network"}} {
         assert_error "*wrong*arguments*ping*" {r ping x y z}
     }
 
-    test "Unbalanced number of quotes" {
+    test "Mixing quoted and unquoted strings" {
         reconnect
-        r write "set \"\"\"test-key\"\"\" test-value\r\n"
-        r write "ping\r\n"
+        r write "set \"\"\"tes\"t-'k'e\"y\" \"test\"'-'value\r\n"
+        r write "get test'-'key\r\n"
         r flush
-        assert_error "*unbalanced*" {r read}
+        assert_equal "OK" [r read]
+        assert_equal "test-value" [r read]
     }
 
     set c 0


### PR DESCRIPTION
Fix an inconsistency of `sdssplitargs` where `foo""` is allowed but `""foo` is rejected.

This patch loosens up the parsing to allow mixing quoted and unquoted text within the same argument, similar to how shell syntax works, allowing the use of `"foo"bar'baz'zzz` to produce a single argument of `"foobarbazzzz"`.

This is a backward compatible change. It affects the inline protocol, the arguments to valkey-cli and the parsing of config files.