### PR TITLE
Add extensions supported to cluster link layer to propagate extension faster during handshake

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4282,6 +4282,8 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip) * (wanted + pfail_wanted));
+    /* If the link or the node indicates that it supports extensions, then we
+     * pass the extensions. */
     if (linkSupportsExtension(link) || (link->node && nodeSupportsExtensions(link->node))) {
         estlen += writePingExtensions(NULL, 0);
     }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3353,7 +3353,7 @@ int clusterProcessPacket(clusterLink *link) {
     int sender_last_reported_as_replica = sender && nodeIsReplica(sender);
     int sender_last_reported_as_primary = sender && nodeIsPrimary(sender);
 
-    if (sender && (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA)) {
+    if (sender && link->support_extension) {
         sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
     }
 
@@ -3471,7 +3471,7 @@ int clusterProcessPacket(clusterLink *link) {
                     memcpy(node->ip, ip, sizeof(ip));
                     getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
                     node->cport = ntohs(hdr->cport);
-                    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+                    if (link->support_extension) {
                         node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
                     }
                     setClusterNodeToInboundClusterLink(node, link);
@@ -4271,9 +4271,7 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip) * (wanted + pfail_wanted));
-    /* If the link or the node indicates that it supports extensions, then we
-     * pass the extensions. */
-    if (link->support_extension || (link->node && nodeSupportsExtensions(link->node))) {
+    if (link->support_extension) {
         estlen += writePingExtensions(NULL, 0);
     }
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
@@ -4349,7 +4347,7 @@ void clusterSendPing(clusterLink *link, int type) {
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
 
-    if (link->support_extension || (link->node && nodeSupportsExtensions(link->node))) {
+    if (link->support_extension) {
         totlen += writePingExtensions(hdr, gossipcount);
     } else {
         serverLog(LL_DEBUG, "Unable to send extensions data, however setting ext data flag to true");

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3361,7 +3361,7 @@ int clusterProcessPacket(clusterLink *link) {
     /* Store some flags about the sender. */
     if (sender) {
         /* Check if the node supports extensions. */
-        if (flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED || linkSupportsExtension(sender->inbound_link)) {
+        if (flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED || linkSupportsExtension(link)) {
             sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
         } else {
             sender->flags &= ~CLUSTER_NODE_EXTENSIONS_SUPPORTED;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3354,17 +3354,15 @@ int clusterProcessPacket(clusterLink *link) {
 
     /* We store this information at the link layer so that we can send extensions
      * during the handshake even if we don't know the sender. */
-    if (!linkSupportsExtension(link) && hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+    if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
         link->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
     }
 
     /* Store some flags about the sender. */
     if (sender) {
         /* Check if the node supports extensions. */
-        if (flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED || linkSupportsExtension(link)) {
+        if (linkSupportsExtension(link)) {
             sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
-        } else {
-            sender->flags &= ~CLUSTER_NODE_EXTENSIONS_SUPPORTED;
         }
 
         /* Check if the node supports light publish message hdr */
@@ -3482,7 +3480,7 @@ int clusterProcessPacket(clusterLink *link) {
                     memcpy(node->ip, ip, sizeof(ip));
                     getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
                     node->cport = ntohs(hdr->cport);
-                    if ((flags & ~CLUSTER_NODE_EXTENSIONS_SUPPORTED) && linkSupportsExtension(link)) {
+                    if (linkSupportsExtension(link)) {
                         node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
                     }
                     setClusterNodeToInboundClusterLink(node, link);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3355,7 +3355,7 @@ int clusterProcessPacket(clusterLink *link) {
     /* We store this information at the link layer so that we can send extensions
      * during the handshake even if we don't know the sender. */
     if (hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
-        link->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+        link->flags |= CLUSTER_LINK_EXTENSIONS_SUPPORTED;
     }
 
     /* Store some flags about the sender. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1495,7 +1495,7 @@ clusterLink *createClusterLink(clusterNode *node) {
     if (!link->inbound) {
         node->link = link;
     }
-    link->support_extension = 0;
+    link->flags = 0;
     return link;
 }
 
@@ -3255,7 +3255,6 @@ int clusterIsValidPacket(clusterLink *link) {
                 explen += extlen;
                 ext = getNextPingExt(ext);
             }
-            link->support_extension = 1;
         }
     } else if (type == CLUSTERMSG_TYPE_FAIL) {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
@@ -3353,18 +3352,29 @@ int clusterProcessPacket(clusterLink *link) {
     int sender_last_reported_as_replica = sender && nodeIsReplica(sender);
     int sender_last_reported_as_primary = sender && nodeIsPrimary(sender);
 
-    if (sender && link->support_extension) {
-        sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+    /* We store this information at the link layer so that we can send extensions
+     * during the handshake even if we don't know the sender. */
+    if (!linkSupportsExtension(link) && hdr->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
+        link->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
     }
 
-    /* Checks if the node supports light message hdr */
+    /* Store some flags about the sender. */
     if (sender) {
+        /* Check if the node supports extensions. */
+        if (flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED || linkSupportsExtension(sender->inbound_link)) {
+            sender->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+        } else {
+            sender->flags &= ~CLUSTER_NODE_EXTENSIONS_SUPPORTED;
+        }
+
+        /* Check if the node supports light publish message hdr */
         if (flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED) {
             sender->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED;
         } else {
             sender->flags &= ~CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED;
         }
 
+        /* Check if the node supports light module message hdr */
         if (flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED) {
             sender->flags |= CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
         } else {
@@ -3465,13 +3475,14 @@ int clusterProcessPacket(clusterLink *link) {
                      * flags, replicaof pointer, and so forth, as this details will be
                      * resolved when we'll receive PONGs from the node. The exception
                      * to this is the flag that indicates extensions are supported, as
-                     * we want to send extensions right away in the return PONG in order
-                     * to reduce the amount of time needed to stabilize the shard ID. */
+                     * we want to propagate extensions support as part of the node flags
+                     * in the gossip section, so that we can send extension right away
+                     * in the future packet. */
                     clusterNode *node = createClusterNode(NULL, CLUSTER_NODE_HANDSHAKE);
                     memcpy(node->ip, ip, sizeof(ip));
                     getClientPortFromClusterMsg(hdr, &node->tls_port, &node->tcp_port);
                     node->cport = ntohs(hdr->cport);
-                    if (link->support_extension) {
+                    if ((flags & ~CLUSTER_NODE_EXTENSIONS_SUPPORTED) && linkSupportsExtension(link)) {
                         node->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED;
                     }
                     setClusterNodeToInboundClusterLink(node, link);
@@ -4271,7 +4282,7 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip) * (wanted + pfail_wanted));
-    if (link->support_extension) {
+    if (linkSupportsExtension(link) || (link->node && nodeSupportsExtensions(link->node))) {
         estlen += writePingExtensions(NULL, 0);
     }
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
@@ -4347,7 +4358,7 @@ void clusterSendPing(clusterLink *link, int type) {
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
 
-    if (link->support_extension) {
+    if (linkSupportsExtension(link) || (link->node && nodeSupportsExtensions(link->node))) {
         totlen += writePingExtensions(hdr, gossipcount);
     } else {
         serverLog(LL_DEBUG, "Unable to send extensions data, however setting ext data flag to true");

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1023,7 +1023,9 @@ void clusterUpdateMyselfFlags(void) {
     int nofailover = server.cluster_replica_no_failover ? CLUSTER_NODE_NOFAILOVER : 0;
     myself->flags &= ~CLUSTER_NODE_NOFAILOVER;
     myself->flags |= nofailover;
-    myself->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED | CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
+    myself->flags |= CLUSTER_NODE_EXTENSIONS_SUPPORTED |
+                     CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED |
+                     CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
     if (myself->flags != oldflags) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
     }
@@ -1493,6 +1495,7 @@ clusterLink *createClusterLink(clusterNode *node) {
     if (!link->inbound) {
         node->link = link;
     }
+    link->support_extension = 0;
     return link;
 }
 
@@ -3252,6 +3255,7 @@ int clusterIsValidPacket(clusterLink *link) {
                 explen += extlen;
                 ext = getNextPingExt(ext);
             }
+            link->support_extension = 1;
         }
     } else if (type == CLUSTERMSG_TYPE_FAIL) {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
@@ -4267,7 +4271,9 @@ void clusterSendPing(clusterLink *link, int type) {
      * to put inside the packet. */
     estlen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     estlen += (sizeof(clusterMsgDataGossip) * (wanted + pfail_wanted));
-    if (link->node && nodeSupportsExtensions(link->node)) {
+    /* If the link or the node indicates that it supports extensions, then we
+     * pass the extensions. */
+    if (link->support_extension || (link->node && nodeSupportsExtensions(link->node))) {
         estlen += writePingExtensions(NULL, 0);
     }
     /* Note: clusterBuildMessageHdr() expects the buffer to be always at least
@@ -4343,7 +4349,7 @@ void clusterSendPing(clusterLink *link, int type) {
     /* Compute the actual total length and send! */
     uint32_t totlen = 0;
 
-    if (link->node && nodeSupportsExtensions(link->node)) {
+    if (link->support_extension || (link->node && nodeSupportsExtensions(link->node))) {
         totlen += writePingExtensions(hdr, gossipcount);
     } else {
         serverLog(LL_DEBUG, "Unable to send extensions data, however setting ext data flag to true");

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -41,6 +41,11 @@ typedef struct clusterLink {
     int flags;                             /* We share CLUSTER_NODE_* with clusterNode->flags. */
 } clusterLink;
 
+/* Cluster link flags and macros. */
+#define CLUSTER_LINK_EXTENSIONS_SUPPORTED (1 << 0)        /* This link supports extensions. */
+
+#define linkSupportsExtension(link) ((link)->flags & CLUSTER_LINK_EXTENSIONS_SUPPORTED)
+
 /* Cluster node flags and macros. */
 #define CLUSTER_NODE_PRIMARY (1 << 0)                      /* The node is a primary */
 #define CLUSTER_NODE_REPLICA (1 << 1)                      /* The node is a replica */
@@ -71,8 +76,6 @@ typedef struct clusterLink {
 #define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
 #define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
-
-#define linkSupportsExtension(link) ((link)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 
 /* This structure represent elements of node->fail_reports. */
 typedef struct clusterNodeFailReport {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -42,7 +42,7 @@ typedef struct clusterLink {
 } clusterLink;
 
 /* Cluster link flags and macros. */
-#define CLUSTER_LINK_EXTENSIONS_SUPPORTED (1 << 0)        /* This link supports extensions. */
+#define CLUSTER_LINK_EXTENSIONS_SUPPORTED (1 << 0) /* This link supports extensions. */
 
 #define linkSupportsExtension(link) ((link)->flags & CLUSTER_LINK_EXTENSIONS_SUPPORTED)
 

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -67,7 +67,6 @@ typedef struct clusterLink {
 #define nodeTimedOut(n) ((n)->flags & CLUSTER_NODE_PFAIL)
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
-#define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 #define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
 #define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -38,7 +38,7 @@ typedef struct clusterLink {
     size_t rcvbuf_alloc;                   /* Allocated size of rcvbuf */
     clusterNode *node;                     /* Node related to this link. Initialized to NULL when unknown */
     int inbound;                           /* 1 if this link is an inbound link accepted from the related node */
-    int support_extension;                 /* 1 if this link supports passing extensions. */
+    int flags;                             /* We share CLUSTER_NODE_* with clusterNode->flags. */
 } clusterLink;
 
 /* Cluster node flags and macros. */
@@ -67,9 +67,12 @@ typedef struct clusterLink {
 #define nodeTimedOut(n) ((n)->flags & CLUSTER_NODE_PFAIL)
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
+#define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 #define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
 #define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
+
+#define linkSupportsExtension(link) ((link)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 
 /* This structure represent elements of node->fail_reports. */
 typedef struct clusterNodeFailReport {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -38,6 +38,7 @@ typedef struct clusterLink {
     size_t rcvbuf_alloc;                   /* Allocated size of rcvbuf */
     clusterNode *node;                     /* Node related to this link. Initialized to NULL when unknown */
     int inbound;                           /* 1 if this link is an inbound link accepted from the related node */
+    int support_extension;                 /* 1 if this link supports passing extensions. */
 } clusterLink;
 
 /* Cluster node flags and macros. */


### PR DESCRIPTION
Add support_extension to cluster link, so that when myself receives a message from sender,
even if myself does not know the sender, for example during handshake the sender node is
still treated as random node, in thi case, the packet we reply to sender can also carry the
extension, since the sender link explicitly indicates that it supports the extension, by doing
this, we can speed up the spread of the extension.

See https://github.com/valkey-io/valkey/pull/2283#issuecomment-3031446204 and
https://github.com/valkey-io/valkey/pull/2279#discussion_r2186673007 for more details.