### PR TITLE
Limiting the new reconnections for failed nodes

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5397,7 +5397,8 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *
     }
 
     if (node->link == NULL) {
-        if (!node->inbound_link && (now - node->outbound_link_attempt_time < server.cluster_node_timeout / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts > max_conn_attempts)) {
+        mstime_t reconnect_interval = server.cluster_node_timeout / 2;
+        if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts > max_conn_attempts)) {
             return 1;
         }
         node->outbound_link_attempt_time = now;
@@ -5453,15 +5454,15 @@ static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
  *
  * We want to guarantee that every node is contacted twice within cluster node timeout.
  */
-static long long maxConnectionAttemptsPerCron(const int nodes, const long long timeout_ms) {
-    if (nodes <= 0 || timeout_ms <= 0)
+static long long maxConnectionAttemptsPerCron(void) {
+    long long reconnect_interval = server.cluster_node_timeout / 2;
+    if (dictSize(server.cluster->nodes) <= 0 || reconnect_interval <= 0)
         return 0;
     /*
      * We run the cron loop every 100 ms.  To reach 100 % of the nodes
-     * within the timeout, we need: ceil(nodes * 100 / timeout_ms)
-     * We use (a + b − 1) / b to give us the integer-ceil without using floating-point.
+     * within the timeout, we need: ceil(nodes * 100 / reconnect_interval)
      */
-    const long long min_nodes_for_coverage = (nodes * 100 + timeout_ms - 1) / timeout_ms;
+    const long long min_nodes_for_coverage = (dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS + reconnect_interval - 1) / reconnect_interval;
     /*
      * Increase the coverage budget so each node can be probed 10 times
      * inside the timeout.
@@ -5490,7 +5491,7 @@ void clusterCron(void) {
     server.cluster->stats_pfail_nodes = 0;
     /* Run through some of the operations we want to do on each cluster node. */
     di = dictGetSafeIterator(server.cluster->nodes);
-    const long long max_conn_attempts = maxConnectionAttemptsPerCron(dictSize(server.cluster->nodes), server.cluster_node_timeout);
+    const long long max_conn_attempts = maxConnectionAttemptsPerCron();
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         /* We free the inbound or outboud link to the node if the link has an

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5398,7 +5398,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
 
     if (node->link == NULL) {
         mstime_t reconnect_interval = server.cluster_node_timeout / 2;
-        /* Skip this outbound connection attempt when all three are true:
+        /* Skip this outbound connection attempt when all these conditions are true:
          *  1. No inbound link from the peer exists.
          *  2. The back‑off window since the last try is still active
          *  3. The cluster has already exceeded its retry budget for this cron cycle
@@ -5453,25 +5453,19 @@ static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
     freeClusterLinkOnBufferLimitReached(node->inbound_link);
 }
 
-/**
- * Compute the maximum number of connection attempts the cluster-cron
+/* Compute the maximum number of connection attempts the clusterCron
  * loop should schedule in a single cron.
  *
- * We want to guarantee that every node is contacted 10 times within node timeout.
- */
+ * We want to guarantee that every node is contacted 10 times within node timeout. */
 static long long maxConnectionAttemptsPerCron(void) {
     long long reconnect_interval = server.cluster_node_timeout / 2;
     if (reconnect_interval <= 0)
         return 0;
-    /*
-     * We run the cron loop every 100 ms.  To reach 100 % of the nodes
-     * within the timeout, we need: ceil(nodes * 100 / reconnect_interval)
-     */
+    /* We run the cron loop every 100 ms.  To reach 100 % of the nodes
+     * within the timeout, we need: ceil(nodes * 100 / reconnect_interval) */
     const long long min_nodes_for_coverage = dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS / reconnect_interval;
-    /*
-     * Increase the coverage budget so each node can be probed 10 times
-     * inside the timeout.
-     */
+    /* Increase the coverage budget so each node can be probed 10 times
+     * inside the timeout. */
     return min_nodes_for_coverage * NODE_CONNECTION_RETRIES_PER_TIMEOUT;
 }
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5363,6 +5363,8 @@ static int nodeExceedsHandshakeTimeout(clusterNode *node, mstime_t now) {
     return now - node->ctime > getHandshakeTimeout() ? 1 : 0;
 }
 
+#define NODE_CONNECTION_RETRIES_PER_TIMEOUT 10
+
 /* Check if the node is disconnected and re-establish the connection.
  * Also update a few stats while we are here, that can be used to make
  * better decisions in other part of the code. */
@@ -5395,7 +5397,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *
     }
 
     if (node->link == NULL) {
-        if (!node->inbound_link && (now - node->outbound_link_attempt_time < server.cluster_node_timeout / 10 && *cluster_conn_attempts > max_conn_attempts)) {
+        if (!node->inbound_link && (now - node->outbound_link_attempt_time < server.cluster_node_timeout / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts > max_conn_attempts)) {
             return 1;
         }
         node->outbound_link_attempt_time = now;
@@ -5461,10 +5463,10 @@ static long long maxConnectionAttemptsPerCron(const int nodes, const long long t
      */
     const long long min_nodes_for_coverage = (nodes * 100 + timeout_ms - 1) / timeout_ms;
     /*
-     * Double the coverage budget so each node can be probed twice
-     * inside the timeout, improving resilience to packet loss.
+     * Increase the coverage budget so each node can be probed 10 times
+     * inside the timeout.
      */
-    return min_nodes_for_coverage * 10;
+    return min_nodes_for_coverage * NODE_CONNECTION_RETRIES_PER_TIMEOUT;
 }
 
 /* This is executed 10 times every second */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5398,6 +5398,11 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *
 
     if (node->link == NULL) {
         mstime_t reconnect_interval = server.cluster_node_timeout / 2;
+        /* Skip this outbound connection attempt when all three are true:
+         *  1. No inbound link from the peer exists.
+         *  2. The back‑off window since the last try is still active
+         *  3. The cluster has already exceeded its retry budget for this cron cycle
+         */
         if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts > max_conn_attempts)) {
             return 1;
         }
@@ -5452,7 +5457,7 @@ static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
  * Compute the maximum number of connection attempts the cluster-cron
  * loop should schedule in a single cron.
  *
- * We want to guarantee that every node is contacted twice within cluster node timeout.
+ * We want to guarantee that every node is contacted 10 times within node timeout.
  */
 static long long maxConnectionAttemptsPerCron(void) {
     long long reconnect_interval = server.cluster_node_timeout / 2;
@@ -5462,7 +5467,7 @@ static long long maxConnectionAttemptsPerCron(void) {
      * We run the cron loop every 100 ms.  To reach 100 % of the nodes
      * within the timeout, we need: ceil(nodes * 100 / reconnect_interval)
      */
-    const long long min_nodes_for_coverage = (dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS + reconnect_interval - 1) / reconnect_interval;
+    const long long min_nodes_for_coverage = ceil(dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS / reconnect_interval);
     /*
      * Increase the coverage budget so each node can be probed 10 times
      * inside the timeout.
@@ -5502,7 +5507,6 @@ void clusterCron(void) {
          */
         if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now, &cluster_node_conn_attempts, max_conn_attempts)) continue;
     }
-    cluster_node_conn_attempts = 0;
     dictReleaseIterator(di);
 
     /* Ping some random node 1 time every 10 iterations, so that we usually ping

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5368,7 +5368,7 @@ static int nodeExceedsHandshakeTimeout(clusterNode *node, mstime_t now) {
 /* Check if the node is disconnected and re-establish the connection.
  * Also update a few stats while we are here, that can be used to make
  * better decisions in other part of the code. */
-static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *cluster_conn_attempts, const long long max_conn_attempts) {
+static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long long *cluster_conn_attempts) {
     /* Not interested in reconnecting the link with myself or nodes
      * for which we have no address. */
     if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) return 1;
