### PR TITLE
Accept socket judge fd overflow

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -326,6 +326,11 @@ static void connSocketAcceptHandler(aeEventLoop *el, int fd, void *privdata, int
             if (errno != EWOULDBLOCK) serverLog(LL_WARNING, "Accepting client connection: %s", server.neterr);
             return;
         }
+        if (cfd >= (int)server.maxclients + CONFIG_FDSET_INCR) {
+            close(cfd);
+            serverLog(LL_WARNING, "Accept %s:%d failed, the cfd is overflow.", cip, cport);
+            return;
+        }
         serverLog(LL_VERBOSE, "Accepted %s:%d", cip, cport);
 
         if (server.tcpkeepalive) anetKeepAlive(NULL, cfd, server.tcpkeepalive);

--- a/src/socket.c
+++ b/src/socket.c
@@ -119,7 +119,11 @@ static int connSocketConnect(connection *conn,
     conn->state = CONN_STATE_CONNECTING;
 
     conn->conn_handler = connect_handler;
-    aeCreateFileEvent(server.el, conn->fd, AE_WRITABLE, conn->type->ae_handler, conn);
+    if (aeCreateFileEvent(server.el, conn->fd, AE_WRITABLE, conn->type->ae_handler, conn) == AE_ERR) {
+        conn->state = CONN_STATE_ERROR;
+        conn->last_errno = errno;
+        return C_ERR
+    }
 
     return C_OK;
 }


### PR DESCRIPTION
when we use sentinel manage a large cluster, the fd may overflow; 
then the clients that cfd greater than the aeEvent size,  lead to 
these clients leak.

Because in createCleint(), we don`t check connSetReadHandler() return values.