### PR TITLE
CLIENT UNBLOCK should't be able to unpause paused clients

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -254,6 +254,22 @@ void unblockClient(client *c, int queue_for_reprocessing) {
     if (queue_for_reprocessing) queueClientForReprocessing(c);
 }
 
+/* Check if the specified client can be safely timed out using
+ * unblockClientOnTimeout(). */
+int blockedClientMayTimeout(client *c) {
+    if (c->bstate->btype == BLOCKED_MODULE) {
+        return moduleBlockedClientMayTimeout(c);
+    }
+
+    if (c->bstate->btype == BLOCKED_LIST ||
+        c->bstate->btype == BLOCKED_ZSET ||
+        c->bstate->btype == BLOCKED_STREAM ||
+        c->bstate->btype == BLOCKED_WAIT) {
+        return 1;
+    }
+    return 0;
+}
+
 /* This function gets called when a blocked client timed out in order to
  * send it a reply of some kind. After this function is called,
  * unblockClient() will be called with the same client as argument. */

--- a/src/networking.c
+++ b/src/networking.c
@@ -4323,11 +4323,12 @@ void clientUnblockCommand(client *c) {
     }
     if (getLongLongFromObjectOrReply(c, c->argv[2], &id, NULL) != C_OK) return;
     struct client *target = lookupClientByID(id);
-    /* Note that we never try to unblock a client blocked on a module command, which
+    /* Note that we never try to unblock a client blocked on a module command,
+     * or a client blocked by CLIENT PAUSE or some other blocking type which
      * doesn't have a timeout callback (even in the case of UNBLOCK ERROR).
      * The reason is that we assume that if a command doesn't expect to be timedout,
      * it also doesn't expect to be unblocked by CLIENT UNBLOCK */
-    if (target && target->flag.blocked && moduleBlockedClientMayTimeout(target)) {
+    if (target && target->flag.blocked && blockedClientMayTimeout(target)) {
         if (unblock_error)
             unblockClientOnError(target, "-UNBLOCKED client unblocked via CLIENT UNBLOCK");
         else

--- a/src/server.h
+++ b/src/server.h
@@ -3552,6 +3552,7 @@ void unblockClient(client *c, int queue_for_reprocessing);
 void unblockClientOnTimeout(client *c);
 void unblockClientOnError(client *c, const char *err_str);
 void queueClientForReprocessing(client *c);
+int blockedClientMayTimeout(client *c);
 void replyToBlockedClientTimedOut(client *c);
 int getTimeoutFromObjectOrReply(client *c, robj *object, mstime_t *timeout, int unit);
 void disconnectAllBlockedClients(void);

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -434,7 +434,23 @@ start_server {tags {"pause network"}} {
 
         r client unpause
         assert_equal [r randomkey] {}
+    }
 
+    test "CLIENT UNBLOCK is not allow to unblock client blocked by CLIENT PAUSE" {
+        set rd [valkey_deferring_client]
+        $rd client id
+        set client_id [$rd read]
+
+        r client pause 100000 write
+        $rd set foo bar
+        wait_for_blocked_clients_count 1 50 100
+
+        # This used to will trigger a panic.
+        assert_equal 0 [r client unblock $client_id timeout]
+        # THis used to will return a UNBLOCKED error.
+        assert_equal 0 [r client unblock $client_id error]
+
+        r client unpause
     }
 
     # Make sure we unpause at the end

--- a/tests/unit/pause.tcl
+++ b/tests/unit/pause.tcl
@@ -437,20 +437,33 @@ start_server {tags {"pause network"}} {
     }
 
     test "CLIENT UNBLOCK is not allow to unblock client blocked by CLIENT PAUSE" {
-        set rd [valkey_deferring_client]
-        $rd client id
-        set client_id [$rd read]
+        set rd1 [valkey_deferring_client]
+        set rd2 [valkey_deferring_client]
+        $rd1 client id
+        $rd2 client id
+        set client_id1 [$rd1 read]
+        set client_id2 [$rd2 read]
 
+        r del mylist
         r client pause 100000 write
-        $rd set foo bar
-        wait_for_blocked_clients_count 1 50 100
+        $rd1 blpop mylist 0
+        $rd2 blpop mylist 0
+        wait_for_blocked_clients_count 2 50 100
 
-        # This used to will trigger a panic.
-        assert_equal 0 [r client unblock $client_id timeout]
-        # THis used to will return a UNBLOCKED error.
-        assert_equal 0 [r client unblock $client_id error]
+        # This used to trigger a panic.
+        assert_equal 0 [r client unblock $client_id1 timeout]
+        # THis used to return a UNBLOCKED error.
+        assert_equal 0 [r client unblock $client_id2 error]
 
+        # After the unpause, it must be able to unblock the client.
         r client unpause
+        assert_equal 1 [r client unblock $client_id1 timeout]
+        assert_equal 1 [r client unblock $client_id2 error]
+        assert_equal {} [$rd1 read]
+        assert_error "UNBLOCKED*" {$rd2 read}
+
+        $rd1 close
+        $rd2 close
     }
 
     # Make sure we unpause at the end


### PR DESCRIPTION
When a client is blocked by something like `CLIENT PAUSE`, we should not
allow `CLIENT UNBLOCK timeout` to unblock it, since some blocking types
does not has the timeout callback, it will trigger a panic in the core,
people should use `CLIENT UNPAUSE` to unblock it.

Also using `CLIENT UNBLOCK error` is not right, it will return a UNBLOCKED
error to the command, people don't expect a `SET` command to get an error.

So in this commit, in these cases, we will return 0 to `CLIENT UNBLOCK`
to indicate the unblock is fail. The reason is that we assume that if
a command doesn't expect to be timedout, it also doesn't expect to be
unblocked by `CLIENT UNBLOCK`.

The old behavior of the following command will trigger panic in timeout
and get UNBLOCKED error in error. Under the new behavior, client unblock
will get the result of 0.
```
client 1> client pause 100000 write
client 2> set x x

client 1> client unblock 2 timeout
or
client 1> client unblock 2 error
```

Potentially breaking change, previously allowed `CLIENT UNBLOCK error`.
Fixes #2111.