### PR TITLE
Fix a case of out of bound read when cluster node ID is provided with wrong length in CLUSTER FORGET

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7131,7 +7131,10 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER FORGET <NODE ID> */
         clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
         if (!n) {
-            if (clusterBlacklistExists((char *)c->argv[2]->ptr))
+            if (sdslen(c->argv[2]->ptr) != CLUSTER_NAMELEN) {
+                /* Sanity check for the provided node ID length*/
+                addReplyErrorFormat(c, "Bad node name %s", (char *)c->argv[2]->ptr);
+            } else if (clusterBlacklistExists((char *)c->argv[2]->ptr))
                 /* Already forgotten. The deletion may have been gossipped by
                  * another node, so we pretend it succeeded. */
                 addReply(c, shared.ok);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2145,14 +2145,10 @@ void clusterBlacklistAddNode(clusterNode *node) {
  * You don't need to pass an sds string here, any pointer to 40 bytes
  * will work. */
 int clusterBlacklistExists(char *nodeid, size_t len) {
-    clusterBlacklistCleanup();
-
-    /* Sanity check. In case the provided node ID length is wrong we can bail early. */
-    if (len != CLUSTER_NAMELEN)
-        return 0;
-
-    sds id = sdsnewlen(nodeid, CLUSTER_NAMELEN);
+    sds id = sdsnewlen(nodeid, len);
     int retval;
+
+    clusterBlacklistCleanup();
 
     retval = dictFind(server.cluster->nodes_black_list, id) != NULL;
     sdsfree(id);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2144,11 +2144,16 @@ void clusterBlacklistAddNode(clusterNode *node) {
 /* Return non-zero if the specified node ID exists in the blacklist.
  * You don't need to pass an sds string here, any pointer to 40 bytes
  * will work. */
-int clusterBlacklistExists(char *nodeid) {
+int clusterBlacklistExists(char *nodeid, size_t len) {
+    clusterBlacklistCleanup();
+
+    /* Sanity check. In case the provided node ID length is wrong we can bail early. */
+    if (len != CLUSTER_NAMELEN)
+        return 0;
+
     sds id = sdsnewlen(nodeid, CLUSTER_NAMELEN);
     int retval;
 
-    clusterBlacklistCleanup();
     retval = dictFind(server.cluster->nodes_black_list, id) != NULL;
     sdsfree(id);
     return retval;
@@ -2484,7 +2489,7 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
              * Note that we require that the sender of this gossip message
              * is a well known node in our cluster, otherwise we risk
              * joining another cluster. */
-            if (sender && !(flags & CLUSTER_NODE_NOADDR) && !clusterBlacklistExists(g->nodename)) {
+            if (sender && !(flags & CLUSTER_NODE_NOADDR) && !clusterBlacklistExists(g->nodename, CLUSTER_NAMELEN)) {
                 clusterNode *node;
                 node = createClusterNode(g->nodename, flags);
                 memcpy(node->ip, g->ip, NET_IP_STR_LEN);
@@ -7131,10 +7136,7 @@ int clusterCommandSpecial(client *c) {
         /* CLUSTER FORGET <NODE ID> */
         clusterNode *n = clusterLookupNode(c->argv[2]->ptr, sdslen(c->argv[2]->ptr));
         if (!n) {
-            if (sdslen(c->argv[2]->ptr) != CLUSTER_NAMELEN) {
-                /* Sanity check for the provided node ID length*/
-                addReplyErrorFormat(c, "Bad node name %s", (char *)c->argv[2]->ptr);
-            } else if (clusterBlacklistExists((char *)c->argv[2]->ptr))
+            if (clusterBlacklistExists((char *)c->argv[2]->ptr, sdslen(c->argv[2]->ptr)))
                 /* Already forgotten. The deletion may have been gossipped by
                  * another node, so we pretend it succeeded. */
                 addReply(c, shared.ok);

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -552,10 +552,10 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
         }
     } {} {needs:debug}
 
-    test "CLUSTER FORGET with invalid node ID skips blacklist check" {
+    test "CLUSTER FORGET with invalid node ID" {
          catch {r cluster forget 1} err
          set _ $err
-    } {*ERR Bad node name*} 
+    } {*ERR Unknown node*} 
 }
 
 start_server {tags {"other external:skip"}} {

--- a/tests/unit/other.tcl
+++ b/tests/unit/other.tcl
@@ -551,6 +551,11 @@ start_cluster 1 0 {tags {"other external:skip cluster slow"}} {
             fail "hash tables weren't resize."
         }
     } {} {needs:debug}
+
+    test "CLUSTER FORGET with invalid node ID skips blacklist check" {
+         catch {r cluster forget 1} err
+         set _ $err
+    } {*ERR Bad node name*} 
 }
 
 start_server {tags {"other external:skip"}} {


### PR DESCRIPTION

In case we issue a cluster forget with a node ID which has a smaller length than 40 bytes, we can read over the allocated string when checking the blacklist.

This will mainly impact memory inspection codes and should not introduce any real bug.

Example:

```
==30858==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000024e3a at pc 0x7f9b9fe7821a bp 0x7ffeb5712980 sp 0x7ffeb5712128
READ of size 40 at 0x603000024e3a thread T0
```