### PR TITLE
valkey-cli: Fix dbid reset after error in MULTI

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -2479,7 +2479,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
                 cliRefreshPrompt();
             } else if (!strcasecmp(command, "exec") && argc == 1 && config.in_multi) {
                 config.in_multi = 0;
-                if (config.last_cmd_type == VALKEY_REPLY_ERROR || config.last_cmd_type == VALKEY_REPLY_NIL) {
+                if (config.last_cmd_type == VALKEY_REPLY_ERROR || config.last_cmd_type == VALKEY_REPLY_NIL ||
+                    config.last_cmd_type == VALKEY_REPLY_ARRAY) {
                     config.conn_info.input_dbnum = config.dbnum = config.pre_multi_dbnum;
                 }
                 cliRefreshPrompt();


### PR DESCRIPTION
I was testing #2309 and found that if you do `MULTI, SELECT incorrect dbid and EXEC`  combination of commands, then database ID right next to valkey-server address won't change, but it should. Turns out, for this combination of commands reply->type is `VALKEY_REPLY_ARRAY`, which was added to if statement for EXEC handling.
```
BEFORE:
127.0.0.1:6379> multi
OK
127.0.0.1:6379(TX)> select 438764
QUEUED
127.0.0.1:6379[438764](TX)> exec
1) (error) ERR DB index is out of range
127.0.0.1:6379[438764]> multi
OK
127.0.0.1:6379[438764](TX)> select 327648273645872634
QUEUED
127.0.0.1:6379[1911465466](TX)> exec
1) (error) ERR value is out of range, value must between -2147483648 and 2147483647

AFTER:
127.0.0.1:6379> multi
OK
127.0.0.1:6379(TX)> select 7463746
QUEUED
127.0.0.1:6379[7463746](TX)> exec
1) (error) ERR DB index is out of range
127.0.0.1:6379>
             /\
No incorrect DB ID
```