### PR TITLE
Mark string2ll_resolver as used

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -625,7 +625,7 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-__attribute__((no_sanitize_address)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+__attribute__((no_sanitize_address, used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     /* Ifunc resolvers run before ASan initialization and before CPU detection
      * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();


### PR DESCRIPTION
Daily test runs that use clang are currently [failing](https://github.com/valkey-io/valkey/actions/runs/15213976527/job/42794864169#step:4:167) with
```
util.c:628:51: error: unused function 'string2ll_resolver' [-Werror,-Wunused-function]
  628 | __attribute__((no_sanitize_address)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
      |                                                   ^~~~~~~~~~~~~~~~~~
```

Marking `string2ll_resolver` as `used` should solve this.