@@ -5403,11 +5403,11 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *
          *  2. The back‑off window since the last try is still active
          *  3. The cluster has already exceeded its retry budget for this cron cycle
          */
-        if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts > max_conn_attempts)) {
+        if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts == 0)) {
             return 1;
         }
         node->outbound_link_attempt_time = now;
-        (*cluster_conn_attempts)++;
+        (*cluster_conn_attempts)--;
         clusterLink *link = createClusterLink(node);
         link->conn = connCreate(connTypeOfCluster());
         connSetPrivateData(link->conn, link);
@@ -5467,7 +5467,7 @@ static long long maxConnectionAttemptsPerCron(void) {
      * We run the cron loop every 100 ms.  To reach 100 % of the nodes
      * within the timeout, we need: ceil(nodes * 100 / reconnect_interval)
      */
-    const long long min_nodes_for_coverage = ceil(dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS / reconnect_interval);
+    const long long min_nodes_for_coverage = dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS / reconnect_interval;
     /*
      * Increase the coverage budget so each node can be probed 10 times
      * inside the timeout.
@@ -5486,8 +5486,6 @@ void clusterCron(void) {
     mstime_t min_pong = 0, now = mstime();
     clusterNode *min_pong_node = NULL;
     static unsigned long long iteration = 0;
-    int cluster_node_conn_attempts = 0;
-
     iteration++; /* Number of times this function was called so far. */
 
     clusterUpdateMyselfHostname();
@@ -5496,7 +5494,7 @@ void clusterCron(void) {
     server.cluster->stats_pfail_nodes = 0;
     /* Run through some of the operations we want to do on each cluster node. */
     di = dictGetSafeIterator(server.cluster->nodes);
-    const long long max_conn_attempts = maxConnectionAttemptsPerCron();
+    long long cluster_node_conn_attempts = maxConnectionAttemptsPerCron();
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         /* We free the inbound or outboud link to the node if the link has an
@@ -5505,7 +5503,7 @@ void clusterCron(void) {
         /* The protocol is that function(s) below return non-zero if the node was
          * terminated.
          */
-        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now, &cluster_node_conn_attempts, max_conn_attempts)) continue;
+        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now, &cluster_node_conn_attempts)) continue;
     }
     dictReleaseIterator(di);
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1661,6 +1661,7 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->replicaof = NULL;
     node->last_in_ping_gossip = 0;
     node->ping_sent = node->pong_received = 0;
