### PR TITLE
Update clusterMoveNodeSlots to also move importing slots and migrating slots

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2734,7 +2734,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                     /* Update importing_slots_from to point to the sender, if it is in the
                      * same shard as the previous slot owner */
                     if (areInSameShard(sender, server.cluster->importing_slots_from[j])) {
-                        serverLog(LL_NOTICE,
+                        serverLog(LL_VERBOSE,
                                   "Failover occurred in migration source. Update importing "
                                   "source for slot %d to node %.40s (%s) in shard %.40s.",
                                   j, sender->name, sender->human_nodename, sender->shard_id);
@@ -2776,7 +2776,7 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 (server.cluster->migrating_slots_to[j]->configEpoch < senderConfigEpoch ||
                  nodeIsReplica(server.cluster->migrating_slots_to[j])) &&
                 areInSameShard(server.cluster->migrating_slots_to[j], sender)) {
-                serverLog(LL_NOTICE,
+                serverLog(LL_VERBOSE,
                           "Failover occurred in migration target."
                           " Slot %d is now being migrated to node %.40s (%s) in shard %.40s.",
                           j, sender->name, sender->human_nodename, sender->shard_id);
@@ -5826,10 +5826,11 @@ int clusterDelNodeSlots(clusterNode *node) {
 /* Transfer slots from `from_node` to `to_node`.
  *
  * Iterates over all cluster slots, transferring each slot covered
- * by `from_node` to `to_node`. */
+ * by `from_node` to `to_node`. Includes importing slots and migrating
+ * slots. This function currently only called after a failover occurs
+ * within a shard, i.e. moving slots from the old primary to the new
+ * primary. It is a special case of clusterUpdateSlotsConfigWith. */
 void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slots, int *importing_slots, int *migrating_slots) {
-    /* This function currently only called after a failover occurs within a shard,
-     * i.e. moving slots from the old primary to the new primary. */
     serverAssert(areInSameShard(from_node, to_node));
     int processed = 0, importing_processed = 0, migrating_processed = 0;
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -72,8 +72,7 @@ int clusterNodeAddReplica(clusterNode *primary, clusterNode *replica);
 int clusterAddSlot(clusterNode *n, int slot);
 int clusterDelSlot(int slot);
 int clusterDelNodeSlots(clusterNode *node);
-void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
-                          int *slots, int *importing_slots, int *migrating_slots);
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slots, int *importing_slots, int *migrating_slots);
 void clusterNodeSetSlotBit(clusterNode *n, int slot);
 static void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required);
 void clusterHandleReplicaFailover(void);
@@ -5828,8 +5827,7 @@ int clusterDelNodeSlots(clusterNode *node) {
  *
  * Iterates over all cluster slots, transferring each slot covered
  * by `from_node` to `to_node`. */
-void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
-                          int *slots, int *importing_slots, int *migrating_slots) {
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slots, int *importing_slots, int *migrating_slots) {
     /* This function currently only called after a failover occurs within a shard,
      * i.e. moving slots from the old primary to the new primary. */
     serverAssert(areInSameShard(from_node, to_node));

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5841,7 +5841,7 @@ void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slo
         }
 
         if (server.cluster->importing_slots_from[j] == from_node) {
-            serverLog(LL_NOTICE,
+            serverLog(LL_VERBOSE,
                       "Failover occurred in migration source. Update importing "
                       "source for slot %d to node %.40s (%s) in shard %.40s.",
                       j, to_node->name, to_node->human_nodename, to_node->shard_id);
@@ -5850,7 +5850,7 @@ void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slo
         }
 
         if (server.cluster->migrating_slots_to[j] == from_node) {
-            serverLog(LL_NOTICE,
+            serverLog(LL_VERBOSE,
                       "Failover occurred in migration target."
                       " Slot %d is now being migrated to node %.40s (%s) in shard %.40s.",
                       j, to_node->name, to_node->human_nodename, to_node->shard_id);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -72,7 +72,8 @@ int clusterNodeAddReplica(clusterNode *primary, clusterNode *replica);
 int clusterAddSlot(clusterNode *n, int slot);
 int clusterDelSlot(int slot);
 int clusterDelNodeSlots(clusterNode *node);
-int clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node);
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
+                          int *slots, int *importing_slots, int *migrating_slots);
 void clusterNodeSetSlotBit(clusterNode *n, int slot);
 static void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required);
 void clusterHandleReplicaFailover(void);
@@ -3668,17 +3669,35 @@ int clusterProcessPacket(clusterLink *link) {
                             /* A failover occurred in the shard where `sender` belongs to and `sender` is
                              * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
                              * which is the new primary in the shard. */
-                            int slots = clusterMoveNodeSlots(sender, sender_claimed_primary);
+                            int slots = 0, importing_slots = 0, migrating_slots = 0;
+                            clusterMoveNodeSlots(sender, sender_claimed_primary,
+                                                 &slots, &importing_slots, &migrating_slots);
                             /* `primary` is still a `replica` in this observer node's view;
                              * update its role and configEpoch */
                             clusterSetNodeAsPrimary(sender_claimed_primary);
                             sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
-                            serverLog(LL_NOTICE,
-                                      "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
-                                      " failed over to node %.40s (%s) with a config epoch of %llu",
-                                      sender->shard_id, sender->name, sender->human_nodename, slots,
-                                      sender_claimed_primary->name, sender_claimed_primary->human_nodename,
-                                      (unsigned long long)sender_claimed_primary->configEpoch);
+                            if (slots) {
+                                serverLog(LL_NOTICE,
+                                          "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
+                                          " failed over to node %.40s (%s) with a config epoch of %llu",
+                                          sender->shard_id, sender->name, sender->human_nodename, slots,
+                                          sender_claimed_primary->name, sender_claimed_primary->human_nodename,
+                                          (unsigned long long)sender_claimed_primary->configEpoch);
+                            }
+                            if (importing_slots) {
+                                serverLog(LL_NOTICE,
+                                          "Failover occurred in migration source. Update importing "
+                                          "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                          importing_slots, sender_claimed_primary->name,
+                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                            }
+                            if (migrating_slots) {
+                                serverLog(LL_NOTICE,
+                                          "Failover occurred in migration target. Update migrating "
+                                          "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                          migrating_slots, sender_claimed_primary->name,
+                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                            }
                             serverAssert(sender->numslots == 0);
                         }
                     } else {
@@ -3699,7 +3718,7 @@ int clusterProcessPacket(clusterLink *link) {
                     sender->flags |= CLUSTER_NODE_REPLICA;
 
                     /* Update config and state. */
-                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
+                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
                 }
 
                 /* Primary node changed for this replica? */
@@ -5807,19 +5826,45 @@ int clusterDelNodeSlots(clusterNode *node) {
 
 /* Transfer slots from `from_node` to `to_node`.
  *
+ * This function is only called after a failover occurs within a shard,
+ * i.e. moving slots from the old primary to the new primary.
+ *
  * Iterates over all cluster slots, transferring each slot covered
- * by `from_node` to `to_node`. Counts and returns the number of
- * slots transferred. */
-int clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node) {
-    int processed = 0;
+ * by `from_node` to `to_node`. */
+void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
+                          int *slots, int *importing_slots, int *migrating_slots) {
+    debugServerAssert(areInSameShard(from_node, to_node));
+    int processed = 0, importing_processed = 0, migrating_processed = 0;
+
     for (int j = 0; j < CLUSTER_SLOTS; j++) {
         if (clusterNodeCoversSlot(from_node, j)) {
             clusterDelSlot(j);
             clusterAddSlot(to_node, j);
             processed++;
         }
+
+        if (server.cluster->importing_slots_from[j] == from_node) {
+            serverLog(LL_NOTICE,
+                      "Failover occurred in migration source. Update importing "
+                      "source for slot %d to node %.40s (%s) in shard %.40s.",
+                      j, to_node->name, to_node->human_nodename, to_node->shard_id);
+            server.cluster->importing_slots_from[j] = to_node;
+            importing_processed++;
+        }
+
+        if (server.cluster->migrating_slots_to[j] == from_node) {
+            serverLog(LL_NOTICE,
+                      "Failover occurred in migration target."
+                      " Slot %d is now being migrated to node %.40s (%s) in shard %.40s.",
+                      j, to_node->name, to_node->human_nodename, to_node->shard_id);
+            server.cluster->migrating_slots_to[j] = to_node;
+            migrating_processed++;
+        }
     }
-    return processed;
+
+    if (slots) (*slots) = processed;
+    if (importing_slots) (*importing_slots) = importing_processed;
+    if (migrating_slots) (*migrating_slots) = migrating_processed;
 }
 
 /* Clear the migrating / importing state for all the slots.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3686,14 +3686,14 @@ int clusterProcessPacket(clusterLink *link) {
                             }
                             if (importing_slots) {
                                 serverLog(LL_NOTICE,
-                                          "Failover occurred in migration source. Update importing "
+                                          "A failover occurred in migration source. Update importing "
                                           "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
                                           importing_slots, sender_claimed_primary->name,
                                           sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
                             }
                             if (migrating_slots) {
                                 serverLog(LL_NOTICE,
-                                          "Failover occurred in migration target. Update migrating "
+                                          "A failover occurred in migration target. Update migrating "
                                           "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
                                           migrating_slots, sender_claimed_primary->name,
                                           sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
@@ -5826,14 +5826,13 @@ int clusterDelNodeSlots(clusterNode *node) {
 
 /* Transfer slots from `from_node` to `to_node`.
  *
- * This function is only called after a failover occurs within a shard,
- * i.e. moving slots from the old primary to the new primary.
- *
  * Iterates over all cluster slots, transferring each slot covered
  * by `from_node` to `to_node`. */
 void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
                           int *slots, int *importing_slots, int *migrating_slots) {
-    debugServerAssert(areInSameShard(from_node, to_node));
+    /* This function currently only called after a failover occurs within a shard,
+     * i.e. moving slots from the old primary to the new primary. */
+    serverAssert(areInSameShard(from_node, to_node));
     int processed = 0, importing_processed = 0, migrating_processed = 0;
 
     for (int j = 0; j < CLUSTER_SLOTS; j++) {
@@ -5862,9 +5861,9 @@ void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node,
         }
     }
 
-    if (slots) (*slots) = processed;
-    if (importing_slots) (*importing_slots) = importing_processed;
-    if (migrating_slots) (*migrating_slots) = migrating_processed;
+    if (slots) *slots = processed;
+    if (importing_slots) *importing_slots = importing_processed;
+    if (migrating_slots) *migrating_slots = migrating_processed;
 }
 
 /* Clear the migrating / importing state for all the slots.

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -433,3 +433,21 @@ proc check_cluster_node_mark {flag ref_node_index instance_id_to_check} {
 proc get_slot_field {slot_output shard_id node_id attrib_id} {
     return [lindex [lindex [lindex $slot_output $shard_id] $node_id] $attrib_id]
 }
+
+proc get_open_slots {srv_idx} {
+    set slots [dict get [cluster_get_myself $srv_idx] slots]
+    if {[regexp {\[.*} $slots slots]} {
+        set slots [regsub -all {[{}]} $slots ""]
+        return $slots
+    } else {
+        return {}
+    }
+}
+
+proc wait_for_slot_state {srv_idx pattern} {
+    wait_for_condition 100 100 {
+        [get_open_slots $srv_idx] eq $pattern
+    } else {
+        fail "incorrect slot state on R $srv_idx: expected $pattern; got [get_open_slots $srv_idx]"
+    }
+}

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -1,13 +1,3 @@
-proc get_open_slots {srv_idx} {
-    set slots [dict get [cluster_get_myself $srv_idx] slots]
-    if {[regexp {\[.*} $slots slots]} {
-        set slots [regsub -all {[{}]} $slots ""]
-        return $slots
-    } else {
-        return {}
-    }
-}
-
 proc get_cluster_role {srv_idx} {
     set flags [dict get [cluster_get_myself $srv_idx] flags]
     set role [lindex $flags 1]
@@ -78,14 +68,6 @@ proc wait_for_role {srv_idx role} {
     }
 
     wait_for_cluster_propagation
-}
-
-proc wait_for_slot_state {srv_idx pattern} {
-    wait_for_condition 100 100 {
-        [get_open_slots $srv_idx] eq $pattern
-    } else {
-        fail "incorrect slot state on R $srv_idx: expected $pattern; got [get_open_slots $srv_idx]"
-    }
 }
 
 # restart a server and wait for it to come back online


### PR DESCRIPTION
In #2301, we added clusterMoveNodeSlots to implement the logic of
moving slots from old primary to new primary, when myself receives
the replica (old primary) message first and the new primary message
later in a shard failover.

However due to this, when myself receives the new primary message
later next time, there is no way to call clusterUpdateSlotsConfigWith,
because we have already updated the slots of the new primary before.
This result in, for example, importing slots and migrating slots
not being updated, see #445.

In this commit, we also make clusterMoveNodeSlots to move importing
slots and migrating slots.

Fixes #2363.