### PR TITLE
Correct VM_Yield timing and deflake blockedclient.tcl

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -943,6 +943,20 @@ ValkeyModuleCtx *moduleAllocateContext(void) {
     return (ValkeyModuleCtx *)zcalloc(sizeof(ValkeyModuleCtx));
 }
 
+static void computeNextYieldTime(ValkeyModuleCtx *ctx) {
+    /* in loading we depend on the server hz, but in other cases we also wait
+     * for busy_reply_threshold.
+     * Note that in theory we could have started processing BUSY_MODULE_YIELD_EVENTS
+     * sooner, and only delay the processing for clients till the busy_reply_threshold,
+     * but this carries some overheads of frequently marking clients with BLOCKED_POSTPONE
+     * and releasing them, i.e. if modules only block for short periods. */
+    if (server.loading) {
+        ctx->next_yield_time = getMonotonicUs() + 1000000 / server.hz;
+    } else {
+        ctx->next_yield_time = getMonotonicUs() + server.busy_reply_threshold * 1000;
+    }
+}
+
 /* Create a module ctx and keep track of the nesting level.
  *
  * Note: When creating ctx for threads (VM_GetThreadSafeContext and
@@ -961,17 +975,8 @@ void moduleCreateContext(ValkeyModuleCtx *out_ctx, ValkeyModule *module, int ctx
         out_ctx->client->flag.fake = 1;
     }
 
-    /* Calculate the initial yield time for long blocked contexts.
-     * in loading we depend on the server hz, but in other cases we also wait
-     * for busy_reply_threshold.
-     * Note that in theory we could have started processing BUSY_MODULE_YIELD_EVENTS
-     * sooner, and only delay the processing for clients till the busy_reply_threshold,
-     * but this carries some overheads of frequently marking clients with BLOCKED_POSTPONE
-     * and releasing them, i.e. if modules only block for short periods. */
-    if (server.loading)
-        out_ctx->next_yield_time = getMonotonicUs() + 1000000 / server.hz;
-    else
-        out_ctx->next_yield_time = getMonotonicUs() + server.busy_reply_threshold * 1000;
+    /* Calculate the initial yield time for long blocked contexts. */
+    computeNextYieldTime(out_ctx);
 
     /* Increment the execution_nesting counter (module is about to execute some code),
      * except in the following cases:
@@ -2544,7 +2549,7 @@ void VM_Yield(ValkeyModuleCtx *ctx, int flags, const char *busy_reply) {
         }
 
         /* decide when the next event should fire. */
-        ctx->next_yield_time = now + 1000000 / server.hz;
+        computeNextYieldTime(ctx);
     }
     yield_nesting--;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -943,17 +943,17 @@ ValkeyModuleCtx *moduleAllocateContext(void) {
     return (ValkeyModuleCtx *)zcalloc(sizeof(ValkeyModuleCtx));
 }
 
-static void computeNextYieldTime(ValkeyModuleCtx *ctx) {
-    /* in loading we depend on the server hz, but in other cases we also wait
+static long long computeNextYieldTime(void) {
+    /* In loading we depend on the server hz, but in other cases we also wait
      * for busy_reply_threshold.
      * Note that in theory we could have started processing BUSY_MODULE_YIELD_EVENTS
      * sooner, and only delay the processing for clients till the busy_reply_threshold,
      * but this carries some overheads of frequently marking clients with BLOCKED_POSTPONE
      * and releasing them, i.e. if modules only block for short periods. */
     if (server.loading) {
-        ctx->next_yield_time = getMonotonicUs() + 1000000 / server.hz;
+        return getMonotonicUs() + 1000000 / server.hz;
     } else {
-        ctx->next_yield_time = getMonotonicUs() + server.busy_reply_threshold * 1000;
+        return getMonotonicUs() + server.busy_reply_threshold * 1000;
     }
 }
 
@@ -976,7 +976,7 @@ void moduleCreateContext(ValkeyModuleCtx *out_ctx, ValkeyModule *module, int ctx
     }
 
     /* Calculate the initial yield time for long blocked contexts. */
-    computeNextYieldTime(out_ctx);
+    out_ctx->next_yield_time = computeNextYieldTime();
 
     /* Increment the execution_nesting counter (module is about to execute some code),
      * except in the following cases:
@@ -2549,7 +2549,7 @@ void VM_Yield(ValkeyModuleCtx *ctx, int flags, const char *busy_reply) {
         }
 
         /* decide when the next event should fire. */
-        computeNextYieldTime(ctx);
+        ctx->next_yield_time = computeNextYieldTime();
     }
     yield_nesting--;
 }

--- a/tests/unit/moduleapi/blockedclient.tcl
+++ b/tests/unit/moduleapi/blockedclient.tcl
@@ -164,7 +164,7 @@ foreach call_type {nested normal} {
 }
 
     test {RM_Call from blocked client} {
-        set busy_time_limit 50
+        set busy_time_limit 5
         set old_time_limit [lindex [r config get busy-reply-threshold] 1]
         r config set busy-reply-threshold $busy_time_limit
 


### PR DESCRIPTION
Previously, the `next_yield_time` for a yielding module command was only correctly calculated for the initial yield, taking into account whether the server was loading an RDB. Subsequent yields incorrectly defaulted to using `server.hz` for the calculation, regardless of the loading state.

This bug had two consequences:
1. Incorrect Yield Timing: If not loading, the module command would yield based on `server.hz` instead of the configured `busy_reply_threshold`. This could lead to the main thread being blocked for significantly longer or shorter periods than intended between yields.
2. Test Flakiness: In the `blockedclient.tcl` test, this incorrect timing meant that new commands from other clients were delayed until the current, potentially overly long, yield cycle completed. With `busy_time_limit` set to 50s, this significantly increased test duration and risked timeouts, causing flakiness.

This commit refactors the `next_yield_time` calculation into a new static function `computeNextYieldTime` and ensures it's called both during the initial context creation and within `VM_Yield` after each yield. This guarantees that `next_yield_time` is always predicated on the current `server.loading` status.

The `busy_time_limit` in `blockedclient.tcl` has also been reduced from 50s to 5s. With the primary bug addressed, this shorter timeout is more appropriate and helps the test complete faster, reducing the risk of timeouts.