### PR TITLE
Fix module context object re-usage in scripting engines

### DIFF
--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -8,6 +8,25 @@
 #include "dict.h"
 #include "functions.h"
 #include "module.h"
+#include "server.h"
+#include "valkeymodule.h"
+
+/* Module context object cache size is set to 3 because at each moment there can
+ * be at most 3 module contexts in use by the scripting engine.
+ *
+ * 1. The module context used by the scripting engine to run the script;
+ * 2. The module context used by `scriptingEngineCallGetMemoryInfo` that is
+ *    periodically called by the server cron; and
+ * 3. The module context used by `scriptingEngineCallFreeFunction` that is
+ *    called when the server needs to reset the evaluation environment in the
+ *    asynchronous mode.
+ */
+enum {
+    COMMON_MODULE_CTX_INDEX = 0,        /* Common module context used by the scripting engine. */
+    GET_MEMORY_MODULE_CTX_INDEX = 1,    /* Module context used by `scriptingEngineCallGetMemoryInfo`. */
+    FREE_FUNCTION_MODULE_CTX_INDEX = 2, /* Module context used by `scriptingEngineCallFreeFunction`. */
+    _MODULE_CTX_CACHE_SIZE = 3          /* Total number of module contexts in the cache. */
+};
 
 typedef struct scriptingEngineImpl {
     /* Engine specific context */
@@ -18,15 +37,15 @@ typedef struct scriptingEngineImpl {
 } scriptingEngineImpl;
 
 typedef struct scriptingEngine {
-    sds name;                    /* Name of the engine */
-    ValkeyModule *module;        /* the module that implements the scripting engine */
-    scriptingEngineImpl impl;    /* engine context and callbacks to interact with the engine */
-    client *client;              /* Client that is used to run commands */
-    ValkeyModuleCtx *module_ctx; /* Cache of the module context object */
+    sds name;                                                  /* Name of the engine */
+    ValkeyModule *module;                                      /* the module that implements the scripting engine */
+    scriptingEngineImpl impl;                                  /* engine context and callbacks to interact with the engine */
+    client *client;                                            /* Client that is used to run commands */
+    ValkeyModuleCtx *module_ctx_cache[_MODULE_CTX_CACHE_SIZE]; /* Cache of module context objects */
 } scriptingEngine;
 
 
-typedef struct engineManger {
+typedef struct engineManager {
     dict *engines;                /* engines dictionary */
     size_t total_memory_overhead; /* the sum of the memory overhead of all registered scripting engines */
 } engineManager;
@@ -113,8 +132,12 @@ int scriptingEngineManagerRegister(const char *engine_name,
             .methods = *engine_methods,
         },
         .client = c,
-        .module_ctx = engine_module ? moduleAllocateContext() : NULL,
+        .module_ctx_cache = {0},
     };
+
+    for (size_t i = 0; i < _MODULE_CTX_CACHE_SIZE; i++) {
+        e->module_ctx_cache[i] = moduleAllocateContext();
+    }
 
     dictAdd(engineMgr.engines, engine_name_sds, e);
 
@@ -148,9 +171,9 @@ int scriptingEngineManagerUnregister(const char *engine_name) {
 
     sdsfree(e->name);
     freeClient(e->client);
-    if (e->module_ctx) {
-        serverAssert(e->module != NULL);
-        zfree(e->module_ctx);
+    for (size_t i = 0; i < _MODULE_CTX_CACHE_SIZE; i++) {
+        serverAssert(e->module_ctx_cache[i] != NULL);
+        zfree(e->module_ctx_cache[i]);
     }
     zfree(e);
 
@@ -200,17 +223,24 @@ void scriptingEngineManagerForEachEngine(engineIterCallback callback,
     dictReleaseIterator(iter);
 }
 
-static void engineSetupModuleCtx(scriptingEngine *e, client *c) {
-    if (e->module != NULL) {
-        serverAssert(e->module_ctx != NULL);
-        moduleScriptingEngineInitContext(e->module_ctx, e->module, c);
+static ValkeyModuleCtx *engineSetupModuleCtx(int module_ctx_cache_index,
+                                             scriptingEngine *e,
+                                             client *c) {
+    debugServerAssert(e != NULL);
+    if (e->module == NULL) {
+        return NULL;
     }
+
+    ValkeyModuleCtx *ctx = e->module_ctx_cache[module_ctx_cache_index];
+    moduleScriptingEngineInitContext(ctx, e->module, c);
+    return ctx;
 }
 
-static void engineTeardownModuleCtx(scriptingEngine *e) {
+static void engineTeardownModuleCtx(int module_ctx_cache_index, scriptingEngine *e) {
+    debugServerAssert(e != NULL);
     if (e->module != NULL) {
-        serverAssert(e->module_ctx != NULL);
-        moduleFreeContext(e->module_ctx);
+        ValkeyModuleCtx *ctx = e->module_ctx_cache[module_ctx_cache_index];
+        moduleFreeContext(ctx);
     }
 }
 
@@ -223,10 +253,11 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
                                                   robj **err) {
     serverAssert(type == VMSE_EVAL || type == VMSE_FUNCTION);
     compiledFunction **functions = NULL;
-    engineSetupModuleCtx(engine, NULL);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(COMMON_MODULE_CTX_INDEX, engine, NULL);
+
     if (engine->impl.methods.version == 1) {
         functions = engine->impl.methods.compile_code_v1(
-            engine->module_ctx,
+            module_ctx,
             engine->impl.ctx,
             type,
             code,
@@ -236,7 +267,7 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
     } else {
         /* Assume versions greater than 1 use updated interface. */
         functions = engine->impl.methods.compile_code(
-            engine->module_ctx,
+            module_ctx,
             engine->impl.ctx,
             type,
             code,
@@ -246,8 +277,7 @@ compiledFunction **scriptingEngineCallCompileCode(scriptingEngine *engine,
             err);
     }
 
-
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(COMMON_MODULE_CTX_INDEX, engine);
 
     return functions;
 }
@@ -256,13 +286,13 @@ void scriptingEngineCallFreeFunction(scriptingEngine *engine,
                                      subsystemType type,
                                      compiledFunction *compiled_func) {
     serverAssert(type == VMSE_EVAL || type == VMSE_FUNCTION);
-    engineSetupModuleCtx(engine, NULL);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(FREE_FUNCTION_MODULE_CTX_INDEX, engine, NULL);
     engine->impl.methods.free_function(
-        engine->module_ctx,
+        module_ctx,
         engine->impl.ctx,
         type,
         compiled_func);
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(FREE_FUNCTION_MODULE_CTX_INDEX, engine);
 }
 
 void scriptingEngineCallFunction(scriptingEngine *engine,
@@ -276,10 +306,10 @@ void scriptingEngineCallFunction(scriptingEngine *engine,
                                  size_t nargs) {
     serverAssert(type == VMSE_EVAL || type == VMSE_FUNCTION);
 
-    engineSetupModuleCtx(engine, caller);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(COMMON_MODULE_CTX_INDEX, engine, caller);
 
     engine->impl.methods.call_function(
-        engine->module_ctx,
+        module_ctx,
         engine->impl.ctx,
         server_ctx,
         compiled_function,
@@ -289,37 +319,37 @@ void scriptingEngineCallFunction(scriptingEngine *engine,
         args,
         nargs);
 
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(COMMON_MODULE_CTX_INDEX, engine);
 }
 
 size_t scriptingEngineCallGetFunctionMemoryOverhead(scriptingEngine *engine,
                                                     compiledFunction *compiled_function) {
-    engineSetupModuleCtx(engine, NULL);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(COMMON_MODULE_CTX_INDEX, engine, NULL);
     size_t mem = engine->impl.methods.get_function_memory_overhead(
-        engine->module_ctx,
+        module_ctx,
         compiled_function);
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(COMMON_MODULE_CTX_INDEX, engine);
     return mem;
 }
 
 callableLazyEvalReset *scriptingEngineCallResetEvalEnvFunc(scriptingEngine *engine,
                                                            int async) {
-    engineSetupModuleCtx(engine, NULL);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(COMMON_MODULE_CTX_INDEX, engine, NULL);
     callableLazyEvalReset *callback = engine->impl.methods.reset_eval_env(
-        engine->module_ctx,
+        module_ctx,
         engine->impl.ctx,
         async);
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(COMMON_MODULE_CTX_INDEX, engine);
     return callback;
 }
 
 engineMemoryInfo scriptingEngineCallGetMemoryInfo(scriptingEngine *engine,
                                                   subsystemType type) {
-    engineSetupModuleCtx(engine, NULL);
+    ValkeyModuleCtx *module_ctx = engineSetupModuleCtx(GET_MEMORY_MODULE_CTX_INDEX, engine, NULL);
     engineMemoryInfo mem_info = engine->impl.methods.get_memory_info(
-        engine->module_ctx,
+        module_ctx,
         engine->impl.ctx,
         type);
-    engineTeardownModuleCtx(engine);
+    engineTeardownModuleCtx(GET_MEMORY_MODULE_CTX_INDEX, engine);
     return mem_info;
 }

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -21,7 +21,7 @@
  *    called when the server needs to reset the evaluation environment in the
  *    asynchronous mode.
  */
-enum {
+enum moduleCtxCacheIndex {
     COMMON_MODULE_CTX_INDEX = 0,        /* Common module context used by the scripting engine. */
     GET_MEMORY_MODULE_CTX_INDEX = 1,    /* Module context used by `scriptingEngineCallGetMemoryInfo`. */
     FREE_FUNCTION_MODULE_CTX_INDEX = 2, /* Module context used by `scriptingEngineCallFreeFunction`. */
@@ -226,7 +226,7 @@ void scriptingEngineManagerForEachEngine(engineIterCallback callback,
 static ValkeyModuleCtx *engineSetupModuleCtx(int module_ctx_cache_index,
                                              scriptingEngine *e,
                                              client *c) {
-    debugServerAssert(e != NULL);
+    serverAssert(e != NULL);
     if (e->module == NULL) return NULL;
 
     ValkeyModuleCtx *ctx = e->module_ctx_cache[module_ctx_cache_index];
@@ -235,7 +235,7 @@ static ValkeyModuleCtx *engineSetupModuleCtx(int module_ctx_cache_index,
 }
 
 static void engineTeardownModuleCtx(int module_ctx_cache_index, scriptingEngine *e) {
-    debugServerAssert(e != NULL);
+    serverAssert(e != NULL);
     if (e->module != NULL) {
         ValkeyModuleCtx *ctx = e->module_ctx_cache[module_ctx_cache_index];
         moduleFreeContext(ctx);

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -25,7 +25,7 @@ enum {
     COMMON_MODULE_CTX_INDEX = 0,        /* Common module context used by the scripting engine. */
     GET_MEMORY_MODULE_CTX_INDEX = 1,    /* Module context used by `scriptingEngineCallGetMemoryInfo`. */
     FREE_FUNCTION_MODULE_CTX_INDEX = 2, /* Module context used by `scriptingEngineCallFreeFunction`. */
-    _MODULE_CTX_CACHE_SIZE = 3          /* Total number of module contexts in the cache. */
+    MODULE_CTX_CACHE_SIZE = 3           /* Total number of module contexts in the cache. */
 };
 
 typedef struct scriptingEngineImpl {
@@ -37,11 +37,11 @@ typedef struct scriptingEngineImpl {
 } scriptingEngineImpl;
 
 typedef struct scriptingEngine {
-    sds name;                                                  /* Name of the engine */
-    ValkeyModule *module;                                      /* the module that implements the scripting engine */
-    scriptingEngineImpl impl;                                  /* engine context and callbacks to interact with the engine */
-    client *client;                                            /* Client that is used to run commands */
-    ValkeyModuleCtx *module_ctx_cache[_MODULE_CTX_CACHE_SIZE]; /* Cache of module context objects */
+    sds name;                                                 /* Name of the engine */
+    ValkeyModule *module;                                     /* the module that implements the scripting engine */
+    scriptingEngineImpl impl;                                 /* engine context and callbacks to interact with the engine */
+    client *client;                                           /* Client that is used to run commands */
+    ValkeyModuleCtx *module_ctx_cache[MODULE_CTX_CACHE_SIZE]; /* Cache of module context objects */
 } scriptingEngine;
 
 
@@ -135,7 +135,7 @@ int scriptingEngineManagerRegister(const char *engine_name,
         .module_ctx_cache = {0},
     };
 
-    for (size_t i = 0; i < _MODULE_CTX_CACHE_SIZE; i++) {
+    for (size_t i = 0; i < MODULE_CTX_CACHE_SIZE; i++) {
         e->module_ctx_cache[i] = moduleAllocateContext();
     }
 
@@ -171,7 +171,7 @@ int scriptingEngineManagerUnregister(const char *engine_name) {
 
     sdsfree(e->name);
     freeClient(e->client);
-    for (size_t i = 0; i < _MODULE_CTX_CACHE_SIZE; i++) {
+    for (size_t i = 0; i < MODULE_CTX_CACHE_SIZE; i++) {
         serverAssert(e->module_ctx_cache[i] != NULL);
         zfree(e->module_ctx_cache[i]);
     }
@@ -227,9 +227,7 @@ static ValkeyModuleCtx *engineSetupModuleCtx(int module_ctx_cache_index,
                                              scriptingEngine *e,
                                              client *c) {
     debugServerAssert(e != NULL);
-    if (e->module == NULL) {
-        return NULL;
-    }
+    if (e->module == NULL) return NULL;
 
     ValkeyModuleCtx *ctx = e->module_ctx_cache[module_ctx_cache_index];
     moduleScriptingEngineInitContext(ctx, e->module, c);


### PR DESCRIPTION
This commit refactors the scripting engine to support multiple cached module contexts per engine, rather than relying on a single cached `ValkeyModuleCtx` object.

Previously, having only one cached context object caused data races over the state stored in the context object, because it's possible that a script that is running for a long time to yield and the server event loop may call the `scriptingEngineCallGetMemoryInfo` function to get the scripting engine memory information, which re-uses the same cached context object. Another possible data-race is caused by the asynchronous scripts flush, which calls the `scriptingEngineCallFreeFunction` function in an background thread, and also re-uses the cached context object.

To address this, a cache array of module contexts was introduced in the scripting engine structure, with each slot dedicated to a specific use case—such as script execution, memory info queries, or function freeing.