### PR TITLE
Add packet-drop to fix the new flaky failover test

### DIFF
--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -147,6 +147,7 @@ proc test_replica_config_epoch_failover {type} {
             R 3 CONFIG SET cluster-replica-no-failover yes
         }
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_ALL
+        # R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 1
 
         set R0_nodeid [R 0 cluster myid]
 
@@ -169,6 +170,7 @@ proc test_replica_config_epoch_failover {type} {
         # Pause the R 0 and wait for the cluster to be down.
         pause_process [srv 0 pid]
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
+        # R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 0
         wait_for_condition 1000 50 {
             [CI 1 cluster_state] == "fail" &&
             [CI 2 cluster_state] == "fail" &&

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -147,7 +147,7 @@ proc test_replica_config_epoch_failover {type} {
             R 3 CONFIG SET cluster-replica-no-failover yes
         }
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_ALL
-        # R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 1
+        R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 1
 
         set R0_nodeid [R 0 cluster myid]
 
@@ -170,7 +170,7 @@ proc test_replica_config_epoch_failover {type} {
         # Pause the R 0 and wait for the cluster to be down.
         pause_process [srv 0 pid]
         R 3 DEBUG DROP-CLUSTER-PACKET-FILTER $CLUSTER_PACKET_TYPE_NONE
-        # R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 0
+        R 3 DEBUG CLOSE-CLUSTER-LINK-ON-PACKET-DROP 0
         wait_for_condition 1000 50 {
             [CI 1 cluster_state] == "fail" &&
             [CI 2 cluster_state] == "fail" &&


### PR DESCRIPTION
The new test was added in #2178, obviously there may be
pending reads in the connection, so there may be a race
in the DROP-CLUSTER-PACKET-FILTER part causing the test
to fail. Add CLOSE-CLUSTER-LINK-ON-PACKET-DROP to ensure
that the replica does not process the packet.