### PR TITLE
Fix missing response when AUTH is errored inside a transaction

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1439,7 +1439,12 @@ int ACLCheckUserCredentials(robj *username, robj *password) {
 /* If `err` is provided, this is added as an error reply to the client.
  * Otherwise, the standard Auth error is added as a reply. */
 void addAuthErrReply(client *c, robj *err) {
+    /* Note that a module auth can add reply in its callback, or not
+     * add reply and just return an error robj in its callback. So in
+     * here, we use buffered_reply flag to determine if auth command
+     * has already had a reply added. */
     if (c->flag.buffered_reply) return;
+
     if (!err) {
         addReplyError(c, "-WRONGPASS invalid username-password pair or user is disabled.");
         return;

--- a/src/acl.c
+++ b/src/acl.c
@@ -1439,7 +1439,7 @@ int ACLCheckUserCredentials(robj *username, robj *password) {
 /* If `err` is provided, this is added as an error reply to the client.
  * Otherwise, the standard Auth error is added as a reply. */
 void addAuthErrReply(client *c, robj *err) {
-    if (clientHasPendingReplies(c)) return;
+    if (c->flag.buffered_reply) return;
     if (!err) {
         addReplyError(c, "-WRONGPASS invalid username-password pair or user is disabled.");
         return;

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -955,6 +955,12 @@ start_server {tags {"multi"}} {
         $rd close
     }
 
+    test "AUTH errored inside MULTI will add the reply" {
+        r config set requirepass ""
+        r multi
+        r auth no-user foobar
+        assert_error {WRONGPASS invalid username-password pair or user is disabled.} {r exec}
+    }
 }
 
 start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} appendfsync always} tags {external:skip}} {


### PR DESCRIPTION
When we add f8a5a4f70ccada85943af90f6f2db3250ee50b27, a module auth
can add reply in its callback, or not add reply and just return an
error robj in its callback, and we have to figure a way to determine
whether it has added the reply.

Before we are using `clientHasPendingReplies` and it had a issue,
the auth might be used inside a transaction or pipeline which already
has some pending replies in the client reply list. It causes us to
not add the error reply to auth.

After #1819, now we have a buffered_reply client flag, it indicates
the reply for the current command was buffered, either in client::reply
or in client::buf. We can use this flag to check.

Fixes #2106.