### PR TITLE
Optimize string2ll with load-time CPU feature check using IFUNC resolver

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -391,4 +391,12 @@ void setcpuaffinity(const char *cpulist);
 #define ATTRIBUTE_TARGET_AVX512
 #endif
 
+#if defined(__linux__) &&                                                               \
+    ((defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))) || \
+     (defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4))))
+#define HAVE_IFUNC 1
+#else
+#define HAVE_IFUNC 0
+#endif
+
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -391,7 +391,7 @@ void setcpuaffinity(const char *cpulist);
 #define ATTRIBUTE_TARGET_AVX512
 #endif
 
-#if defined(__linux__) && defined(__GNUC__) && __GNUC__ > 4
+#if defined(__linux__) && (defined(__GNUC__) && (__GNUC__ > 4) || defined(__clang__) && (__clang_major__) > 5)
 #define HAVE_IFUNC 1
 #else
 #define HAVE_IFUNC 0

--- a/src/config.h
+++ b/src/config.h
@@ -391,9 +391,7 @@ void setcpuaffinity(const char *cpulist);
 #define ATTRIBUTE_TARGET_AVX512
 #endif
 
-#if defined(__linux__) &&                                                               \
-    ((defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))) || \
-     (defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4))))
+#if defined(__linux__) && defined(__GNUC__) && __GNUC__ > 4
 #define HAVE_IFUNC 1
 #else
 #define HAVE_IFUNC 0

--- a/src/util.c
+++ b/src/util.c
@@ -57,7 +57,6 @@
 
 #if HAVE_X86_SIMD
 #include <immintrin.h>
-#include <cpuid.h>
 #endif
 
 #define UNUSED(x) ((void)(x))
@@ -626,55 +625,18 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-/* This function detects if the CPU supports the AVX-512 instruction set extensions
- * required.
- *
- * Execution timing:
- * - Called ONCE at program load time by the dynamic linker
- * - Executes before main() during the IFUNC resolution phase
- * - Not called during normal program execution, eliminating runtime overhead
- *
- * Note on implementation choice:
- * We use direct CPUID calls instead of __builtin_cpu_supports() because:
- * 1. IFUNC resolvers run before C runtime initialization
- * 2. __builtin_cpu_supports() relies on runtime initialization
- * 3. This approach ensures correct feature detection at load time
- * */
-static int cpu_has_avx512_features(void) {
-    unsigned int eax, ebx, ecx, edx;
-    unsigned int max_level;
-
-    /* Get the maximum supported CPUID level,
-     * checks if the CPU supports CPUID leaf 7,
-     * which is where AVX-512 features are reported. */
-    max_level = __get_cpuid_max(0, NULL);
-    if (max_level < 7) {
-        return 0; /* CPUID leaf 7 not supported, return 0. */
-    }
-
-    /* Call CPUID with leaf 7, subleaf 0 to get advanced feature flags */
-    if (!__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
-        return 0; /* CPUID failed */
-    }
-
-    /* The AVX-512 feature bits are in the EBX register.*/
-    int has_avx512f = (ebx & bit_AVX512F) != 0;
-    int has_avx512vl = (ebx & bit_AVX512VL) != 0;
-    int has_avx512bw = (ebx & bit_AVX512BW) != 0;
-    return has_avx512f && has_avx512vl && has_avx512bw;
-}
-
-static int (*string2ll_ifunc(void))(const char *, size_t, long long *) {
-    if (cpu_has_avx512_features()) {
+static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+    __builtin_cpu_init();
+    if (__builtin_cpu_supports("avx512f") &&
+        __builtin_cpu_supports("avx512vl") &&
+        __builtin_cpu_supports("avx512bw"))
         return string2llAVX512;
-    }
     return string2llScalar;
 }
 
 int string2ll(const char *s, size_t slen, long long *value)
-    __attribute__((ifunc("string2ll_ifunc")));
+    __attribute__((ifunc("string2ll_resolver")));
 #else
