### PR TITLE
Avoid freeing cluster link before printing link sender

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3294,12 +3294,12 @@ int clusterProcessPacket(clusterLink *link) {
 
     if (is_light) {
         if (!link->node || nodeInHandshake(link->node)) {
-            freeClusterLink(link);
             serverLog(
                 LL_NOTICE,
                 "Closing link for node %.40s that sent a lightweight message of type %s as its first message on the link",
                 hdr->sender,
                 clusterGetMessageTypeString(type));
+            freeClusterLink(link);
             return 0;
         }
         clusterNode *sender = link->node;


### PR DESCRIPTION
I found a heap-use-after-free bug in `clusterProcessPacket`, where it:

1. Creates a local `clusterMsg *hdr` that points to `link->rcvbuf`: https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L3290
2. Calls [freeClusterLink](https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L3297), which frees `link->rcvbuf`: https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L1498
3. Attempts to read from `hdr`, which points to the newly freed `link->rcvbuf`, in order to print an error message: https://github.com/valkey-io/valkey/blob/unstable/src/cluster_legacy.c#L3298-L3301

The choices here are to either make hdr a copy of `link->rcvbuf` so that it can be accessed after freeing the cluster link, or to print the message before freeing the cluster link. I chose the latter as it's far simpler