### PR TITLE
Redact user data when hide-user-data-from-log enabled

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -7083,7 +7083,7 @@ void moduleRDBLoadError(ValkeyModuleIO *io) {
                 "after reading '%llu' bytes of a value "
                 "for key named: '%s'.",
                 io->type->module->name, io->type->name, (unsigned long long)io->bytes,
-                io->key ? (char *)io->key->ptr : "(null)");
+                io->key ? (server.hide_user_data_from_log ? "*redacted*" : (char *)io->key->ptr) : "(null)");
 }
 
 /* Returns 0 if there's at least one registered data type that did not declare


### PR DESCRIPTION
### Description
User data logged when crash caused by moduleRDBLoadError.

### Change
Redact user data when hide-user-data-from-log enabled.

