### PR TITLE
Update redis to server in internal variable names in benchmark source code

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -77,7 +77,7 @@
 
 struct benchmarkThread;
 struct clusterNode;
-struct serverConfig;
+struct benchmarkConfig;
 
 /* Read from replica options */
 typedef enum readFromReplica {
@@ -126,7 +126,7 @@ static struct config {
     readFromReplica read_from_replica;
     int cluster_node_count;
     struct clusterNode **cluster_nodes;
-    struct serverConfig *server_config;
+    struct benchmarkConfig *benchmark_config;
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     _Atomic int is_fetching_slots;
@@ -183,13 +183,13 @@ typedef struct clusterNode {
     int *updated_slots;      /* Used by updateClusterSlotsConfiguration */
     int updated_slots_count; /* Used by updateClusterSlotsConfiguration */
     int replicas_count;
-    struct serverConfig *server_config;
+    struct benchmarkConfig *benchmark_config;
 } clusterNode;
 
-typedef struct serverConfig {
+typedef struct benchmarkConfig {
     sds save;
     sds appendonly;
-} serverConfig;
+} benchmarkConfig;
 
 /* Prototypes */
 static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask);
@@ -199,9 +199,9 @@ static void freeBenchmarkThread(benchmarkThread *thread);
 static void freeBenchmarkThreads(void);
 static void *execBenchmarkThread(void *ptr);
 static clusterNode *createClusterNode(char *ip, int port);
-static serverConfig *getServerConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port);
+static benchmarkConfig *getBenchmarkConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port);
 static valkeyContext *getValkeyContext(enum valkeyConnectionType ct, const char *ip_or_path, int port);
-static void freeServerConfig(serverConfig *cfg);
+static void freeBenchmarkConfig(benchmarkConfig *cfg);
 static int fetchClusterSlotsConfiguration(client c);
 static void updateClusterSlotsConfiguration(void);
 static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
@@ -297,14 +297,14 @@ cleanup:
 }
 
 
-static serverConfig *getServerConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port) {
-    serverConfig *cfg = zcalloc(sizeof(*cfg));
+static benchmarkConfig *getBenchmarkConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port) {
+    benchmarkConfig *cfg = zcalloc(sizeof(*cfg));
     if (!cfg) return NULL;
     valkeyContext *c = NULL;
     valkeyReply *reply = NULL, *sub_reply = NULL;
     c = getValkeyContext(ct, ip_or_path, port);
     if (c == NULL) {
-        freeServerConfig(cfg);
+        freeBenchmarkConfig(cfg);
         exit(1);
     }
     valkeyAppendCommand(c, "CONFIG GET %s", "save");
@@ -342,11 +342,11 @@ fail:
     }
     freeReplyObject(reply);
     valkeyFree(c);
-    freeServerConfig(cfg);
+    freeBenchmarkConfig(cfg);
     if (abort_test) exit(1);
     return NULL;
 }
