### PR TITLE
Fix unixsocket too long cause addr / laddr being truncated in CLIENT INFO / LIST and logging

### DIFF
--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -398,7 +398,7 @@ struct clusterState {
     int cant_failover_reason;         /* Why a replica is currently not able to
                                        * failover. See the CANT_FAILOVER_* macros. */
     /* Manual failover state in common. */
-    mstime_t mf_end; /* Manual failover time limit (ms unixtime).
+    mstime_t mf_end; /* Manual failover t`ime limit (ms unixtime).
                         It is zero if there is no MF in progress. */
     /* Manual failover state of primary. */
     clusterNode *mf_replica; /* replica performing the manual failover. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -398,7 +398,7 @@ struct clusterState {
     int cant_failover_reason;         /* Why a replica is currently not able to
                                        * failover. See the CANT_FAILOVER_* macros. */
     /* Manual failover state in common. */
-    mstime_t mf_end; /* Manual failover t`ime limit (ms unixtime).
+    mstime_t mf_end; /* Manual failover time limit (ms unixtime).
                         It is zero if there is no MF in progress. */
     /* Manual failover state of primary. */
     clusterNode *mf_replica; /* replica performing the manual failover. */

--- a/src/connection.h
+++ b/src/connection.h
@@ -40,11 +40,10 @@
 #include "ae.h"
 
 #define CONN_INFO_LEN 32
-#define CONN_ADDR_STR_LEN 128 /* Similar to NET_ADDR_STR_LEN, hoping to handle other protocols. */
+#define CONN_ADDR_STR_LEN 128
 
 #define NET_HOST_STR_LEN 256                          /* Longest valid hostname */
 #define NET_IP_STR_LEN 46                             /* INET6_ADDRSTRLEN is 46, but we need to be sure */
-#define NET_ADDR_STR_LEN (NET_IP_STR_LEN + 32)        /* Must be enough for ip:port */
 #define NET_HOST_PORT_STR_LEN (NET_HOST_STR_LEN + 32) /* Must be enough for hostname:port */
 
 struct aeEventLoop;

--- a/src/connection.h
+++ b/src/connection.h
@@ -40,7 +40,7 @@
 #include "ae.h"
 
 #define CONN_INFO_LEN 32
-#define CONN_ADDR_STR_LEN 128 /* Similar to INET6_ADDRSTRLEN, hoping to handle other protocols. */
+#define CONN_ADDR_STR_LEN 128 /* Similar to NET_ADDR_STR_LEN, hoping to handle other protocols. */
 
 #define NET_HOST_STR_LEN 256                          /* Longest valid hostname */
 #define NET_IP_STR_LEN 46                             /* INET6_ADDRSTRLEN is 46, but we need to be sure */

--- a/src/networking.c
+++ b/src/networking.c
@@ -1692,13 +1692,8 @@ void acceptCommonHandler(connection *conn, struct ClientFlags flags, char *ip) {
 
     char addr[CONN_ADDR_STR_LEN] = {0};
     char laddr[CONN_ADDR_STR_LEN] = {0};
-    if (conn->type == connectionTypeUnix()) {
-        snprintf(addr, sizeof(addr), "%s:0", server.unixsocket);
-        snprintf(laddr, sizeof(laddr), "%s:0", server.unixsocket);
-    } else {
-        connFormatAddr(conn, addr, sizeof(addr), 1);
-        connFormatAddr(conn, laddr, sizeof(addr), 0);
-    }
+    connFormatAddr(conn, addr, sizeof(addr), 1);
+    connFormatAddr(conn, laddr, sizeof(addr), 0);
 
     if (connGetState(conn) != CONN_STATE_ACCEPTING) {
         serverLog(LL_VERBOSE, "Accepted client connection in error state: %s (addr=%s laddr=%s)",

--- a/src/networking.c
+++ b/src/networking.c
@@ -3815,13 +3815,7 @@ void readQueryFromClient(connection *conn) {
  * you want to relax error checking or need to display something anyway (see
  * anetFdToString implementation for more info). */
 void genClientAddrString(client *client, char *addr, size_t addr_len, int remote) {
-    if (client->flag.unix_socket) {
-        /* Unix socket client. */
-        snprintf(addr, addr_len, "%s:0", server.unixsocket);
-    } else {
-        /* TCP client. */
-        connFormatAddr(client->conn, addr, addr_len, remote);
-    }
+    connFormatAddr(client->conn, addr, addr_len, remote);
 }
 
 /* This function returns the client peer id, by creating and caching it

--- a/src/networking.c
+++ b/src/networking.c
@@ -1690,10 +1690,15 @@ void acceptCommonHandler(connection *conn, struct ClientFlags flags, char *ip) {
     client *c;
     UNUSED(ip);
 
-    char addr[NET_ADDR_STR_LEN] = {0};
-    char laddr[NET_ADDR_STR_LEN] = {0};
-    connFormatAddr(conn, addr, sizeof(addr), 1);
-    connFormatAddr(conn, laddr, sizeof(addr), 0);
+    char addr[CONN_ADDR_STR_LEN] = {0};
+    char laddr[CONN_ADDR_STR_LEN] = {0};
+    if (conn->type == connectionTypeUnix()) {
+        snprintf(addr, sizeof(addr), "%s:0", server.unixsocket);
+        snprintf(laddr, sizeof(laddr), "%s:0", server.unixsocket);
+    } else {
+        connFormatAddr(conn, addr, sizeof(addr), 1);
+        connFormatAddr(conn, laddr, sizeof(addr), 0);
+    }
 
     if (connGetState(conn) != CONN_STATE_ACCEPTING) {
         serverLog(LL_VERBOSE, "Accepted client connection in error state: %s (addr=%s laddr=%s)",
@@ -3806,9 +3811,9 @@ void readQueryFromClient(connection *conn) {
 /* An "Address String" is a colon separated ip:port pair.
  * For IPv4 it's in the form x.y.z.k:port, example: "127.0.0.1:1234".
  * For IPv6 addresses we use [] around the IP part, like in "[::1]:1234".
- * For Unix sockets we use path:0, like in "/tmp/redis:0".
+ * For Unix sockets we use path:0, like in "/tmp/valkey:0".
  *
- * An Address String always fits inside a buffer of NET_ADDR_STR_LEN bytes,
+ * An Address String always fits inside a buffer of CONN_ADDR_STR_LEN bytes,
  * including the null term.
  *
  * On failure the function still populates 'addr' with the "?:0" string in case
@@ -3829,7 +3834,7 @@ void genClientAddrString(client *client, char *addr, size_t addr_len, int remote
  * The Peer ID never changes during the life of the client, however it
  * is expensive to compute. */
 char *getClientPeerId(client *c) {
-    char peerid[NET_ADDR_STR_LEN] = {0};
+    char peerid[CONN_ADDR_STR_LEN] = {0};
 
     if (c->peerid == NULL) {
         genClientAddrString(c, peerid, sizeof(peerid), 1);
@@ -3843,7 +3848,7 @@ char *getClientPeerId(client *c) {
  * The Socket Name never changes during the life of the client, however it
  * is expensive to compute. */
 char *getClientSockname(client *c) {
-    char sockname[NET_ADDR_STR_LEN] = {0};
+    char sockname[CONN_ADDR_STR_LEN] = {0};
 
     if (c->sockname == NULL) {
         genClientAddrString(c, sockname, sizeof(sockname), 0);

--- a/src/socket.c
+++ b/src/socket.c
@@ -334,16 +334,16 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
 }
 
 static int connSocketAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
-    if (anetFdToString(conn->fd, ip, ip_len, port, remote) == 0) return C_OK;
+    if (anetFdToString(conn->fd, ip, ip_len, port, remote) == 0) return 0;
 
     conn->last_errno = errno;
-    return C_ERR;
+    return -1;
 }
 
 static int connSocketIsLocal(connection *conn) {
     char cip[NET_IP_STR_LEN + 1] = {0};
 
-    if (connSocketAddr(conn, cip, sizeof(cip) - 1, NULL, 1) == C_ERR) return -1;
+    if (connSocketAddr(conn, cip, sizeof(cip) - 1, NULL, 1) == -1) return -1;
 
     return !strncmp(cip, "127.", 4) || !strcmp(cip, "::1");
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -337,8 +337,8 @@ static int connSocketAddr(connection *conn, char *ip, size_t ip_len, int *port, 
     UNUSED(conn);
     UNUSED(remote);
 
-    snprintf(ip, ip_len, "%s", server.unixsocket);
-    *port = 0;
+    snprintf(ip, ip_len, "%s:0", server.unixsocket);
+    if (port) *port = 0;
     return 0;
 }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -334,12 +334,10 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
 }
 
 static int connSocketAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
-    UNUSED(conn);
-    UNUSED(remote);
+    if (anetFdToString(conn->fd, ip, ip_len, port, remote) == 0) return 0;
 
-    snprintf(ip, ip_len, "%s:0", server.unixsocket);
-    if (port) *port = 0;
-    return 0;
+    conn->last_errno = errno;
+    return -1;
 }
 
 static int connSocketIsLocal(connection *conn) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -334,10 +334,12 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
 }
 
 static int connSocketAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
-    if (anetFdToString(conn->fd, ip, ip_len, port, remote) == 0) return 0;
+    UNUSED(conn);
+    UNUSED(remote);
 
-    conn->last_errno = errno;
-    return -1;
+    snprintf(ip, ip_len, "%s", server.unixsocket);
+    *port = 0;
+    return 0;
 }
 
 static int connSocketIsLocal(connection *conn) {

--- a/src/unix.c
+++ b/src/unix.c
@@ -46,7 +46,12 @@ static void connUnixEventHandler(struct aeEventLoop *el, int fd, void *clientDat
 }
 
 static int connUnixAddr(connection *conn, char *ip, size_t ip_len, int *port, int remote) {
-    return connectionTypeTcp()->addr(conn, ip, ip_len, port, remote);
+    UNUSED(conn);
+    UNUSED(remote);
+
+    snprintf(ip, ip_len, "%s:0", server.unixsocket);
+    if (port) *port = 0;
+    return 0;
 }
 
 static int connUnixIsLocal(connection *conn) {


### PR DESCRIPTION
When displaying client addr / laddr using catClientInfoString for example,
if the client is connected via unix domain socket and the unixsocket exceeds
NET_ADDR_STR_LEN, the output will be truncated because NET_ADDR_STR_LEN is
not long enough.

Currently NET_ADDR_STR_LEN is 46+32 that is 78, and the maximum length of a
UNIX domain socket path is typically 108 bytes on Linux and 104 bytes on macOS,
both number including null terminator. In this fix, we use CONN_ADDR_STR_LEN
instead which is 128, that should be long enough for most cases.

It affects the output of CLIENT INFO / CLIENT LIST commands, as well as the
printing of some logs.

Other cleanup:
1. In acceptCommonHandler, when calling connFormatAddr on a unix socket
client, the connFormatAddr function will always return /unixsocket since
in anetFdToString we hardcoded the string. We changed it to the same display.

2. We changed the return value of connSocketAddr from returning C_OK/C_ERR to
returning 0 and -1, which is consistent with the return values of other types.

One change worth mentioning is that in connSocketAddr, we used to call
anetFdToString which would return `/unixsocket` hardcoded in this case.
Now we will use server.unixsocket, the format is `path:0`.