### PR TITLE
Use double quotes to properly escape the release branch

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       # any PR to a release branch.
-      - '[0-9].[0-9]'
+      - "[0-9].[0-9]"
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
test