### PR TITLE
 initialize local robj variable during evictionPoolPopulate

### DIFF
--- a/src/evict.c
+++ b/src/evict.c
@@ -151,7 +151,7 @@ void evictionPoolPopulate(int dbid, dict *sampledict, dict *keydict, struct evic
     for (j = 0; j < count; j++) {
         unsigned long long idle;
         sds key;
-        robj *o;
+        robj *o = NULL;
         dictEntry *de;
 
         de = samples[j];


### PR DESCRIPTION
example fail: 
https://github.com/valkey-io/valkey/actions/runs/15956938912/job/45004461281?pr=2233

```
In function ‘LFUDecrAndReturn’,
    inlined from ‘evictionPoolPopulate’ at evict.c:181:24:
evict.c:321:30: error: ‘o’ may be used uninitialized [-Werror=maybe-uninitialized]
  321 |     unsigned long counter = o->lru & 255;
      |                             ~^~~~~
evict.c: In function ‘evictionPoolPopulate’:
evict.c:154:15: note: ‘o’ was declared here
  154 |         robj *o;
      |               ^
cc1: all warnings being treated as errors
```