### PR TITLE
Remove unnecessary refcount increment in propagateDelete

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1864,8 +1864,6 @@ void propagateDeletion(serverDb *db, robj *key, int lazy) {
 
     argv[0] = lazy ? shared.unlink : shared.del;
     argv[1] = key;
-    incrRefCount(argv[0]);
-    incrRefCount(argv[1]);
 
     /* If the primary decided to delete a key we must propagate it to replicas no matter what.
      * Even if module executed a command without asking for propagation. */
@@ -1873,9 +1871,6 @@ void propagateDeletion(serverDb *db, robj *key, int lazy) {
     server.replication_allowed = 1;
     alsoPropagate(db->id, argv, 2, PROPAGATE_AOF | PROPAGATE_REPL);
     server.replication_allowed = prev_replication_allowed;
-
-    decrRefCount(argv[0]);
-    decrRefCount(argv[1]);
 }
 
 /* Returns 1 if the expire value is expired, 0 otherwise. */


### PR DESCRIPTION
The alsoPropagate increased the refcount, I'm guessing this code was just left over from before that was needed. 