### PR TITLE
Include command fullname in error message when returning NO_MULTI error

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -4193,7 +4193,7 @@ int processCommand(client *c) {
     }
 
     if (c->flag.multi && c->cmd->flags & CMD_NO_MULTI) {
-        rejectCommandFormat(c, "Command not allowed inside a transaction");
+        rejectCommandFormat(c, "Command '%s' not allowed inside a transaction", c->cmd->fullname);
         return C_OK;
     }
 

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -836,16 +836,11 @@ start_server {tags {"multi"}} {
             r del foo
             r multi
             r set foo bar
-            catch {r $cmd} e1
-            catch {r exec} e2
-            if {$cmd == "SAVE"} {
-                assert_match {*Command 'save' not allowed inside a transaction*} $e1
-            } elseif {$cmd == "SHUTDOWN"} {
-                assert_match {*Command 'shutdown' not allowed inside a transaction*} $e1
-            }
-            assert_match {EXECABORT*} $e2
-            r get foo
-        } {}
+            set cmd_lower [string tolower $cmd]
+            assert_error "ERR Command '$cmd_lower' not allowed inside a transaction*" {r $cmd}
+            assert_error "EXECABORT Transaction discarded because of previous errors*" {r exec}
+            assert_equal [r get foo] {}
+        }
     }
 
     test "MULTI with BGREWRITEAOF" {

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -35,7 +35,7 @@ start_server {tags {"multi"}} {
 
     test {Nested MULTI are not allowed} {
         r multi
-        assert_error "ERR*" {r multi}
+        assert_error "ERR Command 'multi' not allowed inside a transaction*" {r multi}
         assert_error "EXECABORT*" {r exec}
     }
 
@@ -48,7 +48,7 @@ start_server {tags {"multi"}} {
 
     test {WATCH inside MULTI is not allowed} {
         r multi
-        assert_error "ERR*" {r watch}
+        assert_error "ERR Command 'watch' not allowed inside a transaction*" {r watch x}
         assert_error "EXECABORT*" {r exec}
     }
 
@@ -838,7 +838,11 @@ start_server {tags {"multi"}} {
             r set foo bar
             catch {r $cmd} e1
             catch {r exec} e2
-            assert_match {*Command not allowed inside a transaction*} $e1
+            if {$cmd == "SAVE"} {
+                assert_match {*Command 'save' not allowed inside a transaction*} $e1
+            } elseif {$cmd == "SHUTDOWN"} {
+                assert_match {*Command 'shutdown' not allowed inside a transaction*} $e1
+            }
             assert_match {EXECABORT*} $e2
             r get foo
         } {}
@@ -904,15 +908,15 @@ start_server {tags {"multi"}} {
 
     test {MULTI is rejected when CLIENT REPLY is ON/OFF/SKIP} {
         r multi
-        assert_error "ERR Command not allowed inside a transaction" {r client reply on}
+        assert_error "ERR Command 'client|reply' not allowed inside a transaction" {r client reply on}
         assert_error "EXECABORT *" {r exec}
 
         r multi
-        assert_error "ERR Command not allowed inside a transaction" {r client reply skip}
+        assert_error "ERR Command 'client|reply' not allowed inside a transaction" {r client reply skip}
         assert_error "EXECABORT *" {r exec}
 
         r multi
-        assert_error "ERR Command not allowed inside a transaction" {r client reply off}
+        assert_error "ERR Command 'client|reply' not allowed inside a transaction" {r client reply off}
         assert_error "EXECABORT *" {r exec}
 
         r client reply on


### PR DESCRIPTION
Including command fullname in error messages can help users locate
problems more clearly. This is a potentially breaking change.

Previously we returned `ERR Command not allowed inside a transaction`,
now we return `ERR Command 'shutdown' not allowed inside a transaction`,
for subcommand it is `ERR Command 'client|reply' not allowed inside a transaction`.

Closes #1629.