### PR TITLE
 Optimize GEORADIUS command performance with  pre-allocated buffer

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -50,21 +50,23 @@ int zslValueLteMax(double value, zrangespec *spec);
  * geoArray implementation
  * ==================================================================== */
 
-/* Create a new array of geoPoints. */
-geoArray *geoArrayCreate(void) {
-    geoArray *ga = zmalloc(sizeof(*ga));
-    /* It gets allocated on first geoArrayAppend() call. */
-    ga->array = NULL;
-    ga->buckets = 0;
+/* Init a new array of geoPoints. */
+void geoArrayInit(geoArray *ga) {
+    ga->buckets = MAX_GEO_ARRAY_BUFFER;
     ga->used = 0;
-    return ga;
+    ga->array = ga->arraybuf;
 }
 
 /* Add and populate with data a new entry to the geoArray. */
 geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist, double score, char *member) {
     if (ga->used == ga->buckets) {
-        ga->buckets = (ga->buckets == 0) ? 8 : ga->buckets * 2;
-        ga->array = zrealloc(ga->array, sizeof(geoPoint) * ga->buckets);
+        ga->buckets = ga->buckets * 2;
+        if (ga->array == ga->arraybuf) {
+            ga->array = zmalloc(sizeof(geoPoint) * ga->buckets);
+            memcpy(ga->array, ga->arraybuf, sizeof(geoPoint) * MAX_GEO_ARRAY_BUFFER);
+        } else {
+            ga->array = zrealloc(ga->array, sizeof(geoPoint) * ga->buckets);
+        }
     }
     geoPoint *gp = ga->array + ga->used;
     gp->longitude = xy[0];
@@ -80,8 +82,9 @@ geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist, double score, ch
 void geoArrayFree(geoArray *ga) {
     size_t i;
     for (i = 0; i < ga->used; i++) sdsfree(ga->array[i].member);
-    zfree(ga->array);
-    zfree(ga);
+    if (ga->array != ga->arraybuf) {
+        zfree(ga->array);
+    }
 }
 
 /* ====================================================================
@@ -681,17 +684,18 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     GeoHashRadius georadius = geohashCalculateAreasByShapeWGS84(&shape);
 
     /* Search the zset for all matching points */
-    geoArray *ga = geoArrayCreate();
-    membersOfAllNeighbors(zobj, &georadius, &shape, ga, any ? count : 0);
+    geoArray ga;
+    geoArrayInit(&ga);
+    membersOfAllNeighbors(zobj, &georadius, &shape, &ga, any ? count : 0);
 
     /* If no matching results, the user gets an empty reply. */
-    if (ga->used == 0 && storekey == NULL) {
+    if (ga.used == 0 && storekey == NULL) {
         addReply(c, shared.emptyarray);
-        geoArrayFree(ga);
+        geoArrayFree(&ga);
         return;
     }
 
-    long result_length = ga->used;
+    long result_length = ga.used;
     long returned_items = (count == 0 || result_length < count) ? result_length : count;
     long option_length = 0;
 
@@ -705,9 +709,9 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         }
 
         if (returned_items == result_length) {
-            qsort(ga->array, result_length, sizeof(geoPoint), sort_gp_callback);
+            qsort(ga.array, result_length, sizeof(geoPoint), sort_gp_callback);
         } else {
-            pqsort(ga->array, result_length, sizeof(geoPoint), sort_gp_callback, 0, (returned_items - 1));
+            pqsort(ga.array, result_length, sizeof(geoPoint), sort_gp_callback, 0, (returned_items - 1));
         }
     }
 
@@ -731,7 +735,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         /* Finally send results back to the caller */
         int i;
         for (i = 0; i < returned_items; i++) {
-            geoPoint *gp = ga->array + i;
+            geoPoint *gp = ga.array + i;
             gp->dist /= shape.conversion; /* Fix according to unit. */
 
             /* If we have options in option_length, return each sub-result
@@ -766,7 +770,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
         for (i = 0; i < returned_items; i++) {
             zskiplistNode *znode;
-            geoPoint *gp = ga->array + i;
+            geoPoint *gp = ga.array + i;
             gp->dist /= shape.conversion; /* Fix according to unit. */
             double score = storedist ? gp->dist : gp->score;
             size_t elelen = sdslen(gp->member);
@@ -791,7 +795,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         }
         addReplyLongLong(c, returned_items);
     }
