### PR TITLE
Free module context even if there was no content written in auxsave2

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1280,6 +1280,10 @@ ssize_t rdbSaveSingleModuleAux(rio *rdb, int when, moduleType *mt) {
              * to allow loading this RDB if the module is not present. */
             sdsfree(io.pre_flush_buffer);
             io.pre_flush_buffer = NULL;
+            if (io.ctx) {
+                moduleFreeContext(io.ctx);
+                zfree(io.ctx);
+            }
             return 0;
         }
     } else {


### PR DESCRIPTION
When a module saves to the Aux metadata with aux_save2 callback, the module context is not freed if the module didn't save anything in the callback. 

https://github.com/valkey-io/valkey/blob/8.1.1/src/rdb.c#L1277-L1284. Note that we return 0, however we should be doing the cleanup done on https://github.com/valkey-io/valkey/blob/8.1.1/src/rdb.c#L1300-L1303 still.

Fixes #2125