+    node->outbound_link_attempt_time = 0;
     node->data_received = 0;
     node->meet_sent = 0;
     node->fail_time = 0;
@@ -5365,7 +5366,7 @@ static int nodeExceedsHandshakeTimeout(clusterNode *node, mstime_t now) {
 /* Check if the node is disconnected and re-establish the connection.
  * Also update a few stats while we are here, that can be used to make
  * better decisions in other part of the code. */
-static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now) {
+static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, int *cluster_conn_attempts, const long long max_conn_attempts) {
     /* Not interested in reconnecting the link with myself or nodes
      * for which we have no address. */
     if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) return 1;
@@ -5394,6 +5395,11 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now) {
     }
 
     if (node->link == NULL) {
+        if (!node->inbound_link && (now - node->outbound_link_attempt_time < server.cluster_node_timeout / 10 && *cluster_conn_attempts > max_conn_attempts)) {
+            return 1;
+        }
+        node->outbound_link_attempt_time = now;
+        (*cluster_conn_attempts)++;
         clusterLink *link = createClusterLink(node);
         link->conn = connCreate(connTypeOfCluster());
         connSetPrivateData(link->conn, link);
@@ -5439,6 +5445,28 @@ static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
     freeClusterLinkOnBufferLimitReached(node->inbound_link);
 }
 
