### PR TITLE
Fix UBSAN run for hashtable unittest

### DIFF
--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -902,9 +902,7 @@ int test_random_entry_sparse_table(int argc, char **argv, int flags) {
     monotonicInit();
 
     /* Populate */
-    unsigned values[1]; /* We don't need to allocate the full size (count) on
-                         * the stack, because the array is never accessed. We
-                         * only use pointers to the array. */
+    unsigned *values = zmalloc(sizeof(unsigned) * count);
     for (size_t j = 0; j < count; j++) {
         TEST_ASSERT(hashtableAdd(ht, &values[j]));
     }
@@ -942,6 +940,7 @@ int test_random_entry_sparse_table(int argc, char **argv, int flags) {
         TEST_ASSERT(us <= us0 * 10);
     }
     hashtableRelease(ht);
+    zfree(values);
     return 0;
 }
 


### PR DESCRIPTION
The unit test declared an array of size 1 and used pointers to elements outside the array. This is fine because the pointers are never dereferenced, but undefined-sanitizer complains.

Now, instead allocate a huge array to make sure all pointers into it are valid.

Example failure:

https://github.com/valkey-io/valkey/actions/runs/15175084203/job/42673713108#step:10:123