### PR TITLE
Remove dead conditions around the multi/exec check

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4340,7 +4340,7 @@ int processCommand(client *c) {
 
     /* Exec the command */
     if (c->flag.multi && c->cmd->proc != execCommand && c->cmd->proc != discardCommand &&
-        c->cmd->proc != multiCommand && c->cmd->proc != watchCommand && c->cmd->proc != quitCommand &&
+        c->cmd->proc != quitCommand &&
         c->cmd->proc != resetCommand) {
         queueMultiCommand(c, cmd_flags);
         addReply(c, shared.queued);


### PR DESCRIPTION
After #723, this became dead conditions since we will reject
the command in advance and now it won't be able to go here
anymore (call won't be called anymore).