### PR TITLE
Check module NO_FAILOVER flag before calling clusterHandleReplicaFailover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5270,7 +5270,7 @@ void manualFailoverCheckTimeout(void) {
     }
 }
 
-/* This function is called from the cluster cron function in order to go
+/* This function is called from clusterCron or clusterBeforeSleep in order to go
  * forward with a manual failover state machine. */
 void clusterHandleManualFailover(void) {
     /* Return ASAP if no manual failover is in progress. */
@@ -5585,9 +5585,13 @@ void clusterBeforeSleep(void) {
             if (!(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) clusterHandleReplicaFailover();
         }
     } else if (flags & CLUSTER_TODO_HANDLE_FAILOVER) {
-        /* Handle failover, this is needed when it is likely that there is already
+        /* Handle failover as soon as possible so that won't have a 100ms
+         * as it was handled only in clusterCron. This is needed when it
+         * is likely that we can start the election or there is already
          * the quorum from primaries in order to react fast. */
-        clusterHandleReplicaFailover();
+        if (nodeIsReplica(myself)) {
+            if (!(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) clusterHandleReplicaFailover();
+        }
     }
 
     /* Update the cluster state. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5589,8 +5589,9 @@ void clusterBeforeSleep(void) {
          * as it was handled only in clusterCron. This is needed when it
          * is likely that we can start the election or there is already
          * the quorum from primaries in order to react fast. */
-        if (nodeIsReplica(myself)) {
-            if (!(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) clusterHandleReplicaFailover();
+        if (nodeIsReplica(myself) &&
+            !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) {
+            clusterHandleReplicaFailover();
         }
     }
 


### PR DESCRIPTION
In other places where clusterHandleReplicaFailover is called, the
CLUSTER_MODULE_FLAG_NO_FAILOVER flag is checked, which is not done
here. It bothered me a lot sometimes, did a minor cleanup to make
them consistent, and update some outdated comments.

This should be no harm since the clusterHandleReplicaFailover call
in clusterCron is the main place that drives the failover forward,
and it had the NO_FAILOVER flag check.