### PR TITLE
Fix replica (the old primary) claims to sitll have slots after manual failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -71,6 +71,7 @@ list *clusterGetNodesInMyShard(clusterNode *node);
 int clusterNodeAddReplica(clusterNode *primary, clusterNode *replica);
 int clusterAddSlot(clusterNode *n, int slot);
 int clusterDelSlot(int slot);
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node);
 int clusterDelNodeSlots(clusterNode *node);
 void clusterNodeSetSlotBit(clusterNode *n, int slot);
 static void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required);
@@ -3638,6 +3639,10 @@ int clusterProcessPacket(clusterLink *link) {
                              * this may cause a primary-replica chain issue. */
                             return 1;
                         } else if (nodeIsReplica(sender_claimed_primary)) {
+                            /* A failover occurred in the shard where `sender` belongs to and `sender` is
+                             * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
+                             * which is the new primary in the shard */
+                            clusterMoveNodeSlots(sender, sender_claimed_primary);
                             /* `primary` is still a `replica` in this observer node's view;
                              * update its role and configEpoch */
                             clusterSetNodeAsPrimary(sender_claimed_primary);
@@ -5742,6 +5747,18 @@ int clusterDelSlot(int slot) {
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
     return C_OK;
+}
+
+/* Transfer slots from `from_node` to `to_node`.
+ * Iterates over all cluster slots, transferring each slot covered
+ * by `from_node` to `to_node`. */
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node) {
+    for (int j = 0; j < CLUSTER_SLOTS; j++) {
+        if (clusterNodeCoversSlot(from_node, j)) {
+            clusterDelSlot(j);
+            clusterAddSlot(to_node, j);
+        }
+    }
 }
 
 /* Delete all the slots associated with the specified node.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3639,6 +3639,7 @@ int clusterProcessPacket(clusterLink *link) {
                              * this may cause a primary-replica chain issue. */
                             return 1;
                         } else if (nodeIsReplica(sender_claimed_primary)) {
+                            serverAssert(sender_claimed_primary->replicaof == sender);
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is
                              * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
                              * which is the new primary in the shard */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -686,7 +686,6 @@ int clusterLoadConfig(char *filename) {
             } else if (!strcasecmp(s, "master") || !strcasecmp(s, "primary")) {
                 n->flags |= CLUSTER_NODE_PRIMARY;
             } else if (!strcasecmp(s, "slave") || !strcasecmp(s, "replica")) {
-                serverAssert(n->numslots == 0);
                 n->flags |= CLUSTER_NODE_REPLICA;
             } else if (!strcasecmp(s, "fail?")) {
                 n->flags |= CLUSTER_NODE_PFAIL;
@@ -3655,6 +3654,7 @@ int clusterProcessPacket(clusterLink *link) {
                                       sender->shard_id, sender->name, sender->human_nodename, slots,
                                       sender_claimed_primary->name, sender_claimed_primary->human_nodename,
                                       (unsigned long long)sender_claimed_primary->configEpoch);
+                            serverAssert(sender->numslots == 0);
                         }
                     } else {
                         /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
@@ -3667,9 +3667,9 @@ int clusterProcessPacket(clusterLink *link) {
                             serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
                                       sender->human_nodename, sender_claimed_primary->shard_id);
                         }
+                        serverAssert(sender->numslots == 0);
                     }
 
-                    serverAssert(sender->numslots == 0);
                     sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
                     sender->flags |= CLUSTER_NODE_REPLICA;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -71,8 +71,8 @@ list *clusterGetNodesInMyShard(clusterNode *node);
 int clusterNodeAddReplica(clusterNode *primary, clusterNode *replica);
 int clusterAddSlot(clusterNode *n, int slot);
 int clusterDelSlot(int slot);
-void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node);
 int clusterDelNodeSlots(clusterNode *node);
+int clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node);
 void clusterNodeSetSlotBit(clusterNode *n, int slot);
 static void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required);
 void clusterHandleReplicaFailover(void);
