### PR TITLE
Build with fast_float by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: make
         # Fail build if there are warnings
         # build with TLS just for compilation coverage
-        run: make -j4 all-with-unit-tests SERVER_CFLAGS='-Werror' BUILD_TLS=yes USE_FAST_FLOAT=yes
+        run: make -j4 all-with-unit-tests SERVER_CFLAGS='-Werror' BUILD_TLS=yes
       - name: install old server for compatibility testing
         run: |
           cd tests/tmp
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: make
         # build with TLS module just for compilation coverage
-        run: make -j4 all-with-unit-tests SANITIZER=address SERVER_CFLAGS='-Werror' BUILD_TLS=module
+        run: make -j4 all-with-unit-tests SANITIZER=address SERVER_CFLAGS='-Werror' BUILD_TLS=module USE_FAST_FLOAT=no
       - name: testprep
         run: sudo apt-get install tcl8.6 tclx -y
       - name: test
@@ -87,7 +87,7 @@ jobs:
       - name: prepare-development-libraries
         run: sudo apt-get install librdmacm-dev libibverbs-dev
       - name: make-rdma-module
-        run: make -j4 BUILD_RDMA=module
+        run: make -j4 BUILD_RDMA=module USE_FAST_FLOAT=no
       - name: make-rdma-builtin
         run: |
           make distclean
@@ -112,7 +112,7 @@ jobs:
       - name: make
         run: |
           apt-get update && apt-get install -y build-essential
-          make -j4 SERVER_CFLAGS='-Werror'
+          make -j4 SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=no
 
   build-macos-latest:
     runs-on: macos-latest
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: make
         # Build with additional upcoming features
-        run: make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=yes
+        run: make -j3 all-with-unit-tests SERVER_CFLAGS='-Werror'
 
   build-32bit:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -361,7 +361,7 @@ jobs:
           ref: ${{ env.GITHUB_HEAD_REF }}
       - name: make
         run: |
-          make BUILD_TLS=yes SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=yes
+          make BUILD_TLS=yes SERVER_CFLAGS='-Werror' USE_FAST_FLOAT=no
       - name: testprep
         run: |
           sudo apt-get install tcl8.6 tclx tcl-tls

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
     % make USE_SYSTEMD=yes
 
+By default, Valkey is built with the fast_float library which requires a C++
+compiler. To build without fast_float, set USE_FAST_FLOAT to no:
+
+    % make USE_FAST_FLOAT=no
+
 To append a suffix to Valkey program names, use:
 
     % make PROG_SUFFIX="-alt"

--- a/src/Makefile
+++ b/src/Makefile
@@ -437,7 +437,7 @@ ENGINE_TEST_OBJ:=$(sort $(patsubst unit/%.c,unit/%.o,$(ENGINE_TEST_FILES)))
 ENGINE_UNIT_TESTS:=$(ENGINE_NAME)-unit-tests$(PROG_SUFFIX)
 ALL_SOURCES=$(sort $(patsubst %.o,%.c,$(ENGINE_SERVER_OBJ) $(ENGINE_CLI_OBJ) $(ENGINE_BENCHMARK_OBJ)))
 
-USE_FAST_FLOAT?=no
+USE_FAST_FLOAT?=yes
 ifeq ($(USE_FAST_FLOAT),yes)
 	# valkey_strtod.h uses this flag to switch valkey_strtod function to fast_float_strtod,
 	# therefore let's pass it to compiler for preprocessing.


### PR DESCRIPTION
When fast_float was added in 8.1 (#1260), we didn't want to build with it by default. It's a change to the build toolchain for the default build configuration and we didn't want to do this change in a minor version. We can do it now for the upcoming 9.0 though.

CI and Daily jobs are updated so that some jobs run without fast_float, which now needs to be specified explicitly. With these changes, most of the jobs run with fast_float and only a few jobs run without it.