### PR TITLE
fix test Flushall while watching several keys by one client

### DIFF
--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -900,6 +900,7 @@ start_server {tags {"multi"}} {
         r watch b{t} a{t}
         r flushall
         r ping
+        r UNWATCH
      }
 
     test {MULTI is rejected when CLIENT REPLY is ON/OFF/SKIP} {


### PR DESCRIPTION
There is a need to unwatch keys at the end of the test inm order to cleanup the dirty multi state so that it is not carried to other tests.