### PR TITLE
Remove unused repl_offset_time field in clusterNode

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1654,7 +1654,6 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->tls_port = 0;
     node->fail_reports = listCreate();
     node->orphaned_time = 0;
-    node->repl_offset_time = 0;
     node->repl_offset = 0;
     listSetFreeMethod(node->fail_reports, zfree);
     node->is_node_healthy = 0;
@@ -3373,7 +3372,6 @@ int clusterProcessPacket(clusterLink *link) {
         }
         /* Update the replication offset info for this node. */
         sender->repl_offset = ntohu64(hdr->offset);
-        sender->repl_offset_time = now;
         /* If we are a replica performing a manual failover and our primary
          * sent its offset while already paused, populate the MF state. */
         if (server.cluster->mf_end && nodeIsReplica(myself) && myself->replicaof == sender &&

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -350,7 +350,6 @@ struct _clusterNode {
     mstime_t data_received;                 /* Unix time we received any data */
     mstime_t meet_sent;                     /* Unix time we sent latest meet packet */
     mstime_t fail_time;                     /* Unix time when FAIL flag was set */
-    mstime_t repl_offset_time;              /* Unix time we received offset for this node */
     mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
     mstime_t inbound_link_freed_time;       /* Last time we freed the inbound link for this node.
                                                If it was never freed, it is the same as ctime */


### PR DESCRIPTION
We add this field in 0b1b25c51cb6e4ed4469d413284d2a8a9051cf0d,
but never used. We can easily add it back if needed in the future.