@@ -686,6 +686,7 @@ int clusterLoadConfig(char *filename) {
             } else if (!strcasecmp(s, "master") || !strcasecmp(s, "primary")) {
                 n->flags |= CLUSTER_NODE_PRIMARY;
             } else if (!strcasecmp(s, "slave") || !strcasecmp(s, "replica")) {
+                serverAssert(n->numslots == 0);
                 n->flags |= CLUSTER_NODE_REPLICA;
             } else if (!strcasecmp(s, "fail?")) {
                 n->flags |= CLUSTER_NODE_PFAIL;
@@ -3642,16 +3643,16 @@ int clusterProcessPacket(clusterLink *link) {
                             serverAssert(sender_claimed_primary->replicaof == sender);
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is
                              * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
-                             * which is the new primary in the shard */
-                            clusterMoveNodeSlots(sender, sender_claimed_primary);
+                             * which is the new primary in the shard. */
+                            int slots = clusterMoveNodeSlots(sender, sender_claimed_primary);
                             /* `primary` is still a `replica` in this observer node's view;
                              * update its role and configEpoch */
                             clusterSetNodeAsPrimary(sender_claimed_primary);
                             sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
                             serverLog(LL_NOTICE,
-                                      "A failover occurred in shard %.40s; node %.40s (%s)"
+                                      "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
                                       " failed over to node %.40s (%s) with a config epoch of %llu",
-                                      sender->shard_id, sender->name, sender->human_nodename,
+                                      sender->shard_id, sender->name, sender->human_nodename, slots,
                                       sender_claimed_primary->name, sender_claimed_primary->human_nodename,
                                       (unsigned long long)sender_claimed_primary->configEpoch);
                         }
@@ -3668,6 +3669,7 @@ int clusterProcessPacket(clusterLink *link) {
                         }
                     }
 
+                    serverAssert(sender->numslots == 0);
                     sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
                     sender->flags |= CLUSTER_NODE_REPLICA;
 
@@ -5433,7 +5435,7 @@ void clusterCron(void) {
         /* The protocol is that function(s) below return non-zero if the node was
          * terminated.
          */
-        if (clusterNodeCronHandleReconnect(node, now)) continue;
+        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now)) continue;
     }
     dictReleaseIterator(di);
 
@@ -5750,18 +5752,6 @@ int clusterDelSlot(int slot) {
     return C_OK;
 }
 
-/* Transfer slots from `from_node` to `to_node`.
- * Iterates over all cluster slots, transferring each slot covered
- * by `from_node` to `to_node`. */
-void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node) {
-    for (int j = 0; j < CLUSTER_SLOTS; j++) {
-        if (clusterNodeCoversSlot(from_node, j)) {
-            clusterDelSlot(j);
-            clusterAddSlot(to_node, j);
-        }
-    }
-}
-
 /* Delete all the slots associated with the specified node.
  * The number of deleted slots is returned. */
 int clusterDelNodeSlots(clusterNode *node) {
@@ -5774,6 +5764,23 @@ int clusterDelNodeSlots(clusterNode *node) {
         }
     }
     return deleted;
+}
+
+/* Transfer slots from `from_node` to `to_node`.
+ *
+ * Iterates over all cluster slots, transferring each slot covered
+ * by `from_node` to `to_node`. Counts and returns the number of
+ * slots transferred. */
+int clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node) {
+    int processed = 0;
+    for (int j = 0; j < CLUSTER_SLOTS; j++) {
+        if (clusterNodeCoversSlot(from_node, j)) {
+            clusterDelSlot(j);
+            clusterAddSlot(to_node, j);
+            processed++;
+        }
+    }
+    return processed;
 }
 
 /* Clear the migrating / importing state for all the slots.

--- a/src/debug.c
+++ b/src/debug.c
@@ -440,6 +440,8 @@ void debugCommand(client *c) {
             "    When set to 1, the cluster link is closed after dropping a packet based on the filter.",
             "DISABLE-CLUSTER-RANDOM-PING <0|1>",
             "    Disable sending cluster ping to a random node every second.",
+            "DISABLE-CLUSTER-RECONNECTION <0|1>",
+            "    Disable cluster reconnection of cluster nodes.",
             "OOM",
             "    Crash the server simulating an out-of-memory error.",
             "PANIC",
@@ -616,6 +618,9 @@ void debugCommand(client *c) {
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "disable-cluster-random-ping") && c->argc == 3) {
         server.debug_cluster_disable_random_ping = atoi(c->argv[2]->ptr);
+        addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "disable-cluster-reconnection") && c->argc == 3) {
+        server.debug_cluster_disable_reconnection = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr, "object") && (c->argc == 3 || c->argc == 4)) {
         robj *val;

--- a/src/server.c
+++ b/src/server.c
@@ -2853,6 +2853,7 @@ void initServer(void) {
     server.thp_enabled = 0;
     server.cluster_drop_packet_filter = -1;
     server.debug_cluster_disable_random_ping = 0;
+    server.debug_cluster_disable_reconnection = 0;
     server.reply_buffer_peak_reset_time = REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME;
     server.reply_buffer_resizing_enabled = 1;
     server.client_mem_usage_buckets = NULL;

--- a/src/server.h
+++ b/src/server.h
@@ -2132,6 +2132,8 @@ struct valkeyServer {
     uint32_t debug_cluster_close_link_on_packet_drop : 1;
     /* Debug config to control the random ping. When set, we will disable the random ping in clusterCron. */
     uint32_t debug_cluster_disable_random_ping : 1;
