### PR TITLE
Update test to unwatch all keys before auth within multi (#2323)

### DIFF
--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -900,6 +900,7 @@ start_server {tags {"multi"}} {
         r watch b{t} a{t}
         r flushall
         r ping
+        r unwatch
      }
 
     test "AUTH errored inside MULTI will add the reply" {


### PR DESCRIPTION
Backport PR to 8.1

Because we are wathcing something, so the multi fail and reply
an empty repsone.
```
*** [err]: AUTH errored inside MULTI will add the reply in tests/unit/multi.tcl
Expected an error matching 'WRONGPASS invalid username-password pair or user is disabled.' but got '' (context: type eval line 5 cmd {assert_error {WRONGPASS invalid username-password pair or user is disabled.} {r exec}} proc ::test)
```

Fixes #2320