### PR TITLE
Log test details at the end when the test times out.

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -351,11 +351,7 @@ proc test_server_cron {} {
                     if {[info exist ::active_clients_file($fd)]} {
                         set file $::active_clients_file($fd)
                     }
-                    if {[string length $file]} {
-                        lappend ::failed_tests "\[TIMEOUT]: $test_name in $file"
-                    } else {
-                        lappend ::failed_tests $test_name
-                    }
+                    lappend ::failed_tests "\[TIMEOUT]: $test_name in $file"
                 }
             }
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -405,7 +405,7 @@ proc read_from_test_client fd {
         lappend ::clients_time_history $elapsed $data
         signal_idle_client $fd
         set ::active_clients_task($fd) "(DONE) $data"
-        catch {unset ::active_clients_file($fd)}
+        unset ::active_clients_file($fd)
     } elseif {$status eq {ok}} {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -319,6 +319,7 @@ proc test_server_main {} {
     set ::idle_clients {}
     set ::active_clients {}
     array set ::active_clients_task {}
+    array set ::active_clients_file {}
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
@@ -346,7 +347,15 @@ proc test_server_cron {} {
                 }
                 set test_name [string trim $test_name]
                 if {[string length $test_name]} {
-                    lappend ::failed_tests $test_name
+                    set file {}
+                    if {[info exist ::active_clients_file($fd)]} {
+                        set file $::active_clients_file($fd)
+                    }
+                    if {[string length $file]} {
+                        lappend ::failed_tests "$file: $test_name"
+                    } else {
+                        lappend ::failed_tests $test_name
+                    }
                 }
             }
         }
@@ -400,6 +409,7 @@ proc read_from_test_client fd {
         lappend ::clients_time_history $elapsed $data
         signal_idle_client $fd
         set ::active_clients_task($fd) "(DONE) $data"
+        catch {unset ::active_clients_file($fd)}
     } elseif {$status eq {ok}} {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
@@ -507,6 +517,7 @@ proc signal_idle_client fd {
             puts [colorstr bold-white "Testing [lindex $::all_tests $::next_test]"]
             set ::active_clients_task($fd) "ASSIGNED: $fd ([lindex $::all_tests $::next_test])"
         }
+        set ::active_clients_file($fd) "tests/[lindex $::all_tests $::next_test].tcl"
         set ::clients_start_time($fd) [clock seconds]
         send_data_packet $fd run [lindex $::all_tests $::next_test]
         lappend ::active_clients $fd
@@ -521,7 +532,9 @@ proc signal_idle_client fd {
             set ::active_clients_task($fd) "ASSIGNED: $fd solo test"
         }
         set ::clients_start_time($fd) [clock seconds]
-        send_data_packet $fd run_code [lpop ::run_solo_tests]
+        set solo_data [lpop ::run_solo_tests]
+        set ::active_clients_file($fd) [lindex $solo_data 1]
+        send_data_packet $fd run_code $solo_data
         lappend ::active_clients $fd
     } else {
         lappend ::idle_clients $fd

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -352,7 +352,7 @@ proc test_server_cron {} {
                         set file $::active_clients_file($fd)
                     }
                     if {[string length $file]} {
-                        lappend ::failed_tests "$file: $test_name"
+                        lappend ::failed_tests "\[TIMEOUT]: $test_name in $file"
                     } else {
                         lappend ::failed_tests $test_name
                     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -338,11 +338,13 @@ proc test_server_cron {} {
         foreach fd $::active_clients {
             if {[info exist ::active_clients_task($fd)]} {
                 set task $::active_clients_task($fd)
-                # Strip leading state description
-                set test_name [string trim [regsub {^\([^)]*\)\s*} $task {}]]
-                if {[regexp {\(([^()]*)\)$} $task -> tn]} {
+                set test_name [regsub {^\([^)]*\)\s*} $task {}]
+                set test_name [regsub {\s*\(pid\s+\d+\)\s*$} $test_name {}]
+                if {![string length [string trim $test_name]] && \
+                    [regexp {\(([^()]*)\)$} $task -> tn]} {
                     set test_name $tn
                 }
+                set test_name [string trim $test_name]
                 if {[string length $test_name]} {
                     lappend ::failed_tests $test_name
                 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -335,7 +335,19 @@ proc test_server_cron {} {
     if {$elapsed > $::timeout} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
-        lappend ::failed_tests $err
+        foreach fd $::active_clients {
+            if {[info exist ::active_clients_task($fd)]} {
+                set task $::active_clients_task($fd)
+                # Strip leading state description
+                set test_name [string trim [regsub {^\([^)]*\)\s*} $task {}]]
+                if {[regexp {\(([^()]*)\)$} $task -> tn]} {
+                    set test_name $tn
+                }
+                if {[string length $test_name]} {
+                    lappend ::failed_tests $test_name
+                }
+            }
+        }
         show_clients_state
         kill_clients
         force_kill_all_servers
@@ -402,7 +414,8 @@ proc read_from_test_client fd {
     } elseif {$status eq {err}} {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
-        lappend ::failed_tests $err
+        set test_name [lindex [split $data "\n"] 0]
+        lappend ::failed_tests $test_name
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts "(Fast fail: test will exit now)"


### PR DESCRIPTION
Resolves #2267

Verified that the name of the test now prints in the bottom during test time out.

```
[TIMEOUT]: clients state report follows.
sock15b01d810 => (IN PROGRESS) WAIT should not acknowledge 2 additional copies of the data
sock15b01dd10 => (IN PROGRESS) WAIT should not acknowledge 2 additional copies of the data
sock15b01d110 => (IN PROGRESS) WAIT should not acknowledge 2 additional copies of the data
sock15b01e490 => (IN PROGRESS) WAIT should not acknowledge 2 additional copies of the data
sock15b01e710 => (IN PROGRESS) WAIT should not acknowledge 2 additional copies of the data
Killing still running Valkey server 26294
Killing still running Valkey server 26299
Killing still running Valkey server 26302
Killing still running Valkey server 26304
Killing still running Valkey server 26306
Killing still running Valkey server 26342
Killing still running Valkey server 26349
Killing still running Valkey server 26357
Killing still running Valkey server 26358
Killing still running Valkey server 26359

                   The End

Execution time of different units:

!!! WARNING The following tests failed:

*** [TIMEOUT]: WAIT should not acknowledge 2 additional copies of the data in tests/unit/wait.tcl
*** [TIMEOUT]: WAIT should not acknowledge 2 additional copies of the data in tests/unit/wait.tcl
*** [TIMEOUT]: WAIT should not acknowledge 2 additional copies of the data in tests/unit/wait.tcl
*** [TIMEOUT]: WAIT should not acknowledge 2 additional copies of the data in tests/unit/wait.tcl
*** [TIMEOUT]: WAIT should not acknowledge 2 additional copies of the data in tests/unit/wait.tcl
Cleanup: may take some time... OK

------- 

[TIMEOUT]: clients state report follows.
sock146070790 => (IN PROGRESS) Check for memory leaks (pid 26494)
Killing still running Valkey server 26480
Killing still running Valkey server 26494

                   The End

Execution time of different units:

!!! WARNING The following tests failed:

*** [TIMEOUT]: Check for memory leaks in tests/unit/introspection.tcl
Cleanup: may take some time... OK
```