### PR TITLE
Unset the active_clients_file before new test is assigned

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -431,9 +431,9 @@ proc read_from_test_client fd {
         set completed_tests_count [expr {$::next_test-$running_tests_count+$completed_solo_tests_count}]
         puts "\[$completed_tests_count/$all_tests_count [colorstr yellow $status]\]: $data ($elapsed seconds)"
         lappend ::clients_time_history $elapsed $data
+        unset ::active_clients_file($fd)
         signal_idle_client $fd
         set ::active_clients_task($fd) "(DONE) $data"
-        unset ::active_clients_file($fd)
     } elseif {$status eq {ok}} {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"


### PR DESCRIPTION
With the change #2276, there are some cases where the the active_clients_file is not set.

```
can't unset "::active_clients_file(sock11d811610)": no such element in array
    while executing
"unset ::active_clients_file($fd)"
    (procedure "read_from_test_client" line 22)
    invoked from within
"read_from_test_client sock11d811610"
```

It is because when the test is done, we were unsetting the active_clients_file after the new task was assigned. Ideally we should unset it before that since the first task is assigned via `ready` state. `make test` is consistently passing now.