### PR TITLE
Unexpected variable overriding from .make-settings file

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -466,17 +466,6 @@ all-with-unit-tests: all $(ENGINE_UNIT_TESTS)
 .PHONY: all
 
 persist-settings: distclean
-	echo STD=$(STD) >> .make-settings
-	echo WARN=$(WARN) >> .make-settings
-	echo OPT=$(OPT) >> .make-settings
-	echo MALLOC=$(MALLOC) >> .make-settings
-	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
-	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
-	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
-	echo CFLAGS=$(CFLAGS) >> .make-settings
-	echo LDFLAGS=$(LDFLAGS) >> .make-settings
-	echo SERVER_CFLAGS=$(SERVER_CFLAGS) >> .make-settings
-	echo SERVER_LDFLAGS=$(SERVER_LDFLAGS) >> .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,33 @@
 # Dependencies are stored in the Makefile.dep file. To rebuild this file
 # Just use 'make dep', but this is only needed by developers.
 
+# Override default settings if undefined
+-include .make-settings
+
+define save_var_if_defined
+$(if $($(1)), \
+    echo "ifndef $(1)" >> .tmp.make-settings; \
+    echo "override $(1)=$($(1))" >> .tmp.make-settings; \
+    echo "endif" >> .tmp.make-settings; \
+)
+endef
+
+$(shell \
+	> .tmp.make-settings; \
+    $(call save_var_if_defined,STD) \
+    $(call save_var_if_defined,WARN) \
+	$(call save_var_if_defined,SANITIZER) \
+    $(call save_var_if_defined,OPT) \
+    $(call save_var_if_defined,MALLOC) \
+    $(call save_var_if_defined,BUILD_TLS) \
+    $(call save_var_if_defined,BUILD_RDMA) \
+    $(call save_var_if_defined,USE_SYSTEMD) \
+    $(call save_var_if_defined,CFLAGS) \
+    $(call save_var_if_defined,LDFLAGS) \
+    $(call save_var_if_defined,SERVER_CFLAGS) \
+    $(call save_var_if_defined,SERVER_LDFLAGS) \
+)
+
 release_hdr := $(shell sh -c './mkreleasehdr.sh')
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
@@ -118,9 +145,6 @@ endif
 endif
 endif
 endif
-
-# Override default settings if possible
--include .make-settings
 
 # For added compatibility REDIS_CFLAGS and REDIS_LDFLAGS are also supported.
 ifdef REDIS_CFLAGS
@@ -466,6 +490,7 @@ all-with-unit-tests: all $(ENGINE_UNIT_TESTS)
 .PHONY: all
 
 persist-settings: distclean
+	mv .tmp.make-settings .make-settings
 	echo PREV_FINAL_CFLAGS=$(FINAL_CFLAGS) >> .make-settings
 	echo PREV_FINAL_LDFLAGS=$(FINAL_LDFLAGS) >> .make-settings
 	-(cd ../deps && $(MAKE) $(DEPENDENCY_TARGETS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,10 +24,10 @@ $(if $($(1)), \
 endef
 
 $(shell \
-	> .tmp.make-settings; \
+    > .tmp.make-settings; \
     $(call save_var_if_defined,STD) \
     $(call save_var_if_defined,WARN) \
-	$(call save_var_if_defined,SANITIZER) \
+    $(call save_var_if_defined,SANITIZER) \
     $(call save_var_if_defined,OPT) \
     $(call save_var_if_defined,MALLOC) \
     $(call save_var_if_defined,BUILD_TLS) \


### PR DESCRIPTION
```
# Override default settings if possible
-include .make-settings
```
The above code will overwrite the original variables, such as `STD`, etc. This results in `FINAL_CFLAGS`, `FINAL_LDFLAGS` not being updated correctly.

```
# Clean everything, persist settings and build dependencies if anything changed
ifneq ($(strip $(PREV_FINAL_CFLAGS)), $(strip $(FINAL_CFLAGS)))
.make-prerequisites: persist-settings
endif

ifneq ($(strip $(PREV_FINAL_LDFLAGS)), $(strip $(FINAL_LDFLAGS)))
.make-prerequisites: persist-settings
endif
```
So the above lines of Makefile don't work properly.

The bug was introduced from https://github.com/valkey-io/valkey/commit/7e7b69fee1c87b4802394a8637bb1dc0b474614c. I'm a little shocked that it's been so long. Am I missing something?