-/* Fallback for platforms without IFUNC support */
 int string2ll(const char *s, size_t slen, long long *value) {
 #if HAVE_X86_SIMD
     if (__builtin_cpu_supports("avx512f") &&
@@ -684,7 +646,7 @@ int string2ll(const char *s, size_t slen, long long *value) {
 #endif
     return string2llScalar(s, slen, value);
 }
-#endif
+#endif /* HAVE_IFUNC && HAVE_X86_SIMD */
 
 /* Helper function to convert a string to an unsigned long long value.
  * The function attempts to use the faster string2ll() function inside

--- a/src/util.c
+++ b/src/util.c
@@ -625,7 +625,7 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+__attribute__((no_sanitize_address)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     __builtin_cpu_init();
     if (__builtin_cpu_supports("avx512f") &&
         __builtin_cpu_supports("avx512vl") &&

--- a/src/util.c
+++ b/src/util.c
@@ -626,6 +626,8 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
 __attribute__((no_sanitize_address)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+    /* Ifunc resolvers run before ASan initialization and before CPU detection
+     * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();
     if (__builtin_cpu_supports("avx512f") &&
         __builtin_cpu_supports("avx512vl") &&

--- a/src/util.c
+++ b/src/util.c
@@ -55,6 +55,11 @@
 
 #include "valkey_strtod.h"
 
+#if HAVE_X86_SIMD
+#include <immintrin.h>
+#include <cpuid.h>
+#endif
+
 #define UNUSED(x) ((void)(x))
 
 /* Glob-style pattern matching. */
@@ -416,7 +421,6 @@ err:
 }
 
 #if HAVE_X86_SIMD
-#include <immintrin.h>
 
 #define MULTIPLIER_10E8 100000000
 #define MULTIPLIER_10E16 10000000000000000ULL
@@ -457,7 +461,7 @@ err:
  * Output: *value = 1234567890
  */
 ATTRIBUTE_TARGET_AVX512
-static int string2llAVX512(const char *s, unsigned long slen, long long *value) {
+static int string2llAVX512(const char *s, size_t slen, long long *value) {
     const char *p = s;
     unsigned long plen = 0;
     int negative = 0;
@@ -621,6 +625,56 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
     return 1;
 }
 
+#if HAVE_IFUNC && HAVE_X86_SIMD
+/* This function detects if the CPU supports the AVX-512 instruction set extensions
+ * required.
+ *
+ * Execution timing:
+ * - Called ONCE at program load time by the dynamic linker
+ * - Executes before main() during the IFUNC resolution phase
+ * - Not called during normal program execution, eliminating runtime overhead
+ *
+ * Note on implementation choice:
+ * We use direct CPUID calls instead of __builtin_cpu_supports() because:
+ * 1. IFUNC resolvers run before C runtime initialization
+ * 2. __builtin_cpu_supports() relies on runtime initialization
+ * 3. This approach ensures correct feature detection at load time
+ * */
+static int cpu_has_avx512_features(void) {
+    unsigned int eax, ebx, ecx, edx;
+    unsigned int max_level;
+
+    /* Get the maximum supported CPUID level,
+     * checks if the CPU supports CPUID leaf 7,
+     * which is where AVX-512 features are reported. */
+    max_level = __get_cpuid_max(0, NULL);
+    if (max_level < 7) {
+        return 0; /* CPUID leaf 7 not supported, return 0. */
+    }
+
+    /* Call CPUID with leaf 7, subleaf 0 to get advanced feature flags */
+    if (!__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+        return 0; /* CPUID failed */
+    }
+
+    /* The AVX-512 feature bits are in the EBX register.*/
+    int has_avx512f = (ebx & bit_AVX512F) != 0;
+    int has_avx512vl = (ebx & bit_AVX512VL) != 0;
+    int has_avx512bw = (ebx & bit_AVX512BW) != 0;
+    return has_avx512f && has_avx512vl && has_avx512bw;
+}
+
+static int (*string2ll_ifunc(void))(const char *, size_t, long long *) {
+    if (cpu_has_avx512_features()) {
+        return string2llAVX512;
+    }
+    return string2llScalar;
+}
+
+int string2ll(const char *s, size_t slen, long long *value)
+    __attribute__((ifunc("string2ll_ifunc")));
+#else
+/* Fallback for platforms without IFUNC support */
 int string2ll(const char *s, size_t slen, long long *value) {
 #if HAVE_X86_SIMD
     if (__builtin_cpu_supports("avx512f") &&
@@ -630,6 +684,7 @@ int string2ll(const char *s, size_t slen, long long *value) {
 #endif
     return string2llScalar(s, slen, value);
 }
+#endif
 
 /* Helper function to convert a string to an unsigned long long value.
  * The function attempts to use the faster string2ll() function inside


### PR DESCRIPTION
### Problem Statement

As we increasingly incorporate SIMD instructions to optimize performance-critical functions, our current runtime CPU feature detection pattern is introducing significant overhead. For example, in the **string2ll** function, the feature detection wrapper adds approximately 3.35% performance overhead (shown as Fig 1), which is very significant especially considering the AVX-optimized implementation itself is highly effective.

Current pattern:
```c
int string2ll(const char *s, size_t slen, long long *value) {
#if HAVE_X86_SIMD
    if (__builtin_cpu_supports("avx512f") &&
        __builtin_cpu_supports("avx512vl") &&
        __builtin_cpu_supports("avx512bw"))
        return string2llAVX512(s, slen, value);
#endif
    return string2llScalar(s, slen, value);
}
``` 
![image](https://github.com/user-attachments/assets/16508faa-cc7d-4437-9de3-09c58522026e)

Fig 1. Profiling of [memtier_benchmark-1key-list-10K-elements-lpos-integer](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-integer.yml)

### Proposed Solution

This PR implements the **GNU IFUNC** (indirect function) mechanism, which resolves the optimal function implementation at program load time rather than checking CPU features during each function call. This approach eliminates repeated detection overhead in hot code paths.

#### Benefits

1. **Performance Improvement**: Eliminates feature detection overhead (~3.35% for string2ll)
2. **One-time Detection**: CPU capabilities are checked once at load time
3. **Zero Runtime Overhead**: No conditionals in the call path
4.  **Maintainability**: Cleaner code without conditional branches

### Performance Boost

The example test suite we can observe a ~3% performance improvement. 
|Benchmark|Performance Boost|
|-|-|
|[memtier_benchmark-1key-list-10K-elements-lpos-integer](https://github.com/redis/redis-benchmarks-specification/blob/main/redis_benchmarks_specification/test-suites/memtier_benchmark-1key-list-10K-elements-lpos-integer.yml)|**3%**|

#### Test Env
- OS: CentOS Stream 9
- Platform: Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz
- Server and Client in same socket

#### Valkey-server configuration
```
taskset -c 0 ~/valkey/src/valkey-server ~/tmp_valkey.conf
port 9001
bind * -::*
daemonize no
protected-mode no
save
```