-    geoArrayFree(ga);
+    geoArrayFree(&ga);
 }
 
 /* GEORADIUS wrapper function. */

--- a/src/geo.c
+++ b/src/geo.c
@@ -63,7 +63,7 @@ geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist, double score, ch
         ga->buckets = ga->buckets * 2;
         if (ga->array == ga->arraybuf) {
             ga->array = zmalloc(sizeof(geoPoint) * ga->buckets);
-            memcpy(ga->array, ga->arraybuf, sizeof(geoPoint) * MAX_GEO_ARRAY_BUFFER);
+            memcpy(ga->array, ga->arraybuf, sizeof(ga->arraybuf));
         } else {
             ga->array = zrealloc(ga->array, sizeof(geoPoint) * ga->buckets);
         }
@@ -79,7 +79,7 @@ geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist, double score, ch
 }
 
 /* Destroy a geoArray created with geoArrayCreate(). */
-void geoArrayFree(geoArray *ga) {
+void geoArrayCleanup(geoArray *ga) {
     size_t i;
     for (i = 0; i < ga->used; i++) sdsfree(ga->array[i].member);
     if (ga->array != ga->arraybuf) {
@@ -691,7 +691,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
     /* If no matching results, the user gets an empty reply. */
     if (ga.used == 0 && storekey == NULL) {
         addReply(c, shared.emptyarray);
-        geoArrayFree(&ga);
+        geoArrayCleanup(&ga);
         return;
     }
 
@@ -795,7 +795,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         }
         addReplyLongLong(c, returned_items);
     }
-    geoArrayFree(&ga);
+    geoArrayCleanup(&ga);
 }
 
 /* GEORADIUS wrapper function. */

--- a/src/geo.c
+++ b/src/geo.c
@@ -78,7 +78,7 @@ geoPoint *geoArrayAppend(geoArray *ga, double *xy, double dist, double score, ch
     return gp;
 }
 
-/* Destroy a geoArray created with geoArrayCreate(). */
+/* Clean a geoArray inited with geoArrayInit(). */
 void geoArrayCleanup(geoArray *ga) {
     size_t i;
     for (i = 0; i < ga->used; i++) sdsfree(ga->array[i].member);

--- a/src/geo.h
+++ b/src/geo.h
@@ -3,6 +3,8 @@
 
 #include "server.h"
 
+#define MAX_GEO_ARRAY_BUFFER 8
+
 /* Structures used inside geo.c in order to represent points and array of
  * points on the earth. */
 typedef struct geoPoint {
@@ -17,6 +19,7 @@ typedef struct geoArray {
     struct geoPoint *array;
     size_t buckets;
     size_t used;
+    struct geoPoint arraybuf[MAX_GEO_ARRAY_BUFFER]; /* Pre-allocated buffer reduces heap allocation */
 } geoArray;
 
 #endif


### PR DESCRIPTION
**Description**

1. The GEORADIUS command stores searched map points in geoArray, which triggers at least two memory allocations: one for the `geoArray` creation and another for each `geoPoint` initialization.
2. We can reduce these two memory allocations: 
   - converting `geoArray` from a heap-allocated variable to a stack-allocated one
   - embedding `geoPoint` directly within geoArray
  
**Benchmark**
Run the benchmark command five times with the command below, and take the peak value as the final result.
> for((x=0;x<5;x+=1));
>do
>valkey-cli flushall;
>valkey-benchmark -r $POINTS_SIZE geoadd key 100 70 l__rand_int__;
>valkey-benchmark -P 2 -n 10000000 georadius key 100 70 300 km;
> done
> 

$POINTS_SIZE | QPS before optimization|QPS after optimization|Performance Boost
-- | -- | -- | -- |
1|430015.06|436585.88|1.5%|
4|381766.81|386279.34|1.2%|
16|264592.28|268391.53|1.4%|
64|120035.05|120277.60|0.2%|

CPU: AMD EPYC 9K65 192-Core Processor* 8
OS: 	Ubuntu Server 24.04 LTS 64bit
Memory: 32GB
VM: Tencent cloud  SA9 | SA9.2XLARGE32

