### PR TITLE
Only mark the client reprocessing flag when unblocked on keys

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -403,7 +403,7 @@ void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeo
 
     initClientBlockingState(c);
 
-    if (!c->flag.reprocessing_command) {
+    if (!c->flag.reexecuting_command) {
         /* If the client is re-processing the command, we do not set the timeout
          * because we need to retain the client's original timeout. */
         c->bstate->timeout = timeout;
@@ -680,7 +680,7 @@ static void unblockClientOnKey(client *c, robj *key) {
      * we need to re process the command again */
     if (c->flag.pending_command) {
         c->flag.pending_command = 0;
-        c->flag.reprocessing_command = 1;
+        c->flag.reexecuting_command = 1;
         /* We want the command processing and the unblock handler (see RM_Call 'K' option)
          * to run atomically, this is why we must enter the execution unit here before
          * running the command, and exit the execution unit after calling the unblock handler (if exists).
@@ -700,7 +700,7 @@ static void unblockClientOnKey(client *c, robj *key) {
         exitExecutionUnit();
         afterCommand(c);
         /* Clear the reprocessing_command flag after the proc is executed. */
-        c->flag.reprocessing_command = 0;
+        c->flag.reexecuting_command = 0;
         server.current_client = old_client;
     }
 }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -699,6 +699,8 @@ static void unblockClientOnKey(client *c, robj *key) {
         }
         exitExecutionUnit();
         afterCommand(c);
+        /* Clear the reprocessing_command flag after the proc is executed. */
+        c->flag.reprocessing_command = 0;
         server.current_client = old_client;
     }
 }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -680,6 +680,7 @@ static void unblockClientOnKey(client *c, robj *key) {
      * we need to re process the command again */
     if (c->flag.pending_command) {
         c->flag.pending_command = 0;
+        c->flag.reprocessing_command = 1;
         /* We want the command processing and the unblock handler (see RM_Call 'K' option)
          * to run atomically, this is why we must enter the execution unit here before
          * running the command, and exit the execution unit after calling the unblock handler (if exists).

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -699,7 +699,7 @@ static void unblockClientOnKey(client *c, robj *key) {
         }
         exitExecutionUnit();
         afterCommand(c);
-        /* Clear the reprocessing_command flag after the proc is executed. */
+        /* Clear the reexecuting_command flag after the proc is executed. */
         c->flag.reexecuting_command = 0;
         server.current_client = old_client;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -4024,7 +4024,7 @@ int processCommand(client *c) {
 
     /* in case we are starting to ProcessCommand and we already have a command we assume
      * this is a reprocessing of this command, so we do not want to perform some of the actions again. */
-    int client_reprocessing_command = c->flag.reprocessing_command ? 1 : 0;
+    int client_reprocessing_command = c->cmd ? 1 : 0;
 
     /* only run command filter if not reprocessing command */
     if (!client_reprocessing_command) {

--- a/src/server.c
+++ b/src/server.c
@@ -4026,7 +4026,7 @@ int processCommand(client *c) {
 
     /* in case we are starting to ProcessCommand and we already have a command we assume
      * this is a reprocessing of this command, so we do not want to perform some of the actions again. */
-    int client_reprocessing_command = c->flag.reprocessing_command;
+    int client_reprocessing_command = c->flag.reprocessing_command ? 1 : 0;
     /* we should clear this flag, since it is possible the processing will bail out due to some error
      * and we do not want to keep this flag on for the next commands */
     c->flag.reprocessing_command = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -3733,8 +3733,6 @@ void call(client *c, int flags) {
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
     if (!c->flag.blocked) c->flag.executing_command = 0;
-    /* Clear the reprocessing_command flag after the proc is executed. */
-    c->flag.reprocessing_command = 0;
 
     /* In order to avoid performance implication due to querying the clock using a system call 3 times,
      * we use a monotonic clock, when we are sure its cost is very low, and fall back to non-monotonic call otherwise. */

--- a/src/server.c
+++ b/src/server.c
@@ -3732,10 +3732,8 @@ void call(client *c, int flags) {
 
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
-    if (!c->flag.blocked) {
-        c->flag.executing_command = 0;
-    }
-    /* Clear the CLIENT_REPROCESSING_COMMAND flag after the proc is executed. */
+    if (!c->flag.blocked) c->flag.executing_command = 0;
+    /* Clear the reprocessing_command flag after the proc is executed. */
     c->flag.reprocessing_command = 0;
 
     /* In order to avoid performance implication due to querying the clock using a system call 3 times,

--- a/src/server.c
+++ b/src/server.c
@@ -3691,7 +3691,7 @@ void call(client *c, int flags) {
      * and a client which is reprocessing command again (after being unblocked).
      * Blocked clients can be blocked in different places and not always it means the call() function has been
      * called. For example this is required for avoiding double logging to monitors.*/
-    int reprocessing_command = flags & CMD_CALL_REPROCESSING;
+    int reprocessing_command = c->flag.reprocessing_command ? 1 : 0;
 
     /* Initialization: clear the flags that must be set by the command on
      * demand, and initialize the array for additional commands propagation. */
@@ -3722,24 +3722,21 @@ void call(client *c, int flags) {
 
     c->flag.buffered_reply = 0;
     c->flag.keyspace_notified = 0;
-    /* Setting the CLIENT_REPROCESSING_COMMAND flag so that during the actual
-     * processing of the command proc, the client is aware that it is being
-     * re-processed. */
-    if (reprocessing_command) c->flag.reprocessing_command = 1;
 
     monotime monotonic_start = 0;
     if (monotonicGetType() == MONOTONIC_CLOCK_HW) monotonic_start = getMonotonicUs();
 
     c->cmd->proc(c);
 
-    /* Clear the CLIENT_REPROCESSING_COMMAND flag after the proc is executed. */
-    if (reprocessing_command) c->flag.reprocessing_command = 0;
-
     exitExecutionUnit();
 
     /* In case client is blocked after trying to execute the command,
      * it means the execution is not yet completed and we MIGHT reprocess the command in the future. */
-    if (!c->flag.blocked) c->flag.executing_command = 0;
+    if (!c->flag.blocked) {
+        c->flag.executing_command = 0;
+    }
+    /* Clear the CLIENT_REPROCESSING_COMMAND flag after the proc is executed. */
+    c->flag.reprocessing_command = 0;
 
     /* In order to avoid performance implication due to querying the clock using a system call 3 times,
      * we use a monotonic clock, when we are sure its cost is very low, and fall back to non-monotonic call otherwise. */
@@ -4031,7 +4028,10 @@ int processCommand(client *c) {
 
     /* in case we are starting to ProcessCommand and we already have a command we assume
      * this is a reprocessing of this command, so we do not want to perform some of the actions again. */
-    int client_reprocessing_command = c->cmd ? 1 : 0;
+    int client_reprocessing_command = c->flag.reprocessing_command;
+    /* we should clear this flag, since it is possible the processing will bail out due to some error
+     * and we do not want to keep this flag on for the next commands */
+    c->flag.reprocessing_command = 0;
 
     /* only run command filter if not reprocessing command */
     if (!client_reprocessing_command) {
@@ -4355,7 +4355,9 @@ int processCommand(client *c) {
         addReply(c, shared.queued);
     } else {
         int flags = CMD_CALL_FULL;
-        if (client_reprocessing_command) flags |= CMD_CALL_REPROCESSING;
+        /* we should re-tag the client as reprocessing in case it was reprocessing the same command */
+        if (client_reprocessing_command)
+            c->flag.reprocessing_command = 1;
         call(c, flags);
         if (listLength(server.ready_keys) && !isInsideYieldingLongCommand()) handleClientsBlockedOnKeys();
     }

--- a/src/server.c
+++ b/src/server.c
@@ -4025,9 +4025,6 @@ int processCommand(client *c) {
     /* in case we are starting to ProcessCommand and we already have a command we assume
      * this is a reprocessing of this command, so we do not want to perform some of the actions again. */
     int client_reprocessing_command = c->flag.reprocessing_command ? 1 : 0;
-    /* we should clear this flag, since it is possible the processing will bail out due to some error
-     * and we do not want to keep this flag on for the next commands */
-    c->flag.reprocessing_command = 0;
 
     /* only run command filter if not reprocessing command */
     if (!client_reprocessing_command) {
@@ -4351,9 +4348,6 @@ int processCommand(client *c) {
         addReply(c, shared.queued);
     } else {
         int flags = CMD_CALL_FULL;
-        /* we should re-tag the client as reprocessing in case it was reprocessing the same command */
-        if (client_reprocessing_command)
-            c->flag.reprocessing_command = 1;
         call(c, flags);
         if (listLength(server.ready_keys) && !isInsideYieldingLongCommand()) handleClientsBlockedOnKeys();
     }

--- a/src/server.c
+++ b/src/server.c
@@ -3691,7 +3691,7 @@ void call(client *c, int flags) {
      * and a client which is reprocessing command again (after being unblocked).
      * Blocked clients can be blocked in different places and not always it means the call() function has been
      * called. For example this is required for avoiding double logging to monitors.*/
-    int reprocessing_command = c->flag.reprocessing_command ? 1 : 0;
+    int reprocessing_command = c->flag.reexecuting_command ? 1 : 0;
 
     /* Initialization: clear the flags that must be set by the command on
      * demand, and initialize the array for additional commands propagation. */

--- a/src/server.h
+++ b/src/server.h
@@ -1086,7 +1086,7 @@ typedef struct ClientFlags {
                                               from the Module. */
     uint64_t module_prevent_aof_prop : 1;  /* Module client do not want to propagate to AOF */
     uint64_t module_prevent_repl_prop : 1; /* Module client do not want to propagate to replica */
-    uint64_t reexecuting_command : 1;     /* The client is re-executing the command. */
+    uint64_t reexecuting_command : 1;      /* The client is re-executing the command. */
     uint64_t replication_done : 1;         /* Indicate that replication has been done on the client */
     uint64_t authenticated : 1;            /* Indicate a client has successfully authenticated */
     uint64_t ever_authenticated : 1;       /* Indicate a client was ever successfully authenticated during it's lifetime */

--- a/src/server.h
+++ b/src/server.h
@@ -1086,7 +1086,7 @@ typedef struct ClientFlags {
                                               from the Module. */
     uint64_t module_prevent_aof_prop : 1;  /* Module client do not want to propagate to AOF */
     uint64_t module_prevent_repl_prop : 1; /* Module client do not want to propagate to replica */
-    uint64_t reprocessing_command : 1;     /* The client is re-processing the command. */
+    uint64_t reexecuting_command : 1;     /* The client is re-executing the command. */
     uint64_t replication_done : 1;         /* Indicate that replication has been done on the client */
     uint64_t authenticated : 1;            /* Indicate a client has successfully authenticated */
     uint64_t ever_authenticated : 1;       /* Indicate a client was ever successfully authenticated during it's lifetime */

--- a/src/server.h
+++ b/src/server.h
@@ -578,8 +578,7 @@ typedef enum {
 #define CMD_CALL_NONE 0
 #define CMD_CALL_PROPAGATE_AOF (1 << 0)
 #define CMD_CALL_PROPAGATE_REPL (1 << 1)
-#define CMD_CALL_REPROCESSING (1 << 2)
-#define CMD_CALL_FROM_MODULE (1 << 3) /* From RM_Call */
+#define CMD_CALL_FROM_MODULE (1 << 2) /* From RM_Call */
 #define CMD_CALL_PROPAGATE (CMD_CALL_PROPAGATE_AOF | CMD_CALL_PROPAGATE_REPL)
 #define CMD_CALL_FULL (CMD_CALL_PROPAGATE)
 

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -2430,4 +2430,30 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
         close_replication_stream $repl
     } {} {needs:repl}
 
+    test "Blocking timeout following PAUSE should honor the timeout" {
+        # cleanup first
+        r del mylist
+        
+        # create a test client
+        set rd [valkey_deferring_client]
+        
+        # reset the server stats
+        r config resetstat
+        
+        # first PAUSE all writes for a very long time
+        r client pause 10000000000000 write
+
+        # block a client on the list
+        $rd BLPOP mylist 1
+        wait_for_blocked_clients_count 1
+        
+        # now unpause the writes
+        r client unpause
+
+        # client should time-out
+        wait_for_blocked_clients_count 0
+        
+        $rd close
+    }
+
 } ;# stop servers

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -2437,9 +2437,6 @@ foreach {pop} {BLPOP BLMPOP_RIGHT} {
         # create a test client
         set rd [valkey_deferring_client]
         
-        # reset the server stats
-        r config resetstat
-        
         # first PAUSE all writes for a very long time
         r client pause 10000000000000 write
 


### PR DESCRIPTION
When we refactored the blocking framework we introduced the client reprocessing infrastructure. In cases the client was blocked on keys, it will attempt to reprocess the command. One challenge was to keep track of the command timeout, since we are reprocessing and do not want to re-register the client with a fresh timeout each time. The solution was to consider the client reprocessing flag when the client is blockedOnKeys:

```
if (!c->flag.reprocessing_command) {
        /* If the client is re-processing the command, we do not set the timeout
         * because we need to retain the client's original timeout. */
        c->bstate->timeout = timeout;
    }
```

However, this introduced a new issue. There are cases where the client will consecutive blocking of different types for example:
```
CLIENT PAUSE 10000 ALL
BZPOPMAX zset 1
```
would have the client blocked on the zset endlessly if nothing will be written to it. 

**Credits to @uriyage for locating this with his fuzzer testing**

The suggested solution is to only flag the client when it is specifically unblocked on keys.