### PR TITLE
[optimization] Improve the speed of sending switch-master from sentinel

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -5381,8 +5381,11 @@ void sentinelHandleDictOfValkeyInstances(dict *instances) {
                 switch_to_promoted = ri;
             }
         }
+        if (switch_to_promoted) {
+            sentinelFailoverSwitchToPromotedReplica(switch_to_promoted);
+            switch_to_promoted = NULL;
+        }
     }
-    if (switch_to_promoted) sentinelFailoverSwitchToPromotedReplica(switch_to_promoted);
     dictReleaseIterator(di);
 }
 


### PR DESCRIPTION
Sentinel sends switch-master message more quickly, ref [#2282](https://github.com/valkey-io/valkey/issues/2282).