### PR TITLE
[draft] Replace void** with opaque hashtablePosition

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -325,7 +325,7 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, ha
     if (old_position == NULL) {
         int dict_index = getKVStoreIndexForKey(key->ptr);
         old_position = &stackPosition;
-        int found = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, old_position);
+        bool found = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, old_position);
         serverAssertWithInfo(NULL, key, found);
     }
     robj *old = hashtableGetEntryAtPosition(old_position);
@@ -440,7 +440,7 @@ robj *dbRandomKey(serverDb *db) {
     while (1) {
         void *entry;
         int randomDictIndex = kvstoreGetFairRandomHashtableIndex(db->keys);
-        int ok = kvstoreHashtableFairRandomEntry(db->keys, randomDictIndex, &entry);
+        bool ok = kvstoreHashtableFairRandomEntry(db->keys, randomDictIndex, &entry);
         if (!ok) return NULL;
         robj *valkey = entry;
         sds key = objectGetKey(valkey);
@@ -486,10 +486,10 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
          * (The expires table has no destructor callback.) */
         kvstoreHashtableTwoPhasePopDelete(db->keys, dict_index, &pos);
         if (objectGetExpire(val) != -1) {
-            int deleted = kvstoreHashtableDelete(db->expires, dict_index, key->ptr);
+            bool deleted = kvstoreHashtableDelete(db->expires, dict_index, key->ptr);
             serverAssert(deleted);
         } else {
-            debugServerAssert(0 == kvstoreHashtableDelete(db->expires, dict_index, key->ptr));
+            debugServerAssert(false == kvstoreHashtableDelete(db->expires, dict_index, key->ptr));
         }
 
         if (async) {
@@ -1783,7 +1783,7 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
             hashtableReplaceEntryAtPosition(&position, newval);
             val = newval;
         }
-        int added = kvstoreHashtableAdd(db->expires, dict_index, newval);
+        bool added = kvstoreHashtableAdd(db->expires, dict_index, newval);
         serverAssert(added);
     }
 

--- a/src/db.c
+++ b/src/db.c
@@ -57,7 +57,7 @@ static keyStatus expireIfNeededWithDictIndex(serverDb *db, robj *key, robj *val,
 static keyStatus expireIfNeeded(serverDb *db, robj *key, robj *val, int flags);
 static int keyIsExpiredWithDictIndex(serverDb *db, robj *key, int dict_index);
 static int objectIsExpired(robj *val);
-static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, void **oldref);
+static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, hashtablePosition *old_position);
 static int getKVStoreIndexForKey(sds key);
 static robj *dbFindWithDictIndex(serverDb *db, sds key, int dict_index);
 static robj *dbFindExpiresWithDictIndex(serverDb *db, sds key, int dict_index);
@@ -212,15 +212,14 @@ robj *lookupKeyWriteOrReply(client *c, robj *key, robj *reply) {
  * if the key already exists, otherwise, it can fall back to dbOverwrite. */
 static void dbAddInternal(serverDb *db, robj *key, robj **valref, int update_if_existing) {
     int dict_index = getKVStoreIndexForKey(key->ptr);
-    void **oldref = NULL;
+    hashtablePosition position;
     if (update_if_existing) {
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
-        if (oldref != NULL) {
-            dbSetValue(db, key, valref, 1, oldref);
+        if (kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, &position)) {
+            dbSetValue(db, key, valref, 1, &position);
             return;
         }
     } else {
-        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, key->ptr) == NULL);
+        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, &position) == 0);
     }
 
     /* Not existing. Convert val to valkey object and insert. */
@@ -320,14 +319,16 @@ int dbAddRDBLoad(serverDb *db, sds key, robj **valref) {
  * value should be stored.
  *
  * The program is aborted if the key was not already present. */
-static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, void **oldref) {
+static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, hashtablePosition *old_position) {
     robj *val = *valref;
-    if (oldref == NULL) {
+    hashtablePosition stackPosition;
+    if (old_position == NULL) {
         int dict_index = getKVStoreIndexForKey(key->ptr);
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
+        old_position = &stackPosition;
+        int found = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, old_position);
+        serverAssertWithInfo(NULL, key, found);
     }
-    serverAssertWithInfo(NULL, key, oldref != NULL);
-    robj *old = *oldref;
+    robj *old = hashtableGetEntryAtPosition(old_position);
     robj *new;
 
     if (overwrite) {
@@ -342,7 +343,7 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         signalDeletedKeyAsReady(db, key, old->type);
         decrRefCount(old);
         /* Because of VM_StringDMA, old may be changed, so we need get old again */
-        old = *oldref;
+        old = hashtableGetEntryAtPosition(old_position);
     }
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
@@ -366,13 +367,13 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         val->lru = old->lru;
         long long expire = objectGetExpire(old);
         new = objectSetKeyAndExpire(val, key->ptr, expire);
-        *oldref = new;
+        hashtableReplaceEntryAtPosition(old_position, new);
         /* Replace the old value at its location in the expire space. */
         if (expire >= 0) {
             int dict_index = getKVStoreIndexForKey(key->ptr);
-            void **expireref = kvstoreHashtableFindRef(db->expires, dict_index, key->ptr);
-            serverAssert(expireref != NULL);
-            *expireref = new;
+            hashtablePosition expire_position;
+            serverAssert(kvstoreHashtableFindRef(db->expires, dict_index, key->ptr, &expire_position));
+            hashtableReplaceEntryAtPosition(&expire_position, new);
         }
     }
     /* For efficiency, let the I/O thread that allocated an object also deallocate it. */
@@ -467,9 +468,8 @@ robj *dbRandomKey(serverDb *db) {
 
 int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, int dict_index) {
     hashtablePosition pos;
-    void **ref = kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, key->ptr, &pos);
-    if (ref != NULL) {
-        robj *val = *ref;
+    if (kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, key->ptr, &pos)) {
+        robj *val = hashtableGetEntryAtPosition(&pos);
         /* VM_StringDMA may call dbUnshareStringValue which may free val, so we
          * need to incr to retain val */
         incrRefCount(val);
@@ -480,7 +480,7 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
         /* Match the incrRefCount above. */
         decrRefCount(val);
         /* Because of dbUnshareStringValue, the val in de may change. */
-        val = *ref;
+        val = hashtableGetEntryAtPosition(&pos);
 
         /* Delete from keys and expires tables. This will not free the object.
          * (The expires table has no destructor callback.) */
@@ -1766,9 +1766,9 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
      * expire in an robj, it's potentially reallocated. We need to updates the
      * pointer(s) to it. */
     int dict_index = getKVStoreIndexForKey(key->ptr);
-    void **valref = kvstoreHashtableFindRef(db->keys, dict_index, key->ptr);
-    serverAssertWithInfo(NULL, key, valref != NULL);
-    val = *valref;
+    hashtablePosition position;
+    serverAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, key->ptr, &position));
+    val = hashtableGetEntryAtPosition(&position);
     long long old_when = objectGetExpire(val);
     robj *newval = objectSetExpire(val, when);
     if (old_when != -1) {
@@ -1780,7 +1780,8 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
         /* No old expire. Update the pointer in the keys hashtable, if needed,
          * and add it to the expires hashtable. */
         if (newval != val) {
-            val = *valref = newval;
+            hashtableReplaceEntryAtPosition(&position, newval);
+            val = newval;
         }
         int added = kvstoreHashtableAdd(db->expires, dict_index, newval);
         serverAssert(added);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -697,7 +697,7 @@ static void defragKey(defragKeysCtx *ctx, robj **elemref) {
             /* Replace the pointer in the expire table without accessing the old
              * pointer. */
             hashtable *expires_ht = kvstoreGetHashtable(db->expires, slot);
-            int replaced = hashtableReplaceReallocatedEntry(expires_ht, ob, newob);
+            bool replaced = hashtableReplaceReallocatedEntry(expires_ht, ob, newob);
             serverAssert(replaced);
         }
         ob = newob;
@@ -779,7 +779,7 @@ static void defragPubsubScanCallback(void *privdata, void *elemref) {
         void *c;
         while (hashtableNext(&iter, &c)) {
             hashtable *client_channels = ctx->getPubSubChannels(c);
-            int replaced = hashtableReplaceReallocatedEntry(client_channels, channel, newchannel);
+            bool replaced = hashtableReplaceReallocatedEntry(client_channels, channel, newchannel);
             serverAssert(replaced);
         }
         hashtableResetIterator(&iter);

--- a/src/evict.c
+++ b/src/evict.c
@@ -606,7 +606,7 @@ int performEvictions(void) {
                         kvs = server.db[bestdbid].expires;
                     }
                     void *entry = NULL;
-                    int found = kvstoreHashtableFind(kvs, pool[k].slot, pool[k].key, &entry);
+                    bool found = kvstoreHashtableFind(kvs, pool[k].slot, pool[k].key, &entry);
 
                     /* Remove the entry from the pool. */
                     if (pool[k].key != pool[k].cached) sdsfree(pool[k].key);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1318,17 +1318,25 @@ int hashtableFind(hashtable *ht, const void *key, void **found) {
     }
 }
 
-/* Returns a pointer to where an entry is stored within the hash table, or
- * NULL if not found. To get the entry, dereference the returned pointer. The
- * pointer can be used to replace the entry with an equivalent entry (same
- * key, same hash value), but note that the pointer may be invalidated by future
- * accesses to the hash table due to incermental rehashing, so use with care. */
-void **hashtableFindRef(hashtable *ht, const void *key) {
-    if (hashtableSize(ht) == 0) return NULL;
+/* Returns 1 when found, 0 when not found. If found, the position of the entry
+ * is returned via the position argument, which can be used to access or replace
+ * the entry with one with same key and hash. The position is for immediate use
+ * and may be invalidated by the next hashtable operation that triggers
+ * incremental rehashing or modifies the table. This method does not pause
+ * rehashing. */
+int hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *pos) {
+    position *p = positionFromOpaque(pos);
+    if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
-    int pos_in_bucket = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
-    return b ? &b->entries[pos_in_bucket] : NULL;
+    int pos_in_bucket, table_index;
+    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, &table_index);
+    if (b != NULL) {
+        p->bucket = b;
+        p->pos_in_bucket = pos_in_bucket;
+        p->table_index = table_index;
+    }
+    
+    return b != NULL;
 }
 
 /* Adds an entry. Returns 1 on success. Returns 0 if there was already an entry
@@ -1426,6 +1434,29 @@ void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *po
     /* Hash bits are already set by hashtableFindPositionForInsert. */
 }
 