+    /* Debug config to control the reconnection. When set, we will disable the reconnection in clusterCron. */
+    uint32_t debug_cluster_disable_reconnection : 1;
     sds cached_cluster_slot_info[CACHE_CONN_TYPE_MAX]; /* Index in array is a bitwise or of CACHE_CONN_TYPE_* */
     /* Scripting */
     mstime_t busy_reply_threshold;  /* Script / module timeout in milliseconds */

--- a/tests/unit/cluster/manual-failover.tcl
+++ b/tests/unit/cluster/manual-failover.tcl
@@ -344,7 +344,7 @@ start_cluster 3 1 {tags {external:skip cluster} overrides {cluster-ping-interval
 
         # Make sure we don't send PINGs for a short period of time.
         for {set j 0} {$j < [llength $::servers]} {incr j} {
-            R $j debug disable-cluster-random-ping 0
+            R $j debug disable-cluster-random-ping 1
             R $j config set cluster-ping-interval 300000
         }
 
@@ -395,3 +395,82 @@ start_cluster 3 1 {tags {external:skip cluster} overrides {cluster-ping-interval
         }
     }
 } ;# start_cluster
+
+start_cluster 3 1 {tags {external:skip cluster}} {
+    # In the R0/R3 shard, R0 is the primary node and R3 is the replica.
+    #
+    # We trigger a manually failover on R3.
+    #
+    # When R3 becomes the new primary node, it will broadcast a message to all
+    # nodes in the cluster.
+    # When R0 receives the message, it becomes the new replica and also will
+    # broadcast the message to all nodes in the cluster.
+    #
+    # Let's assume that R1 and R2 receive the message from R0 (new replica) first
+    # and then the message from R3 (new primary) later.
+    #
+    # The purpose of this test is to verify the behavior of R1 and R2 after receiving
+    # the message from R0 (new replica) first. R1 and R2 will update R0 as a replica
+    # and R3 as a primary, and transfer all slots of R0 to R3.
+    #
+    # The role change and the slot ownership change should've been an atomic operation.
+    test "111 Broadcast PONG to the cluster when the node role changes" {
+        set R0_nodeid [R 0 cluster myid]
+        set R1_nodeid [R 1 cluster myid]
+        set R2_nodeid [R 2 cluster myid]
+        set R3_nodeid [R 3 cluster myid]
+
+        set R0_shardid [R 0 cluster myshardid]
+        set R3_shardid [R 3 cluster myshardid]
+        assert_equal $R0_shardid $R3_shardid
+
+        # Ensure that related nodes do not reconnect.
+        R 1 debug disable-cluster-reconnection 1
+        R 2 debug disable-cluster-reconnection 1
+        R 3 debug disable-cluster-reconnection 1
+
+        # After killing the cluster link, ensure that R1 and R3 do not receive
+        # messages from R3 (new primary).
+        R 1 debug clusterlink kill all $R3_nodeid
+        R 2 debug clusterlink kill all $R3_nodeid
+        R 3 debug clusterlink kill all $R1_nodeid
+        R 3 debug clusterlink kill all $R2_nodeid
+
+        set loglines1 [count_log_lines -1]
+        set loglines2 [count_log_lines -2]
+
+        R 3 cluster failover takeover
+
+        # Check that from the perspectives of R1 and R2, R0 becomes a replica and
+        # R3 becomes the new primary.
+        wait_for_condition 1000 10 {
+            [cluster_has_flag [cluster_get_node_by_id 1 $R0_nodeid] slave] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 1 $R3_nodeid] master] eq 1 &&
+
+            [cluster_has_flag [cluster_get_node_by_id 2 $R0_nodeid] slave] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 2 $R3_nodeid] master] eq 1
+        } else {
+            fail "The node is not marked with the correct flag"
+        }
+
+        # Check that R0 (replica) does not own any slots and R3 (new primary) owns
+        # the slots.
+        assert_equal {} [dict get [cluster_get_node_by_id 1 $R0_nodeid] slots]
+        assert_equal {} [dict get [cluster_get_node_by_id 2 $R0_nodeid] slots]
+        assert_equal {0-5461} [dict get [cluster_get_node_by_id 1 $R3_nodeid] slots]
+        assert_equal {0-5461} [dict get [cluster_get_node_by_id 2 $R3_nodeid] slots]
+
+        # A failover occurred in shard, we will only go to this code branch,
+        # verify we print the logs.
+        set R0_slots 5462
+        set pattern "*A failover occurred in shard $R3_shardid; node $R0_nodeid () lost $R0_slots slot(s) and failed over to node $R3_nodeid*"
+        verify_log_message -1 $pattern $loglines1
+        verify_log_message -2 $pattern $loglines2
+
+        R 1 debug disable-cluster-reconnection 0
+        R 2 debug disable-cluster-reconnection 0
+        R 3 debug disable-cluster-reconnection 0
+
+        wait_for_cluster_propagation
+    }
+}

