### PR TITLE
Reset failover failed primary rank when doing a manual failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4981,6 +4981,7 @@ void clusterHandleReplicaFailover(void) {
         if (server.cluster->mf_end) {
             server.cluster->failover_auth_time = now;
             server.cluster->failover_auth_rank = 0;
+            server.cluster->failover_failed_primary_rank = 0;
             /* Reset auth_age since it is outdated now and we can bypass the auth_timeout
              * check in the next state and start the election ASAP. */
             auth_age = 0;


### PR DESCRIPTION
This rank was added in #1018, we should reset it to zero when doing
the manual failover, just like we reset failover auth rank.

It affects subsequent log printing. When there is a manual failover
and there are multiple primaries failure, `Start of election` will
print a confusing log.