### PR TITLE
Remove extra concurrency group from the 7.2 daily test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -32,10 +32,6 @@ concurrency:
   group: daily-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-concurrency:
-  group: daily-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
At some point we added an extra concurrency group in the 7.2 branch, which prevented the full test run from running.