--- a/tests/unit/cluster/manual-failover.tcl
+++ b/tests/unit/cluster/manual-failover.tcl
@@ -412,9 +412,7 @@ start_cluster 3 1 {tags {external:skip cluster}} {
     # The purpose of this test is to verify the behavior of R1 and R2 after receiving
     # the message from R0 (new replica) first. R1 and R2 will update R0 as a replica
     # and R3 as a primary, and transfer all slots of R0 to R3.
-    #
-    # The role change and the slot ownership change should've been an atomic operation.
-    test "111 Broadcast PONG to the cluster when the node role changes" {
+    test "The role change and the slot ownership change should be an atomic operation" {
         set R0_nodeid [R 0 cluster myid]
         set R1_nodeid [R 1 cluster myid]
         set R2_nodeid [R 2 cluster myid]

--- a/tests/unit/cluster/manual-failover.tcl
+++ b/tests/unit/cluster/manual-failover.tcl
@@ -429,7 +429,7 @@ start_cluster 3 1 {tags {external:skip cluster}} {
         R 2 debug disable-cluster-reconnection 1
         R 3 debug disable-cluster-reconnection 1
 
-        # After killing the cluster link, ensure that R1 and R3 do not receive
+        # After killing the cluster link, ensure that R1 and R2 do not receive
         # messages from R3 (new primary).
         R 1 debug clusterlink kill all $R3_nodeid
         R 2 debug clusterlink kill all $R3_nodeid


### PR DESCRIPTION
## update
Please also pick #2370 and #2431 and #2441 and #2477 you want to pick this one.

================

After a failover occurs, when the PING-PONG of the replica, that is,
the old primary, reaches other shard nodes faster, the corresponding
code path will be reached. We will adjust the sender to be a replica
and sender_claimed_primary to be the primary node, but in myself view,
slots still belong to the sender, which is a replica.

This actually restores part of the code in 28976a9003c6dd5cdd7225c5bc90743b4fcde13c.
It was lost in the changes to #445 and #754.

These 3 changes are about avoiding the replicaof cycle but ended up creating
a "cycle" of assumptions themselves. when #445 removed this logic, it was
assumed that a replica could also drive clusterUpdateSlotsConfigWith
but this was actually a regression that resulted in a replicaof cycle (#753).
#754 fixed the replicaof cycle by disallowing a replica to drive
clusterUpdateSlotsConfigWith but missed restoring the original logic.

Added a new `DEBUG DISABLE-CLUSTER-RECONNECTION <0|1>` this will prevent
cluster nodes from reconnecting so that the issue can be reproduce in test.