### PR TITLE
fix: use replica's last selected db for dual-channel sync

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2701,7 +2701,7 @@ int sendCurrentOffsetToReplica(client *replica) {
     char buf[128];
     int buflen;
     buflen = snprintf(buf, sizeof(buf), "$ENDOFF:%lld %s %d %llu\r\n", server.primary_repl_offset, server.replid,
-                      server.db[0]->id, (long long unsigned int)replica->id);
+                      server.replicas_eldb, (long long unsigned int)replica->id);
     dualChannelServerLog(LL_NOTICE, "Sending to replica %s RDB end offset %lld and client-id %llu",
                          replicationGetReplicaName(replica), server.primary_repl_offset,
                          (long long unsigned int)replica->id);


### PR DESCRIPTION
When sending current offset to replica, use the last selected db sent to the replicas instead of always using `server.db[0]->id`. This fixes a potential issue where the dual channel sync relied on the primary always resending the `SELECT` command after PSYNC.

While the db id argument could be removed from the sync API, it's retained to maintain backward compatibility.

Fixed #2194.