### PR TITLE
Fix unsigned difference expression compared to zero

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -883,7 +883,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * - It has enough room already allocated
      * - And not too large (avoid large memmove)
      * - And the client is not in a pending I/O state */
-    if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->size - prev->used > 0 &&
+    if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->used < prev->size &&
         c->io_write_state != CLIENT_PENDING_IO) {
         size_t len_to_copy = prev->size - prev->used;
         if (len_to_copy > length) len_to_copy = length;


### PR DESCRIPTION
https://github.com/valkey-io/valkey/blob/daea05b1e26db29bfd1c033e27f9d519a2f8ccbb/src/networking.c#L886-L886

Fix the issue need to ensure that the subtraction `prev->size - prev->used` does not underflow. This can be achieved by explicitly checking that `prev->used` is less than `prev->size` before performing the subtraction. This approach avoids relying on unsigned arithmetic and ensures the logic is clear and robust.

The specific changes are:
1. Replace the condition `prev->size - prev->used > 0` with `prev->used < prev->size`.
2. This change ensures that the logic checks whether there is remaining space in the buffer without risking underflow.

**References**
[INT02-C. Understand integer conversion rules](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules)
[CWE-191](https://cwe.mitre.org/data/definitions/191.html)


---


