### PR TITLE
Fix the incorrect stdout redirect logic

### DIFF
--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -452,7 +452,7 @@ void rdbShowGenericInfo(void) {
             stats_fd = open(rdbstate.stats_output, O_WRONLY | O_CREAT, 0644);
             if (stats_fd == -1) {
                 fprintf(stderr, "Cannot open output file: '%s': %s\n", rdbstate.stats_output, strerror(errno));
-                exit(0);
+                exit(1);
             } else {
                 dup2(stats_fd, STDOUT_FILENO);
             }

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -446,10 +446,10 @@ void rdbShowGenericInfo(void) {
 
     char buffer[64];
     int stats_fd = -1;
-    int original_stdout_fd = -1;
+    int saved_stdout = -1;
     if (rdbCheckStats) {
         if (rdbCheckOutput) {
-            original_stdout_fd = dup(STDOUT_FILENO);
+            saved_stdout = dup(STDOUT_FILENO);
             stats_fd = open(rdbstate.stats_output, O_WRONLY | O_CREAT, 0644);
             if (stats_fd == -1) {
                 fprintf(stderr, "Cannot open output file: '%s': %s\n", rdbstate.stats_output, strerror(errno));
@@ -499,9 +499,9 @@ void rdbShowGenericInfo(void) {
             }
         }
         if (rdbCheckOutput) {
-            dup2(original_stdout_fd, STDOUT_FILENO);
+            dup2(saved_stdout, STDOUT_FILENO);
             close(stats_fd);
-            close(original_stdout_fd);
+            close(saved_stdout);
         }
     }
 }

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -38,6 +38,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 
 void createSharedObjects(void);
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -444,13 +444,17 @@ void rdbShowGenericInfo(void) {
     }
 
     char buffer[64];
-    FILE *stats_fp = NULL;
+    int stats_fd = -1;
+    int original_stdout_fd = -1;
     if (rdbCheckStats) {
         if (rdbCheckOutput) {
-            stats_fp = freopen(rdbstate.stats_output, "w", stdout);
-            if (stats_fp == NULL) {
-                printf("Cannot open output file: %s\n", rdbstate.stats_output);
+            original_stdout_fd = dup(STDOUT_FILENO);
+            stats_fd = open(rdbstate.stats_output, O_WRONLY | O_CREAT, 0644);
+            if (stats_fd == -1) {
+                fprintf(stderr, "Cannot open output file: '%s': %s\n", rdbstate.stats_output, strerror(errno));
                 exit(0);
+            } else {
+                dup2(stats_fd, STDOUT_FILENO);
             }
         }
 
@@ -494,8 +498,9 @@ void rdbShowGenericInfo(void) {
             }
         }
         if (rdbCheckOutput) {
-            fclose(stats_fp);
-            stdout = fdopen(1, "w");
+            dup2(original_stdout_fd, STDOUT_FILENO);
+            close(stats_fd);
+            close(original_stdout_fd);
         }
     }
 }


### PR DESCRIPTION
Use the standard `dup2` to redirect `stdout`

Closes #2224
Follow-up of #1743