### PR TITLE
Prevent getNodeByQuery from leaking DB changes into client

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1135,7 +1135,8 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
         mc.cmd = c->cmd;
     }
 
-    serverDb *currentDb = c->db;
+    serverDb *origDb = c->db;
+    serverDb *currentDb = origDb;
 
     /* Check for multiple keys, existing keys, missing keys. */
     for (i = 0; i < ms->count; i++) {
@@ -1155,7 +1156,6 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
 
         if (mcmd->proc == selectCommand) {
             /* Failed SELECT is ignored since it doesn't modify the database. */
-            serverDb *origDb = currentDb;
             long long id;
             if (getLongLongFromObject(margv[1], &id) == C_OK && selectDb(c, id) == C_OK) {
                 currentDb = c->db;

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -535,6 +535,19 @@ start_cluster 3 3 {tags {external:skip cluster} } {
         set result [catch {R $primary_id_src exec} err]
         assert_match "ERR DB index is out of range" $err
 
+        # Multi/Exec on source before migration, mixed key existence
+        R $primary_id_src select 0
+        R $primary_id_src multi
+        R $primary_id_src exists "{3560}key1"
+        R $primary_id_src select 1
+        R $primary_id_src exists "{3560}key2"
+        R $primary_id_src select 2
+        R $primary_id_src exists "{3560}no_key"
+        set result [catch {R $primary_id_src exec} err]
+        assert_match "TRYAGAIN Multiple keys request during rehashing of slot" $err
+        # Connection must still be on db 0 after aborted MULTI
+        assert_equal [R $primary_id_src get "{3560}key1"] "value1_db0"
+
         # Multi/Exec on target before migration should fail at EXEC
         R $primary_id_target ASKING
         R $primary_id_target multi

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -543,8 +543,7 @@ start_cluster 3 3 {tags {external:skip cluster} } {
         R $primary_id_src exists "{3560}key2"
         R $primary_id_src select 2
         R $primary_id_src exists "{3560}no_key"
-        set result [catch {R $primary_id_src exec} err]
-        assert_match "TRYAGAIN Multiple keys request during rehashing of slot" $err
+        assert_error "TRYAGAIN Multiple keys*" {R $primary_id_src exec}
         # Connection must still be on db 0 after aborted MULTI
         assert_equal [R $primary_id_src get "{3560}key1"] "value1_db0"
 


### PR DESCRIPTION
To support multiple databases in cluster mode (see #1671), `getNodeByQuery` temporarily switches databases when tracking `SELECT` statements during slot migration/import. The intended logic is to revert any database change after the operation. However, this approach is flawed: in some transactions the database change is not properly reverted, causing the client to remain on the wrong database.

For example, if a transaction includes `SELECT` statements, the current database may be changed even if the transaction is never executed (see added test).

Fix the issue by saving the original database once and restoring to it after a switch.