### PR TITLE
Disable active expiry until it's needed

### DIFF
--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -953,6 +953,7 @@ start_server {tags {"expire"}} {
 
 start_server {tags {expire} overrides {hz 100}} {
     test {Active expiration triggers hashtable shrink} {
+        r debug SET-ACTIVE-EXPIRE 0
         set persistent_keys 5
         set volatile_keys 100
         set total_keys [expr $persistent_keys + $volatile_keys]
@@ -969,6 +970,7 @@ start_server {tags {expire} overrides {hz 100}} {
         assert_equal $total_keys [r dbsize]
 
         # Wait for active expiration
+        r debug SET-ACTIVE-EXPIRE 1
         wait_for_condition 100 50 {
             [r dbsize] eq $persistent_keys
         } else {


### PR DESCRIPTION
Resolves test failures like https://github.com/valkey-io/valkey/actions/runs/16093360514/job/45412856532. Valgrind tests can run slowly, so the 100 ms expire time may have partially began to get expire items during the ingestion phase.