### PR TITLE
Exit early when all the covered slots are deleted

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5754,12 +5754,14 @@ int clusterDelSlot(int slot) {
 /* Delete all the slots associated with the specified node.
  * The number of deleted slots is returned. */
 int clusterDelNodeSlots(clusterNode *node) {
-    int deleted = 0, j;
+    int deleted = 0;
+    int remaining = node->numslots;
 
-    for (j = 0; j < CLUSTER_SLOTS; j++) {
+    for (int j = 0; j < CLUSTER_SLOTS && remaining > 0; j++) {
         if (clusterNodeCoversSlot(node, j)) {
             clusterDelSlot(j);
             deleted++;
+            remaining--;
         }
     }
     return deleted;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4883,7 +4883,6 @@ void clusterLogCantFailover(int reason) {
  * Note that it's up to the caller to be sure that the node got a new
  * configuration epoch already. */
 void clusterFailoverReplaceYourPrimary(void) {
-    int j;
     clusterNode *old_primary = myself->replicaof;
 
     if (clusterNodeIsPrimary(myself) || old_primary == NULL) return;
@@ -4896,10 +4895,14 @@ void clusterFailoverReplaceYourPrimary(void) {
     replicationUnsetPrimary();
 
     /* 2) Claim all the slots assigned to our primary. */
-    for (j = 0; j < CLUSTER_SLOTS; j++) {
-        if (clusterNodeCoversSlot(old_primary, j)) {
-            clusterDelSlot(j);
-            clusterAddSlot(myself, j);
+    for (unsigned long byte = 0; byte < sizeof(old_primary->slots); ++byte) {
+        unsigned char bits = old_primary->slots[byte];
+        while (bits) {
+            unsigned bit = __builtin_ctz(bits);
+            int slot = (byte << 3) | bit;
+            clusterDelSlot(slot);
+            clusterAddSlot(myself, slot);
+            bits &= bits - 1;
         }
     }
 
@@ -5755,13 +5758,16 @@ int clusterDelSlot(int slot) {
  * The number of deleted slots is returned. */
 int clusterDelNodeSlots(clusterNode *node) {
     int deleted = 0;
-    int remaining = node->numslots;
+    if (node->numslots == 0) return 0;
 
-    for (int j = 0; j < CLUSTER_SLOTS && remaining > 0; j++) {
-        if (clusterNodeCoversSlot(node, j)) {
-            clusterDelSlot(j);
-            deleted++;
-            remaining--;
+    for (unsigned long i = 0; i < sizeof(node->slots); ++i) {
+        unsigned char bits = node->slots[i];
+        while (bits) {
+            unsigned bit = __builtin_ctz(bits);
+            int slot = (i << 3) | bit;
+            clusterDelSlot(slot);
+            bits &= bits - 1;
+            ++deleted;
         }
     }
     return deleted;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4894,8 +4894,9 @@ void clusterFailoverReplaceYourPrimary(void) {
     clusterSetNodeAsPrimary(myself);
     replicationUnsetPrimary();
 
+    int remaining = old_primary->numslots;
     /* 2) Claim all the slots assigned to our primary. */
-    for (unsigned long byte = 0; byte < sizeof(old_primary->slots); ++byte) {
+    for (unsigned long byte = 0; byte < sizeof(old_primary->slots) && remaining > 0; ++byte) {
         unsigned char bits = old_primary->slots[byte];
         while (bits) {
             unsigned bit = __builtin_ctz(bits);
@@ -4903,6 +4904,7 @@ void clusterFailoverReplaceYourPrimary(void) {
             clusterDelSlot(slot);
             clusterAddSlot(myself, slot);
             bits &= bits - 1;
+            remaining--;
         }
     }
 
@@ -5759,15 +5761,17 @@ int clusterDelSlot(int slot) {
 int clusterDelNodeSlots(clusterNode *node) {
     int deleted = 0;
     if (node->numslots == 0) return 0;
+    int remaining = node->numslots;
 
-    for (unsigned long i = 0; i < sizeof(node->slots); ++i) {
-        unsigned char bits = node->slots[i];
+    for (unsigned long byte = 0; byte < sizeof(node->slots) && remaining > 0; ++byte) {
+        unsigned char bits = node->slots[byte];
         while (bits) {
             unsigned bit = __builtin_ctz(bits);
-            int slot = (i << 3) | bit;
+            int slot = (byte << 3) | bit;
             clusterDelSlot(slot);
             bits &= bits - 1;
-            ++deleted;
+            deleted++;
+            remaining--;
         }
     }
     return deleted;


### PR DESCRIPTION
We do not need to iterate through all the slots while deleting the slots. We can short circuit the loop as soon as all the covered slots are deleted.