### PR TITLE
Add bug / test-failure / enhancement label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Help us improve by reporting a bug
 title: '[BUG]'
-labels: ''
+labels: ['bug']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,6 +1,7 @@
 name: Crash report
 description: Submit a crash report
 title: '[CRASH] <short description>'
+labels: ['bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a feature
 title: '[NEW]'
-labels: 'enhancement'
+labels: '[enhancement]'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a feature
 title: '[NEW]'
-labels: '[enhancement]'
+labels: ['enhancement']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a feature
 title: '[NEW]'
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/test-failure.md
+++ b/.github/ISSUE_TEMPLATE/test-failure.md
@@ -1,0 +1,22 @@
+---
+name: Test failure
+about: Report a failing or a flaky test
+title: '[TEST-FAILURE] <short description>'
+labels: ['test-failure']
+assignees: ''
+---
+
+<!--Before submitting a test failure report, please check open issues to ensure this failure has not already been reported. -->
+
+**Summary**
+
+A short description of the failure.
+
+**Failing test(s)**
+
+- Test name:
+- CI link(s):
+
+**Error stack trace**
+
+A relevant stack trace for the test failure.


### PR DESCRIPTION
I noticed for the [bugs](https://github.com/valkey-io/valkey/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug) that are raised by the community, somebody has to manually apply the label to the issue. I think this can be easily automated with this small change.