### PR TITLE
handle prefetch-batch-max-size config update from zero to positive value

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3267,7 +3267,7 @@ standardConfig static_configs[] = {
     createIntConfig("min-io-threads-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_io_threads_copy_avoid, 7, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-string-size-avoid-copy-reply", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid, 16384, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("min-string-size-avoid-copy-reply-threaded", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, INT_MAX, server.min_string_size_copy_avoid_threaded, 65536, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("prefetch-batch-max-size", NULL, MODIFIABLE_CONFIG, 0, 128, server.prefetch_batch_max_size, 16, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("prefetch-batch-max-size", NULL, MODIFIABLE_CONFIG, 0, 128, server.prefetch_batch_max_size, 16, INTEGER_CONFIG, NULL, onMaxBatchSizeChange),
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, server.cluster_replica_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* replica max data age factor. */
     createIntConfig("list-max-listpack-size", "list-max-ziplist-size", MODIFIABLE_CONFIG, INT_MIN, INT_MAX, server.list_max_listpack_size, -2, INTEGER_CONFIG, NULL, NULL),

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -71,14 +71,16 @@ void prefetchCommandsBatchInit(void) {
     batch->prefetch_info = zcalloc(max_prefetch_size * sizeof(KeyPrefetchInfo));
 }
 
-void onMaxBatchSizeChange(void) {
+int onMaxBatchSizeChange(const char **err) {
+    UNUSED(err);
     if (batch && batch->client_count > 0) {
         /* We need to process the current batch before updating the size */
-        return;
+        return 1;
     }
 
     freePrefetchCommandsBatch();
     prefetchCommandsBatchInit();
+    return 1;
 }
 
 /* Move to the next key in the batch. */
@@ -236,7 +238,7 @@ void processClientsCommandsBatch(void) {
 
     /* Handle the case where the max prefetch size has been changed. */
     if (batch->max_prefetch_size != (size_t)server.prefetch_batch_max_size) {
-        onMaxBatchSizeChange();
+        onMaxBatchSizeChange(NULL);
     }
 }
 

--- a/src/memory_prefetch.h
+++ b/src/memory_prefetch.h
@@ -7,5 +7,6 @@ void prefetchCommandsBatchInit(void);
 void processClientsCommandsBatch(void);
 int addCommandToBatchAndProcessIfFull(struct client *c);
 void removeClientFromPendingCommandsBatch(struct client *c);
+int onMaxBatchSizeChange(const char **err);
 
 #endif /* MEMORY_PREFETCH_H */


### PR DESCRIPTION
Previously, onMaxBatchSizeChange was only called during processClientsCommandsBatch, making it impossible to change prefetch-batch-max-size from 0 to a positive number since the batch processing would never occur with size 0.

Now onMaxBatchSizeChange is called when the configuration changes, ensuring the new batch size takes effect. Note that the change may not be immediate and will be applied during the next batch processing cycle.