+/**
+ * Compute the maximum number of connection attempts the cluster-cron
+ * loop should schedule in a single cron.
+ *
+ * We want to guarantee that every node is contacted twice within cluster node timeout.
+ */
+static long long maxConnectionAttemptsPerCron(const int nodes, const long long timeout_ms) {
+    if (nodes <= 0 || timeout_ms <= 0)
+        return 0;
+    /*
+     * We run the cron loop every 100 ms.  To reach 100 % of the nodes
+     * within the timeout, we need: ceil(nodes * 100 / timeout_ms)
+     * We use (a + b − 1) / b to give us the integer-ceil without using floating-point.
+     */
+    const long long min_nodes_for_coverage = (nodes * 100 + timeout_ms - 1) / timeout_ms;
+    /*
+     * Double the coverage budget so each node can be probed twice
+     * inside the timeout, improving resilience to packet loss.
+     */
+    return min_nodes_for_coverage * 10;
+}
+
 /* This is executed 10 times every second */
 void clusterCron(void) {
     dictIterator *di;
@@ -5450,6 +5478,7 @@ void clusterCron(void) {
     mstime_t min_pong = 0, now = mstime();
     clusterNode *min_pong_node = NULL;
     static unsigned long long iteration = 0;
+    int cluster_node_conn_attempts = 0;
 
     iteration++; /* Number of times this function was called so far. */
 
@@ -5459,6 +5488,7 @@ void clusterCron(void) {
     server.cluster->stats_pfail_nodes = 0;
     /* Run through some of the operations we want to do on each cluster node. */
     di = dictGetSafeIterator(server.cluster->nodes);
+    const long long max_conn_attempts = maxConnectionAttemptsPerCron(dictSize(server.cluster->nodes), server.cluster_node_timeout);
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         /* We free the inbound or outboud link to the node if the link has an
@@ -5467,8 +5497,9 @@ void clusterCron(void) {
         /* The protocol is that function(s) below return non-zero if the node was
          * terminated.
          */
-        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now)) continue;
+        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now, &cluster_node_conn_attempts, max_conn_attempts)) continue;
     }