+/* Returns the entry at the given position. The position must be valid */
+void *hashtableGetEntryAtPosition(hashtablePosition *pos) {
+    position *p = positionFromOpaque(pos);
+    bucket *b = p->bucket;
+    int pos_in_bucket = p->pos_in_bucket;
+    if (isPositionFilled(b, pos_in_bucket)) {
+        return b->entries[pos_in_bucket];
+    } else {
+        return NULL;
+    }
+}
+
+/* Replaces the existing entry at the given position with a new entry.
+ * It's the caller's responsibility to ensure that the new entry has the same
+ * key and hash, and that the position is valid. */
+void hashtableReplaceEntryAtPosition(hashtablePosition* pos, void *entry) {
+    position *p = positionFromOpaque(pos);
+    bucket *b = p->bucket;
+    int pos_in_bucket = p->pos_in_bucket;
+    assert(isPositionFilled(b, pos_in_bucket));
+    b->entries[pos_in_bucket] = entry;
+}
+
 /* Removes the entry with the matching key and returns it. The entry
  * destructor is not called. Returns 1 and points 'popped' to the entry if a
  * matching entry was found. Returns 0 if no matching entry was found. */
@@ -1499,19 +1530,18 @@ int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void 
 /* Two-phase pop: Look up an entry, do something with it, then delete it
  * without searching the hash table again.
  *
- * hashtableTwoPhasePopFindRef finds an entry in the table and also the position
- * of the entry within the table, so that it can be deleted without looking it
- * up in the table again. The function returns a pointer to the entry pointer
- * within the hash table, if an entry with a matching key is found, and NULL
- * otherwise.
+ * hashtableTwoPhasePopFindRef finds the position
+ * of an entry within the table, so that it can be deleted without looking it
+ * up in the table again. The function returns 1 if an entry with a
+ * matching key is found, and 0 otherwise.
  *
- * If non-NULL is returned, call 'hashtableTwoPhasePopDelete' with the returned
+ * If 1 is returned, call 'hashtableTwoPhasePopDelete' with the returned
  * 'position' afterwards to actually delete the entry from the table. These two
  * functions are designed be used in pair. `hashtableTwoPhasePopFindRef` pauses
  * rehashing and `hashtableTwoPhasePopDelete` resumes rehashing.
  *
  * While hashtablePop finds and returns an entry, the purpose of two-phase pop
- * is to provide an optimized equivalent of hashtableFindRef followed by
+ * is to provide an optimized equivalent of hashtableFindPosition followed by
  * hashtableDelete, where the first call finds the entry but doesn't delete it
  * from the hash table and the latter doesn't need to look up the entry in the
  * hash table again.
@@ -1519,22 +1549,20 @@ int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void 
  * Example:
  *
  *     hashtablePosition position;
- *     void **ref = hashtableTwoPhasePopFindRef(ht, key, &position)
- *     if (ref != NULL) {
- *         void *entry = *ref;
+ *     if (hashtableTwoPhasePopFindRef(ht, key, &position)) {
+ *         void *entry = hashtableGetEntryAtPosition(&position);
  *         // do something with the entry, then...
  *         hashtableTwoPhasePopDelete(ht, &position);
  *     }
  */
 
-/* Like hashtableTwoPhasePopFind, but returns a pointer to where the entry is
- * stored in the table, or NULL if no matching entry is found. The 'position'
- * argument is populated with a representation of where the entry is stored.
- * This must be provided to hashtableTwoPhasePopDelete to complete the
- * operation. */
-void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *pos) {
+/* Like hashtableTwoPhasePopFind, but returns 1 when found and 0 if not found.
+ * The 'position' argument is populated with a representation of where the entry
+ * is stored. This must be provided to hashtableTwoPhasePopDelete to complete
+ * the operation. */
+int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
-    if (hashtableSize(ht) == 0) return NULL;
+    if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
     int pos_in_bucket = 0;
     int table_index = 0;
@@ -1547,9 +1575,9 @@ void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosi
         p->bucket = b;
         p->pos_in_bucket = pos_in_bucket;
         p->table_index = table_index;
-        return &b->entries[pos_in_bucket];
+        return 1;
     } else {
-        return NULL;
+        return 0;
     }
 }
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -294,6 +294,7 @@ struct hashtable {
     int16_t pause_rehash;      /* Non-zero = rehashing is paused */
     int16_t pause_auto_shrink; /* Non-zero = automatic resizing disallowed. */
     size_t child_buckets[2];   /* Number of allocated child buckets. */
+    uint32_t epoch;            /* Incremented on each modification. */
     void *metadata[];
 };
 
