### PR TITLE
Remove unused calculation

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -406,7 +406,7 @@ robj *dupStringObject(const robj *o) {
         d->encoding = OBJ_ENCODING_INT;
         d->ptr = o->ptr;
         return d;
-    default: serverPanic("Wrong encoding."); break;
+    default: serverPanic("Wrong encoding.");
     }
 }
 
@@ -564,7 +564,7 @@ void decrRefCount(robj *o) {
             case OBJ_HASH: freeHashObject(o); break;
             case OBJ_MODULE: freeModuleObject(o); break;
             case OBJ_STREAM: freeStreamObject(o); break;
-            default: serverPanic("Unknown object type"); break;
+            default: serverPanic("Unknown object type");
             }
         }
         zfree(o);

--- a/src/object.c
+++ b/src/object.c
@@ -256,7 +256,7 @@ sds objectGetKey(const robj *val) {
 
 long long objectGetExpire(const robj *val) {
     if (val->hasexpire) {
-        unsigned char *data = (void *) (val + 1);
+        unsigned char *data = (void *)(val + 1);
         return *(long long *)data;
     } else {
         return -1;

--- a/src/object.c
+++ b/src/object.c
@@ -80,7 +80,6 @@ robj *createObjectWithKeyAndExpire(int type, void *ptr, const sds key, long long
      * don't need it now. Then we don't need to realloc if it's needed later. */
     if (has_embkey && !has_expire && bufsize >= min_size + sizeof(long long)) {
         has_expire = 1;
-        min_size += sizeof(long long);
     }
     o->hasexpire = has_expire;
 
@@ -176,7 +175,6 @@ static robj *createEmbeddedStringObjectWithKeyAndExpire(const char *val_ptr,
      * don't need it now. Then we don't need to realloc if it's needed later. */
     if (!o->hasexpire && bufsize >= min_size + sizeof(long long)) {
         o->hasexpire = 1;
-        min_size += sizeof(long long);
     }
 
     /* The memory after the struct where we embedded data. */
@@ -257,8 +255,8 @@ sds objectGetKey(const robj *val) {
 }
 
 long long objectGetExpire(const robj *val) {
-    unsigned char *data = (void *)(val + 1);
     if (val->hasexpire) {
+        unsigned char *data = (void *) (val + 1);
         return *(long long *)data;
     } else {
         return -1;


### PR DESCRIPTION

This PR cleans up some unused or redundant code in `object.c`.
1. Since `min_size` is a local variable that’s not used or returned, there’s no need to update it again.
2. Remove unreachable `break` after `serverPanic` in default case
3. Refactor `objectGetExpire` to avoid unnecessary pointer initialization