+    cluster_node_conn_attempts = 0;
     dictReleaseIterator(di);
 
     /* Ping some random node 1 time every 10 iterations, so that we usually ping

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5461,7 +5461,7 @@ static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
  */
 static long long maxConnectionAttemptsPerCron(void) {
     long long reconnect_interval = server.cluster_node_timeout / 2;
-    if (dictSize(server.cluster->nodes) <= 0 || reconnect_interval <= 0)
+    if (reconnect_interval <= 0)
         return 0;
     /*
      * We run the cron loop every 100 ms.  To reach 100 % of the nodes

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5401,7 +5401,7 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
         /* Skip this outbound connection attempt when all these conditions are true:
          *  1. No inbound link from the peer exists.
          *  2. The back‑off window since the last try is still active
-         *  3. The cluster has already exceeded its retry budget for this cron cycle
+         *  3. The node has already exceeded its retry budget for this cron cycle
          */
         if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts == 0)) {
             return 1;

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -357,6 +357,7 @@ struct _clusterNode {
     mstime_t meet_sent;                     /* Unix time we sent latest meet packet */
     mstime_t fail_time;                     /* Unix time when FAIL flag was set */
     mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
+    mstime_t outbound_link_attempt_time;    /* Unix time we last tried to establish an outgoing link */
     mstime_t inbound_link_freed_time;       /* Last time we freed the inbound link for this node.
                                                If it was never freed, it is the same as ctime */
     long long repl_offset;                  /* Last known repl offset for this node. */

--- a/src/server.c
+++ b/src/server.c
@@ -1653,7 +1653,7 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
 
     /* Run the Cluster cron. */
     if (server.cluster_enabled) {
-        run_with_period(100) clusterCron();
+        run_with_period(CLUSTER_CRON_PERIOD_MS) clusterCron();
     }
 
     /* Run the Sentinel timer if we are in sentinel mode. */

--- a/src/server.h
+++ b/src/server.h
@@ -665,6 +665,9 @@ typedef enum {
     (NOTIFY_GENERIC | NOTIFY_STRING | NOTIFY_LIST | NOTIFY_SET | NOTIFY_HASH | NOTIFY_ZSET | NOTIFY_EXPIRED | \
      NOTIFY_EVICTED | NOTIFY_STREAM | NOTIFY_MODULE) /* A flag */
 
+/* Period in milliseconds between successive clusterCron() executions */
+#define CLUSTER_CRON_PERIOD_MS 100
+
 /* Using the following macro you can run code inside serverCron() with the
  * specified period, specified in milliseconds.
  * The actual resolution depends on server.hz. */

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -111,18 +111,6 @@ proc cluster_nodes_all_know_each_other {num_nodes} {
     return 1
 }
 
-proc is_node_in_handshake {from_node_id} {
-    set links_output [R $from_node_id cluster links]
-    set to_node_id [cluster_get_first_node_in_handshake $from_node_id]
-    foreach link $links_output {
-        array set linkinfo $link
-        if {[info exists linkinfo(node)] && $linkinfo(direction) eq "to" && $linkinfo(node) eq $to_node_id} {
-            return 1
-        }
-    }
-    return 0
-}
-
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 4000 cluster-replica-no-failover yes}} {
     set CLUSTER_PACKET_TYPE_PING 0
     set CLUSTER_PACKET_TYPE_PONG 1
@@ -172,13 +160,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
                 after 100
                 # Since we are in handshake, we use a randomly generated ID we have to find
                 R 1 DEBUG CLUSTERLINK KILL ALL [cluster_get_first_node_in_handshake 1]
-
-                wait_for_condition 5 400 {
-                    [is_node_in_handshake 1] && [is_node_in_handshake 0]
-                } else {
-                    fail "Node 0 or Node 1 never entered in handshake state"
-                }
-
                 incr meet_retry 1
             }
 

--- a/tests/unit/cluster/cluster-reliable-meet.tcl
+++ b/tests/unit/cluster/cluster-reliable-meet.tcl
@@ -111,6 +111,18 @@ proc cluster_nodes_all_know_each_other {num_nodes} {
     return 1
 }
 
+proc is_node_in_handshake {from_node_id} {
+    set links_output [R $from_node_id cluster links]
+    set to_node_id [cluster_get_first_node_in_handshake $from_node_id]
+    foreach link $links_output {
+        array set linkinfo $link
+        if {[info exists linkinfo(node)] && $linkinfo(direction) eq "to" && $linkinfo(node) eq $to_node_id} {
+            return 1
+        }
+    }
+    return 0
+}
+
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 4000 cluster-replica-no-failover yes}} {
     set CLUSTER_PACKET_TYPE_PING 0
     set CLUSTER_PACKET_TYPE_PONG 1
@@ -160,6 +172,13 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-node-timeout 
                 after 100
                 # Since we are in handshake, we use a randomly generated ID we have to find
                 R 1 DEBUG CLUSTERLINK KILL ALL [cluster_get_first_node_in_handshake 1]
+
+                wait_for_condition 5 400 {
+                    [is_node_in_handshake 1] && [is_node_in_handshake 0]
+                } else {
+                    fail "Node 0 or Node 1 never entered in handshake state"
+                }
+
                 incr meet_retry 1
             }
 


### PR DESCRIPTION
In cluster mode, the node attempts to reconnect to nodes where `link == NULL` during each execution cycle, which occurs every 100 milliseconds by default. This behavior results in continuous reconnection attempts to nodes that are unreachable or in a failed state (PFAIL or FAIL)

This PR addresses an issue where the system aggressively attempts to reconnect to failed nodes, which can lead to resource exhaustion and potential instability. This change limits the number of attempts we make per failed node. 

The PR improves engine CPU of the P99 nodes (20-30 nodes in a cluster) in the by **35%,** P90 (200-300 nodes) and Avg (across all nodes) by **10%** when there are failed nodes in the cluster.

<img width="1560" alt="Screenshot 2025-06-11 at 2 20 11 PM" src="https://github.com/user-attachments/assets/0f300a60-3876-4887-be66-c4197f5d5bd5" />

<img width="1172" alt="Screenshot 2025-06-12 at 7 16 48 PM" src="https://github.com/user-attachments/assets/0279fd25-382d-4ddb-9e51-ab133e89c9f5" />




Resolves #2122 