@@ -305,8 +306,8 @@ typedef struct {
     uint8_t table;
     uint8_t flags;
     union {
-        /* Unsafe iterator fingerprint for misuse detection. */
-        uint64_t fingerprint;
+        /* Unsafe iterator saved epoch for misuse detection. */
+        uint32_t epoch;
         /* Safe iterator temporary storage for bucket chain compaction. */
         uint64_t last_seen_size;
     };
@@ -319,8 +320,10 @@ static_assert(sizeof(hashtableIterator) >= sizeof(iter),
 /* Position, used by some hashtable functions such as two-phase insert and delete. */
 typedef struct {
     bucket *bucket;
-    uint16_t pos_in_bucket;
-    uint16_t table_index;
+    uint32_t *current_epoch; /* Pointer to the epoch of the hashtable. */
+    uint32_t position_epoch;
+    uint8_t pos_in_bucket;
+    uint8_t table_index;
 } position;
 
 static_assert(sizeof(hashtablePosition) >= sizeof(position),
@@ -546,6 +549,7 @@ static void rehashBucket(hashtable *ht, bucket *b) {
 
 static void rehashStep(hashtable *ht) {
     assert(hashtableIsRehashing(ht));
+    ht->epoch++;
     size_t idx = ht->rehash_idx;
     bucket *b = &ht->tables[0][idx];
     rehashBucket(ht, b);
@@ -589,11 +593,11 @@ static inline void rehashStepOnWriteIfNeeded(hashtable *ht) {
 }
 
 /* Allocates a new table and initiates incremental rehashing if necessary.
- * Returns 1 on resize (success), 0 on no resize (failure). If 0 is returned and
- * 'malloc_failed' is provided, it is set to 1 if allocation failed. If
- * 'malloc_failed' is not provided, an allocation failure triggers a panic. */
-static int resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
-    if (malloc_failed) *malloc_failed = 0;
+ * Returns true if resize happened. If allocation fails and 'malloc_failed' is
+ * provided it will be set to true. If 'malloc_failed' is not provided,
+ * an allocation failure triggers a panic. */
+static bool resize(hashtable *ht, size_t min_capacity, bool *malloc_failed) {
+    if (malloc_failed) *malloc_failed = false;
 
     /* Adjust minimum size. We don't resize to zero currently. */
     if (min_capacity == 0) min_capacity = 1;
@@ -604,21 +608,21 @@ static int resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
     size_t new_capacity = num_buckets * ENTRIES_PER_BUCKET;
     if (new_capacity < min_capacity || num_buckets * sizeof(bucket) < num_buckets) {
         /* Overflow */
-        return 0;
+        return false;
     }
 
     signed char old_exp = ht->bucket_exp[hashtableIsRehashing(ht) ? 1 : 0];
     size_t alloc_size = num_buckets * sizeof(bucket);
     if (exp == old_exp) {
         /* Can't resize to same size. */
-        return 0;
+        return false;
     }
 
     if (ht->type->resizeAllowed) {
         double fill_factor = (double)min_capacity / ((double)numBuckets(old_exp) * ENTRIES_PER_BUCKET);
         if (fill_factor * 100 < MAX_FILL_PERCENT_HARD && !ht->type->resizeAllowed(alloc_size, fill_factor)) {
             /* Resize callback says no. */
-            return 0;
+            return false;
         }
     }
 
@@ -638,8 +642,8 @@ static int resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
     if (malloc_failed) {
         new_table = ztrycalloc(alloc_size);
         if (new_table == NULL) {
-            *malloc_failed = 1;
-            return 0;
+            *malloc_failed = true;
+            return false;
         }
     } else {
         new_table = zcalloc(alloc_size);
@@ -659,15 +663,14 @@ static int resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
             rehashStep(ht);
         }
     }
-    return 1;
+    return true;
 }
 
-/* Returns 1 if the table is expanded, 0 if not expanded. If 0 is returned and
- * 'malloc_failed' is provided, it is set to 1 if malloc failed and 0
- * otherwise. */
-static int expand(hashtable *ht, size_t size, int *malloc_failed) {
+/* Returns true if the table is expanded. If not expanded and
+ * 'malloc_failed' is provided, it is set to true if malloc failed */
+static bool expand(hashtable *ht, size_t size, bool *malloc_failed) {
     if (size < hashtableSize(ht)) {
-        return 0;
+        return false;
     }
     return resize(ht, size, malloc_failed);
 }
@@ -841,6 +844,7 @@ static void fillBucketHole(hashtable *ht, bucket *b, int pos_in_bucket, int tabl
  * the end of the bucket chain to fill the holes and free any empty buckets in
  * the end of the chain. */
 static void compactBucketChain(hashtable *ht, size_t bucket_index, int table_index) {
+    ht->epoch++;
     bucket *b = &ht->tables[table_index][bucket_index];
     while (b->chained) {
         bucket *next = getChildBucket(b);
@@ -906,6 +910,7 @@ static bucket *findBucketForInsert(hashtable *ht, uint64_t hash, int *pos_in_buc
 /* Helper to insert an entry. Doesn't check if an entry with a matching key
  * already exists. This must be ensured by the caller. */
 static void insert(hashtable *ht, uint64_t hash, void *entry) {
+    ht->epoch++;
     hashtableExpandIfNeeded(ht);
     rehashStepOnWriteIfNeeded(ht);
     int pos_in_bucket;
@@ -915,31 +920,6 @@ static void insert(hashtable *ht, uint64_t hash, void *entry) {
     b->presence |= (1 << pos_in_bucket);
     b->hashes[pos_in_bucket] = highBits(hash);
     ht->used[table_index]++;
-}
-
-/* A 64-bit fingerprint of some of the state of the hash table. */
-static uint64_t hashtableFingerprint(hashtable *ht) {
-    uint64_t integers[6], hash = 0;
-    integers[0] = (uintptr_t)ht->tables[0];
-    integers[1] = ht->bucket_exp[0];
-    integers[2] = ht->used[0];
-    integers[3] = (uintptr_t)ht->tables[1];
-    integers[4] = ht->bucket_exp[1];
-    integers[5] = ht->used[1];
-
-    /* Result = hash(hash(hash(int1)+int2)+int3) */
-    for (int j = 0; j < 6; j++) {
-        hash += integers[j];
-        /* Tomas Wang's 64 bit integer hash. */
-        hash = (~hash) + (hash << 21); /* hash = (hash << 21) - hash - 1; */
-        hash = hash ^ (hash >> 24);
-        hash = (hash + (hash << 3)) + (hash << 8); /* hash * 265 */
-        hash = hash ^ (hash >> 14);
-        hash = (hash + (hash << 2)) + (hash << 4); /* hash * 21 */
-        hash = hash ^ (hash >> 28);
-        hash = hash + (hash << 31);
-    }
-    return hash;
 }
 
 /* Scan callback function used by hashtableGetSomeEntries() for sampling entries
@@ -1059,6 +1039,7 @@ hashtable *hashtableCreate(hashtableType *type) {
     ht->pause_auto_shrink = 0;
     resetTable(ht, 0);
     resetTable(ht, 1);
+    ht->epoch = 0;
     if (type->trackMemUsage) type->trackMemUsage(ht, alloc_size);
     return ht;
 }
@@ -1066,6 +1047,7 @@ hashtable *hashtableCreate(hashtableType *type) {
 /* Deletes all the entries. If a callback is provided, it is called from time
  * to time to indicate progress. */
 void hashtableEmpty(hashtable *ht, void(callback)(hashtable *)) {
+    ht->epoch++;
     if (hashtableIsRehashing(ht)) {
         /* Pretend rehashing completed. */
         if (ht->type->rehashingCompleted) ht->type->rehashingCompleted(ht);
@@ -1191,13 +1173,13 @@ static void hashtableResumeRehashing(hashtable *ht) {
     ht->pause_rehash--;
 }
 
-/* Returns 1 if incremental rehashing is paused, 0 if it isn't. */
-int hashtableIsRehashingPaused(hashtable *ht) {
+/* Returns true if incremental rehashing is paused, false if it isn't. */
+bool hashtableIsRehashingPaused(hashtable *ht) {
     return ht->pause_rehash > 0;
 }
 
-/* Returns 1 if incremental rehashing is in progress, 0 otherwise. */
-int hashtableIsRehashing(hashtable *ht) {
+/* Returns true if incremental rehashing is in progress, false otherwise. */
+bool hashtableIsRehashing(hashtable *ht) {
     return ht->rehash_idx != -1;
 }
 
@@ -1229,29 +1211,29 @@ int hashtableRehashMicroseconds(hashtable *ht, uint64_t us) {
     return rehashes;
 }
 
-/* Return 1 if expand was performed; 0 otherwise. */
-int hashtableExpand(hashtable *ht, size_t size) {
+/* Return true if expand was performed; false otherwise. */
+bool hashtableExpand(hashtable *ht, size_t size) {
     return expand(ht, size, NULL);
 }
 
-/* Returns 1 if expand was performed or if expand is not needed. Returns 0 if
- * expand failed due to memory allocation failure. */
-int hashtableTryExpand(hashtable *ht, size_t size) {
-    int malloc_failed = 0;
+/* Returns true if expand was performed or if expand is not needed. Returns
+ * false if expand failed due to memory allocation failure. */
+bool hashtableTryExpand(hashtable *ht, size_t size) {
+    bool malloc_failed = 0;
     return expand(ht, size, &malloc_failed) || !malloc_failed;
 }
 
 /* Expanding is done automatically on insertion, but less eagerly if resize
  * policy is set to AVOID or FORBID. After restoring resize policy to ALLOW, you
- * may want to call hashtableExpandIfNeeded. Returns 1 if expanding, 0 if not
- * expanding. */
-int hashtableExpandIfNeeded(hashtable *ht) {
+ * may want to call hashtableExpandIfNeeded. Returns true if expanding, false if
+ *  not expanding. */
+bool hashtableExpandIfNeeded(hashtable *ht) {
     size_t min_capacity = ht->used[0] + ht->used[1] + 1;
     size_t num_buckets = numBuckets(ht->bucket_exp[hashtableIsRehashing(ht) ? 1 : 0]);
     size_t current_capacity = num_buckets * ENTRIES_PER_BUCKET;
     unsigned max_fill_percent = resize_policy == HASHTABLE_RESIZE_AVOID ? MAX_FILL_PERCENT_HARD : MAX_FILL_PERCENT_SOFT;
     if (min_capacity * 100 <= current_capacity * max_fill_percent) {
-        return 0;
+        return false;
     }
     return resize(ht, min_capacity, NULL);
 }
@@ -1259,15 +1241,15 @@ int hashtableExpandIfNeeded(hashtable *ht) {
 /* Shrinking is done automatically on deletion, but less eagerly if resize
  * policy is set to AVOID and not at all if set to FORBID. After restoring
  * resize policy to ALLOW, you may want to call hashtableShrinkIfNeeded. */
-int hashtableShrinkIfNeeded(hashtable *ht) {
+bool hashtableShrinkIfNeeded(hashtable *ht) {
     /* Don't shrink if rehashing is already in progress. */
     if (hashtableIsRehashing(ht) || resize_policy == HASHTABLE_RESIZE_FORBID) {
-        return 0;
+        return false;
     }
     size_t current_capacity = numBuckets(ht->bucket_exp[0]) * ENTRIES_PER_BUCKET;
     unsigned min_fill_percent = resize_policy == HASHTABLE_RESIZE_AVOID ? MIN_FILL_PERCENT_HARD : MIN_FILL_PERCENT_SOFT;
     if (ht->used[0] * 100 > current_capacity * min_fill_percent) {
-        return 0;
+        return false;
     }
     return resize(ht, ht->used[0], NULL);
 }
@@ -1303,28 +1285,24 @@ void dismissHashtable(hashtable *ht) {
     }
 }
 
-/* Returns 1 if an entry was found matching the key. Also points *found to it,
- * if found is provided. Returns 0 if no matching entry was found. */
-int hashtableFind(hashtable *ht, const void *key, void **found) {
+/* Returns true if an entry was found matching the key. Also points *found to
+ * it, if found is provided. Returns false if no matching entry was found. */
+bool hashtableFind(hashtable *ht, const void *key, void **found) {
     if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
     int pos_in_bucket = 0;
     bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
-    if (b) {
-        if (found) *found = b->entries[pos_in_bucket];
-        return 1;
-    } else {
-        return 0;
-    }
+    if (b && found) *found = b->entries[pos_in_bucket];
+    return b != NULL;
 }
 
-/* Returns 1 when found, 0 when not found. If found, the position of the entry
- * is returned via the position argument, which can be used to access or replace
- * the entry with one with same key and hash. The position is for immediate use
- * and may be invalidated by the next hashtable operation that triggers
- * incremental rehashing or modifies the table. This method does not pause
- * rehashing. */
-int hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *pos) {
+/* Returns true when found, false when not found. If found, the position of the
+ * entry is returned via the position argument, which can be used to access or
+ * replace the entry with one with same key and hash. The position is for
+ * immediate use and may be invalidated by the next hashtable operation that
+ * triggers incremental rehashing or modifies the table. This method does not
+ * pause rehashing. */
+bool hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
     if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
@@ -1334,31 +1312,33 @@ int hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *pos
         p->bucket = b;
         p->pos_in_bucket = pos_in_bucket;
         p->table_index = table_index;
+        p->position_epoch = ht->epoch;
+        p->current_epoch = &ht->epoch;
     }
-    
+
     return b != NULL;
 }
 
-/* Adds an entry. Returns 1 on success. Returns 0 if there was already an entry
+/* Adds an entry. Returns true on success, false if there was already an entry
  * with the same key. */
-int hashtableAdd(hashtable *ht, void *entry) {
+bool hashtableAdd(hashtable *ht, void *entry) {
     return hashtableAddOrFind(ht, entry, NULL);
 }
 
-/* Adds an entry and returns 1 on success. Returns 0 if there was already an
- * entry with the same key and, if an 'existing' pointer is provided, it is
- * pointed to the existing entry. */
-int hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
+/* Adds an entry and returns true on success. If there was already an entry with
+ * the same key, it returns false and if `existing` is provided points
+ * `existing` to the existing entry. */
+bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
     const void *key = entryGetKey(ht, entry);
     uint64_t hash = hashKey(ht, key);
     int pos_in_bucket = 0;
     bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
     if (b != NULL) {
         if (existing) *existing = b->entries[pos_in_bucket];
-        return 0;
+        return false;
     } else {
         insert(ht, hash, entry);
-        return 1;
+        return true;
     }
 }
 
@@ -1368,12 +1348,12 @@ int hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
  * creating an entry before you know if it already exists in the table or not,
  * and without a separate lookup to the table.
  *
- * The function returns 1 if a position was found where an entry with the
+ * The function returns true if a position was found where an entry with the
  * given key can be inserted. The position is stored in provided 'position'
  * argument, which can be stack-allocated. This position should then be used in
  * a call to hashtableInsertAtPosition.
  *
- * If the function returns 0, it means that an an entry with the given key
+ * If the function returns false, it means that an an entry with the given key
  * already exists in the table. If an 'existing' pointer is provided, it is
  * pointed to the existing entry with the matching key.
  *
@@ -1390,15 +1370,16 @@ int hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
  *         doSomethingWithExistingEntry(existing);
  *     }
  */
-int hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *pos, void **existing) {
+bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *pos, void **existing) {
     position *p = positionFromOpaque(pos);
     uint64_t hash = hashKey(ht, key);
     int pos_in_bucket, table_index;
     bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
     if (b != NULL) {
         if (existing) *existing = b->entries[pos_in_bucket];
-        return 0;
+        return false;
     } else {
+        ht->epoch++;
         hashtableExpandIfNeeded(ht);
         rehashStepOnWriteIfNeeded(ht);
         b = findBucketForInsert(ht, hash, &pos_in_bucket, &table_index);
@@ -1413,7 +1394,9 @@ int hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *
         p->bucket = b;
         p->pos_in_bucket = pos_in_bucket;
         p->table_index = table_index;
-        return 1;
+        p->position_epoch = ht->epoch;
+        p->current_epoch = &ht->epoch;
+        return true;
     }
 }
 
@@ -1424,6 +1407,7 @@ int hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *
  * hashtableFind() may cause incremental rehashing to move entries in memory. */
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
+    assert(p->position_epoch == *p->current_epoch);
     bucket *b = p->bucket;
     int pos_in_bucket = p->pos_in_bucket;
     int table_index = p->table_index;
@@ -1437,6 +1421,7 @@ void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *po
 /* Returns the entry at the given position. The position must be valid */
 void *hashtableGetEntryAtPosition(hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
+    assert(p->position_epoch == *p->current_epoch);
     bucket *b = p->bucket;
     int pos_in_bucket = p->pos_in_bucket;
     if (isPositionFilled(b, pos_in_bucket)) {
@@ -1449,8 +1434,9 @@ void *hashtableGetEntryAtPosition(hashtablePosition *pos) {
 /* Replaces the existing entry at the given position with a new entry.
  * It's the caller's responsibility to ensure that the new entry has the same
  * key and hash, and that the position is valid. */
-void hashtableReplaceEntryAtPosition(hashtablePosition* pos, void *entry) {
+void hashtableReplaceEntryAtPosition(hashtablePosition *pos, void *entry) {
     position *p = positionFromOpaque(pos);
+    assert(p->position_epoch == *p->current_epoch);
     bucket *b = p->bucket;
     int pos_in_bucket = p->pos_in_bucket;
     assert(isPositionFilled(b, pos_in_bucket));
@@ -1458,9 +1444,10 @@ void hashtableReplaceEntryAtPosition(hashtablePosition* pos, void *entry) {
 }
 
 /* Removes the entry with the matching key and returns it. The entry
- * destructor is not called. Returns 1 and points 'popped' to the entry if a
- * matching entry was found. Returns 0 if no matching entry was found. */
-int hashtablePop(hashtable *ht, const void *key, void **popped) {
+ * destructor is not called. Returns true and points 'popped' to the entry if a
+ * matching entry was found. Returns false if no matching entry was found. */
+bool hashtablePop(hashtable *ht, const void *key, void **popped) {
+    ht->epoch++;
     if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
     int pos_in_bucket = 0;
@@ -1477,30 +1464,30 @@ int hashtablePop(hashtable *ht, const void *key, void **popped) {
             fillBucketHole(ht, b, pos_in_bucket, table_index);
         }
         hashtableShrinkIfNeeded(ht);
-        return 1;
+        return true;
     } else {
-        return 0;
+        return false;
     }
 }
 
-/* Deletes the entry with the matching key. Returns 1 if an entry was
- * deleted, 0 if no matching entry was found. */
-int hashtableDelete(hashtable *ht, const void *key) {
+/* Deletes the entry with the matching key. Returns true if an entry was
+ * deleted, false if no matching entry was found. */
+bool hashtableDelete(hashtable *ht, const void *key) {
     void *entry;
     if (hashtablePop(ht, key, &entry)) {
         freeEntry(ht, entry);
-        return 1;
+        return true;
     } else {
-        return 0;
+        return false;
     }
 }
 
 /* When an entry has been reallocated, it can be replaced in a hash table
  * without dereferencing the old pointer which may no longer be valid. The new
  * entry with the same key and hash is used for finding the old entry and
- * replacing it with the new entry. Returns 1 if the entry was replaced and 0 if
- * the entry wasn't found. */
-int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry) {
+ * replacing it with the new entry. Returns true if the entry was replaced and
+ * false if the entry wasn't found. */
+bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry) {
     const void *key = entryGetKey(ht, new_entry);
     uint64_t hash = hashKey(ht, key);
     uint8_t h2 = highBits(hash);
@@ -1532,10 +1519,10 @@ int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void 
  *
  * hashtableTwoPhasePopFindRef finds the position
  * of an entry within the table, so that it can be deleted without looking it
- * up in the table again. The function returns 1 if an entry with a
- * matching key is found, and 0 otherwise.
+ * up in the table again. The function returns true if an entry with a
+ * matching key is found, and false otherwise.
  *
- * If 1 is returned, call 'hashtableTwoPhasePopDelete' with the returned
+ * If true is returned, call 'hashtableTwoPhasePopDelete' with the returned
  * 'position' afterwards to actually delete the entry from the table. These two
  * functions are designed be used in pair. `hashtableTwoPhasePopFindRef` pauses
  * rehashing and `hashtableTwoPhasePopDelete` resumes rehashing.
@@ -1556,11 +1543,11 @@ int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void 
  *     }
  */
 
-/* Like hashtableTwoPhasePopFind, but returns 1 when found and 0 if not found.
+/* Like hashtableTwoPhasePopFind, but returns true when an entry is found.
  * The 'position' argument is populated with a representation of where the entry
  * is stored. This must be provided to hashtableTwoPhasePopDelete to complete
  * the operation. */
-int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *pos) {
+bool hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
     if (hashtableSize(ht) == 0) return 0;
     uint64_t hash = hashKey(ht, key);
@@ -1575,9 +1562,11 @@ int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePositio
         p->bucket = b;
         p->pos_in_bucket = pos_in_bucket;
         p->table_index = table_index;
-        return 1;
+        p->position_epoch = ht->epoch;
+        p->current_epoch = &ht->epoch;
+        return true;
     } else {
-        return 0;
+        return false;
     }
 }
 
@@ -1587,6 +1576,7 @@ int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePositio
 void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *pos) {
     /* Read position. */
     position *p = positionFromOpaque(pos);
+    assert(p->position_epoch == *p->current_epoch);
     bucket *b = p->bucket;
     int pos_in_bucket = p->pos_in_bucket;
     int table_index = p->table_index;
@@ -1595,6 +1585,7 @@ void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *pos) {
     assert(isPositionFilled(b, pos_in_bucket));
     b->presence &= ~(1 << pos_in_bucket);
     ht->used[table_index]--;
+    ht->epoch++;
     hashtableResumeRehashing(ht);
     if (b->chained && !hashtableIsRehashingPaused(ht)) {
         /* Rehashing paused also means bucket chain compaction paused. It is
@@ -1627,10 +1618,10 @@ void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtabl
     }
 }
 
-/* Returns 1 if more work is needed, 0 when done. Call this function repeatedly
- * until it returns 0. Then use hashtableIncrementalFindGetResult to fetch the
+/* Returns true if more work is needed. Call this function repeatedly
+ * until it returns false. Then use hashtableIncrementalFindGetResult to fetch the
  * result. */
-int hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
+bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
     incrementalFind *data = incrementalFindFromOpaque(state);
     switch (data->state) {
     case HASHTABLE_CHECK_ENTRY:
@@ -1642,7 +1633,7 @@ int hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
             if (compareKeys(ht, data->key, elem_key) == 0) {
                 /* It's a match. */
                 data->state = HASHTABLE_FOUND;
-                return 0;
+                return false;
             }
             /* No match. Look for next candidate entry in the bucket. */
             data->pos++;
@@ -1660,7 +1651,7 @@ int hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
                     valkey_prefetch(b->entries[pos]);
                     data->pos = pos;
                     data->state = HASHTABLE_CHECK_ENTRY;
-                    return 1;
+                    return true;
                 }
             }
         }
@@ -1691,33 +1682,33 @@ int hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
             } else {
                 /* No more tables. */
                 data->state = HASHTABLE_NOT_FOUND;
-                return 0;
+                return false;
             }
             valkey_prefetch(data->bucket);
             data->state = HASHTABLE_NEXT_ENTRY;
             data->pos = 0;
         }
-        return 1;
+        return true;
     case HASHTABLE_FOUND:
-        return 0;
+        return false;
     case HASHTABLE_NOT_FOUND:
-        return 0;
+        return false;
     }
-    assert(0);
+    assert(false);
 }
 
-/* Call only when hashtableIncrementalFindStep has returned 0.
+/* Call only when hashtableIncrementalFindStep has returned false.
  *
- * Returns 1 and points 'found' to the entry if an entry was found, 0 if it
- * was not found. */
-int hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found) {
+ * Returns true and points 'found' to the entry if an entry was found, false if
+ * it was not found. */
+bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found) {
     incrementalFind *data = incrementalFindFromOpaque(state);
     if (data->state == HASHTABLE_FOUND) {
         if (found) *found = data->bucket->entries[data->pos];
-        return 1;
+        return true;
     } else {
         assert(data->state == HASHTABLE_NOT_FOUND);
-        return 0;
+        return false;
     }
 }
 
@@ -1784,6 +1775,8 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
 
     /* Flags. */
     int emit_ref = (flags & HASHTABLE_SCAN_EMIT_REF);
+
+    if (emit_ref || defragfn != NULL) ht->epoch++;
 
     if (!hashtableIsRehashing(ht)) {
         /* Emit entries at the cursor index. */
@@ -1956,7 +1949,7 @@ void hashtableResetIterator(hashtableIterator *iterator) {
             hashtableResumeRehashing(iter->hashtable);
             assert(iter->hashtable->pause_rehash >= 0);
         } else {
-            assert(iter->fingerprint == hashtableFingerprint(iter->hashtable));
+            assert(iter->epoch == iter->hashtable->epoch);
         }
     }
 }
@@ -1979,16 +1972,16 @@ void hashtableReleaseIterator(hashtableIterator *iterator) {
 
 /* Points elemptr to the next entry and returns 1 if there is a next entry.
  * Returns 0 if there are no more entries. */
-int hashtableNext(hashtableIterator *iterator, void **elemptr) {
+bool hashtableNext(hashtableIterator *iterator, void **elemptr) {
     iter *iter = iteratorFromOpaque(iterator);
-    while (1) {
+    while (true) {
         if (iter->index == -1 && iter->table == 0) {
             /* It's the first call to next. */
             if (isSafe(iter)) {
                 hashtablePauseRehashing(iter->hashtable);
                 iter->last_seen_size = iter->hashtable->used[iter->table];
             } else {
-                iter->fingerprint = hashtableFingerprint(iter->hashtable);
+                iter->epoch = iter->hashtable->epoch;
             }
             if (iter->hashtable->tables[0] == NULL) {
                 /* Empty hashtable. We're done. */
@@ -2053,35 +2046,36 @@ int hashtableNext(hashtableIterator *iterator, void **elemptr) {
         if (elemptr) {
             *elemptr = b->entries[iter->pos_in_bucket];
         }
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /* --- Random entries --- */
 
-/* Points 'found' to a random entry in the hash table and returns 1. Returns 0
- * if the table is empty. */
-int hashtableRandomEntry(hashtable *ht, void **found) {
+/* Points 'found' to a random entry in the hash table and returns true. Returns
+ * false if the table is empty. */
+bool hashtableRandomEntry(hashtable *ht, void **found) {
     void *samples[WEAK_RANDOM_SAMPLE_SIZE];
     unsigned count = hashtableSampleEntries(ht, &samples[0], WEAK_RANDOM_SAMPLE_SIZE);
-    if (count == 0) return 0;
+    if (count == 0) return false;
     unsigned idx = random() % count;
     *found = samples[idx];
-    return 1;
+    return true;
 }
 
-/* Points 'found' to a random entry in the hash table and returns 1. Returns 0
- * if the table is empty. This one is more fair than hashtableRandomEntry(). */
-int hashtableFairRandomEntry(hashtable *ht, void **found) {
+/* Points 'found' to a random entry in the hash table and returns true. Returns
+ * false if the table is empty. This one is more fair than
+ * hashtableRandomEntry(). */
+bool hashtableFairRandomEntry(hashtable *ht, void **found) {
     /* Sample less if it's very sparse. */
     size_t num_samples = hashtableSize(ht) >= hashtableBuckets(ht) ? FAIR_RANDOM_SAMPLE_SIZE : WEAK_RANDOM_SAMPLE_SIZE;
     void *samples[num_samples];
     unsigned count = hashtableSampleEntries(ht, &samples[0], num_samples);
-    if (count == 0) return 0;
+    if (count == 0) return false;
     unsigned idx = random() % count;
     *found = samples[idx];
-    return 1;
+    return true;
 }
 
 /* This function samples a sequence of entries starting at a random location in

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -134,14 +134,16 @@ void dismissHashtable(hashtable *ht);
 
 /* Entries */
 int hashtableFind(hashtable *ht, const void *key, void **found);
-void **hashtableFindRef(hashtable *ht, const void *key);
+int hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *position);
 int hashtableAdd(hashtable *ht, void *entry);
 int hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
 int hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
+void *hashtableGetEntryAtPosition(hashtablePosition *position);
+void hashtableReplaceEntryAtPosition(hashtablePosition* position, void *entry);
 int hashtablePop(hashtable *ht, const void *key, void **popped);
 int hashtableDelete(hashtable *ht, const void *key);
-void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
+int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
 void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *position);
 int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry);
 void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -28,6 +28,7 @@
  */
 
 #include "fmacros.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <unistd.h>
@@ -39,7 +40,7 @@ typedef struct hashtableStats hashtableStats;
 
 /* Can types that can be stack allocated. */
 typedef uint64_t hashtableIterator[5];
-typedef uint64_t hashtablePosition[2];
+typedef uint64_t hashtablePosition[3];
 typedef uint64_t hashtableIncrementalFindState[5];
 
 /* --- Non-opaque types --- */
@@ -63,7 +64,7 @@ typedef struct {
     /* Callback to prefetch the value associated with a hashtable entry. */
     void (*entryPrefetchValue)(const void *entry);
     /* Callback to control when resizing should be allowed. */
-    int (*resizeAllowed)(size_t moreMem, double usedRatio);
+    bool (*resizeAllowed)(size_t moreMem, double usedRatio);
     /* Invoked at the start of rehashing. */
     void (*rehashingStarted)(hashtable *ht);
     /* Invoked at the end of rehashing. */
@@ -121,34 +122,34 @@ unsigned hashtableEntriesPerBucket(void);
 size_t hashtableMemUsage(hashtable *ht);
 void hashtablePauseAutoShrink(hashtable *ht);
 void hashtableResumeAutoShrink(hashtable *ht);
-int hashtableIsRehashing(hashtable *ht);
-int hashtableIsRehashingPaused(hashtable *ht);
+bool hashtableIsRehashing(hashtable *ht);
+bool hashtableIsRehashingPaused(hashtable *ht);
 void hashtableRehashingInfo(hashtable *ht, size_t *from_size, size_t *to_size);
 int hashtableRehashMicroseconds(hashtable *ht, uint64_t us);
-int hashtableExpand(hashtable *ht, size_t size);
-int hashtableTryExpand(hashtable *ht, size_t size);
-int hashtableExpandIfNeeded(hashtable *ht);
-int hashtableShrinkIfNeeded(hashtable *ht);
+bool hashtableExpand(hashtable *ht, size_t size);
+bool hashtableTryExpand(hashtable *ht, size_t size);
+bool hashtableExpandIfNeeded(hashtable *ht);
+bool hashtableShrinkIfNeeded(hashtable *ht);
 hashtable *hashtableDefragTables(hashtable *ht, void *(*defragfn)(void *));
 void dismissHashtable(hashtable *ht);
 
 /* Entries */
-int hashtableFind(hashtable *ht, const void *key, void **found);
-int hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *position);
-int hashtableAdd(hashtable *ht, void *entry);
-int hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
-int hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
+bool hashtableFind(hashtable *ht, const void *key, void **found);
+bool hashtableFindPosition(hashtable *ht, const void *key, hashtablePosition *position);
+bool hashtableAdd(hashtable *ht, void *entry);
+bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
+bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
 void *hashtableGetEntryAtPosition(hashtablePosition *position);
-void hashtableReplaceEntryAtPosition(hashtablePosition* position, void *entry);
-int hashtablePop(hashtable *ht, const void *key, void **popped);
-int hashtableDelete(hashtable *ht, const void *key);
-int hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
+void hashtableReplaceEntryAtPosition(hashtablePosition *position, void *entry);
+bool hashtablePop(hashtable *ht, const void *key, void **popped);
+bool hashtableDelete(hashtable *ht, const void *key);
+bool hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
 void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *position);
-int hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry);
+bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry);
 void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);
-int hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
-int hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
+bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
+bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
 
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);
@@ -158,11 +159,11 @@ void hashtableReinitIterator(hashtableIterator *iterator, hashtable *ht);
 void hashtableResetIterator(hashtableIterator *iter);
 hashtableIterator *hashtableCreateIterator(hashtable *ht, uint8_t flags);
 void hashtableReleaseIterator(hashtableIterator *iter);
-int hashtableNext(hashtableIterator *iter, void **elemptr);
+bool hashtableNext(hashtableIterator *iter, void **elemptr);
 
 /* Random entries */
-int hashtableRandomEntry(hashtable *ht, void **found);
-int hashtableFairRandomEntry(hashtable *ht, void **found);
+bool hashtableRandomEntry(hashtable *ht, void **found);
+bool hashtableFairRandomEntry(hashtable *ht, void **found);
 unsigned hashtableSampleEntries(hashtable *ht, void **dst, unsigned count);
 
 /* Debug & stats */

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -103,9 +103,9 @@ static hashtable **kvstoreGetHashtableRef(kvstore *kvs, int didx) {
     return &kvs->hashtables[didx];
 }
 
-static int kvstoreHashtableIsRehashingPaused(kvstore *kvs, int didx) {
+static bool kvstoreHashtableIsRehashingPaused(kvstore *kvs, int didx) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    return ht ? hashtableIsRehashingPaused(ht) : 0;
+    return ht ? hashtableIsRehashingPaused(ht) : false;
 }
 
 /* Returns total (cumulative) number of keys up until given hashtable-index (inclusive).
@@ -610,8 +610,9 @@ int kvstoreIteratorGetCurrentHashtableIndex(kvstoreIterator *kvs_it) {
     return kvs_it->didx;
 }
 
-/* Fetches the next element and returns 1. Returns 0 if there are no more elements. */
-int kvstoreIteratorNext(kvstoreIterator *kvs_it, void **next) {
+/* Fetches the next element and returns true. Returns false if there are no more
+ * elements. */
+bool kvstoreIteratorNext(kvstoreIterator *kvs_it, void **next) {
     if (kvs_it->didx != -1 && hashtableNext(&kvs_it->di, next)) {
         return 1;
     } else {
@@ -705,22 +706,22 @@ void kvstoreReleaseHashtableIterator(kvstoreHashtableIterator *kvs_di) {
 }
 
 /* Get the next element of the hashtable through kvstoreHashtableIterator and hashtableNext. */
-int kvstoreHashtableIteratorNext(kvstoreHashtableIterator *kvs_di, void **next) {
+bool kvstoreHashtableIteratorNext(kvstoreHashtableIterator *kvs_di, void **next) {
     /* The hashtable may be deleted during the iteration process, so here need to check for NULL. */
     hashtable *ht = kvstoreGetHashtable(kvs_di->kvs, kvs_di->didx);
     if (!ht) return 0;
     return hashtableNext(&kvs_di->di, next);
 }
 
-int kvstoreHashtableRandomEntry(kvstore *kvs, int didx, void **entry) {
+bool kvstoreHashtableRandomEntry(kvstore *kvs, int didx, void **entry) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableRandomEntry(ht, entry);
 }
 
-int kvstoreHashtableFairRandomEntry(kvstore *kvs, int didx, void **entry) {
+bool kvstoreHashtableFairRandomEntry(kvstore *kvs, int didx, void **entry) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableFairRandomEntry(ht, entry);
 }
 
@@ -730,9 +731,9 @@ unsigned int kvstoreHashtableSampleEntries(kvstore *kvs, int didx, void **dst, u
     return hashtableSampleEntries(ht, dst, count);
 }
 
-int kvstoreHashtableExpand(kvstore *kvs, int didx, unsigned long size) {
+bool kvstoreHashtableExpand(kvstore *kvs, int didx, unsigned long size) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableExpand(ht, size);
 }
 
@@ -778,33 +779,33 @@ uint64_t kvstoreGetHash(kvstore *kvs, const void *key) {
     return kvs->dtype->hashFunction(key);
 }
 
-int kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found) {
+bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableFind(ht, key, found);
 }
 
-int kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
+bool kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableFindPosition(ht, key, position);
 }
 
-int kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing) {
+bool kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing) {
     hashtable *ht = createHashtableIfNeeded(kvs, didx);
-    int ret = hashtableAddOrFind(ht, key, existing);
+    bool ret = hashtableAddOrFind(ht, key, existing);
     if (ret) cumulativeKeyCountAdd(kvs, didx, 1);
     return ret;
 }
 
-int kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry) {
+bool kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry) {
     hashtable *ht = createHashtableIfNeeded(kvs, didx);
-    int ret = hashtableAdd(ht, entry);
+    bool ret = hashtableAdd(ht, entry);
     if (ret) cumulativeKeyCountAdd(kvs, didx, 1);
     return ret;
 }
 
-int kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing) {
+bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing) {
     hashtable *ht = createHashtableIfNeeded(kvs, didx);
     return hashtableFindPositionForInsert(ht, key, position, existing);
 }
@@ -817,9 +818,9 @@ void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, hasht
     cumulativeKeyCountAdd(kvs, didx, 1);
 }
 
-int kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
+bool kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return 0;
+    if (!ht) return false;
     return hashtableTwoPhasePopFindRef(ht, key, position);
 }
 
@@ -830,10 +831,10 @@ void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position) {
     freeHashtableIfNeeded(kvs, didx);
 }
 
-int kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped) {
+bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return 0;
-    int ret = hashtablePop(ht, key, popped);
+    bool ret = hashtablePop(ht, key, popped);
     if (ret) {
         cumulativeKeyCountAdd(kvs, didx, -1);
         freeHashtableIfNeeded(kvs, didx);
@@ -841,10 +842,10 @@ int kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped) 
     return ret;
 }
 
-int kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key) {
+bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return 0;
-    int ret = hashtableDelete(ht, key);
+    bool ret = hashtableDelete(ht, key);
     if (ret) {
         cumulativeKeyCountAdd(kvs, didx, -1);
         freeHashtableIfNeeded(kvs, didx);

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -784,10 +784,10 @@ int kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found) {
     return hashtableFind(ht, key, found);
 }
 
-void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key) {
+int kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return NULL;
-    return hashtableFindRef(ht, key);
+    if (!ht) return 0;
+    return hashtableFindPosition(ht, key, position);
 }
 
 int kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing) {
@@ -811,15 +811,15 @@ int kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, has
 
 /* Must be used together with kvstoreHashtableFindPositionForInsert, with returned
  * position and with the same didx. */
-void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, void *position) {
+void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, hashtablePosition *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     hashtableInsertAtPosition(ht, entry, position);
     cumulativeKeyCountAdd(kvs, didx, 1);
 }
 
-void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, void *position) {
+int kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
-    if (!ht) return NULL;
+    if (!ht) return 0;
     return hashtableTwoPhasePopFindRef(ht, key, position);
 }
 

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -46,7 +46,7 @@ size_t kvstoreHashtableMetadataSize(void);
 kvstoreIterator *kvstoreIteratorInit(kvstore *kvs, uint8_t flags);
 void kvstoreIteratorRelease(kvstoreIterator *kvs_it);
 int kvstoreIteratorGetCurrentHashtableIndex(kvstoreIterator *kvs_it);
-int kvstoreIteratorNext(kvstoreIterator *kvs_it, void **next);
+bool kvstoreIteratorNext(kvstoreIterator *kvs_it, void **next);
 
 /* Rehashing */
 void kvstoreTryResizeHashtables(kvstore *kvs, int limit);
@@ -59,11 +59,11 @@ unsigned long kvstoreHashtableRehashingCount(kvstore *kvs);
 unsigned long kvstoreHashtableSize(kvstore *kvs, int didx);
 kvstoreHashtableIterator *kvstoreGetHashtableIterator(kvstore *kvs, int didx, uint8_t flags);
 void kvstoreReleaseHashtableIterator(kvstoreHashtableIterator *kvs_id);
-int kvstoreHashtableIteratorNext(kvstoreHashtableIterator *kvs_di, void **next);
-int kvstoreHashtableRandomEntry(kvstore *kvs, int didx, void **found);
-int kvstoreHashtableFairRandomEntry(kvstore *kvs, int didx, void **found);
+bool kvstoreHashtableIteratorNext(kvstoreHashtableIterator *kvs_di, void **next);
+bool kvstoreHashtableRandomEntry(kvstore *kvs, int didx, void **found);
+bool kvstoreHashtableFairRandomEntry(kvstore *kvs, int didx, void **found);
 unsigned int kvstoreHashtableSampleEntries(kvstore *kvs, int didx, void **dst, unsigned int count);
-int kvstoreHashtableExpand(kvstore *kvs, int didx, unsigned long size);
+bool kvstoreHashtableExpand(kvstore *kvs, int didx, unsigned long size);
 unsigned long kvstoreHashtableScanDefrag(kvstore *kvs,
                                          int didx,
                                          unsigned long v,
@@ -72,18 +72,18 @@ unsigned long kvstoreHashtableScanDefrag(kvstore *kvs,
                                          void *(*defragfn)(void *),
                                          int flags);
 unsigned long kvstoreHashtableDefragTables(kvstore *kvs, unsigned long cursor, void *(*defragfn)(void *));
-int kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found);
-int kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
-int kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing);
-int kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry);
+bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found);
+bool kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
+bool kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing);
+bool kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry);
 
