### PR TITLE
Properly account for checking zmalloc_used_memory()

### DIFF
--- a/src/unit/test_main.c
+++ b/src/unit/test_main.c
@@ -41,6 +41,7 @@ int runTestSuite(struct unitTestSuite *test, int argc, char **argv, int flags) {
     }
 
     /* Check if the test suite has cleaned up all the memory used. */
+    test_num++;
     if (zmalloc_used_memory() > 0) {
         printf("[" KRED "%s" KRESET "] Memory leak detected of %zu bytes\n", test->filename, zmalloc_used_memory());
         failed_tests++;


### PR DESCRIPTION
The `zmalloc_used_memory()` check is _actually_ a test, and thus it needs to be accounted for, otherwise you can get a nonsensical result as seen here:

https://github.com/jsoref/valkey/actions/runs/15787893006/job/44508156695#step:5:482
```
[test_zmalloc.c] Memory leak detected of 29072 bytes
[END] - test_zmalloc.c: 3 tests, -1 passed, 4 failed
```
