### PR TITLE
Add size_t cast in modules

### DIFF
--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -38,7 +38,7 @@ int set_aclcheck_key(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) 
         return VALKEYMODULE_OK;
     }
 
-    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, "SET", "v", argv + 2, argc - 2);
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, "SET", "v", argv + 2, (size_t)argc - 2);
     if (!rep) {
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -68,7 +68,7 @@ int publish_aclcheck_channel(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, in
         return VALKEYMODULE_OK;
     }
 
-    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, "PUBLISH", "v", argv + 1, argc - 1);
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, "PUBLISH", "v", argv + 1, (size_t)argc - 1);
     if (!rep) {
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -98,7 +98,7 @@ int rm_call_aclcheck_cmd(ValkeyModuleCtx *ctx, ValkeyModuleUser *user, ValkeyMod
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "v", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "v", argv + 2, (size_t)argc - 2);
     if(!rep){
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -146,7 +146,7 @@ int rm_call_aclcheck_with_errors(ValkeyModuleCtx *ctx, ValkeyModuleString **argv
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "vEC", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "vEC", argv + 2, (size_t)argc - 2);
     ValkeyModule_ReplyWithCallReply(ctx, rep);
     ValkeyModule_FreeCallReply(rep);
     return VALKEYMODULE_OK;
@@ -163,7 +163,7 @@ int rm_call_aclcheck(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "vC", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "vC", argv + 2, (size_t)argc - 2);
     if(!rep) {
         char err[100];
         switch (errno) {

--- a/tests/modules/blockedclient.c
+++ b/tests/modules/blockedclient.c
@@ -133,7 +133,7 @@ void *bg_call_worker(void *arg) {
     }
     const char *format = ValkeyModule_StringPtrLen(format_valkey_str, NULL);
     const char *cmd = ValkeyModule_StringPtrLen(bg->argv[cmd_pos], NULL);
-    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, bg->argc - cmd_pos - 1);
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, format, bg->argv + cmd_pos + 1, (size_t)bg->argc - cmd_pos - 1);
     ValkeyModule_FreeString(NULL, format_valkey_str);
 
     /* Free the arguments within GIL to prevent simultaneous freeing in main thread. */
@@ -209,7 +209,7 @@ int do_rm_call(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if(!rep){
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -245,7 +245,7 @@ int do_rm_call_async_fire_and_forget(ValkeyModuleCtx *ctx, ValkeyModuleString **
     }
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "!KEv", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "!KEv", argv + 2, (size_t)argc - 2);
 
     if(ValkeyModule_CallReplyType(rep) != VALKEYMODULE_REPLY_PROMISE) {
         ValkeyModule_ReplyWithCallReply(ctx, rep);
@@ -308,7 +308,7 @@ int do_rm_call_async(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, format, argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, format, argv + 2, (size_t)argc - 2);
 
     if(ValkeyModule_CallReplyType(rep) != VALKEYMODULE_REPLY_PROMISE) {
         rm_call_async_send_reply(ctx, rep);
@@ -365,7 +365,7 @@ int do_rm_call_async_on_thread(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, 
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "KEv", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "KEv", argv + 2, (size_t)argc - 2);
 
     if(ValkeyModule_CallReplyType(rep) != VALKEYMODULE_REPLY_PROMISE) {
         rm_call_async_send_reply(ctx, rep);
@@ -405,7 +405,7 @@ static void wait_and_do_rm_call_async_on_unblocked(ValkeyModuleCtx *ctx, ValkeyM
     reply = NULL;
 
     const char* cmd = ValkeyModule_StringPtrLen(wctx->argv[0], NULL);
-    reply = ValkeyModule_Call(ctx, cmd, "!EKv", wctx->argv + 1, wctx->argc - 1);
+    reply = ValkeyModule_Call(ctx, cmd, "!EKv", wctx->argv + 1, (size_t)wctx->argc - 1);
 
 done:
     if(ValkeyModule_CallReplyType(reply) != VALKEYMODULE_REPLY_PROMISE) {

--- a/tests/modules/commandfilter.c
+++ b/tests/modules/commandfilter.c
@@ -80,7 +80,7 @@ int CommandFilter_LogCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, in
 
     size_t cmdlen;
     const char *cmdname = ValkeyModule_StringPtrLen(argv[1], &cmdlen);
-    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, cmdname, "v", &argv[2], argc - 2);
+    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, cmdname, "v", &argv[2], (size_t)argc - 2);
     if (reply) {
         ValkeyModule_ReplyWithCallReply(ctx, reply);
         ValkeyModule_FreeCallReply(reply);

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -65,7 +65,7 @@ int test_call_generic(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
     }
 
     const char* cmdname = ValkeyModule_StringPtrLen(argv[1], NULL);
-    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, cmdname, "v", argv+2, argc-2);
+    ValkeyModuleCallReply *reply = ValkeyModule_Call(ctx, cmdname, "v", argv+2, (size_t)argc-2);
     if (reply) {
         ValkeyModule_ReplyWithCallReply(ctx, reply);
         ValkeyModule_FreeCallReply(reply);
@@ -397,7 +397,7 @@ int test_rm_call(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
 
     const char* cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if(!rep){
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     }else{
@@ -429,7 +429,7 @@ int test_rm_call_flags(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc
     const char* flg = ValkeyModule_StringPtrLen(flags, NULL);
     const char* cmd = ValkeyModule_StringPtrLen(argv[2], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, flg, argv + 3, argc - 3);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, flg, argv + 3, (size_t)argc - 3);
     if(!rep){
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     }else{

--- a/tests/modules/usercall.c
+++ b/tests/modules/usercall.c
@@ -13,7 +13,7 @@ int call_without_user(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
 
     const char *cmd = ValkeyModule_StringPtrLen(argv[1], NULL);
 
-    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, argc - 2);
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, "Ev", argv + 2, (size_t)argc - 2);
     if (!rep) {
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -37,7 +37,7 @@ int call_with_user_flag(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     const char* flg = ValkeyModule_StringPtrLen(flags, NULL);
     const char* cmd = ValkeyModule_StringPtrLen(argv[2], NULL);
 
-    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, flg, argv + 3, argc - 3);
+    ValkeyModuleCallReply* rep = ValkeyModule_Call(ctx, cmd, flg, argv + 3, (size_t)argc - 3);
     if (!rep) {
         ValkeyModule_ReplyWithError(ctx, "NULL reply returned");
     } else {
@@ -134,7 +134,7 @@ void *bg_call_worker(void *arg) {
     ValkeyModule_StringAppendBuffer(NULL, format_valkey_str, "E", 1);
     format = ValkeyModule_StringPtrLen(format_valkey_str, NULL);
     const char *cmd = ValkeyModule_StringPtrLen(bg->argv[2], NULL);
-    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, format, bg->argv + 3, bg->argc - 3);
+    ValkeyModuleCallReply *rep = ValkeyModule_Call(ctx, cmd, format, bg->argv + 3, (size_t)bg->argc - 3);
     ValkeyModule_FreeString(NULL, format_valkey_str);
 
     /* Free the arguments within GIL to prevent simultaneous freeing in main thread. */


### PR DESCRIPTION
This PR addresses a potential misalignment issue when using `va_args`. Without this fix, [argument](https://github.com/valkey-io/valkey/blob/30599c4936ccee982f7e94c4913e82014ff0d779/src/module.c#L6173-L6188) values may occasionally become incorrect due to stack alignment inconsistencies.