### PR TITLE
Fix large allocations crashing Valkey during active defrag

### DIFF
--- a/src/allocator_defrag.c
+++ b/src/allocator_defrag.c
@@ -385,7 +385,7 @@ int allocatorShouldDefrag(void *ptr) {
     assert(SLAB_NUM_REGS(out, 0) > 0);
     assert(SLAB_LEN(out, 0) > 0);
     assert(SLAB_NFREE(out, 0) != (size_t)-1);
-    unsigned region_size = SLAB_LEN(out, 0) / SLAB_NUM_REGS(out, 0);
+    size_t region_size = SLAB_LEN(out, 0) / SLAB_NUM_REGS(out, 0);
     /* check that the allocation size is in range of small bins */
     if (region_size > je_cb.bin_info[je_cb.nbins - 1].reg_size) {
         return 0;


### PR DESCRIPTION
When querying large objects, the memory allocator may return allocation sizes (for example 4GiB, `4294967296`) that fit into the `out` array which is a `size_t` so the resulting `out` array becomes `{0, 1, 4294967296}`. When calculating the `region_size` we try to fit the allocation size into an `unsigned` which causes `4294967296` to overflow to `0`. With that 0, we unconditionally call `jeSize2BinIndexLgQ3` which _basically_ returns `sz-1`, so the return value becomes `-1`, overflowing the `unsigned binind` integer to `4294967295` which is far outside the length of `je_cb.bin_info` triggering the asserting sanity check.

Using `size_t` instead of `unsigned` for `region_size` ensures we can actually fit the allocated size into a variable and then return early on the `region_size > je_cb.bin_info[je_cb.nbins - 1].reg_size` check that follows right after.

Fixes https://github.com/valkey-io/valkey/issues/2348

Reproduction steps:

* Start up Valkey:
  ```
  valkey-server \
  --activedefrag no \
  --enable-debug-command local \
  --save '' \
  --active-defrag-cycle-min 99 \
  --active-defrag-threshold-lower 0 \
  --active-defrag-ignore-bytes 1
  ```
* Allocate a 10GiB string: `valkey-cli debug populate 1 '' 10737418240`
* Enable active defrag: `valkey-cli config set activedefrag yes`
* Valkey process crashes with `allocator_defrag.c:396 'binind < je_cb.nbins && region_size == je_cb.bin_info[binind].reg_size' is not true`

Unsure how to properly implement a test for this case considering it seemingly requires at least 10GiB to test. Open for suggestions.