-int kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing);
+bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing);
 void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, hashtablePosition *position);
 
-int kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
+bool kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
 void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position);
-int kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped);
-int kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key);
+bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped);
+bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key);
 hashtable *kvstoreGetHashtable(kvstore *kvs, int didx);
 
 #endif /* KVSTORE_H */

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -73,14 +73,14 @@ unsigned long kvstoreHashtableScanDefrag(kvstore *kvs,
                                          int flags);
 unsigned long kvstoreHashtableDefragTables(kvstore *kvs, unsigned long cursor, void *(*defragfn)(void *));
 int kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found);
-void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key);
+int kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
 int kvstoreHashtableAddOrFind(kvstore *kvs, int didx, void *key, void **existing);
 int kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry);
 
 int kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing);
-void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, void *position);
+void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, hashtablePosition *position);
 
-void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, void *position);
+int kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, hashtablePosition *position);
 void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position);
 int kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped);
 int kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key);

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -378,7 +378,7 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
         void *next_client;
         while (hashtableNext(&client_iter, &next_client)) {
             client *c = next_client;
-            int retval = hashtableDelete(c->pubsub_data->pubsubshard_channels, channel);
+            bool retval = hashtableDelete(c->pubsub_data->pubsubshard_channels, channel);
             serverAssertWithInfo(c, channel, retval);
             addReplyPubsubUnsubscribed(c, channel, pubSubShardType);
             /* If the client has no other pubsub subscription,
@@ -393,11 +393,10 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
     kvstoreReleaseHashtableIterator(kvs_di);
 }
 
-/* Subscribe a client to a pattern. Returns 1 if the operation succeeded, or 0 if the client was already subscribed to
- * that pattern. */
-int pubsubSubscribePattern(client *c, robj *pattern) {
+/* Subscribe a client to a pattern. */
+static void pubsubSubscribePattern(client *c, robj *pattern) {
     if (!c->pubsub_data) initClientPubSubData(c);
-    int pattern_added = hashtableAdd(c->pubsub_data->pubsub_patterns, pattern);
+    bool pattern_added = hashtableAdd(c->pubsub_data->pubsub_patterns, pattern);
     if (pattern_added) {
         incrRefCount(pattern);
         /* Add the client to the pattern -> list of clients hash table */
@@ -414,16 +413,16 @@ int pubsubSubscribePattern(client *c, robj *pattern) {
     }
     /* Notify the client */
     addReplyPubsubPatSubscribed(c, pattern);
-    return pattern_added;
+    return;
 }
 
-/* Unsubscribe a client from a channel. Returns 1 if the operation succeeded, or
- * 0 if the client was not subscribed to the specified channel. */
-int pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
+/* Unsubscribe a client from a channel. Returns true if the operation succeeded,
+ * or false if the client was not subscribed to the specified channel. */
+static bool pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
     if (!c->pubsub_data) initClientPubSubData(c);
 
     incrRefCount(pattern); /* Protect the object. May be the same we remove */
-    int pattern_deleted = hashtableDelete(c->pubsub_data->pubsub_patterns, pattern);
+    bool pattern_deleted = hashtableDelete(c->pubsub_data->pubsub_patterns, pattern);
     if (pattern_deleted) {
         /* Remove the client from the pattern -> clients list hash table */
         dictEntry *de = dictFind(server.pubsub_patterns, pattern);

--- a/src/server.c
+++ b/src/server.c
@@ -511,17 +511,17 @@ uint64_t dictEncObjHash(const void *key) {
     }
 }
 
-/* Return 1 if we allow a hash table to expand. It may allocate a huge amount of
- * memory to contain hash buckets when it expands, that may lead the server to
- * reject user's requests or evict some keys. We can prevent expansion
- * provisionally if used memory will be over maxmemory after it expands,
- * but to guarantee the performance of the server, we still allow it to expand
- * if the load factor exceeds the hard limit defined in hashtable.c. */
-int hashtableResizeAllowed(size_t moreMem, double usedRatio) {
+/* Return true if we allow a hash table to expand. It may allocate a huge amount
+ * of memory to contain hash buckets when it expands, that may lead the server
+ * to reject user's requests or evict some keys. We can prevent expansion
+ * provisionally if used memory will be over maxmemory after it expands, but to
+ * guarantee the performance of the server, we still allow it to expand if the
+ * load factor exceeds the hard limit defined in hashtable.c. */
+bool hashtableResizeAllowed(size_t moreMem, double usedRatio) {
     UNUSED(usedRatio);
 
     /* For debug purposes, not allowed to be resized. */
-    if (!server.dict_resizing) return 0;
+    if (!server.dict_resizing) return false;
 
     /* Avoid resizing over max memory. */
     return !overMaxmemoryAfterAlloc(moreMem);
@@ -3243,7 +3243,7 @@ void populateCommandTable(void) {
         c = serverCommandTable + j;
         if (c->declared_name == NULL) break;
 
-        int retval1, retval2;
+        bool retval1, retval2;
 
         c->fullname = sdsnew(c->declared_name);
         c->current_name = c->fullname;
@@ -3319,11 +3319,11 @@ void serverOpArrayFree(serverOpArray *oa) {
 
 /* ====================== Commands lookup and execution ===================== */
 
-int isContainerCommandBySds(sds s) {
+bool isContainerCommandBySds(sds s) {
     void *entry;
-    int found_command = hashtableFind(server.commands, s, &entry);
+    bool found_command = hashtableFind(server.commands, s, &entry);
     struct serverCommand *base_cmd = entry;
-    int has_subcommands = found_command && base_cmd->subcommands_ht;
+    bool has_subcommands = found_command && base_cmd->subcommands_ht;
     return has_subcommands;
 }
 
@@ -3344,9 +3344,9 @@ struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_
  */
 struct serverCommand *lookupCommandLogic(hashtable *commands, robj **argv, int argc, int strict) {
     void *entry = NULL;
-    int found_command = hashtableFind(commands, argv[0]->ptr, &entry);
+    bool found_command = hashtableFind(commands, argv[0]->ptr, &entry);
     struct serverCommand *base_cmd = entry;
-    int has_subcommands = found_command && base_cmd->subcommands_ht;
+    bool has_subcommands = found_command && base_cmd->subcommands_ht;
     if (argc == 1 || !has_subcommands) {
         if (strict && argc != 1) return NULL;
         /* Note: It is possible that base_cmd->proc==NULL (e.g. CONFIG) */

--- a/src/server.h
+++ b/src/server.h
@@ -3281,7 +3281,7 @@ void freeHashTypeEntry(hashTypeEntry *entry);
 void hashTypeConvert(robj *o, int enc);
 void hashTypeTryConversion(robj *subject, robj **argv, int start, int end);
 int hashTypeExists(robj *o, sds key);
-int hashTypeDelete(robj *o, sds key);
+bool hashTypeDelete(robj *o, sds key);
 unsigned long hashTypeLength(const robj *o);
 void hashTypeInitIterator(robj *subject, hashTypeIterator *hi);
 void hashTypeResetIterator(hashTypeIterator *hi);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -476,7 +476,7 @@ int hashTypeSet(robj *o, sds field, sds value, int flags) {
             void *new_entry = hashTypeEntryReplaceValue(existing, v);
             if (new_entry != existing) {
                 /* It has been reallocated. */
-                int replaced = hashtableReplaceReallocatedEntry(ht, existing, new_entry);
+                bool replaced = hashtableReplaceReallocatedEntry(ht, existing, new_entry);
                 serverAssert(replaced);
             }
             update = 1;
@@ -493,9 +493,9 @@ int hashTypeSet(robj *o, sds field, sds value, int flags) {
 }
 
 /* Delete an element from a hash.
- * Return 1 on deleted and 0 on not found. */
-int hashTypeDelete(robj *o, sds field) {
-    int deleted = 0;
+ * Return true on deleted, false if not found. */
+bool hashTypeDelete(robj *o, sds field) {
+    bool deleted = false;
 
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl, *fptr;
@@ -1245,7 +1245,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
 
         /* Add all the elements into the temporary hashtable. */
         while (hashtableNext(&iter, &entry)) {
-            int res = hashtableAdd(ht, entry);
+            bool res = hashtableAdd(ht, entry);
             serverAssert(res);
         }
         serverAssert(hashtableSize(ht) == size);

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -309,7 +309,7 @@ int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_
         return hashtableFind(set->ptr, (sds)str, NULL);
     } else if (set->encoding == OBJ_ENCODING_HASHTABLE) {
         sds sdsval = sdsnewlen(str, len);
-        int result = hashtableFind(set->ptr, sdsval, NULL);
+        bool result = hashtableFind(set->ptr, sdsval, NULL);
         sdsfree(sdsval);
         return result;
     } else {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1499,15 +1499,15 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
     if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = zobj->ptr;
 
-        void **node_ref_in_hashtable = hashtableFindRef(zs->ht, ele);
-        if (node_ref_in_hashtable != NULL) {
+        hashtablePosition position;
+        if (hashtableFindPosition(zs->ht, ele, &position)) {
             /* NX? Return, same element already exists. */
             if (nx) {
                 *out_flags |= ZADD_OUT_NOP;
                 return 1;
             }
 
-            zskiplistNode *old_node = *node_ref_in_hashtable;
+            zskiplistNode *old_node = hashtableGetEntryAtPosition(&position);
             curscore = old_node->score;
 
             /* Prepare the score for the increment if needed. */
@@ -1530,9 +1530,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
             /* Remove and re-insert when score changes. */
             if (score != curscore) {
                 zskiplistNode *new_node = zslUpdateScore(zs->zsl, old_node, score);
-                /* Note that this assignment updates the node pointer stored in
-                 * the hashtable */
-                if (new_node) *node_ref_in_hashtable = new_node;
+                if (new_node) hashtableReplaceEntryAtPosition(&position, new_node);
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4200,7 +4200,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         void *entry;
         /* Add all the elements into the temporary hashtable. */
         while (hashtableNext(&iter, &entry)) {
-            int res = hashtableAdd(ht, entry);
+            bool res = hashtableAdd(ht, entry);
             serverAssert(res);
         }
         serverAssert(hashtableSize(ht) == size);

--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -299,9 +299,8 @@ int test_two_phase_insert_and_pop(int argc, char **argv, int flags) {
         snprintf(val, sizeof(val), "%d", count - j + 42);
         hashtablePosition position;
         size_t size_before_find = hashtableSize(ht);
-        void **ref = hashtableTwoPhasePopFindRef(ht, key, &position);
-        TEST_ASSERT(ref != NULL);
-        keyval *e = *ref;
+        TEST_ASSERT(hashtableTwoPhasePopFindRef(ht, key, &position));
+        keyval *e = hashtableGetEntryAtPosition(&position);
         TEST_ASSERT(!strcmp(val, getval(e)));
         TEST_ASSERT(hashtableSize(ht) == size_before_find);
         hashtableTwoPhasePopDelete(ht, &position);

--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -271,8 +271,8 @@ int test_two_phase_insert_and_pop(int argc, char **argv, int flags) {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", count - j + 42);
         hashtablePosition position;
-        int ret = hashtableFindPositionForInsert(ht, key, &position, NULL);
-        TEST_ASSERT(ret == 1);
+        bool ret = hashtableFindPositionForInsert(ht, key, &position, NULL);
+        TEST_ASSERT(ret == true);
         keyval *e = create_keyval(key, val);
         hashtableInsertAtPosition(ht, e, &position);
     }


### PR DESCRIPTION
This is still a draft - I'm currently running benchmarks to ensure there are no regressions.

This neatly avoids void** references to internal hashtable data, instead using hashtablePosition to replace elements when needed. The result is safer and more readable. (At present I've not changed the hashtableScanDefrag callback signature though.)