### PR TITLE
Fix memory leak with CLIENT LIST/KILL duplicate filters

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -4457,12 +4457,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
         int moreargs = c->argc > index + 1;
 
         if (!strcasecmp(c->argv[index]->ptr, "id")) {
-            if (filter->ids) {
-                zfree(filter->ids);
-            }
+            if (filter->ids == NULL) {
             /* Initialize the intset for IDs */
             filter->ids = intsetNew();
-
+            }
             index++; /* Move to the first ID after "ID" */
 
             /* Process all IDs until a non-numeric argument or end of args */
@@ -4481,12 +4479,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 index++; /* Move to the next argument */
             }
         } else if (!strcasecmp(c->argv[index]->ptr, "not-id")) {
-            if (filter->not_ids) {
-                zfree(filter->not_ids);
-            }
+            if (filter->not_ids == NULL) {
             /* Initialize the intset for NOT-IDs */
             filter->not_ids = intsetNew();
-
+            }
             index++; /* Move to the first ID after "NOT-ID" */
 
             /* Process all NOT-IDs until a non-numeric argument or end of args */

--- a/src/networking.c
+++ b/src/networking.c
@@ -4460,6 +4460,9 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             if (filter->ids == NULL) {
                 /* Initialize the intset for IDs */
                 filter->ids = intsetNew();
+            } else {
+                zfree(filter->ids);
+                filter->ids = intsetNew();
             }
             index++; /* Move to the first ID after "ID" */
 
@@ -4481,6 +4484,9 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
         } else if (!strcasecmp(c->argv[index]->ptr, "not-id")) {
             if (filter->not_ids == NULL) {
                 /* Initialize the intset for NOT-IDs */
+                filter->not_ids = intsetNew();
+            } else {
+                zfree(filter->not_ids);
                 filter->not_ids = intsetNew();
             }
             index++; /* Move to the first ID after "NOT-ID" */

--- a/src/networking.c
+++ b/src/networking.c
@@ -71,8 +71,6 @@ typedef struct {
     int type;
     int not_type;
     /* Boolean flag to determine if the current client (`me`) should be filtered. 1 means "skip me", 0 means otherwise. */
-    /* Flag to determine if the current client (`me`) should be filtered. 1 means "skip me", 0 means otherwise.
-     * If set to -1, the filter is not applied. */
     int skipme;
     /* Client name to filter. If NULL, no name filtering is applied. */
     char *name;
@@ -4760,7 +4758,7 @@ static int clientMatchesFilter(client *client, clientFilter *client_filter) {
     if (client_filter->type != -1 && getClientType(client) != client_filter->type) return 0;
     if (client_filter->ids && !intsetFind(client_filter->ids, client->id)) return 0;
     if (client_filter->user && client->user != client_filter->user) return 0;
-    if (client_filter->skipme == 1 && client == server.current_client) return 0;
+    if (client_filter->skipme && client == server.current_client) return 0;
     if (client_filter->max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) < client_filter->max_age) return 0;
     if (client_filter->idle != 0 && (long long)(commandTimeSnapshot() / 1000 - client->last_interaction) < client_filter->idle) return 0;
     if (client_filter->flags && clientMatchesFlagFilter(client, client_filter->flags) == 0) return 0;
@@ -5058,7 +5056,6 @@ void clientListCommand(client *c) {
         filter.not_type = -1;
         filter.db_number = -1;
         filter.not_db_number = -1;
-        filter.skipme = -1;
 
         int i = 2;
 
@@ -5137,11 +5134,6 @@ void clientKillCommand(client *c) {
         if (parseClientFiltersOrReply(c, i, &client_filter) != C_OK) {
             /* Free the intset on error */
             goto client_kill_done;
-        } else {
-            /* No skipme option provided, default behavior with the new syntax is to skip */
-            if (client_filter.skipme == -1) {
-                client_filter.skipme = 1;
-            }
         }
     } else {
         addReplyErrorObject(c, shared.syntaxerr);

--- a/src/networking.c
+++ b/src/networking.c
@@ -71,6 +71,8 @@ typedef struct {
     int type;
     int not_type;
     /* Boolean flag to determine if the current client (`me`) should be filtered. 1 means "skip me", 0 means otherwise. */
+    /* Flag to determine if the current client (`me`) should be filtered. 1 means "skip me", 0 means otherwise.
+     * If set to -1, the filter is not applied. */
     int skipme;
     /* Client name to filter. If NULL, no name filtering is applied. */
     char *name;
@@ -4577,6 +4579,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             filter->idle = idle_time;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "flags") && moreargs) {
+            if (filter->flags) {
+                sdsfree(filter->flags);
+                filter->flags = NULL;
+            }
             filter->flags = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientFlagFilter(filter->flags) == C_ERR) {
                 addReplyErrorFormat(c, "Unknown flags found in the provided filter: %s", filter->flags);
@@ -4584,6 +4590,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "not-flags") && moreargs) {
+            if (filter->not_flags) {
+                sdsfree(filter->not_flags);
+                filter->not_flags = NULL;
+            }
             filter->not_flags = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientFlagFilter(filter->not_flags) == C_ERR) {
                 addReplyErrorFormat(c, "Unknown flags found in the NOT-FLAGS filter: %s", filter->not_flags);
@@ -4597,18 +4607,34 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             filter->not_name = c->argv[index + 1]->ptr;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "lib-name") && moreargs) {
+            if (filter->lib_name) {
+                decrRefCount(filter->lib_name);
+                filter->lib_name = NULL;
+            }
             filter->lib_name = c->argv[index + 1];
             incrRefCount(filter->lib_name);
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "not-lib-name") && moreargs) {
+            if (filter->not_lib_name) {
+                decrRefCount(filter->not_lib_name);
+                filter->not_lib_name = NULL;
+            }
             filter->not_lib_name = c->argv[index + 1];
             incrRefCount(filter->not_lib_name);
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "lib-ver") && moreargs) {
+            if (filter->lib_ver) {
+                decrRefCount(filter->lib_ver);
+                filter->lib_ver = NULL;
+            }
             filter->lib_ver = c->argv[index + 1];
             incrRefCount(filter->lib_ver);
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "not-lib-ver") && moreargs) {
+            if (filter->not_lib_ver) {
+                decrRefCount(filter->not_lib_ver);
+                filter->not_lib_ver = NULL;
+            }
             filter->not_lib_ver = c->argv[index + 1];
             incrRefCount(filter->not_lib_ver);
             index += 2;
@@ -4635,6 +4661,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             filter->not_db_number = not_db_id;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "capa") && moreargs) {
+            if (filter->capa) {
+                sdsfree(filter->capa);
+                filter->capa = NULL;
+            }
             filter->capa = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientCapaFilter(filter->capa) == C_ERR) {
                 addReplyErrorFormat(c, "Unknown capa found in the provided filter: %s", filter->capa);
@@ -4642,6 +4672,10 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "not-capa") && moreargs) {
+            if (filter->not_capa) {
+                sdsfree(filter->not_capa);
+                filter->not_capa = NULL;
+            }
             filter->not_capa = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientCapaFilter(filter->not_capa) == C_ERR) {
                 addReplyErrorFormat(c, "Unknown capa found in the NOT-CAPA filter: %s", filter->not_capa);
@@ -4649,9 +4683,17 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "ip") && moreargs) {
+            if (filter->ip) {
+                sdsfree(filter->ip);
+                filter->ip = NULL;
+            }
             filter->ip = sdsnew(c->argv[index + 1]->ptr);
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "not-ip") && moreargs) {
+            if (filter->not_ip) {
+                sdsfree(filter->not_ip);
+                filter->not_ip = NULL;
+            }
             filter->not_ip = sdsnew(c->argv[index + 1]->ptr);
             index += 2;
         } else {
@@ -4718,7 +4760,7 @@ static int clientMatchesFilter(client *client, clientFilter *client_filter) {
     if (client_filter->type != -1 && getClientType(client) != client_filter->type) return 0;
     if (client_filter->ids && !intsetFind(client_filter->ids, client->id)) return 0;
     if (client_filter->user && client->user != client_filter->user) return 0;
-    if (client_filter->skipme && client == server.current_client) return 0;
+    if (client_filter->skipme == 1 && client == server.current_client) return 0;
     if (client_filter->max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) < client_filter->max_age) return 0;
     if (client_filter->idle != 0 && (long long)(commandTimeSnapshot() / 1000 - client->last_interaction) < client_filter->idle) return 0;
     if (client_filter->flags && clientMatchesFlagFilter(client, client_filter->flags) == 0) return 0;
@@ -5016,6 +5058,8 @@ void clientListCommand(client *c) {
         filter.not_type = -1;
         filter.db_number = -1;
         filter.not_db_number = -1;
+        filter.skipme = -1;
+
         int i = 2;
 
         if (parseClientFiltersOrReply(c, i, &filter) != C_OK) {
@@ -5093,6 +5137,11 @@ void clientKillCommand(client *c) {
         if (parseClientFiltersOrReply(c, i, &client_filter) != C_OK) {
             /* Free the intset on error */
             goto client_kill_done;
+        } else {
+            /* No skipme option provided, default behavior with the new syntax is to skip */
+            if (client_filter.skipme == -1) {
+                client_filter.skipme = 1;
+            }
         }
     } else {
         addReplyErrorObject(c, shared.syntaxerr);

--- a/src/networking.c
+++ b/src/networking.c
@@ -4458,8 +4458,8 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
 
         if (!strcasecmp(c->argv[index]->ptr, "id")) {
             if (filter->ids == NULL) {
-            /* Initialize the intset for IDs */
-            filter->ids = intsetNew();
+                /* Initialize the intset for IDs */
+                filter->ids = intsetNew();
             }
             index++; /* Move to the first ID after "ID" */
 
@@ -4480,8 +4480,8 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
         } else if (!strcasecmp(c->argv[index]->ptr, "not-id")) {
             if (filter->not_ids == NULL) {
-            /* Initialize the intset for NOT-IDs */
-            filter->not_ids = intsetNew();
+                /* Initialize the intset for NOT-IDs */
+                filter->not_ids = intsetNew();
             }
             index++; /* Move to the first ID after "NOT-ID" */
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -4457,13 +4457,12 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
         int moreargs = c->argc > index + 1;
 
         if (!strcasecmp(c->argv[index]->ptr, "id")) {
-            if (filter->ids == NULL) {
-                /* Initialize the intset for IDs */
-                filter->ids = intsetNew();
-            } else {
+            if (filter->ids) {
                 zfree(filter->ids);
-                filter->ids = intsetNew();
             }
+            /* Initialize the intset for IDs */
+            filter->ids = intsetNew();
+
             index++; /* Move to the first ID after "ID" */
 
             /* Process all IDs until a non-numeric argument or end of args */
@@ -4482,13 +4481,12 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 index++; /* Move to the next argument */
             }
         } else if (!strcasecmp(c->argv[index]->ptr, "not-id")) {
-            if (filter->not_ids == NULL) {
-                /* Initialize the intset for NOT-IDs */
-                filter->not_ids = intsetNew();
-            } else {
+            if (filter->not_ids) {
                 zfree(filter->not_ids);
-                filter->not_ids = intsetNew();
             }
+            /* Initialize the intset for NOT-IDs */
+            filter->not_ids = intsetNew();
+
             index++; /* Move to the first ID after "NOT-ID" */
 
             /* Process all NOT-IDs until a non-numeric argument or end of args */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -93,7 +93,7 @@ start_server {tags {"introspection"}} {
         set id3 [$c3 client id]
 
         # Filter by multiple IDs and TYPE
-        set cl [split [r client list id $id1 $id2 type normal] "\r\n"]
+        set cl [split [r client list id $id3 id $id1 $id2 type normal] "\r\n"]
 
         # Assert only c1 and c2 are present and match TYPE=N (NORMAL)
         foreach line $cl {
@@ -434,6 +434,41 @@ start_server {tags {"introspection"}} {
         assert_match "*name=client1*" $cl
         assert_no_match "*name=mytestclient*" $cl
         catch {$c1 close}
+    }
+
+    test {CLIENT LIST with multiple id filters} {
+        # Create multiple clients
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+        set c3 [valkey_client]
+
+        # Fetch their IDs
+        set id1 [$c1 client id]
+        set id2 [$c2 client id]
+        set id3 [$c3 client id]
+
+        set result [r client list id $id1 id $id2 id $id3]
+        assert_no_match "*id=$id1*" $result
+        assert_no_match "*id=$id2*" $result
+        assert_match "*id=$id3*" $result
+
+        catch {$c1 close}
+        catch {$c2 close}
+        catch {$c3 close}
+    }
+
+    test {CLIENT KILL with multiple id filters} {
+        # Create multiple clients
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+        set c3 [valkey_client]
+
+        # Fetch their IDs
+        set id1 [$c1 client id]
+        set id2 [$c2 client id]
+        set id3 [$c3 client id]
+
+        assert_equal [r client kill id $id1 id $id2 id $id3] 1
     }
 
     test {CLIENT LIST with multiple negative filters} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -93,7 +93,7 @@ start_server {tags {"introspection"}} {
         set id3 [$c3 client id]
 
         # Filter by multiple IDs and TYPE
-        set cl [split [r client list id $id3 id $id1 $id2 type normal] "\r\n"]
+        set cl [split [r client list id $id1 $id2 type normal] "\r\n"]
 
         # Assert only c1 and c2 are present and match TYPE=N (NORMAL)
         foreach line $cl {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -448,8 +448,8 @@ start_server {tags {"introspection"}} {
         set id3 [$c3 client id]
 
         set result [r client list id $id1 id $id2 id $id3]
-        assert_no_match "*id=$id1*" $result
-        assert_no_match "*id=$id2*" $result
+        assert_match "*id=$id1*" $result
+        assert_match "*id=$id2*" $result
         assert_match "*id=$id3*" $result
 
         catch {$c1 close}
@@ -468,7 +468,7 @@ start_server {tags {"introspection"}} {
         set id2 [$c2 client id]
         set id3 [$c3 client id]
 
-        assert_equal [r client kill id $id1 id $id2 id $id3] 1
+        assert_equal [r client kill id $id1 id $id2 id $id3] 3
     }
 
     test {CLIENT LIST with multiple negative filters} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -221,7 +221,7 @@ start_server {tags {"introspection"}} {
         regexp {addr=([^:]+):} $client_info -> iponly
 
         # Use the extracted IP for filtering.
-        set filtered [r client list ip $iponly]
+        set filtered [r client list ip $iponly ip $iponly]
         assert_match *client-ip* $filtered
     } {}
 
@@ -245,7 +245,7 @@ start_server {tags {"introspection"}} {
         $c1 client setname "client-with-r"
         $c1 client capa redirect
 
-        set output [r client list capa r]
+        set output [r client list capa r capa r]
         assert_match *client-with-r* $output
         catch {$c1 close}
     }
@@ -296,8 +296,8 @@ start_server {tags {"introspection"}} {
         set c1 [valkey_client]
         $c1 client setname mytestclient
 
-        # Kill the client by name
-        r client kill name mytestclient
+        # Kill the client by name - last filter value takes precedence
+        r client kill name myclient name mytestclient
 
         # Assert the client was killed
         assert_error "*I/O error*" {$c1 ping}
@@ -311,8 +311,8 @@ start_server {tags {"introspection"}} {
         set c1 [valkey_client]
         $c1 client setname mytestclient
 
-        # Kill the client by flag
-        r client kill flags N
+        # Kill the client by flag - last filter value takes precedence
+        r client kill flags O flags N
 
         # Assert the client was killed
         assert_error "*I/O error*" {$c1 ping}
@@ -326,7 +326,7 @@ start_server {tags {"introspection"}} {
         set c1 [valkey_client]
 
         # Kill the client by type
-        r client kill type normal
+        r client kill type replica type normal
 
         # Assert the client was killed
         assert_error "*I/O error*" {$c1 ping}
@@ -368,7 +368,7 @@ start_server {tags {"introspection"}} {
         after 1000
 
         # Kill the client with name and idle time filters
-        r client kill name client1 idle 1
+        r client kill name client1 idle 100 idle 1
 
         # Assert client1 was killed
         set err1 [catch {$c1 ping} error_message1]
@@ -387,7 +387,7 @@ start_server {tags {"introspection"}} {
         r client setname mytestclient
         set c1 [valkey_client]
         $c1 client setname client1
-        set cl [r client list not-name mytestclient]
+        set cl [r client list not-name mytestclient not-name mytestclient]
         assert_match "*name=client1*" $cl
         assert_no_match "*name=mytestclient*" $cl
         catch {$c1 close}
@@ -397,7 +397,7 @@ start_server {tags {"introspection"}} {
     test {CLIENT LIST with NOT-FLAGS filter} {
         set c1 [valkey_client]
         $c1 readonly
-        set cl [r client list not-flags N]
+        set cl [r client list not-flags r not-flags N]
         assert_match "*flags=r*" $cl
         assert_no_match "*flags=N*" $cl
         catch {$c1 close}
@@ -409,7 +409,7 @@ start_server {tags {"introspection"}} {
         set c1 [valkey_client]
         $c1 client setname client1
         $c1 subscribe x
-        set cl [r client list not-type normal]
+        set cl [r client list not-type pubsub not-type normal]
         assert_match "*name=client1*" $cl
         assert_no_match "*name=mytestclient*" $cl
         catch {$c1 close}
@@ -472,7 +472,7 @@ start_server {tags {"introspection"}} {
         regexp {addr=([^:]+):} $client_info -> not_ip
 
         # Use the extracted IP for filtering.
-        r client list not-ip $not_ip
+        r client list not-ip $not_ip not-ip $not_ip
     } {}
 
     start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
@@ -483,7 +483,7 @@ start_server {tags {"introspection"}} {
             set client_info [$c client info]
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-            set filtered [$c client list not-ip $ipv6only]
+            set filtered [$c client list not-ip "1.2.3.4" not-ip $ipv6only]
             assert_no_match *client-ipv6* $filtered
 
             $c close
@@ -495,7 +495,7 @@ start_server {tags {"introspection"}} {
         set c1 [valkey_client]
         $c1 client setname client-with-r
         $c1 client capa redirect
-        set cl [r client list not-capa r]
+        set cl [r client list not-capa r not-capa r]
         assert_match "*name=mytestclient*" $cl
         assert_no_match "*name=client-with-r*" $cl
         catch {$c1 close}
@@ -523,7 +523,7 @@ start_server {tags {"introspection"}} {
         r client setname "client-normal"
 
         # Kill using not-capa filter
-        r client kill not-capa r skipme yes
+        r client kill not-capa r not-capa r skipme yes
 
         assert_error "*I/O error*" {$c1 ping}
         catch {$c1 close}
@@ -540,7 +540,7 @@ start_server {tags {"introspection"}} {
         $c1 client setname "killme-not-name"
 
         # Kill the client by not-name
-        r client kill not-name client-normal
+        r client kill not-name client-normal not-name client-normal
 
         # Assert the client was killed
         assert_error "*I/O error*" {$c1 ping}
@@ -559,7 +559,7 @@ start_server {tags {"introspection"}} {
         $c1 readonly
 
         # Kill the client by not-flag
-        r client kill not-flags N
+        r client kill not-flags N not-flags N
 
         # Assert the client was killed
         assert_error "*I/O error*" {$c1 ping}
@@ -1561,22 +1561,34 @@ start_server {tags {"introspection"}} {
 
 
     test {CLIENT LIST can filter by LIB-NAME} {
+        set c1 [valkey_client]
+        $c1 client setinfo lib-name test-lib
         r CLIENT SETINFO lib-name mylib
-        set result [r client list lib-name mylib]
+        set result [r client list lib-name test-lib lib-name mylib]
         assert_match {*lib-name=mylib*} $result
+        assert_no_match {*lib-name=test-lib*} $result
+        catch {$c1 close}
     }
 
     test {CLIENT LIST can filter by LIB-VER} {
+        set c1 [valkey_client]
+        $c1 client setinfo lib-ver 3.2.1
         r CLIENT SETINFO lib-ver 1.2.3
-        set result [r client list lib-ver 1.2.3]
+        set result [r client list lib-ver 3.2.1 lib-ver 1.2.3]
         assert_match {*lib-ver=1.2.3*} $result
+        assert_no_match {*lib-ver=3.2.1*} $result
+        catch {$c1 close}
     }
 
     test {CLIENT LIST can filter by DB number} {
+        set c1 [valkey_client]
+        $c1 select 0
         r select 2
-        set result [r client list db 2]
+        set result [r client list db 0 db 2]
         assert_match {*db=2*} $result
-    } {} {external:skip}
+        assert_no_match {*db=0*} $result
+        catch {$c1 close}
+    }
 
     test {CLIENT KILL can filter by DB} {
         set c1 [valkey_client]
@@ -1584,10 +1596,13 @@ start_server {tags {"introspection"}} {
         $c1 select 2
         r select 0
 
-        r client kill db 2
+        r client kill db 0 db 2
 
-        assert {[string match "*db=2*" [r client list]] == 0}
-    } {} {external:skip}
+        set result [r client list]
+        assert_no_match {*db=2*} $result
+        assert_match {*db=0*} $result
+        catch {$c1 close}
+    }
 
     test {CLIENT KILL can filter by LIB-NAME} {
         r client setinfo lib-name ""
@@ -1596,7 +1611,8 @@ start_server {tags {"introspection"}} {
         set c2 [valkey_client]
 
         $c1 client setinfo lib-name mylib
-        $c2 client kill lib-name mylib
+        $c2 client setinfo lib-name test
+        $c2 client kill lib-name test lib-name mylib
 
         set result [$c2 client list]
         assert {[string match {*lib-name=mylib*} $result] == 0}
@@ -1609,28 +1625,45 @@ start_server {tags {"introspection"}} {
         set c2 [valkey_client]
 
         $c1 client setinfo lib-ver 1.2.3
-        $c2 client kill lib-ver 1.2.3
+        $c2 client setinfo lib-ver 3.2.1
+        $c2 client kill lib-ver 3.2.1 lib-ver 1.2.3
 
         set result [$c2 client list]
-        assert {[string match {*lib-ver=1.2.3*} $result] == 0}
-
+        assert_no_match {*lib-ver=1.2.3*} $result
+        assert_match {*lib-ver=3.2.1*} $result
+        catch {$c1 close}
         catch {$c2 close}
     }
 
     test {CLIENT LIST can filter by NOT-LIB-NAME} {
+        set c1 [valkey_client]
+        $c1 CLIENT SETINFO lib-name testlib
         r CLIENT SETINFO lib-name mylib
-        r client list not-lib-name mylib
-    } {}
+        set result [r client list not-lib-name testlib not-lib-name mylib]
+        assert_no_match {*lib-name=mylib*} $result
+        assert_match {*lib-name=testlib*} $result
+        catch {$c1 close}
+    }
 
     test {CLIENT LIST can filter by NOT-LIB-VER} {
+        set c1 [valkey_client]
+        $c1 CLIENT SETINFO lib-ver 3.2.1
         r CLIENT SETINFO lib-ver 1.2.3
-        r client list not-lib-ver 1.2.3
-    } {}
+        set result [r client list not-lib-ver 3.2.1 not-lib-ver 1.2.3]
+        assert_no_match {*lib-ver=1.2.3*} $result
+        assert_match {*lib-ver=3.2.1*} $result
+        catch {$c1 close}
+    }
 
     test {CLIENT LIST can filter by NOT-DB number} {
+        set c1 [valkey_client]
+        $c1 select 0
         r select 2
-        r client list not-db 2
-    } {} {external:skip}
+        set result [r client list not-db 0 not-db 2]
+        assert_no_match {*db=2*} $result
+        assert_match {*db=0*} $result
+        catch {$c1 close}
+    }
 
     test {CLIENT KILL can filter by NOT-DB} {
         set c1 [valkey_client]
@@ -1638,21 +1671,25 @@ start_server {tags {"introspection"}} {
         $c1 select 2
         r select 0
 
-        r client kill not-db 0
+        r client kill not-db 2 not-db 0
 
-        assert {[string match "*db=2*" [r client list]] == 0}
-        catch {$c1 close}
-    } {0} {external:skip}
+        set result [r client list]
+        assert_no_match {*db=2*} $result
+        assert_match {*db=0*} $result
+    }
 
     test {CLIENT KILL can filter by NOT-LIB-NAME} {
         set c1 [valkey_client]
         set c2 [valkey_client]
 
         $c1 client setinfo lib-name mylib
-        $c2 client kill not-lib-name not-mylib
+        $c2 client setinfo lib-name not-mylib
+        $c2 client kill not-lib-name mylib not-lib-name not-mylib
 
         set result [$c2 client list]
-        assert {[string match {*lib-name=mylib*} $result] == 0}
+        assert_no_match {*lib-name=mylib*} $result
+        assert_match {*lib-name=not-mylib*} $result
+
 
         catch {$c2 close}
     }
@@ -1662,7 +1699,7 @@ start_server {tags {"introspection"}} {
         set c2 [valkey_client]
 
         $c1 client setinfo lib-ver 1.2.3
-        $c2 client kill not-lib-ver 0.0.0
+        $c2 client kill not-lib-ver 1.2.3 not-lib-ver 0.0.0
 
         set result [$c2 client list]
         assert {[string match {*lib-ver=1.2.3*} $result] == 0}


### PR DESCRIPTION
With #1401, we introduced additional filters to CLIENT LIST/KILL subcommand. The intended behavior was to pick the last  value of the filter. However, we introduced memory leak for all the preceding filters. 

Before this change:
```
> CLIENT LIST IP 127.0.0.1 IP 127.0.0.1
id=4 addr=127.0.0.1:37866 laddr=127.0.0.1:6379 fd=10 name= age=0 idle=0 flags=N capa= db=0 sub=0 psub=0 ssub=0 multi=-1 watch=0 qbuf=0 qbuf-free=0 argv-mem=21 multi-mem=0 rbs=16384 rbp=16384 obl=0 oll=0 omem=0 tot-mem=16989 events=r cmd=client|list user=default redir=-1 resp=2 lib-name= lib-ver= tot-net-in=49 tot-net-out=0 tot-cmds=0
```
Leak:
```
Direct leak of 11 byte(s) in 1 object(s) allocated from:
    #0 0x7f2901aa557d in malloc (/lib64/libasan.so.4+0xd857d)
    #1 0x76db76 in ztrymalloc_usable_internal /workplace/harkrisp/valkey/src/zmalloc.c:156
    #2 0x76db76 in zmalloc_usable /workplace/harkrisp/valkey/src/zmalloc.c:200
    #3 0x4c4121 in _sdsnewlen.constprop.230 /workplace/harkrisp/valkey/src/sds.c:113
    #4 0x4dc456 in parseClientFiltersOrReply.constprop.63 /workplace/harkrisp/valkey/src/networking.c:4264
    #5 0x4bb9f7 in clientListCommand /workplace/harkrisp/valkey/src/networking.c:4600
    #6 0x641159 in call /workplace/harkrisp/valkey/src/server.c:3772
    #7 0x6431a6 in processCommand /workplace/harkrisp/valkey/src/server.c:4434
    #8 0x4bfa9b in processCommandAndResetClient /workplace/harkrisp/valkey/src/networking.c:3571
    #9 0x4bfa9b in processInputBuffer /workplace/harkrisp/valkey/src/networking.c:3702
    #10 0x4bffa3 in readQueryFromClient /workplace/harkrisp/valkey/src/networking.c:3812
    #11 0x481015 in callHandler /workplace/harkrisp/valkey/src/connhelpers.h:79
    #12 0x481015 in connSocketEventHandler.lto_priv.394 /workplace/harkrisp/valkey/src/socket.c:301
    #13 0x7d3fb3 in aeProcessEvents /workplace/harkrisp/valkey/src/ae.c:486
    #14 0x7d4d44 in aeMain /workplace/harkrisp/valkey/src/ae.c:543
    #15 0x453925 in main /workplace/harkrisp/valkey/src/server.c:7319
    #16 0x7f2900cd7139 in __libc_start_main (/lib64/libc.so.6+0x21139)
```

Note: For filter ID / NOT-ID we group all the option and perform filtering whereas for remaining filters we only pick the last filter option.