### PR TITLE
Fix client tracking memory overhead calculation

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -5397,7 +5397,7 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
     /* Add memory overhead of the tracking prefixes, this is an underestimation so we don't need to traverse the entire
      * rax */
     if (c->pubsub_data && c->pubsub_data->client_tracking_prefixes)
-        mem += c->pubsub_data->client_tracking_prefixes->numnodes * (sizeof(raxNode) * sizeof(raxNode *));
+        mem += c->pubsub_data->client_tracking_prefixes->numnodes * (sizeof(raxNode) + sizeof(raxNode *));
 
     return mem;
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -293,6 +293,30 @@ proc CI {index field} {
     getInfoProperty [R $index cluster info] $field
 }
 
+# Provide easy access to CLIENT INFO properties from CLIENT INFO string.
+proc get_field_in_client_info {info field} {
+    set info [string trim $info]
+    foreach item [split $info " "] {
+        set kv [split $item "="]
+        set k [lindex $kv 0]
+        if {[string match $field $k]} {
+            return [lindex $kv 1]
+        }
+    }
+    return ""
+}
+
+# Provide easy access to CLIENT INFO properties from CLIENT LIST string.
+proc get_field_in_client_list {id client_list filed} {
+    set list [split $client_list "\r\n"]
+    foreach info $list {
+        if {[string match "id=$id *" $info] } {
+            return [get_field_in_client_info $info $filed]
+        }
+    }
+    return ""
+}
+
 # Test wrapped into run_solo are sent back from the client to the
 # test server, so that the test server will send them again to
 # clients once the clients are idle.

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -398,28 +398,6 @@ start_server {tags {"introspection"}} {
         assert_error "ERR *greater than 0*" {r client list maxage -1}
     }
 
-    proc get_field_in_client_info {info field} {
-        set info [string trim $info]
-        foreach item [split $info " "] {
-            set kv [split $item "="]
-            set k [lindex $kv 0]
-            if {[string match $field $k]} {
-                return [lindex $kv 1]
-            }
-        }
-        return ""
-    }
-
-    proc get_field_in_client_list {id client_list filed} {
-        set list [split $client_list "\r\n"]
-        foreach info $list {
-            if {[string match "id=$id *" $info] } {
-                return [get_field_in_client_info $info $filed]
-            }
-        }
-        return ""
-    }
-
     proc get_client_tot_in_out_cmds {id} {
         set info_list [r client list]
         set in [get_field_in_client_list $id $info_list "tot-net-in"]

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -38,6 +38,34 @@ start_server {tags {"tracking network logreqres:skip"}} {
         }
     }
 
+    test {Client tracking prefixes memory overhead} {
+        r CLIENT TRACKING off
+        set tot_mem_before [get_field_in_client_info [r client info] "tot-mem"]
+
+        # We add multiple $i to prefix to avoid prefix conflicts, so in this
+        # args we will have about 20000 rax nodes.
+        set args {}
+        for {set i 0} {$i < 10240} {incr i} {
+            lappend args PREFIX
+            lappend args PREFIX-$i-$i-$i-$i-$i-$i-$i
+        }
+        r CLIENT TRACKING on BCAST {*}$args
+
+        set arch_bits [s arch_bits]
+        set tot_mem_after [get_field_in_client_info [r client info] "tot-mem"]
+        set diff [expr $tot_mem_after - $tot_mem_before]
+
+        # In 64 bits, before we would consume about 20000 * (4 * 8), that is 640000.
+        # And now we are 20000 * (4 + 8), that is 240000.
+        if {$arch_bits == "64"} {
+            assert_lessthan $diff 300000
+        } elseif {$arch_bits == "32"} {
+            assert_lessthan $diff 200000
+        }
+
+        r CLIENT TRACKING off
+    }
+
     test {Clients are able to enable tracking and redirect it} {
         r CLIENT TRACKING on REDIRECT $redir_id
     } {*OK}

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -57,9 +57,9 @@ start_server {tags {"tracking network logreqres:skip"}} {
 
         # In 64 bits, before we would consume about 20000 * (4 * 8), that is 640000.
         # And now we are 20000 * (4 + 8), that is 240000.
-        if {$arch_bits == "64"} {
+        if {$arch_bits == 64} {
             assert_lessthan $diff 300000
-        } elseif {$arch_bits == "32"} {
+        } elseif {$arch_bits == 32} {
             assert_lessthan $diff 200000
         }
 


### PR DESCRIPTION
This should be + instread of *, otherwise it does not make any sense.
Otherwise we would have to calculate 20 more bytes for each prefix rax
node in 64 bits build.