### PR TITLE
Skip empty db when doing FLUSHALL to reduce some NOP

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -583,6 +583,8 @@ long long emptyDbStructure(serverDb *dbarray, int dbnum, int async, void(callbac
     }
 
     for (int j = startdb; j <= enddb; j++) {
+        if (kvstoreSize(dbarray[j].keys) == 0) continue;
+
         removed += kvstoreSize(dbarray[j].keys);
         if (async) {
             emptyDbAsync(&dbarray[j]);


### PR DESCRIPTION
When only a few dbs are used in multidb, FLUSHALL will do
some NOPs. For example, in FLUSHALL ASYNC we will need to
re-create objects and submit the bio jobs. This somehow will
cause FLUSHALL ASYNC to be logged in the slowlog.