-static void freeServerConfig(serverConfig *cfg) {
+static void freeBenchmarkConfig(benchmarkConfig *cfg) {
     if (cfg->save) sdsfree(cfg->save);
     if (cfg->appendonly) sdsfree(cfg->appendonly);
     zfree(cfg);
@@ -888,16 +888,16 @@ static void showLatencyReport(void) {
             int m;
             for (m = 0; m < config.cluster_node_count; m++) {
                 clusterNode *node = config.cluster_nodes[m];
-                serverConfig *cfg = node->server_config;
+                benchmarkConfig *cfg = node->benchmark_config;
                 if (cfg == NULL) continue;
                 printf("  node [%d] configuration:\n", m);
                 printf("    save: %s\n", sdslen(cfg->save) ? cfg->save : "NONE");
                 printf("    appendonly: %s\n", cfg->appendonly);
             }
         } else {
-            if (config.server_config) {
-                printf("  host configuration \"save\": %s\n", config.server_config->save);
-                printf("  host configuration \"appendonly\": %s\n", config.server_config->appendonly);
+            if (config.benchmark_config) {
+                printf("  host configuration \"save\": %s\n", config.benchmark_config->save);
+                printf("  host configuration \"appendonly\": %s\n", config.benchmark_config->appendonly);
             }
         }
         printf("  multi-thread: %s\n", (config.num_threads ? "yes" : "no"));
@@ -1065,7 +1065,7 @@ static clusterNode *createClusterNode(char *ip, int port) {
     node->slots_count = 0;
     node->updated_slots = NULL;
     node->updated_slots_count = 0;
-    node->server_config = NULL;
+    node->benchmark_config = NULL;
     return node;
 }
 
@@ -1076,7 +1076,7 @@ static void freeClusterNode(clusterNode *node) {
      * config.conn_info.hostip and config.conn_info.hostport, then the node ip has been
      * allocated by fetchClusterConfiguration, so it must be freed. */
     if (node->ip && strcmp(node->ip, config.conn_info.hostip) != 0) sdsfree(node->ip);
-    if (node->server_config != NULL) freeServerConfig(node->server_config);
+    if (node->benchmark_config != NULL) freeBenchmarkConfig(node->benchmark_config);
     zfree(node->slots);
     zfree(node);
 }
@@ -1800,7 +1800,7 @@ int main(int argc, char **argv) {
     config.read_from_replica = FROM_PRIMARY_ONLY;
     config.cluster_node_count = 0;
     config.cluster_nodes = NULL;
-    config.server_config = NULL;
+    config.benchmark_config = NULL;
     config.is_fetching_slots = 0;
     config.is_updating_slots = 0;
     config.slots_last_update = 0;
@@ -1869,8 +1869,8 @@ int main(int argc, char **argv) {
             printf("Node %d(%s): ", i, node_type);
             if (node->name) printf("%s ", node->name);
             printf("%s:%d\n", node->ip, node->port);
-            node->server_config = getServerConfig(config.ct, node->ip, node->port);
-            if (node->server_config == NULL) {
+            node->benchmark_config = getBenchmarkConfig(config.ct, node->ip, node->port);
+            if (node->benchmark_config == NULL) {
                 fprintf(stderr, "WARNING: Could not fetch node CONFIG %s:%d\n", node->ip, node->port);
             }
         }
@@ -1879,8 +1879,8 @@ int main(int argc, char **argv) {
          * by the user. */
         if (config.num_threads == 0) config.num_threads = config.cluster_node_count;
     } else {
-        config.server_config = getServerConfig(config.ct, config.conn_info.hostip, config.conn_info.hostport);
-        if (config.server_config == NULL) {
+        config.benchmark_config = getBenchmarkConfig(config.ct, config.conn_info.hostip, config.conn_info.hostport);
+        if (config.benchmark_config == NULL) {
             fprintf(stderr, "WARNING: Could not fetch server CONFIG\n");
         }
     }
@@ -1995,7 +1995,7 @@ int main(int argc, char **argv) {
         sdsfreesplitres(sds_args, argc);
 
         sdsfree(title);
-        if (config.server_config != NULL) freeServerConfig(config.server_config);
+        if (config.benchmark_config != NULL) freeBenchmarkConfig(config.benchmark_config);
         zfree(argvlen);
         return 0;
     }
@@ -2202,7 +2202,7 @@ int main(int argc, char **argv) {
 
     zfree(data);
     freeCliConnInfo(config.conn_info);
-    if (config.server_config != NULL) freeServerConfig(config.server_config);
+    if (config.benchmark_config != NULL) freeBenchmarkConfig(config.benchmark_config);
 
     return 0;
 }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -77,7 +77,7 @@
 
 struct benchmarkThread;
 struct clusterNode;
-struct benchmarkConfig;
+struct serverConfig;
 
 /* Read from replica options */
 typedef enum readFromReplica {
@@ -126,7 +126,7 @@ static struct config {
     readFromReplica read_from_replica;
     int cluster_node_count;
     struct clusterNode **cluster_nodes;
-    struct benchmarkConfig *benchmark_config;
+    struct serverConfig *server_config;
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     _Atomic int is_fetching_slots;
@@ -183,13 +183,13 @@ typedef struct clusterNode {
     int *updated_slots;      /* Used by updateClusterSlotsConfiguration */
     int updated_slots_count; /* Used by updateClusterSlotsConfiguration */
     int replicas_count;
-    struct benchmarkConfig *benchmark_config;
+    struct serverConfig *server_config;
 } clusterNode;
 
-typedef struct benchmarkConfig {
+typedef struct serverConfig {
     sds save;
     sds appendonly;
-} benchmarkConfig;
+} serverConfig;
 
 /* Prototypes */
 static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask);
@@ -199,9 +199,9 @@ static void freeBenchmarkThread(benchmarkThread *thread);
 static void freeBenchmarkThreads(void);
 static void *execBenchmarkThread(void *ptr);
 static clusterNode *createClusterNode(char *ip, int port);
-static benchmarkConfig *getBenchmarkConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port);
+static serverConfig *getServerConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port);
 static valkeyContext *getValkeyContext(enum valkeyConnectionType ct, const char *ip_or_path, int port);
-static void freeBenchmarkConfig(benchmarkConfig *cfg);
+static void freeServerConfig(serverConfig *cfg);
 static int fetchClusterSlotsConfiguration(client c);
 static void updateClusterSlotsConfiguration(void);
 static long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData);
@@ -297,14 +297,14 @@ cleanup:
 }
 
 
-static benchmarkConfig *getBenchmarkConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port) {
-    benchmarkConfig *cfg = zcalloc(sizeof(*cfg));
+static serverConfig *getServerConfig(enum valkeyConnectionType ct, const char *ip_or_path, int port) {
+    serverConfig *cfg = zcalloc(sizeof(*cfg));
     if (!cfg) return NULL;
     valkeyContext *c = NULL;
     valkeyReply *reply = NULL, *sub_reply = NULL;
     c = getValkeyContext(ct, ip_or_path, port);
     if (c == NULL) {
-        freeBenchmarkConfig(cfg);
+        freeServerConfig(cfg);
         exit(1);
     }
     valkeyAppendCommand(c, "CONFIG GET %s", "save");
@@ -342,11 +342,11 @@ fail:
     }
     freeReplyObject(reply);
     valkeyFree(c);
-    freeBenchmarkConfig(cfg);
+    freeServerConfig(cfg);
     if (abort_test) exit(1);
     return NULL;
 }
-static void freeBenchmarkConfig(benchmarkConfig *cfg) {
+static void freeServerConfig(serverConfig *cfg) {
     if (cfg->save) sdsfree(cfg->save);
     if (cfg->appendonly) sdsfree(cfg->appendonly);
     zfree(cfg);
@@ -888,16 +888,16 @@ static void showLatencyReport(void) {
             int m;
             for (m = 0; m < config.cluster_node_count; m++) {
                 clusterNode *node = config.cluster_nodes[m];
-                benchmarkConfig *cfg = node->benchmark_config;
+                serverConfig *cfg = node->server_config;
                 if (cfg == NULL) continue;
                 printf("  node [%d] configuration:\n", m);
                 printf("    save: %s\n", sdslen(cfg->save) ? cfg->save : "NONE");
                 printf("    appendonly: %s\n", cfg->appendonly);
             }
         } else {
-            if (config.benchmark_config) {
-                printf("  host configuration \"save\": %s\n", config.benchmark_config->save);
-                printf("  host configuration \"appendonly\": %s\n", config.benchmark_config->appendonly);
+            if (config.server_config) {
+                printf("  host configuration \"save\": %s\n", config.server_config->save);
+                printf("  host configuration \"appendonly\": %s\n", config.server_config->appendonly);
             }
         }
         printf("  multi-thread: %s\n", (config.num_threads ? "yes" : "no"));
@@ -1065,7 +1065,7 @@ static clusterNode *createClusterNode(char *ip, int port) {
     node->slots_count = 0;
     node->updated_slots = NULL;
     node->updated_slots_count = 0;
-    node->benchmark_config = NULL;
+    node->server_config = NULL;
     return node;
 }
 
@@ -1076,7 +1076,7 @@ static void freeClusterNode(clusterNode *node) {
      * config.conn_info.hostip and config.conn_info.hostport, then the node ip has been
      * allocated by fetchClusterConfiguration, so it must be freed. */
     if (node->ip && strcmp(node->ip, config.conn_info.hostip) != 0) sdsfree(node->ip);
-    if (node->benchmark_config != NULL) freeBenchmarkConfig(node->benchmark_config);
+    if (node->server_config != NULL) freeServerConfig(node->server_config);
     zfree(node->slots);
     zfree(node);
 }
@@ -1800,7 +1800,7 @@ int main(int argc, char **argv) {
     config.read_from_replica = FROM_PRIMARY_ONLY;
     config.cluster_node_count = 0;
     config.cluster_nodes = NULL;
-    config.benchmark_config = NULL;
+    config.server_config = NULL;
     config.is_fetching_slots = 0;
     config.is_updating_slots = 0;
     config.slots_last_update = 0;
@@ -1869,8 +1869,8 @@ int main(int argc, char **argv) {
             printf("Node %d(%s): ", i, node_type);
             if (node->name) printf("%s ", node->name);
             printf("%s:%d\n", node->ip, node->port);
-            node->benchmark_config = getBenchmarkConfig(config.ct, node->ip, node->port);
-            if (node->benchmark_config == NULL) {
+            node->server_config = getServerConfig(config.ct, node->ip, node->port);
+            if (node->server_config == NULL) {
                 fprintf(stderr, "WARNING: Could not fetch node CONFIG %s:%d\n", node->ip, node->port);
             }
         }
@@ -1879,8 +1879,8 @@ int main(int argc, char **argv) {
          * by the user. */
         if (config.num_threads == 0) config.num_threads = config.cluster_node_count;
     } else {
-        config.benchmark_config = getBenchmarkConfig(config.ct, config.conn_info.hostip, config.conn_info.hostport);
-        if (config.benchmark_config == NULL) {
+        config.server_config = getServerConfig(config.ct, config.conn_info.hostip, config.conn_info.hostport);
+        if (config.server_config == NULL) {
             fprintf(stderr, "WARNING: Could not fetch server CONFIG\n");
         }
     }
@@ -1995,7 +1995,7 @@ int main(int argc, char **argv) {
         sdsfreesplitres(sds_args, argc);
 
         sdsfree(title);
-        if (config.benchmark_config != NULL) freeBenchmarkConfig(config.benchmark_config);
+        if (config.server_config != NULL) freeServerConfig(config.server_config);
         zfree(argvlen);
         return 0;
     }
@@ -2202,7 +2202,7 @@ int main(int argc, char **argv) {
 
     zfree(data);
     freeCliConnInfo(config.conn_info);
-    if (config.benchmark_config != NULL) freeBenchmarkConfig(config.benchmark_config);
+    if (config.server_config != NULL) freeServerConfig(config.server_config);
 
     return 0;
 }


### PR DESCRIPTION
Update Redis legacy word in valkey-benchmark tool: rename variable names redis_config to server_config.