### PR TITLE
Add cross engine (Redis OSS) compatible test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -78,6 +78,24 @@ jobs:
       - name: unittest
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: ./src/valkey-unit-tests --accurate
+      - name: install Redis OSS 6.2 server for compatibility testing
+        run: |
+          cd tests/tmp
+          wget https://download.redis.io/releases/redis-6.2.14.tar.gz
+          tar -xvf redis-6.2.14.tar.gz
+      - name: backward compatibility tests with OSS Redis 6.2
+        run: |
+          sudo apt-get install tcl8.6 tclx
+          ./runtest --verbose --tags compatible-redis --dump-logs --other-server-path tests/tmp/redis-6.2.14/src/redis-server
+      - name: install Redis OSS 7.0 server for compatibility testing
+        run: |
+          cd tests/tmp
+          wget https://download.redis.io/releases/redis-7.0.15.tar.gz
+          tar -xvf redis-7.0.15.tar.gz
+      - name: backward compatibility tests with OSS Redis 7.0
+        run: |
+          sudo apt-get install tcl8.6 tclx
+          ./runtest --verbose --tags compatible-redis --dump-logs --other-server-path tests/tmp/redis-7.0.15/src/redis-server
 
   test-ubuntu-arm:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -83,6 +83,10 @@ jobs:
           cd tests/tmp
           wget https://download.redis.io/releases/redis-6.2.14.tar.gz
           tar -xvf redis-6.2.14.tar.gz
+      - name: make Redis OSS 6.2 server
+        run: |
+          cd tests/tmp/redis-6.2.14
+          make
       - name: backward compatibility tests with OSS Redis 6.2
         run: |
           sudo apt-get install tcl8.6 tclx
@@ -92,6 +96,10 @@ jobs:
           cd tests/tmp
           wget https://download.redis.io/releases/redis-7.0.15.tar.gz
           tar -xvf redis-7.0.15.tar.gz
+      - name: make Redis OSS 7.0 server
+        run: |
+          cd tests/tmp/redis-7.0.15
+          make
       - name: backward compatibility tests with OSS Redis 7.0
         run: |
           sudo apt-get install tcl8.6 tclx

--- a/tests/assets/minimal-cluster-legacy.conf
+++ b/tests/assets/minimal-cluster-legacy.conf
@@ -1,0 +1,6 @@
+# Minimal configuration for testing.
+always-show-logo yes
+daemonize no
+pidfile /var/run/valkey.pid
+loglevel verbose
+cluster-enabled yes

--- a/tests/integration/cross-version-replication.tcl
+++ b/tests/integration/cross-version-replication.tcl
@@ -11,7 +11,7 @@ proc server_name_and_version {} {
     return "$server_name $server_version"
 }
 
-start_server {tags {"repl needs:other-server external:skip"} start-other-server 1 config "minimal.conf"} {
+start_server {tags {"repl needs:other-server external:skip compatible-redis"} start-other-server 1 config "minimal.conf"} {
     set primary_name_and_version [server_name_and_version]
     r set foo bar
 

--- a/tests/unit/cluster/cross-version-cluster.tcl
+++ b/tests/unit/cluster/cross-version-cluster.tcl
@@ -2,29 +2,51 @@
 #
 # Use minimal.conf to make sure we don't use any configs not supported on the old version.
 
+# To run this test use the `--other-server-path` parameter and pass in a compatible server path.
+#
+# ./runtest --single unit/cluster/cross-version-cluster --other-server-path tests/tmp/valkey-7-2/valkey-server
+
 tags {external:skip needs:other-server cluster singledb} {
-    # To run this test use the `--other-server-path` parameter and pass in a compatible server path supporting
-    # SendClusterMessage module API.
-    #
-    # ./runtest --single unit/cluster/cross-version-cluster --other-server-path tests/tmp/valkey-7-2/valkey-server
+    test "Cross version cluster - failover" {
 
-    # Test cross version compatibility of cluster module send message API.
-    start_cluster 3 1 {tags {external:skip cluster} overrides {auto-failover-on-shutdown yes cluster-ping-interval 1000}} {
-        set primary [srv 0 client]
-        set primary_host [srv 0 host]
-        set primary_port [srv 0 port]
-        set primary_id [$primary cluster myid]
+        # Test cross version compatibility of cluster module send message API.
+        start_cluster 3 1 {tags {external:skip cluster} overrides {auto-failover-on-shutdown yes cluster-ping-interval 1000}} {
+            set primary [srv 0 client]
+            set primary_host [srv 0 host]
+            set primary_port [srv 0 port]
+            set primary_id [$primary cluster myid]
 
-        start_server {config "minimal-cluster.conf" start-other-server 1 overrides {cluster-ping-interval 1000}} {
-            # Add a replica of the old version to the cluster
-            r cluster meet $primary_host $primary_port
-            wait_for_cluster_propagation
-            r cluster replicate $primary_id
-            wait_for_cluster_state "ok"
+            start_server {config "minimal-cluster.conf" start-other-server 1 overrides {cluster-ping-interval 1000}} {
+                # Add a replica of the old version to the cluster
+                r cluster meet $primary_host $primary_port
+                wait_for_cluster_propagation
+                r cluster replicate $primary_id
+                wait_for_cluster_state "ok"
 
-            # Make sure the primary won't do the auto-failover.
-            catch {$primary shutdown nosave}
-            verify_log_message -1 "*Unable to perform auto failover on shutdown since there are legacy replicas*" 0
+                # Make sure the primary won't do the auto-failover.
+                catch {$primary shutdown nosave}
+                verify_log_message -1 "*Unable to perform auto failover on shutdown since there are legacy replicas*" 0
+            }
+        }
+    }
+
+    test "Cross version cluster - PING/PONG" {
+        start_server {config "minimal-cluster-legacy.conf" start-other-server 1} {
+            set other_node_name [r CLUSTER MYID]
+
+            start_server {config "minimal-cluster.conf"} {
+                r CLUSTER MEET [srv -1 host] [srv -1 port]
+
+                # Link establishment requires few PING-PONG between two nodes
+                wait_for_condition 50 100 {
+                    [string match {*handshake*} [r CLUSTER NODES]] eq 0 &&
+                    [string match {*handshake*} [r -1 CLUSTER NODES]] eq 0
+                } else {
+                    puts [r CLUSTER NODES]
+                    puts [r -1 CLUSTER NODES]
+                    fail "Cluster meet stuck in handshake state"
+                }
+            }
         }
     }
 }

--- a/tests/unit/cluster/cross-version-cluster.tcl
+++ b/tests/unit/cluster/cross-version-cluster.tcl
@@ -29,7 +29,9 @@ tags {external:skip needs:other-server cluster singledb} {
             }
         }
     }
+}
 
+tags {external:skip needs:other-server cluster singledb compatible-redis} {
     test "Cross version cluster - PING/PONG" {
         start_server {config "minimal-cluster-legacy.conf" start-other-server 1} {
             set other_node_name [r CLUSTER MYID]


### PR DESCRIPTION
Add cross engine test to ensure we don't introduce regression with older engine version compatibility. 

Engine version added: Redis OSS 6.2 / 7.0