### PR TITLE
Offload slot calculation and cross-slot detection to I/O threads

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -962,7 +962,43 @@ void clusterCommand(client *c) {
     }
 }
 
+/* Compute cluster slot for the given command and arguments and detect cluster
+ * cross-slot errors. Returns the slot. If -1 is returned, one of the flags
+ * READ_FLAGS_NO_KEYS or READ_FLAGS_CROSSSLOT is set in `*read_flags` to
+ * indicate why the slot couldn't be determined. This function has no
+ * side-effects and can be called from I/O threads. */
+int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *read_flags) {
+    getKeysResult result;
+    initGetKeysResult(&result);
+    int numkeys = getKeysFromCommand(cmd, argv, argc, &result);
+    int slot = -1;
+    if (numkeys == 0) *read_flags |= READ_FLAGS_NO_KEYS;
+    for (int i = 0; i < numkeys; i++) {
+        sds key = argv[result.keys[i].pos]->ptr;
+        int keyslot = keyHashSlot(key, sdslen(key));
+        if (slot == -1) {
+            slot = keyslot;
+        } else if (keyslot != slot) {
+            slot = -1;
+            *read_flags |= READ_FLAGS_CROSSSLOT;
+            break;
+        }
+    }
+    getKeysFreeResult(&result);
+    return slot;
+}
+
 /* Return the pointer to the cluster node that is able to serve the command.
+ *
+ * Note that this function doesn't compute the slot for each key. The client's
+ * slot needs to be set before calling this function. If it's set to -1, the
+ * client's read flags should indicate if it's a cross-slot command or if the
+ * command has no keys. This is computed by clusterSlotByCommand(). The commands
+ * can be called together like this:
+ *
+ *     c->slot = clusterSlotByCommand(c->cmd, c->argv, c->argc, &c->read_flags);
+ *     node = getNodeByQuery(c, &error_code);
+ *
  * For the function to succeed the command should only target either:
  *
  * 1) A single key (even multiple times like RPOPLPUSH mylist mylist).
@@ -994,15 +1030,17 @@ void clusterCommand(client *c) {
  *
  * CLUSTER_REDIR_DOWN_STATE and CLUSTER_REDIR_DOWN_RO_STATE if the cluster is
  * down but the user attempts to execute a command that addresses one or more keys. */
