### PR TITLE
Stabilize dual channel test: Adjust RDB loading progress calls

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1176,6 +1176,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
         $replica config set repl-timeout 10
+        $replica config set loading-process-events-interval-bytes 1024
         set load_handle [start_one_key_write_load $primary_host $primary_port 100 "mykey"]
         test "Replica recover rdb-connection killed" {
             $replica replicaof $primary_host $primary_port


### PR DESCRIPTION
Modify test to increase frequency of `rdbLoadProgressCallback` calls by reducing `loading-process-events-interval-bytes` to 1024. 
This adjustment is needed because `rdb-key-save-delay` slows down bulk transfers, which may cause the replica to miss main connection messages. The change ensures that:
1. Messages on main channel are not missed.
2. Test properly handles graceful shutdown after user interrupt.