### PR TITLE
Make Tclx optional in tests (fix Daily failure)

### DIFF
--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -114,29 +114,36 @@ start_server [list overrides [list "dir" $server_path] keep_persistence true] {
     r del stream
 }
 
-# Prepare custom umask test scenario
-package require Tclx
-set old_umask [umask]
-set old_perm [expr {666 - $old_umask}]
 set dump_path [file join $server_path dump.rdb]
-assert_equal [file attributes $dump_path -permissions] 00$old_perm
 
-if {$old_umask == 22} {
-    set new_umask 2
-} else {
-    set new_umask 22
-}
-set new_perm [expr {666 - $new_umask}]
-
-umask $new_umask
-start_server [list overrides [list "dir" $server_path] keep_persistence true] {
-    test {Test nondefault umask applied} {
-        r save
-        # Use numeric comparison for compatibility with Tcl 8 and 9.
-        assert_range [file attributes $dump_path -permissions] 00$new_perm 00$new_perm
+# Prepare custom umask test scenario
+if {[catch {package require Tclx}]} {
+    if {$::verbose} {
+        puts "Skipping umask test. Package Tclx not available."
     }
+} else {
+    # We have umask from the Tclx package.
+    set old_umask [umask]
+    set old_perm [expr {666 - $old_umask}]
+    assert_equal [file attributes $dump_path -permissions] 00$old_perm
+
+    if {$old_umask == 22} {
+        set new_umask 2
+    } else {
+        set new_umask 22
+    }
+    set new_perm [expr {666 - $new_umask}]
+
+    umask $new_umask
+    start_server [list overrides [list "dir" $server_path] keep_persistence true] {
+        test {Test nondefault umask applied} {
+            r save
+            # Use numeric comparison for compatibility with Tcl 8 and 9.
+            assert_range [file attributes $dump_path -permissions] 00$new_perm 00$new_perm
+        }
+    }
+    umask $old_umask
 }
-umask $old_umask
 
 # Make the RDB file unreadable
 file attributes $dump_path -permissions 0222

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -119,7 +119,7 @@ set dump_path [file join $server_path dump.rdb]
 # Prepare custom umask test scenario
 if {[catch {package require Tclx}]} {
     if {$::verbose} {
-        puts "Skipping umask test. Package Tclx not available."
+        puts "Skipping umask test. Package Tclx not installed."
     }
 } else {
     # We have umask from the Tclx package.


### PR DESCRIPTION
Tclx is not available on all platforms. Skip tests that require it if it's not available.

This also fixes the Daily failures such as this: https://github.com/valkey-io/valkey/actions/runs/15175084203/job/42673707836#step:8:4677

The diff looks large, but it isn't. The test code is just wapped in a check and indented.

```
if {[catch {package require Tclx}]} {
    if {$::verbose} {
        puts "Skipping umask test. Package Tclx not available."
    }
} else {
    (old code here)
}
```