-clusterNode *
-getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *error_code) {
+clusterNode *getNodeByQuery(client *c, int *error_code) {
     clusterNode *myself = getMyClusterNode();
     clusterNode *n = NULL;
     robj *firstkey = NULL;
     int multiple_keys = 0;
     multiState *ms, _ms;
     multiCmd mc;
-    int i, slot = 0, migrating_slot = 0, importing_slot = 0, missing_keys = 0, existing_keys = 0;
+    int i, migrating_slot = 0, importing_slot = 0, missing_keys = 0, existing_keys = 0;
+
+    /* Slot must be calculated in advance, or cross-slot or no keys detected. */
+    serverAssert(c->slot >= 0 || c->read_flags & (READ_FLAGS_NO_KEYS | READ_FLAGS_CROSSSLOT));
 
     /* Allow any key to be set if a module disabled cluster redirections. */
     if (server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_REDIRECTION) return myself;
@@ -1014,9 +1052,63 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
      * when writing a module that implements a completely different
      * distributed system. */
 
+    /* Determine transaction slot and return early on cross-slot. */
+    if (c->cmd->proc == execCommand && c->flag.multi) {
+        int slot = -1;
+        for (i = 0; i < c->mstate->count; i++) {
+            if (slot == -1) {
+                slot = c->mstate->commands[i].slot;
+            } else if (c->mstate->commands[i].slot != -1 && c->mstate->commands[i].slot != slot) {
+                if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
+                return NULL;
+            }
+        }
+        c->slot = slot;
+    } else if (c->read_flags & READ_FLAGS_CROSSSLOT) {
+        if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
+        return NULL;
+    }
+
+    /* No key at all in command? then we can serve the request
+     * without redirections or errors in all the cases. */
+    if (c->slot == -1) return myself;
+
+    n = getNodeBySlot(c->slot);
+
+    /* If a slot is not served, we are in "cluster down" state.
+     * This check is done early to preserve historical behavior. */
+    if (n == NULL) {
+        if (error_code) *error_code = CLUSTER_REDIR_DOWN_UNBOUND;
+        return NULL;
+    }
+
+    /* If we are migrating or importing this slot, we need to check
+     * if we have all the keys in the request (the only way we
+     * can safely serve the request, otherwise we return a TRYAGAIN
+     * error). To do so we set the importing/migrating state and
+     * increment a counter for every missing key. */
+    if (clusterNodeIsPrimary(myself) || c->flag.readonly) {
+        if (n == clusterNodeGetPrimary(myself) && getMigratingSlotDest(c->slot) != NULL) {
+            migrating_slot = 1;
+        } else if (getImportingSlotSource(c->slot) != NULL) {
+            importing_slot = 1;
+        }
+    }
+
+    uint64_t cmd_flags = getCommandFlags(c);
+
+    /* Only valid for sharded pubsub as regular pubsub can operate on any node and bypasses this layer. */
+    int pubsubshard_included =
+        (cmd_flags & CMD_PUBSUB) || (c->cmd->proc == execCommand && (c->mstate->cmd_flags & CMD_PUBSUB));
+
+    /* For migrating and importing slots, we need to go over all the keys to
+     * count existing keys and missing keys that we need for TRYAGAIN and ASK
+     * redirects. Skip this if we're not importing or migrating. */
+    if (!migrating_slot && !importing_slot) goto after_checking_each_key;
+
     /* We handle all the cases as if they were EXEC commands, so we have
      * a common code path for everything */
-    if (cmd->proc == execCommand) {
+    if (c->cmd->proc == execCommand) {
         /* If CLIENT_MULTI flag is not set EXEC is just going to return an
          * error. */
         if (!c->flag.multi) return myself;
@@ -1028,21 +1120,14 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
         ms = &_ms;
         _ms.commands = &mc;
         _ms.count = 1;
-        mc.argv = argv;
-        mc.argc = argc;
-        mc.cmd = cmd;
+        mc.argv = c->argv;
+        mc.argc = c->argc;
+        mc.cmd = c->cmd;
     }
-
-    uint64_t cmd_flags = getCommandFlags(c);
-
-    /* Only valid for sharded pubsub as regular pubsub can operate on any node and bypasses this layer. */
-    int pubsubshard_included =
-        (cmd_flags & CMD_PUBSUB) || (c->cmd->proc == execCommand && (c->mstate->cmd_flags & CMD_PUBSUB));
 
     serverDb *currentDb = c->db;
 
-    /* Check that all the keys are in the same hash slot, and obtain this
-     * slot and the node associated. */
+    /* Check for multiple keys, existing keys, missing keys. */
     for (i = 0; i < ms->count; i++) {
         struct serverCommand *mcmd;
         robj **margv;
@@ -1070,47 +1155,13 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
 
         for (j = 0; j < numkeys; j++) {
             robj *thiskey = margv[keyindex[j].pos];
-            int thisslot = keyHashSlot((char *)thiskey->ptr, sdslen(thiskey->ptr));
 
             if (firstkey == NULL) {
-                /* This is the first key we see. Check what is the slot
-                 * and node. */
+                /* This is the first key we see. */
                 firstkey = thiskey;
-                slot = thisslot;
-                n = getNodeBySlot(slot);
-
-                /* Error: If a slot is not served, we are in "cluster down"
-                 * state. However the state is yet to be updated, so this was
-                 * not trapped earlier in processCommand(). Report the same
-                 * error to the client. */
-                if (n == NULL) {
-                    getKeysFreeResult(&result);
-                    if (error_code) *error_code = CLUSTER_REDIR_DOWN_UNBOUND;
-                    return NULL;
-                }
-
-                /* If we are migrating or importing this slot, we need to check
-                 * if we have all the keys in the request (the only way we
-                 * can safely serve the request, otherwise we return a TRYAGAIN
-                 * error). To do so we set the importing/migrating state and
-                 * increment a counter for every missing key. */
-                if (clusterNodeIsPrimary(myself) || c->flag.readonly) {
-                    if (n == clusterNodeGetPrimary(myself) && getMigratingSlotDest(slot) != NULL) {
-                        migrating_slot = 1;
-                    } else if (getImportingSlotSource(slot) != NULL) {
-                        importing_slot = 1;
-                    }
-                }
-
             } else {
                 /* If it is not the first key/channel, make sure it is exactly
                  * the same key/channel as the first we saw. */
-                if (slot != thisslot) {
-                    /* Error: multiple keys from different slots. */
-                    getKeysFreeResult(&result);
-                    if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;
-                    return NULL;
-                }
                 if (importing_slot && !multiple_keys && !equalStringObjects(firstkey, thiskey)) {
                     /* Flag this request as one with multiple different
                      * keys/channels when the slot is in importing state. */
@@ -1119,7 +1170,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
             }
 
             /* Block MOVE command as the destination key is not expected to exist, and we don't know if it was migrated */
-            if ((migrating_slot || importing_slot) && mcmd->proc == moveCommand) {
+            if (mcmd->proc == moveCommand) {
                 if (error_code) *error_code = CLUSTER_REDIR_UNSTABLE;
                 getKeysFreeResult(&result);
                 return NULL;
@@ -1128,8 +1179,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
             /* Block the COPY command if it's cross-DB to keep the code simple.
              * Allowing cross-DB COPY is possible, but it would require looking up the second key in the target DB.
              * The command should only be allowed if the key exists. We may revisit this decision in the future. */
-            if ((migrating_slot || importing_slot) &&
-                mcmd->proc == copyCommand &&
+            if (mcmd->proc == copyCommand &&
                 margc >= 4 && !strcasecmp(margv[3]->ptr, "db")) {
                 long long value;
                 if (getLongLongFromObject(margv[4], &value) != C_OK || value != currentDb->id) {
@@ -1146,10 +1196,9 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
              * node until the migration completes with CLUSTER SETSLOT <slot>
              * NODE <node-id>. */
             int flags = LOOKUP_NOTOUCH | LOOKUP_NOSTATS | LOOKUP_NONOTIFY | LOOKUP_NOEXPIRE;
-            if ((migrating_slot || importing_slot) &&
-                !pubsubshard_included &&
-                (!c->flag.multi || (c->flag.multi && cmd->proc == execCommand)) // Multi/Exec validation happens on exec
-            ) {
+            if (!pubsubshard_included &&
+                (!c->flag.multi || (c->flag.multi && c->cmd->proc == execCommand))) {
+                /* Multi/Exec validation happens on exec */
                 if (lookupKeyReadWithFlags(currentDb, thiskey, flags) == NULL)
                     missing_keys++;
                 else
@@ -1159,9 +1208,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
         getKeysFreeResult(&result);
     }
 
-    /* No key at all in command? then we can serve the request
-     * without redirections or errors in all the cases. */
-    if (n == NULL) return myself;
+after_checking_each_key:
 
     /* Cluster is globally down but we got keys? We only serve the request
      * if it is a read command and when allow_reads_when_down is enabled. */
@@ -1187,13 +1234,10 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
         }
     }
 
-    /* Return the hashslot by reference. */
-    if (hashslot) *hashslot = slot;
-
     /* MIGRATE always works in the context of the local node if the slot
      * is open (migrating or importing state). We need to be able to freely
      * move keys among instances in this case. */
-    if ((migrating_slot || importing_slot) && cmd->proc == migrateCommand && clusterNodeIsPrimary(myself)) {
+    if ((migrating_slot || importing_slot) && c->cmd->proc == migrateCommand && clusterNodeIsPrimary(myself)) {
         return myself;
     }
 
@@ -1206,7 +1250,7 @@ getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int 
             return NULL;
         } else {
             if (error_code) *error_code = CLUSTER_REDIR_ASK;
-            return getMigratingSlotDest(slot);
+            return getMigratingSlotDest(c->slot);
         }
     }
 
@@ -1307,6 +1351,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
         if ((de = dictNext(di)) != NULL) {
             robj *key = dictGetKey(de);
             int slot = keyHashSlot((char *)key->ptr, sdslen(key->ptr));
+            serverAssert(slot == c->slot);
             clusterNode *node = getNodeBySlot(slot);
 
             /* if the client is read-only and attempting to access key that our

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1005,6 +1005,10 @@ int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *
  * 2) Multiple keys in the same hash slot, while the slot is stable (no
  *    resharding in progress).
  *
+ * The EXEC command is a special case. It takes no keys so the slot for this
+ * command is -1, but this function updates the client's slot to be the slot of
+ * the complete MULTI-EXEC transaction.
+ *
  * On success the function returns the node that is able to serve the request.
  * If the node is not 'myself' a redirection must be performed. The kind of
  * redirection is specified setting the integer passed by reference
@@ -1063,6 +1067,8 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
                 return NULL;
             }
         }
+        /* EXEC will execute all queued commands in the transaction, so we
+         * overwrite the EXEC commands's slot with the transaction's slot. */
         c->slot = slot;
     } else if (c->read_flags & READ_FLAGS_CROSSSLOT) {
         if (error_code) *error_code = CLUSTER_REDIR_CROSS_SLOT;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1107,9 +1107,13 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
     int pubsubshard_included =
         (cmd_flags & CMD_PUBSUB) || (c->cmd->proc == execCommand && (c->mstate->cmd_flags & CMD_PUBSUB));
 
-    /* For migrating and importing slots, we need to go over all the keys to
-     * count existing keys and missing keys that we need for TRYAGAIN and ASK
-     * redirects. Skip this if we're not importing or migrating. */
+    /* If we're importing or migration the slot, we need to do some more checks:
+     *
+     *   1. Go over all the keys to count existing keys and missing keys that we
+     *      need for TRYAGAIN and ASK redirects.
+     *   2. Check for some commands that are forbiddedn during slot migration.
+     *
+     * Skip this if we're not importing or migrating this slot. */
     if (!migrating_slot && !importing_slot) goto after_checking_each_key;
 
     /* We handle all the cases as if they were EXEC commands, so we have

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1107,7 +1107,7 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
     int pubsubshard_included =
         (cmd_flags & CMD_PUBSUB) || (c->cmd->proc == execCommand && (c->mstate->cmd_flags & CMD_PUBSUB));
 
-    /* If we're importing or migration the slot, we need to do some more checks:
+    /* If we're importing or migrating the slot, we need to do some more checks:
      *
      *   1. Go over all the keys to count existing keys and missing keys that we
      *      need for TRYAGAIN and ASK redirects.

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -119,7 +119,8 @@ int getSlotOrReply(client *c, robj *o);
 
 /* functions with shared implementations */
 int clusterNodeIsMyself(clusterNode *n);
-clusterNode *getNodeByQuery(client *c, struct serverCommand *cmd, robj **argv, int argc, int *hashslot, int *ask);
+int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *read_flags);
+clusterNode *getNodeByQuery(client *c, int *error_code);
 int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -245,7 +245,7 @@ int addCommandToBatchAndProcessIfFull(client *c) {
     batch->clients[batch->client_count++] = c;
 
     /* Get command's keys positions */
-    if (c->io_parsed_cmd) {
+    if (c->io_parsed_cmd && !(c->read_flags & READ_FLAGS_BAD_ARITY)) {
         getKeysResult result;
         initGetKeysResult(&result);
         int num_keys = getKeysFromCommand(c->io_parsed_cmd, c->argv, c->argc, &result);

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -245,10 +245,10 @@ int addCommandToBatchAndProcessIfFull(client *c) {
     batch->clients[batch->client_count++] = c;
 
     /* Get command's keys positions */
-    if (c->io_parsed_cmd && !(c->read_flags & READ_FLAGS_BAD_ARITY)) {
+    if (c->parsed_cmd && !(c->read_flags & READ_FLAGS_BAD_ARITY)) {
         getKeysResult result;
         initGetKeysResult(&result);
-        int num_keys = getKeysFromCommand(c->io_parsed_cmd, c->argv, c->argc, &result);
+        int num_keys = getKeysFromCommand(c->parsed_cmd, c->argv, c->argc, &result);
         for (int i = 0; i < num_keys && batch->key_count < batch->max_prefetch_size; i++) {
             batch->keys[batch->key_count] = c->argv[result.keys[i].pos];
             batch->slots[batch->key_count] = c->slot > 0 ? c->slot : 0;

--- a/src/module.c
+++ b/src/module.c
@@ -10944,9 +10944,9 @@ void moduleCallCommandFilters(client *c) {
     c->argv_len = filter.argv_len;
     c->argc = filter.argc;
     if (tmp != c->argv[0]) {
-        /* With I/O thread command-lookup offload, we set c->io_parsed_cmd to the command corresponding to c->argv[0].
-         * Since the command filter just changed it, we need to reset c->io_parsed_cmd to null. */
-        c->io_parsed_cmd = NULL;
+        /* Reset and lookup the command and cluster slot again. */
+        unprepareCommand(c);
+        prepareCommand(c);
     }
     decrRefCount(tmp);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -738,7 +738,7 @@ void moduleReleaseTempClient(client *c) {
     c->flag.module = 1;
     c->flag.fake = 1;
     c->user = NULL; /* Root user */
-    c->cmd = c->lastcmd = c->realcmd = c->io_parsed_cmd = NULL;
+    c->cmd = c->lastcmd = c->realcmd = c->parsed_cmd = NULL;
     if (c->bstate && c->bstate->async_rm_call_handle) {
         ValkeyModuleAsyncRMCallPromise *promise = c->bstate->async_rm_call_handle;
         promise->c = NULL; /* Remove the client from the promise so it will no longer be possible to abort it. */

--- a/src/module.c
+++ b/src/module.c
@@ -6551,7 +6551,8 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
         /* Duplicate relevant flags in the module client. */
         c->flag.readonly = ctx->client->flag.readonly;
         c->flag.asking = ctx->client->flag.asking;
-        if (getNodeByQuery(c, c->cmd, c->argv, c->argc, NULL, &error_code) != getMyClusterNode()) {
+        c->slot = clusterSlotByCommand(c->cmd, c->argv, c->argc, &c->read_flags);
+        if (getNodeByQuery(c, &error_code) != getMyClusterNode()) {
             sds msg = NULL;
             if (error_code == CLUSTER_REDIR_DOWN_RO_STATE) {
                 if (error_as_call_replies) {

--- a/src/multi.c
+++ b/src/multi.c
@@ -96,6 +96,7 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
     mc->argc = c->argc;
     mc->argv = c->argv;
     mc->argv_len = c->argv_len;
+    mc->slot = c->slot;
 
     c->mstate->count++;
     c->mstate->cmd_flags |= cmd_flags;

--- a/src/networking.c
+++ b/src/networking.c
@@ -230,7 +230,7 @@ client *createClient(connection *conn) {
     c->nread = 0;
     c->read_flags = 0;
     c->write_flags = 0;
-    c->cmd = c->lastcmd = c->realcmd = c->io_parsed_cmd = NULL;
+    c->cmd = c->lastcmd = c->realcmd = c->parsed_cmd = NULL;
     c->cur_script = NULL;
     c->multibulklen = 0;
     c->bulklen = -1;
@@ -1603,7 +1603,7 @@ void freeClientArgv(client *c) {
     }
     c->argc = 0;
     c->cmd = NULL;
-    c->io_parsed_cmd = NULL;
+    c->parsed_cmd = NULL;
     c->argv_len_sum = 0;
     c->argv_len = 0;
     c->argv = NULL;
@@ -2708,7 +2708,7 @@ void resetClientIOState(client *c) {
     c->nwritten = 0;
     c->nread = 0;
     c->io_read_state = c->io_write_state = CLIENT_IDLE;
-    c->io_parsed_cmd = NULL;
+    c->parsed_cmd = NULL;
     c->flag.pending_command = 0;
     c->io_last_bufpos = 0;
     c->io_last_reply_block = NULL;

--- a/src/networking.c
+++ b/src/networking.c
@@ -3240,23 +3240,6 @@ int canParseCommand(client *c) {
     return 1;
 }
 
-/* Prepare a parsed command for processing, including looking up the command,
- * checking arity and calculating cluster slot. This can be done by I/O threads
- * to offload the main-thread. */
-static void prepareCommand(client *c) {
-    c->io_parsed_cmd = lookupCommand(c->argv, c->argc);
-    if (c->io_parsed_cmd && commandCheckArity(c->io_parsed_cmd, c->argc, NULL) == 0) {
-        /* The command was found, but the arity is invalid. */
-        c->read_flags |= READ_FLAGS_BAD_ARITY;
-    } else if (c->io_parsed_cmd && server.cluster_enabled) {
-        /* Make sure we don't do this twice. This shouldn't be calculated yet. */
-        debugServerAssert(c->slot == -1 &&
-                          !(c->read_flags & READ_FLAGS_CROSSSLOT) &&
-                          !(c->read_flags & READ_FLAGS_NO_KEYS));
-        c->slot = clusterSlotByCommand(c->io_parsed_cmd, c->argv, c->argc, &c->read_flags);
-    }
-}
-
 int processInputBuffer(client *c) {
     /* Parse the query buffer. */
     while (c->querybuf && c->qb_pos < sdslen(c->querybuf)) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -3240,6 +3240,23 @@ int canParseCommand(client *c) {
     return 1;
 }
 
+/* Prepare a parsed command for processing, including looking up the command,
+ * checking arity and calculating cluster slot. This can be done by I/O threads
+ * to offload the main-thread. */
+static void prepareCommand(client *c) {
+    c->io_parsed_cmd = lookupCommand(c->argv, c->argc);
+    if (c->io_parsed_cmd && commandCheckArity(c->io_parsed_cmd, c->argc, NULL) == 0) {
+        /* The command was found, but the arity is invalid. */
+        c->read_flags |= READ_FLAGS_BAD_ARITY;
+    } else if (c->io_parsed_cmd && server.cluster_enabled) {
+        /* Make sure we don't do this twice. This shouldn't be calculated yet. */
+        debugServerAssert(c->slot == -1 &&
+                          !(c->read_flags & READ_FLAGS_CROSSSLOT) &&
+                          !(c->read_flags & READ_FLAGS_NO_KEYS));
+        c->slot = clusterSlotByCommand(c->io_parsed_cmd, c->argv, c->argc, &c->read_flags);
+    }
+}
+
 int processInputBuffer(client *c) {
     /* Parse the query buffer. */
     while (c->querybuf && c->qb_pos < sdslen(c->querybuf)) {
@@ -3267,6 +3284,9 @@ int processInputBuffer(client *c) {
              * the shared qb for other clients during processEventsWhileBlocked */
             resetSharedQueryBuf(c);
         }
+
+        /* Lookup command, check arity, calculate cluster slot. */
+        prepareCommand(c);
 
         /* We are finally ready to execute the command. */
         if (processCommandAndResetClient(c) == C_ERR) {
@@ -5516,25 +5536,8 @@ void ioThreadReadQueryFromClient(void *data) {
         goto done;
     }
 
-    /* Lookup command offload */
-    c->io_parsed_cmd = lookupCommand(c->argv, c->argc);
-    if (c->io_parsed_cmd && commandCheckArity(c->io_parsed_cmd, c->argc, NULL) == 0) {
-        /* The command was found, but the arity is invalid.
-         * In this case, we reset the parsed_cmd and will let the main thread handle it. */
-        c->io_parsed_cmd = NULL;
-    }
-
-    /* Offload slot calculations to the I/O thread to reduce main-thread load. */
-    if (c->io_parsed_cmd && server.cluster_enabled) {
-        getKeysResult result;
-        initGetKeysResult(&result);
-        int numkeys = getKeysFromCommand(c->io_parsed_cmd, c->argv, c->argc, &result);
-        if (numkeys) {
-            robj *first_key = c->argv[result.keys[0].pos];
-            c->slot = keyHashSlot(first_key->ptr, sdslen(first_key->ptr));
-        }
-        getKeysFreeResult(&result);
-    }
+    /* Lookup command and cluster slot calculation. */
+    prepareCommand(c);
 
 done:
     /* Only trim query buffer for non-primary clients

--- a/src/script.c
+++ b/src/script.c
@@ -431,8 +431,8 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
     /* Duplicate relevant flags in the script client. */
     c->flag.readonly = original_c->flag.readonly;
     c->flag.asking = original_c->flag.asking;
-    int hashslot = -1;
-    if (getNodeByQuery(c, c->cmd, c->argv, c->argc, &hashslot, &error_code) != getMyClusterNode()) {
+    int hashslot = c->slot = clusterSlotByCommand(c->cmd, c->argv, c->argc, &c->read_flags);
+    if (getNodeByQuery(c, &error_code) != getMyClusterNode()) {
         if (error_code == CLUSTER_REDIR_DOWN_RO_STATE) {
             *err = sdsnew("Script attempted to execute a write command while the "
                           "cluster is down and readonly");
@@ -474,7 +474,6 @@ static int scriptVerifyClusterState(scriptRunCtx *run_ctx, client *c, client *or
         }
     }
 
-    c->slot = hashslot;
     original_c->slot = hashslot;
 
     return C_OK;

--- a/src/server.c
+++ b/src/server.c
@@ -4010,23 +4010,23 @@ uint64_t getCommandFlags(client *c) {
  * main-thread. */
 void prepareCommand(client *c) {
     /* Make sure we don't do this twice. */
-    debugServerAssert(c->io_parsed_cmd == NULL && !(c->read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
-    c->io_parsed_cmd = lookupCommand(c->argv, c->argc);
-    if (c->io_parsed_cmd && commandCheckArity(c->io_parsed_cmd, c->argc, NULL) == 0) {
+    debugServerAssert(c->parsed_cmd == NULL && !(c->read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
+    c->parsed_cmd = lookupCommand(c->argv, c->argc);
+    if (c->parsed_cmd && commandCheckArity(c->parsed_cmd, c->argc, NULL) == 0) {
         /* The command was found, but the arity is invalid. */
         c->read_flags |= READ_FLAGS_BAD_ARITY;
-    } else if (c->io_parsed_cmd && server.cluster_enabled) {
+    } else if (c->parsed_cmd && server.cluster_enabled) {
         c->read_flags |= READ_FLAGS_BAD_ARITY;
         debugServerAssert(c->slot == -1 &&
                           !(c->read_flags & READ_FLAGS_CROSSSLOT) &&
                           !(c->read_flags & READ_FLAGS_NO_KEYS));
-        c->slot = clusterSlotByCommand(c->io_parsed_cmd, c->argv, c->argc, &c->read_flags);
+        c->slot = clusterSlotByCommand(c->parsed_cmd, c->argv, c->argc, &c->read_flags);
     }
 }
 
 /* Undo prepareCommand(), to allow prepareCommand() again after applying command filters. */
 void unprepareCommand(client *c) {
-    c->io_parsed_cmd = NULL;
+    c->parsed_cmd = NULL;
     c->read_flags &= ~(READ_FLAGS_COMMAND_NOT_FOUND |
                        READ_FLAGS_BAD_ARITY |
                        READ_FLAGS_CROSSSLOT |
@@ -4075,7 +4075,7 @@ int processCommand(client *c) {
      * In case we are reprocessing a command after it was blocked,
      * we do not have to repeat the same checks */
     if (!client_reprocessing_command) {
-        struct serverCommand *cmd = c->io_parsed_cmd;
+        struct serverCommand *cmd = c->parsed_cmd;
         if (!cmd) {
             /* Handle possible security attacks. */
             if (!strcasecmp(c->argv[0]->ptr, "host:") || !strcasecmp(c->argv[0]->ptr, "post")) {

--- a/src/server.c
+++ b/src/server.c
@@ -4012,11 +4012,10 @@ void prepareCommand(client *c) {
     /* Make sure we don't do this twice. */
     debugServerAssert(c->parsed_cmd == NULL && !(c->read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
     c->parsed_cmd = lookupCommand(c->argv, c->argc);
-    if (c->parsed_cmd && commandCheckArity(c->parsed_cmd, c->argc, NULL) == 0) {
+    if (c->parsed_cmd && !commandCheckArity(c->parsed_cmd, c->argc, NULL)) {
         /* The command was found, but the arity is invalid. */
         c->read_flags |= READ_FLAGS_BAD_ARITY;
     } else if (c->parsed_cmd && server.cluster_enabled) {
-        c->read_flags |= READ_FLAGS_BAD_ARITY;
         debugServerAssert(c->slot == -1 &&
                           !(c->read_flags & READ_FLAGS_CROSSSLOT) &&
                           !(c->read_flags & READ_FLAGS_NO_KEYS));
@@ -4094,7 +4093,9 @@ int processCommand(client *c) {
             rejectCommandSds(c, err);
             return C_OK;
         }
-        if (!commandCheckArity(c->cmd, c->argc, &err)) {
+        if (c->read_flags & READ_FLAGS_BAD_ARITY) {
+            /* Already detected this, but do it again just to get the error message. */
+            serverAssert(!commandCheckArity(c->cmd, c->argc, &err));
             rejectCommandSds(c, err);
             return C_OK;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -4004,6 +4004,36 @@ uint64_t getCommandFlags(client *c) {
     return cmd_flags;
 }
 
+/* Prepare a parsed command for processing, including looking up the command,
+ * checking arity and calculating cluster slot. This should be done before
+ * calling processCommand() and can be done by I/O threads to offload the
+ * main-thread. */
+void prepareCommand(client *c) {
+    /* Make sure we don't do this twice. */
+    debugServerAssert(c->io_parsed_cmd == NULL && !(c->read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
+    c->io_parsed_cmd = lookupCommand(c->argv, c->argc);
+    if (c->io_parsed_cmd && commandCheckArity(c->io_parsed_cmd, c->argc, NULL) == 0) {
+        /* The command was found, but the arity is invalid. */
+        c->read_flags |= READ_FLAGS_BAD_ARITY;
+    } else if (c->io_parsed_cmd && server.cluster_enabled) {
+        c->read_flags |= READ_FLAGS_BAD_ARITY;
+        debugServerAssert(c->slot == -1 &&
+                          !(c->read_flags & READ_FLAGS_CROSSSLOT) &&
+                          !(c->read_flags & READ_FLAGS_NO_KEYS));
+        c->slot = clusterSlotByCommand(c->io_parsed_cmd, c->argv, c->argc, &c->read_flags);
+    }
+}
+
+/* Undo prepareCommand(), to allow prepareCommand() again after applying command filters. */
+void unprepareCommand(client *c) {
+    c->io_parsed_cmd = NULL;
+    c->read_flags &= ~(READ_FLAGS_COMMAND_NOT_FOUND |
+                       READ_FLAGS_BAD_ARITY |
+                       READ_FLAGS_CROSSSLOT |
+                       READ_FLAGS_NO_KEYS);
+    c->slot = -1;
+}
+
 /* If this function gets called we already read a whole
  * command, arguments are in the client argv/argc fields.
  * processCommand() execute the command or prepare the
@@ -4052,6 +4082,9 @@ int processCommand(client *c) {
                 securityWarningCommand(c);
                 return C_ERR;
             }
+            /* Check that the command lookup should has been done before calling
+             * this function, by calling prepareCommand(). */
+            serverAssert(!(c->read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
         }
         c->cmd = c->lastcmd = c->realcmd = cmd;
         c->flag.buffered_reply = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -4045,7 +4045,7 @@ int processCommand(client *c) {
      * In case we are reprocessing a command after it was blocked,
      * we do not have to repeat the same checks */
     if (!client_reprocessing_command) {
-        struct serverCommand *cmd = c->io_parsed_cmd ? c->io_parsed_cmd : lookupCommand(c->argv, c->argc);
+        struct serverCommand *cmd = c->io_parsed_cmd;
         if (!cmd) {
             /* Handle possible security attacks. */
             if (!strcasecmp(c->argv[0]->ptr, "host:") || !strcasecmp(c->argv[0]->ptr, "post")) {
@@ -4056,6 +4056,7 @@ int processCommand(client *c) {
         c->cmd = c->lastcmd = c->realcmd = cmd;
         c->flag.buffered_reply = 0;
         sds err;
+
         if (!commandCheckExistence(c, &err)) {
             rejectCommandSds(c, err);
             return C_OK;
@@ -4132,7 +4133,7 @@ int processCommand(client *c) {
     if (server.cluster_enabled && !obey_client &&
         !(!(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand)) {
         int error_code;
-        clusterNode *n = getNodeByQuery(c, c->cmd, c->argv, c->argc, &c->slot, &error_code);
+        clusterNode *n = getNodeByQuery(c, &error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
             if (c->cmd->proc == execCommand) {
                 discardTransaction(c);

--- a/src/server.h
+++ b/src/server.h
@@ -1198,12 +1198,12 @@ typedef struct client {
     long bulklen;        /* Length of bulk argument in multi bulk request. */
     long long woff;      /* Last write global replication offset. */
     /* Command execution state and command information */
-    struct serverCommand *cmd;           /* Current command. */
-    struct serverCommand *lastcmd;       /* Last command executed. */
-    struct serverCommand *realcmd;       /* The original command that was executed by the client */
-    struct serverCommand *io_parsed_cmd; /* The command that was parsed e.g. by the IO thread. */
-    time_t last_interaction;             /* Time of the last interaction, used for timeout */
-    serverDb *db;                        /* Pointer to currently SELECTed DB. */
+    struct serverCommand *cmd;        /* Current command. */
+    struct serverCommand *lastcmd;    /* Last command executed. */
+    struct serverCommand *realcmd;    /* The original command that was executed by the client */
+    struct serverCommand *parsed_cmd; /* The command that was parsed. */
+    time_t last_interaction;          /* Time of the last interaction, used for timeout */
+    serverDb *db;                     /* Pointer to currently SELECTed DB. */
     /* Client state structs. */
     ClientPubSubData *pubsub_data;    /* Required for: pubsub commands and tracking. lazily initialized when first needed */
     ClientReplicationData *repl_data; /* Required for Replication operations. lazily initialized when first needed */

--- a/src/server.h
+++ b/src/server.h
@@ -858,6 +858,7 @@ typedef struct multiCmd {
     int argv_len;
     int argc;
     struct serverCommand *cmd;
+    int slot;
 } multiCmd;
 
 typedef struct multiState {
@@ -1200,7 +1201,7 @@ typedef struct client {
     struct serverCommand *cmd;           /* Current command. */
     struct serverCommand *lastcmd;       /* Last command executed. */
     struct serverCommand *realcmd;       /* The original command that was executed by the client */
-    struct serverCommand *io_parsed_cmd; /* The command that was parsed by the IO thread. */
+    struct serverCommand *io_parsed_cmd; /* The command that was parsed e.g. by the IO thread. */
     time_t last_interaction;             /* Time of the last interaction, used for timeout */
     serverDb *db;                        /* Pointer to currently SELECTed DB. */
     /* Client state structs. */
@@ -2642,6 +2643,9 @@ void dictVanillaFree(void *val);
 #define READ_FLAGS_PRIMARY (1 << 14)
 #define READ_FLAGS_DONT_PARSE (1 << 15)
 #define READ_FLAGS_AUTH_REQUIRED (1 << 16)
+#define READ_FLAGS_BAD_ARITY (1 << 17)
+#define READ_FLAGS_NO_KEYS (1 << 18)
+#define READ_FLAGS_CROSSSLOT (1 << 19)
 
 /* Write flags for various write errors and states */
 #define WRITE_FLAGS_WRITE_ERROR (1 << 0)

--- a/src/server.h
+++ b/src/server.h
@@ -2643,9 +2643,10 @@ void dictVanillaFree(void *val);
 #define READ_FLAGS_PRIMARY (1 << 14)
 #define READ_FLAGS_DONT_PARSE (1 << 15)
 #define READ_FLAGS_AUTH_REQUIRED (1 << 16)
-#define READ_FLAGS_BAD_ARITY (1 << 17)
-#define READ_FLAGS_NO_KEYS (1 << 18)
-#define READ_FLAGS_CROSSSLOT (1 << 19)
+#define READ_FLAGS_COMMAND_NOT_FOUND (1 << 17)
+#define READ_FLAGS_BAD_ARITY (1 << 18)
+#define READ_FLAGS_NO_KEYS (1 << 19)
+#define READ_FLAGS_CROSSSLOT (1 << 20)
 
 /* Write flags for various write errors and states */
 #define WRITE_FLAGS_WRITE_ERROR (1 << 0)
@@ -3164,6 +3165,8 @@ int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *lev
 size_t freeMemoryGetNotCountedMemory(void);
 int overMaxmemoryAfterAlloc(size_t moremem);
 uint64_t getCommandFlags(client *c);
+void prepareCommand(client *c);
+void unprepareCommand(client *c);
 int processCommand(client *c);
 int processPendingCommandAndInputBuffer(client *c);
 int processCommandAndResetClient(client *c);

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -24,3 +24,12 @@ start_cluster 2 2 {tags {external:skip cluster}} {
     }
 }
 
+start_cluster 1 1 {tags {external:skip cluster}} {
+    test {Cross-slot transaction} {
+        assert_equal OK [R 0 multi]
+        assert_equal QUEUED [r get foo]
+        assert_equal QUEUED [r get bar]
+        assert_error {CROSSSLOT *} {r exec}
+    }
+}
+


### PR DESCRIPTION
Refactors `getNodeByQuery()` to be able to move the CRC16 slot calculations in I/O threads and skip many checks if slot migrations are not ongoing.

The slot calculation for a command is moved out of `getNodeByQuery()` into a new function `clusterSlotByCommand()` which is safe to call from I/O threads.

For MULTI-EXEC transactions, the slot is stored per command in the multi-state, to be able to detect cross-slot transactions on EXEC without computing the slots again.

Sorry for the large diff within `getNodeByQuery()`. This function is quite long and complex. I added a `goto` to skip parts of it, to avoid indenting a large code block. (We can do it, but it gives a larger diff to review.)

Additionally, cross-slot detection and arity check is offloaded to I/O threads. To unify the code paths for commands parsed by I/O threads and commands parsed by the main thread, the command lookup, arity check, slot lookup are moved out of `processCommand()` to a new `prepareCommand()` function that needs to be called before `processCommand()`.

The client's read flags are used for passing information about bad arity and cross-slot. These flags are already used to convey information per command between I/O thread and main thread.

Fixes #2077
Related to #632