### PR TITLE
Show more decimal digits for `avg chain length` field in `debug htstats` full output

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2151,7 +2151,7 @@ size_t hashtableGetStatsMsg(char *buf, size_t bufsize, hashtableStats *stats, in
                       " top-level buckets: %lu\n"
                       " child buckets: %lu\n"
                       " max chain length: %lu\n"
-                      " avg chain length: %.02f\n"
+                      " avg chain length: %f\n"
                       " chain length distribution:\n",
                       stats->toplevel_buckets,
                       stats->child_buckets,


### PR DESCRIPTION
There's not really a reason why we're truncating the `avg chain length` field in the `debug htstats` full output and it just makes debugging a little harder so let's just show a longer representation of the value.