### PR TITLE
Update extended-redis-compatibility conf to remove the specific words

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -502,8 +502,8 @@ locale-collate ""
 # Valkey identifies itself itself as "Valkey" rather than "Redis". Extended
 # Redis OSS compatibility mode makes Valkey pretend to be Redis. Enable this
 # only if you have problems with tools or clients. This is a temporary
-# configuration added in Valkey 8.0 and is scheduled to have no effect in Valkey
-# 9.0 and be completely removed in Valkey 10.0.
+# configuration added in Valkey 8.0 and is scheduled to have no effect and
+# will be removed in a future version.
 #
 # extended-redis-compatibility no
 


### PR DESCRIPTION
In #2189, we decided to keep it for at least another year.
Closes #2189.