### PR TITLE
Combine range element ranks calculation with range elements search to improve zcount performance

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -290,7 +290,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
         zskiplist *zsl = zs->zsl;
         zskiplistNode *ln;
 
-        if ((ln = zslNthInRange(zsl, &range, 0)) == NULL) {
+        if ((ln = zslNthInRange(zsl, &range, 0, NULL)) == NULL) {
             /* Nothing exists starting at our min.  No results. */
             return 0;
         }

--- a/src/module.c
+++ b/src/module.c
@@ -4976,7 +4976,7 @@ int zsetInitScoreRange(ValkeyModuleKey *key, double min, double max, int minex, 
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = key->value->ptr;
         zskiplist *zsl = zs->zsl;
-        key->u.zset.current = first ? zslNthInRange(zsl, zrs, 0) : zslNthInRange(zsl, zrs, -1);
+        key->u.zset.current = first ? zslNthInRange(zsl, zrs, 0, NULL) : zslNthInRange(zsl, zrs, -1, NULL);
     } else {
         serverPanic("Unsupported zset encoding");
     }

--- a/src/server.h
+++ b/src/server.h
@@ -3121,7 +3121,7 @@ typedef struct {
 zskiplist *zslCreate(void);
 void zslFree(zskiplist *zsl);
 zskiplistNode *zslInsert(zskiplist *zsl, double score, sds ele);
-zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n);
+zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
 double zzlGetScore(unsigned char *sptr);
 void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -529,12 +529,11 @@ static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, un
 /* Find the rank for a specific skiplist member node. Counts nodes after the one
  * specified and subtracts from list length. Note that rank is 1-based.  */
 static unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
-    int highest_node_span = zslGetNodeHeight(node) - 1;
-    unsigned long count_after_node = zslGetNodeSpanAtLevel(node, highest_node_span);
-    while (node->level[highest_node_span].forward) {
-        node = node->level[highest_node_span].forward;
-        highest_node_span = zslGetNodeHeight(node) - 1;
+    unsigned long count_after_node = 0;
+    while (node) { /* note this is never null the first time */
+        int highest_node_span = zslGetNodeHeight(node) - 1;
         count_after_node += zslGetNodeSpanAtLevel(node, highest_node_span);
+        node = node->level[highest_node_span].forward;
     }
 
     unsigned long rank = zsl->length - count_after_node;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -526,26 +526,19 @@ static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, un
     return removed;
 }
 
-/* Find the rank for a specific skiplist node.
- * Returns 0 when the element cannot be found, rank otherwise.
- * Note that the rank is 1-based due to the span of zsl->header to the
- * first element. */
+/* Find the rank for a specific skiplist member node. Counts nodes after the one
+ * specified and subtracts from list length. Note that rank is 1-based.  */
 static unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
-    unsigned long rank = 0;
-
-    /* Count up nodes that come before */
-    zskiplistNode *x = zsl->header;
-    for (int i = zsl->level - 1; i >= 0; i--) {
-        while (zslCompareNodes(x->level[i].forward, node) <= 0) {
-            rank += zslGetNodeSpanAtLevel(x, i);
-            x = x->level[i].forward;
-        }
-
-        if (x == node) {
-            return rank;
-        }
+    int highest_node_span = zslGetNodeHeight(node) - 1;
+    unsigned long count_after_node = zslGetNodeSpanAtLevel(node, highest_node_span);
+    while (node->level[highest_node_span].forward) {
+        node = node->level[highest_node_span].forward;
+        highest_node_span = zslGetNodeHeight(node) - 1;
+        count_after_node += zslGetNodeSpanAtLevel(node, highest_node_span);
     }
-    return 0;
+
+    unsigned long rank = zsl->length - count_after_node;
+    return rank;
 }
 
 /* Finds an element by its rank from start node. The rank argument needs to be 1-based. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -304,16 +304,13 @@ static void zslDelete(zskiplist *zsl, zskiplistNode *node) {
  * Otherwise the skiplist is modified by removing and re-adding a new
  * element, which is more costly. A pointer to the new node is returned. */
 static zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore) {
-    /* Update score in place if it doesn't invalidate correct ordering */
-    const double old_score = node->score;
-    node->score = newscore;
-    if (zslCompareNodes(node->backward, node) < 0 && zslCompareNodes(node->level[0].forward, node) > 0) {
-        /* list ordering is correct: we are able to update in place */
+    /* If the node, after the score update, would be still exactly
+     * at the same position, we can just update the score without
+     * actually removing and re-inserting the element in the skiplist. */
+    if ((node->backward == NULL || node->backward->score < newscore) &&
+        (node->level[0].forward == NULL || node->level[0].forward->score > newscore)) {
+        node->score = newscore;
         return NULL;
-    } else {
-        /* incorrect list ordering is an invalid state - we must restore previous
-         * state and use another method. */
-        node->score = old_score;
     }
 
     /* We need to remove the node from the skiplist and insert a new one */
@@ -361,40 +358,36 @@ int zslIsInRange(zskiplist *zsl, zrangespec *range) {
 
 /* Find the Nth node that is contained in the specified range. N should be 0-based.
  * Negative N works for reversed order (-1 represents the last element). Returns
- * NULL when no element is contained in the range. */
-zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n) {
-    zskiplistNode *x;
-    int i;
-    long edge_rank = 0;
-    long last_highest_level_rank = 0;
-    zskiplistNode *last_highest_level_node = NULL;
-    unsigned long rank_diff;
-
+ * NULL when no element is contained in the range.
+ * If rank is not NULL it will be set to the element's overall rank */
+zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank) {
     /* If everything is out of range, return early. */
     if (!zslIsInRange(zsl, range)) return NULL;
 
     /* Go forward while *OUT* of range at level of zsl->level-1. */
-    x = zsl->header;
-    i = zsl->level - 1;
+    zskiplistNode *x = zsl->header;
+    int i = zsl->level - 1;
+    long last_highest_level_rank = 0;
     while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, range)) {
-        edge_rank += zslGetNodeSpanAtLevel(x, i);
+        last_highest_level_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
-    /* Remember the last node which has zsl->level-1 levels and its rank. */
-    last_highest_level_node = x;
-    last_highest_level_rank = edge_rank;
+    /* Remember the last node which has zsl->level-1 levels */
+    zskiplistNode *last_highest_level_node = x;
 
     if (n >= 0) {
+        long start_rank = last_highest_level_rank;
         for (i = zsl->level - 2; i >= 0; i--) {
             /* Go forward while *OUT* of range. */
             while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element smaller than the range. */
-                edge_rank += zslGetNodeSpanAtLevel(x, i);
+                start_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
             }
         }
         /* Check if zsl is long enough. */
-        if ((unsigned long)(edge_rank + n) >= zsl->length) return NULL;
+        if ((unsigned long)(start_rank + n) >= zsl->length) return NULL;
+        if (rank) *rank = start_rank + n;
         if (n < ZSKIPLIST_MAX_SEARCH) {
             /* If offset is small, we can just jump node by node */
             /* rank+1 is the first element in range, so we need n+1 steps to reach target. */
@@ -403,22 +396,24 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n) {
             }
         } else {
             /* If offset is big, we can jump from the last zsl->level-1 node. */
-            rank_diff = edge_rank + 1 + n - last_highest_level_rank;
+            unsigned long rank_diff = start_rank + 1 + n - last_highest_level_rank;
             x = zslGetElementByRankFromNode(last_highest_level_node, zsl->level - 1, rank_diff);
         }
         /* Check if score <= max. */
         if (x && !zslValueLteMax(x->score, range)) return NULL;
     } else {
+        long end_rank = last_highest_level_rank;
         for (i = zsl->level - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
             while (x->level[i].forward && zslValueLteMax(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element in range. */
-                edge_rank += zslGetNodeSpanAtLevel(x, i);
+                end_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
             }
         }
         /* Check if the range is big enough. */
-        if (edge_rank < -n) return NULL;
+        if (end_rank < -n) return NULL;
+        if (rank) *rank = end_rank + n;
         if (n + 1 > -ZSKIPLIST_MAX_SEARCH) {
             /* If offset is small, we can just jump node by node */
             /* rank is the -1th element in range, so we need -n-1 steps to reach target. */
@@ -428,7 +423,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n) {
         } else {
             /* If offset is big, we can jump from the last zsl->level-1 node. */
             /* rank is the last element in range, n is -1-based, so we need n+1 to count backwards. */
-            rank_diff = edge_rank + 1 + n - last_highest_level_rank;
+            unsigned long rank_diff = end_rank + 1 + n - last_highest_level_rank;
             x = zslGetElementByRankFromNode(last_highest_level_node, zsl->level - 1, rank_diff);
         }
         /* Check if score >= min. */
@@ -3193,9 +3188,9 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
 
         /* If reversed, get the last node in range as starting point. */
         if (reverse) {
-            ln = zslNthInRange(zsl, range, -offset - 1);
+            ln = zslNthInRange(zsl, range, -offset - 1, NULL);
         } else {
-            ln = zslNthInRange(zsl, range, offset);
+            ln = zslNthInRange(zsl, range, offset, NULL);
         }
 
         while (ln && limit--) {
@@ -3287,22 +3282,20 @@ void zcountCommand(client *c) {
         zset *zs = zobj->ptr;
         zskiplist *zsl = zs->zsl;
         zskiplistNode *zn;
-        unsigned long rank;
+        long rank;
 
         /* Find first element in range */
-        zn = zslNthInRange(zsl, &range, 0);
+        zn = zslNthInRange(zsl, &range, 0, &rank);
 
         /* Use rank of first element, if any, to determine preliminary count */
         if (zn != NULL) {
-            rank = zslGetRank(zsl, zn);
             count = (zsl->length - (rank - 1));
 
             /* Find last element in range */
-            zn = zslNthInRange(zsl, &range, -1);
+            zn = zslNthInRange(zsl, &range, -1, &rank);
 
             /* Use rank of last element, if any, to determine the actual count */
             if (zn != NULL) {
-                rank = zslGetRank(zsl, zn);
                 count -= (zsl->length - rank);
             }
         }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -304,15 +304,16 @@ static void zslDelete(zskiplist *zsl, zskiplistNode *node) {
  * Otherwise the skiplist is modified by removing and re-adding a new
  * element, which is more costly. A pointer to the new node is returned. */
 static zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore) {
-    /* If the node, after the score update, would be still exactly
-     * at the same position, we can just update the score without
-     * actually removing and re-inserting the element in the skiplist.
-     * (TODO: The check can be extended to check also equality of the
-     * score, but then we'll also need to compare the key order). */
-    if ((node->backward == NULL || node->backward->score < newscore) &&
-        (node->level[0].forward == NULL || node->level[0].forward->score > newscore)) {
-        node->score = newscore;
+    /* Update score in place if it doesn't invalidate correct ordering */
+    const double old_score = node->score;
+    node->score = newscore;
+    if (zslCompareNodes(node->backward, node) < 0 && zslCompareNodes(node->level[0].forward, node) > 0) {
+        /* list ordering is correct: we are able to update in place */
         return NULL;
+    } else {
+        /* incorrect list ordering is an invalid state - we must restore previous
+         * state and use another method. */
+        node->score = old_score;
     }
 
     /* We need to remove the node from the skiplist and insert a new one */
@@ -545,22 +546,6 @@ static unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
         }
     }
     return 0;
-}
-
-/* Find the rank for a specific skiplist node. Alternate method that counts
- * nodes after the one specified and subtracts from list length.
- * TODO investigate whether both rank methods are needed and compare perf */
-static unsigned long zslGetRankCountingNodesAfter(zskiplist *zsl, const zskiplistNode *node) {
-    int highest_node_span = zslGetNodeHeight(node) - 1;
-    unsigned long count_after_node = zslGetNodeSpanAtLevel(node, highest_node_span);
-    while (node->level[highest_node_span].forward) {
-        node = node->level[highest_node_span].forward;
-        highest_node_span = zslGetNodeHeight(node) - 1;
-        count_after_node += zslGetNodeSpanAtLevel(node, highest_node_span);
-    }
-
-    unsigned long rank = zsl->length - count_after_node;
-    return rank;
 }
 
 /* Finds an element by its rank from start node. The rank argument needs to be 1-based. */
@@ -1639,7 +1624,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
         if (!hashtableFind(zs->ht, ele, &entry)) return -1;
         zskiplistNode *node = entry;
 
-        rank = zslGetRankCountingNodesAfter(zs->zsl, node);
+        rank = zslGetRank(zs->zsl, node);
         /* Existing elements always have a rank. */
         serverAssert(rank != 0);
         if (output_score) *output_score = node->score;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -387,7 +387,6 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         }
         /* Check if zsl is long enough. */
         if ((unsigned long)(start_rank + n) >= zsl->length) return NULL;
-        if (rank) *rank = start_rank + n;
         if (n < ZSKIPLIST_MAX_SEARCH) {
             /* If offset is small, we can just jump node by node */
             /* rank+1 is the first element in range, so we need n+1 steps to reach target. */
@@ -401,6 +400,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         }
         /* Check if score <= max. */
         if (x && !zslValueLteMax(x->score, range)) return NULL;
+        if (rank) *rank = start_rank + n;
     } else {
         long end_rank = last_highest_level_rank;
         for (i = zsl->level - 1; i >= 0; i--) {
@@ -413,7 +413,6 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         }
         /* Check if the range is big enough. */
         if (end_rank < -n) return NULL;
-        if (rank) *rank = end_rank + n;
         if (n + 1 > -ZSKIPLIST_MAX_SEARCH) {
             /* If offset is small, we can just jump node by node */
             /* rank is the -1th element in range, so we need -n-1 steps to reach target. */
@@ -428,6 +427,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         }
         /* Check if score >= min. */
         if (x && !zslValueGteMin(x->score, range)) return NULL;
+        if (rank) *rank = end_rank + n;
     }
 
     return x;


### PR DESCRIPTION
Currently in ZCOUNT we search the sorted list twice to locate the range endpoints and then we use an extra 2 searches to take each point rank.
This PR introduce 2 modifications:
1. Calculate the rank while searching each of the range points, thus avoid extra rank calculations
2. polish the code by removing the extra implementation for GetRank which was kept in order to avoid zcount performance degradation.

Following tests this PR seems to improve ZCOUNT performance by ~10%