### PR TITLE
support negative filtering for client command filters

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1334,7 +1334,7 @@ commandHistory CLIENT_KILL_History[] = {
 {"8.0.0","`MAXAGE` option."},
 {"8.0.0","Replaced `master` `TYPE` with `primary`. `master` still supported for backward compatibility."},
 {"8.1.0","`ID` option accepts multiple IDs."},
-{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
+{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
 };
 #endif
 
@@ -1396,9 +1396,7 @@ struct COMMAND_ARG CLIENT_KILL_filter_new_format_Subargs[] = {
 {MAKE_ARG("not-username",ARG_TYPE_STRING,-1,"NOT-USER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-addr",ARG_TYPE_STRING,-1,"NOT-ADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
 {MAKE_ARG("not-laddr",ARG_TYPE_STRING,-1,"NOT-LADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
-{MAKE_ARG("not-maxage",ARG_TYPE_INTEGER,-1,"NOT-MAXAGE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-name",ARG_TYPE_STRING,-1,"NOT-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("not-idle",ARG_TYPE_INTEGER,-1,"NOT-IDLE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-flags",ARG_TYPE_STRING,-1,"NOT-FLAGS",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-lib-name",ARG_TYPE_STRING,-1,"NOT-LIB-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-lib-ver",ARG_TYPE_STRING,-1,"NOT-LIB-VER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
@@ -1410,7 +1408,7 @@ struct COMMAND_ARG CLIENT_KILL_filter_new_format_Subargs[] = {
 /* CLIENT KILL filter argument table */
 struct COMMAND_ARG CLIENT_KILL_filter_Subargs[] = {
 {MAKE_ARG("old-format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,"2.8.12"),.display_text="ip:port"},
-{MAKE_ARG("new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,29,NULL),.subargs=CLIENT_KILL_filter_new_format_Subargs},
+{MAKE_ARG("new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,27,NULL),.subargs=CLIENT_KILL_filter_new_format_Subargs},
 };
 
 /* CLIENT KILL argument table */
@@ -1431,7 +1429,7 @@ commandHistory CLIENT_LIST_History[] = {
 {"7.0.3","Added `ssub` field."},
 {"8.0.0","Replaced `master` `TYPE` with `primary`. `master` still supported for backward compatibility."},
 {"8.1.0","Added filters USER, ADDR, LADDR, SKIPME, and MAXAGE."},
-{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
+{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
 };
 #endif
 
@@ -1491,9 +1489,7 @@ struct COMMAND_ARG CLIENT_LIST_Args[] = {
 {MAKE_ARG("not-username",ARG_TYPE_STRING,-1,"NOT-USER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-addr",ARG_TYPE_STRING,-1,"NOT-ADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
 {MAKE_ARG("not-laddr",ARG_TYPE_STRING,-1,"NOT-LADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
-{MAKE_ARG("not-maxage",ARG_TYPE_INTEGER,-1,"NOT-MAXAGE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-name",ARG_TYPE_STRING,-1,"NOT-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
-{MAKE_ARG("not-idle",ARG_TYPE_INTEGER,-1,"NOT-IDLE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-flags",ARG_TYPE_STRING,-1,"NOT-FLAGS",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-lib-name",ARG_TYPE_STRING,-1,"NOT-LIB-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("not-lib-ver",ARG_TYPE_STRING,-1,"NOT-LIB-VER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
@@ -1782,7 +1778,7 @@ struct COMMAND_STRUCT CLIENT_Subcommands[] = {
 {MAKE_CMD("import-source","Mark this client as an import source when server is in import mode.","O(1)","8.1.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_IMPORT_SOURCE_History,0,CLIENT_IMPORT_SOURCE_Tips,0,clientImportSourceCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_IMPORT_SOURCE_Keyspecs,0,NULL,1),.args=CLIENT_IMPORT_SOURCE_Args},
 {MAKE_CMD("info","Returns information about the connection.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_INFO_History,0,CLIENT_INFO_Tips,1,clientInfoCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_INFO_Keyspecs,0,NULL,0)},
 {MAKE_CMD("kill","Terminates open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_KILL_History,9,CLIENT_KILL_Tips,0,clientKillCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_KILL_Keyspecs,0,NULL,1),.args=CLIENT_KILL_Args},
-{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientListCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,29),.args=CLIENT_LIST_Args},
+{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientListCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,27),.args=CLIENT_LIST_Args},
 {MAKE_CMD("no-evict","Sets the client eviction mode of the connection.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_EVICT_History,0,CLIENT_NO_EVICT_Tips,0,clientNoEvictCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_NO_EVICT_Keyspecs,0,NULL,1),.args=CLIENT_NO_EVICT_Args},
 {MAKE_CMD("no-touch","Controls whether commands sent by the client affect the LRU/LFU of accessed keys.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_TOUCH_History,0,CLIENT_NO_TOUCH_Tips,0,clientNoTouchCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_NO_TOUCH_Keyspecs,0,NULL,1),.args=CLIENT_NO_TOUCH_Args},
 {MAKE_CMD("pause","Suspends commands processing.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_PAUSE_History,1,CLIENT_PAUSE_Tips,0,clientPauseCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_PAUSE_Keyspecs,0,NULL,2),.args=CLIENT_PAUSE_Args},

--- a/src/commands.def
+++ b/src/commands.def
@@ -1334,7 +1334,7 @@ commandHistory CLIENT_KILL_History[] = {
 {"8.0.0","`MAXAGE` option."},
 {"8.0.0","Replaced `master` `TYPE` with `primary`. `master` still supported for backward compatibility."},
 {"8.1.0","`ID` option accepts multiple IDs."},
-{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP."},
+{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
 };
 #endif
 
@@ -1364,6 +1364,16 @@ struct COMMAND_ARG CLIENT_KILL_filter_new_format_skipme_Subargs[] = {
 {MAKE_ARG("no",ARG_TYPE_PURE_TOKEN,-1,"NO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* CLIENT KILL filter new_format not_client_type argument table */
+struct COMMAND_ARG CLIENT_KILL_filter_new_format_not_client_type_Subargs[] = {
+{MAKE_ARG("normal",ARG_TYPE_PURE_TOKEN,-1,"NORMAL",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("master",ARG_TYPE_PURE_TOKEN,-1,"MASTER",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("primary",ARG_TYPE_PURE_TOKEN,-1,"PRIMARY",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("slave",ARG_TYPE_PURE_TOKEN,-1,"SLAVE",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("replica",ARG_TYPE_PURE_TOKEN,-1,"REPLICA",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pubsub",ARG_TYPE_PURE_TOKEN,-1,"PUBSUB",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /* CLIENT KILL filter new_format argument table */
 struct COMMAND_ARG CLIENT_KILL_filter_new_format_Subargs[] = {
 {MAKE_ARG("client-id",ARG_TYPE_INTEGER,-1,"ID",NULL,"2.8.12",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
@@ -1381,12 +1391,26 @@ struct COMMAND_ARG CLIENT_KILL_filter_new_format_Subargs[] = {
 {MAKE_ARG("db",ARG_TYPE_INTEGER,-1,"DB",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("capa",ARG_TYPE_STRING,-1,"CAPA",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("ip",ARG_TYPE_STRING,-1,"IP",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-client-type",ARG_TYPE_ONEOF,-1,"NOT-TYPE",NULL,"9.0.0",CMD_ARG_OPTIONAL,6,NULL),.subargs=CLIENT_KILL_filter_new_format_not_client_type_Subargs},
+{MAKE_ARG("not-client-id",ARG_TYPE_INTEGER,-1,"NOT-ID",NULL,"9.0.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
+{MAKE_ARG("not-username",ARG_TYPE_STRING,-1,"NOT-USER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-addr",ARG_TYPE_STRING,-1,"NOT-ADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
+{MAKE_ARG("not-laddr",ARG_TYPE_STRING,-1,"NOT-LADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
+{MAKE_ARG("not-maxage",ARG_TYPE_INTEGER,-1,"NOT-MAXAGE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-name",ARG_TYPE_STRING,-1,"NOT-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-idle",ARG_TYPE_INTEGER,-1,"NOT-IDLE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-flags",ARG_TYPE_STRING,-1,"NOT-FLAGS",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-lib-name",ARG_TYPE_STRING,-1,"NOT-LIB-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-lib-ver",ARG_TYPE_STRING,-1,"NOT-LIB-VER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-db",ARG_TYPE_INTEGER,-1,"NOT-DB",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-capa",ARG_TYPE_STRING,-1,"NOT-CAPA",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-ip",ARG_TYPE_STRING,-1,"NOT-IP",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /* CLIENT KILL filter argument table */
 struct COMMAND_ARG CLIENT_KILL_filter_Subargs[] = {
 {MAKE_ARG("old-format",ARG_TYPE_STRING,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,"2.8.12"),.display_text="ip:port"},
-{MAKE_ARG("new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,15,NULL),.subargs=CLIENT_KILL_filter_new_format_Subargs},
+{MAKE_ARG("new-format",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_MULTIPLE,29,NULL),.subargs=CLIENT_KILL_filter_new_format_Subargs},
 };
 
 /* CLIENT KILL argument table */
@@ -1407,7 +1431,7 @@ commandHistory CLIENT_LIST_History[] = {
 {"7.0.3","Added `ssub` field."},
 {"8.0.0","Replaced `master` `TYPE` with `primary`. `master` still supported for backward compatibility."},
 {"8.1.0","Added filters USER, ADDR, LADDR, SKIPME, and MAXAGE."},
-{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP."},
+{"9.0.0","Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."},
 };
 #endif
 
@@ -1437,6 +1461,14 @@ struct COMMAND_ARG CLIENT_LIST_skipme_Subargs[] = {
 {MAKE_ARG("no",ARG_TYPE_PURE_TOKEN,-1,"NO",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
+/* CLIENT LIST not_client_type argument table */
+struct COMMAND_ARG CLIENT_LIST_not_client_type_Subargs[] = {
+{MAKE_ARG("normal",ARG_TYPE_PURE_TOKEN,-1,"NORMAL",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("master",ARG_TYPE_PURE_TOKEN,-1,"MASTER",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("replica",ARG_TYPE_PURE_TOKEN,-1,"REPLICA",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("pubsub",ARG_TYPE_PURE_TOKEN,-1,"PUBSUB",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /* CLIENT LIST argument table */
 struct COMMAND_ARG CLIENT_LIST_Args[] = {
 {MAKE_ARG("client-type",ARG_TYPE_ONEOF,-1,"TYPE",NULL,"5.0.0",CMD_ARG_OPTIONAL,4,NULL),.subargs=CLIENT_LIST_client_type_Subargs},
@@ -1454,6 +1486,20 @@ struct COMMAND_ARG CLIENT_LIST_Args[] = {
 {MAKE_ARG("db",ARG_TYPE_INTEGER,-1,"DB",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("capa",ARG_TYPE_STRING,-1,"CAPA",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 {MAKE_ARG("ip",ARG_TYPE_STRING,-1,"IP",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-client-type",ARG_TYPE_ONEOF,-1,"NOT-TYPE",NULL,"9.0.0",CMD_ARG_OPTIONAL,4,NULL),.subargs=CLIENT_LIST_not_client_type_Subargs},
+{MAKE_ARG("not-client-id",ARG_TYPE_INTEGER,-1,"NOT-ID",NULL,"9.0.0",CMD_ARG_OPTIONAL|CMD_ARG_MULTIPLE,0,NULL)},
+{MAKE_ARG("not-username",ARG_TYPE_STRING,-1,"NOT-USER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-addr",ARG_TYPE_STRING,-1,"NOT-ADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
+{MAKE_ARG("not-laddr",ARG_TYPE_STRING,-1,"NOT-LADDR",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL),.display_text="ip:port"},
+{MAKE_ARG("not-maxage",ARG_TYPE_INTEGER,-1,"NOT-MAXAGE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-name",ARG_TYPE_STRING,-1,"NOT-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-idle",ARG_TYPE_INTEGER,-1,"NOT-IDLE",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-flags",ARG_TYPE_STRING,-1,"NOT-FLAGS",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-lib-name",ARG_TYPE_STRING,-1,"NOT-LIB-NAME",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-lib-ver",ARG_TYPE_STRING,-1,"NOT-LIB-VER",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-db",ARG_TYPE_INTEGER,-1,"NOT-DB",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-capa",ARG_TYPE_STRING,-1,"NOT-CAPA",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
+{MAKE_ARG("not-ip",ARG_TYPE_STRING,-1,"NOT-IP",NULL,"9.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** CLIENT NO_EVICT ********************/
@@ -1736,7 +1782,7 @@ struct COMMAND_STRUCT CLIENT_Subcommands[] = {
 {MAKE_CMD("import-source","Mark this client as an import source when server is in import mode.","O(1)","8.1.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_IMPORT_SOURCE_History,0,CLIENT_IMPORT_SOURCE_Tips,0,clientImportSourceCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_IMPORT_SOURCE_Keyspecs,0,NULL,1),.args=CLIENT_IMPORT_SOURCE_Args},
 {MAKE_CMD("info","Returns information about the connection.","O(1)","6.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_INFO_History,0,CLIENT_INFO_Tips,1,clientInfoCommand,2,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_INFO_Keyspecs,0,NULL,0)},
 {MAKE_CMD("kill","Terminates open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_KILL_History,9,CLIENT_KILL_Tips,0,clientKillCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_KILL_Keyspecs,0,NULL,1),.args=CLIENT_KILL_Args},
-{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientListCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,15),.args=CLIENT_LIST_Args},
+{MAKE_CMD("list","Lists open connections.","O(N) where N is the number of client connections","2.4.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_LIST_History,9,CLIENT_LIST_Tips,1,clientListCommand,-2,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_LIST_Keyspecs,0,NULL,29),.args=CLIENT_LIST_Args},
 {MAKE_CMD("no-evict","Sets the client eviction mode of the connection.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_EVICT_History,0,CLIENT_NO_EVICT_Tips,0,clientNoEvictCommand,3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_NO_EVICT_Keyspecs,0,NULL,1),.args=CLIENT_NO_EVICT_Args},
 {MAKE_CMD("no-touch","Controls whether commands sent by the client affect the LRU/LFU of accessed keys.","O(1)","7.2.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_NO_TOUCH_History,0,CLIENT_NO_TOUCH_Tips,0,clientNoTouchCommand,3,CMD_NOSCRIPT|CMD_LOADING|CMD_STALE,ACL_CATEGORY_CONNECTION,CLIENT_NO_TOUCH_Keyspecs,0,NULL,1),.args=CLIENT_NO_TOUCH_Args},
 {MAKE_CMD("pause","Suspends commands processing.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"connection",COMMAND_GROUP_CONNECTION,CLIENT_PAUSE_History,1,CLIENT_PAUSE_Tips,0,clientPauseCommand,-3,CMD_ADMIN|CMD_NOSCRIPT|CMD_LOADING|CMD_STALE|CMD_SENTINEL,ACL_CATEGORY_CONNECTION,CLIENT_PAUSE_Keyspecs,0,NULL,2),.args=CLIENT_PAUSE_Args},

--- a/src/commands/client-kill.json
+++ b/src/commands/client-kill.json
@@ -42,7 +42,7 @@
             ],
             [
                 "9.0.0",
-                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
+                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
             ]
         ],
         "command_flags": [
@@ -294,23 +294,9 @@
                                 "since": "9.0.0"
                             },
                             {
-                                "token": "NOT-MAXAGE",
-                                "name": "not-maxage",
-                                "type": "integer",
-                                "optional": true,
-                                "since": "9.0.0"
-                            },
-                            {
                                 "token": "NOT-NAME",
                                 "name": "not-name",
                                 "type": "string",
-                                "optional": true,
-                                "since": "9.0.0"
-                            },
-                            {
-                                "token": "NOT-IDLE",
-                                "name": "not-idle",
-                                "type": "integer",
                                 "optional": true,
                                 "since": "9.0.0"
                             },

--- a/src/commands/client-kill.json
+++ b/src/commands/client-kill.json
@@ -42,7 +42,7 @@
             ],
             [
                 "9.0.0",
-                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP."
+                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
             ]
         ],
         "command_flags": [
@@ -219,6 +219,139 @@
                             {
                                 "token": "IP",
                                 "name": "ip",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-TYPE",
+                                "name": "not-client-type",
+                                "type": "oneof",
+                                "optional": true,
+                                "since": "9.0.0",
+                                "arguments": [
+                                    {
+                                        "name": "normal",
+                                        "type": "pure-token",
+                                        "token": "normal"
+                                    },
+                                    {
+                                        "name": "master",
+                                        "type": "pure-token",
+                                        "token": "master"
+                                    },
+                                    {
+                                        "name": "primary",
+                                        "type": "pure-token",
+                                        "token": "primary"
+                                    },
+                                    {
+                                        "name": "slave",
+                                        "type": "pure-token",
+                                        "token": "slave"
+                                    },
+                                    {
+                                        "name": "replica",
+                                        "type": "pure-token",
+                                        "token": "replica"
+                                    },
+                                    {
+                                        "name": "pubsub",
+                                        "type": "pure-token",
+                                        "token": "pubsub"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "not-client-id",
+                                "token": "NOT-ID",
+                                "type": "integer",
+                                "optional": true,
+                                "multiple": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-USER",
+                                "name": "not-username",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-ADDR",
+                                "name": "not-addr",
+                                "display": "ip:port",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-LADDR",
+                                "name": "not-laddr",
+                                "display": "ip:port",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-MAXAGE",
+                                "name": "not-maxage",
+                                "type": "integer",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-NAME",
+                                "name": "not-name",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-IDLE",
+                                "name": "not-idle",
+                                "type": "integer",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-FLAGS",
+                                "name": "not-flags",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-LIB-NAME",
+                                "name": "not-lib-name",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-LIB-VER",
+                                "name": "not-lib-ver",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-DB",
+                                "name": "not-db",
+                                "type": "integer",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-CAPA",
+                                "name": "not-capa",
+                                "type": "string",
+                                "optional": true,
+                                "since": "9.0.0"
+                            },
+                            {
+                                "token": "NOT-IP",
+                                "name": "not-ip",
                                 "type": "string",
                                 "optional": true,
                                 "since": "9.0.0"

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -42,7 +42,7 @@
             ],
             [
                 "9.0.0",
-                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
+                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
             ]
         ],
         "command_flags": [
@@ -266,23 +266,9 @@
                 "since": "9.0.0"
             },
             {
-                "token": "NOT-MAXAGE",
-                "name": "not-maxage",
-                "type": "integer",
-                "optional": true,
-                "since": "9.0.0"
-            },
-            {
                 "token": "NOT-NAME",
                 "name": "not-name",
                 "type": "string",
-                "optional": true,
-                "since": "9.0.0"
-            },
-            {
-                "token": "NOT-IDLE",
-                "name": "not-idle",
-                "type": "integer",
                 "optional": true,
                 "since": "9.0.0"
             },

--- a/src/commands/client-list.json
+++ b/src/commands/client-list.json
@@ -42,7 +42,7 @@
             ],
             [
                 "9.0.0",
-                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP."
+                "Added filters NAME, IDLE, FLAGS, LIB-NAME, LIB-VER, DB, CAPA, and IP. And negative filters NOT-ID, NOT-MAXAGE, NOT-TYPE, NOT-ADDR, NOT-LADDR, NOT-USER, NOT-IDLE, NOT-FLAGS, NOT-NAME, NOT-LIB-NAME, NOT-LIB-VER, NOT-DB, NOT-CAPA, NOT-IP."
             ]
         ],
         "command_flags": [
@@ -201,6 +201,129 @@
             {
                 "token": "IP",
                 "name": "ip",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-TYPE",
+                "name": "not-client-type",
+                "type": "oneof",
+                "optional": true,
+                "since": "9.0.0",
+                "arguments": [
+                    {
+                        "name": "normal",
+                        "type": "pure-token",
+                        "token": "normal"
+                    },
+                    {
+                        "name": "master",
+                        "type": "pure-token",
+                        "token": "master"
+                    },
+                    {
+                        "name": "replica",
+                        "type": "pure-token",
+                        "token": "replica"
+                    },
+                    {
+                        "name": "pubsub",
+                        "type": "pure-token",
+                        "token": "pubsub"
+                    }
+                ]
+            },
+            {
+                "name": "not-client-id",
+                "token": "NOT-ID",
+                "type": "integer",
+                "optional": true,
+                "multiple": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-USER",
+                "name": "not-username",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-ADDR",
+                "name": "not-addr",
+                "display": "ip:port",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-LADDR",
+                "name": "not-laddr",
+                "display": "ip:port",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-MAXAGE",
+                "name": "not-maxage",
+                "type": "integer",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-NAME",
+                "name": "not-name",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-IDLE",
+                "name": "not-idle",
+                "type": "integer",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-FLAGS",
+                "name": "not-flags",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-LIB-NAME",
+                "name": "not-lib-name",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-LIB-VER",
+                "name": "not-lib-ver",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-DB",
+                "name": "not-db",
+                "type": "integer",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-CAPA",
+                "name": "not-capa",
+                "type": "string",
+                "optional": true,
+                "since": "9.0.0"
+            },
+            {
+                "token": "NOT-IP",
+                "name": "not-ip",
                 "type": "string",
                 "optional": true,
                 "since": "9.0.0"

--- a/src/networking.c
+++ b/src/networking.c
@@ -52,38 +52,52 @@
 typedef struct {
     /* A set of client IDs to filter. If NULL, no ID filtering is applied. */
     intset *ids;
+    intset *not_ids;
     /* Maximum age (in seconds) of a client connection for filtering.
      * Connections younger than this value will not match.
      * A value of 0 means no age filtering. */
     long long max_age;
+    long long not_max_age;
     /* Address/port of the client. If NULL, no address filtering is applied. */
     char *addr;
+    char *not_addr;
     /* Remote address/port of the client. If NULL, no address filtering is applied. */
     char *laddr;
+    char *not_laddr;
     /* Filtering clients by authentication user. If NULL, no user-based filtering is applied. */
     user *user;
+    user *not_user;
     /* Client type to filter. If set to -1, no type filtering is applied. */
     int type;
+    int not_type;
     /* Boolean flag to determine if the current client (`me`) should be filtered. 1 means "skip me", 0 means otherwise. */
     int skipme;
     /* Client name to filter. If NULL, no name filtering is applied. */
     char *name;
+    char *not_name;
     /* Idle time (in seconds) of a client connection for filtering.
      * Connections with idle time more than this value will match.
      * A value of 0 means no idle time filtering. */
     long long idle;
+    long long not_idle;
     /* Client flags for filtering. If NULL, no filtering is applied. */
     sds flags;
+    sds not_flags;
     /* Library name to filter. If NULL, no library name filtering is applied. */
     robj *lib_name;
+    robj *not_lib_name;
     /* Library version to filter. If NULL, no library version filtering is applied. */
     robj *lib_ver;
+    robj *not_lib_ver;
     /* Database index to filter. If set to -1, no DB number filtering is applied. */
     int db_number;
+    int not_db_number;
     /* Client capa for filtering. If NULL, no filtering is applied. */
     sds capa;
+    sds not_capa;
     /* Client ip for filtering. If NULL, no filtering is applied. */
     sds ip;
+    sds not_ip;
 } clientFilter;
 
 /* Types of payloads in reply buffers (c->buf and c->reply)
@@ -4168,6 +4182,28 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 filter->ids = intsetAdd(filter->ids, id, &added);
                 index++; /* Move to the next argument */
             }
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-id")) {
+            if (filter->not_ids == NULL) {
+                /* Initialize the intset for NOT-IDs */
+                filter->not_ids = intsetNew();
+            }
+            index++; /* Move to the first ID after "NOT-ID" */
+
+            /* Process all NOT-IDs until a non-numeric argument or end of args */
+            while (index < c->argc) {
+                long long not_id;
+                if (!string2ll(c->argv[index]->ptr, sdslen(c->argv[index]->ptr), &not_id)) {
+                    break; /* Stop processing NOT-IDs if a non-numeric argument is encountered */
+                }
+                if (not_id < 1) {
+                    addReplyError(c, "client-id should be greater than 0");
+                    return C_ERR;
+                }
+
+                uint8_t added;
+                filter->not_ids = intsetAdd(filter->not_ids, not_id, &added);
+                index++; /* Move to the next argument */
+            }
         } else if (!strcasecmp(c->argv[index]->ptr, "maxage") && moreargs) {
             long long maxage;
 
@@ -4181,6 +4217,19 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
 
             filter->max_age = maxage;
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-maxage") && moreargs) {
+            long long not_maxage;
+
+            if (getLongLongFromObjectOrReply(c, c->argv[index + 1], &not_maxage,
+                                             "not-maxage is not an integer or out of range") != C_OK)
+                return C_ERR;
+            if (not_maxage <= 0) {
+                addReplyError(c, "not-maxage should be greater than 0");
+                return C_ERR;
+            }
+
+            filter->not_max_age = not_maxage;
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "type") && moreargs) {
             filter->type = getClientTypeByName(c->argv[index + 1]->ptr);
             if (filter->type == -1) {
@@ -4188,15 +4237,35 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 return C_ERR;
             }
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-type") && moreargs) {
+            filter->not_type = getClientTypeByName(c->argv[index + 1]->ptr);
+            if (filter->not_type == -1) {
+                addReplyErrorFormat(c, "Unknown client type '%s'", (char *)c->argv[index + 1]->ptr);
+                return C_ERR;
+            }
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "addr") && moreargs) {
             filter->addr = c->argv[index + 1]->ptr;
+            index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-addr") && moreargs) {
+            filter->not_addr = c->argv[index + 1]->ptr;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "laddr") && moreargs) {
             filter->laddr = c->argv[index + 1]->ptr;
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-laddr") && moreargs) {
+            filter->not_laddr = c->argv[index + 1]->ptr;
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "user") && moreargs) {
             filter->user = ACLGetUserByName(c->argv[index + 1]->ptr, sdslen(c->argv[index + 1]->ptr));
             if (filter->user == NULL) {
+                addReplyErrorFormat(c, "No such user '%s'", (char *)c->argv[index + 1]->ptr);
+                return C_ERR;
+            }
+            index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-user") && moreargs) {
+            filter->not_user = ACLGetUserByName(c->argv[index + 1]->ptr, sdslen(c->argv[index + 1]->ptr));
+            if (filter->not_user == NULL) {
                 addReplyErrorFormat(c, "No such user '%s'", (char *)c->argv[index + 1]->ptr);
                 return C_ERR;
             }
@@ -4224,6 +4293,19 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
 
             filter->idle = idle_time;
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-idle") && moreargs) {
+            long long not_idle_time;
+
+            if (getLongLongFromObjectOrReply(c, c->argv[index + 1], &not_idle_time,
+                                             "not-idle is not an integer or out of range") != C_OK)
+                return C_ERR;
+            if (not_idle_time <= 0) {
+                addReplyError(c, "idle should be greater than 0");
+                return C_ERR;
+            }
+
+            filter->not_idle = not_idle_time;
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "flags") && moreargs) {
             filter->flags = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientFlagFilter(filter->flags) == C_ERR) {
@@ -4231,16 +4313,34 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 return C_ERR;
             }
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-flags") && moreargs) {
+            filter->not_flags = sdsnew(c->argv[index + 1]->ptr);
+            if (validateClientFlagFilter(filter->not_flags) == C_ERR) {
+                addReplyErrorFormat(c, "Unknown flags found in the NOT-FLAGS filter: %s", filter->not_flags);
+                return C_ERR;
+            }
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "name") && moreargs) {
             filter->name = c->argv[index + 1]->ptr;
+            index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-name") && moreargs) {
+            filter->not_name = c->argv[index + 1]->ptr;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "lib-name") && moreargs) {
             filter->lib_name = c->argv[index + 1];
             incrRefCount(filter->lib_name);
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-lib-name") && moreargs) {
+            filter->not_lib_name = c->argv[index + 1];
+            incrRefCount(filter->not_lib_name);
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "lib-ver") && moreargs) {
             filter->lib_ver = c->argv[index + 1];
             incrRefCount(filter->lib_ver);
+            index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-lib-ver") && moreargs) {
+            filter->not_lib_ver = c->argv[index + 1];
+            incrRefCount(filter->not_lib_ver);
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "db") && moreargs) {
             int db_id;
@@ -4253,6 +4353,17 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
             filter->db_number = db_id;
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-db") && moreargs) {
+            int not_db_id;
+            if (getIntFromObjectOrReply(c, c->argv[index + 1], &not_db_id,
+                                        "NOT-DB is not an integer or out of range") != C_OK)
+                return C_ERR;
+            if (not_db_id < 0 || not_db_id >= server.dbnum) {
+                addReplyErrorFormat(c, "NOT-DB number should be between 0 and %d", server.dbnum - 1);
+                return C_ERR;
+            }
+            filter->not_db_number = not_db_id;
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "capa") && moreargs) {
             filter->capa = sdsnew(c->argv[index + 1]->ptr);
             if (validateClientCapaFilter(filter->capa) == C_ERR) {
@@ -4260,8 +4371,18 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
                 return C_ERR;
             }
             index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-capa") && moreargs) {
+            filter->not_capa = sdsnew(c->argv[index + 1]->ptr);
+            if (validateClientCapaFilter(filter->not_capa) == C_ERR) {
+                addReplyErrorFormat(c, "Unknown capa found in the NOT-CAPA filter: %s", filter->not_capa);
+                return C_ERR;
+            }
+            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "ip") && moreargs) {
             filter->ip = sdsnew(c->argv[index + 1]->ptr);
+            index += 2;
+        } else if (!strcasecmp(c->argv[index]->ptr, "not-ip") && moreargs) {
+            filter->not_ip = sdsnew(c->argv[index + 1]->ptr);
             index += 2;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
@@ -4339,6 +4460,26 @@ static int clientMatchesFilter(client *client, clientFilter *client_filter) {
     if (client_filter->db_number != -1 && client->db->id != client_filter->db_number) return 0;
     if (client_filter->capa && clientMatchesCapaFilter(client, client_filter->capa) == 0) return 0;
     if (client_filter->ip && clientMatchesIpFilter(client, client_filter->ip) == 0) return 0;
+
+    /* Check each negative filter condition and return false if the client matches. */
+    if (client_filter->not_addr && strcmp(getClientPeerId(client), client_filter->not_addr) == 0) return 0;
+    if (client_filter->not_laddr && strcmp(getClientSockname(client), client_filter->not_laddr) == 0) return 0;
+    if (client_filter->not_type != -1 && getClientType(client) == client_filter->not_type) return 0;
+    if (client_filter->not_ids && intsetFind(client_filter->not_ids, client->id)) return 0;
+    if (client_filter->not_user && client->user == client_filter->not_user) return 0;
+    if (client_filter->not_max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) >= client_filter->not_max_age) return 0;
+    if (client_filter->not_idle != 0 && (long long)(commandTimeSnapshot() / 1000 - client->last_interaction) >= client_filter->not_idle) return 0;
+    if (client_filter->not_flags && clientMatchesFlagFilter(client, client_filter->not_flags) != 0) return 0;
+    if (client_filter->not_name) {
+        if (client->name && client->name->ptr && strcmp(client->name->ptr, client_filter->not_name) == 0) {
+            return 0;
+        }
+    }
+    if (client_filter->not_lib_name && (client->lib_name && compareStringObjects(client->lib_name, client_filter->not_lib_name) == 0)) return 0;
+    if (client_filter->not_lib_ver && (client->lib_ver && compareStringObjects(client->lib_ver, client_filter->not_lib_ver) == 0)) return 0;
+    if (client_filter->not_db_number != -1 && client->db->id == client_filter->not_db_number) return 0;
+    if (client_filter->not_capa && clientMatchesCapaFilter(client, client_filter->not_capa) != 0) return 0;
+    if (client_filter->not_ip && clientMatchesIpFilter(client, client_filter->not_ip) != 0) return 0;
 
     /* If all conditions are satisfied, the client matches the filter. */
     return 1;
@@ -4444,15 +4585,15 @@ static int clientMatchesFlagFilter(client *c, sds flag_filter) {
             if (!c->flag.import_source) return 0;
             break;
         case 'N': /* Check for no flags */
-            if (!c->flag.replica && !c->flag.primary && !c->flag.pubsub &&
-                !c->flag.multi && !c->flag.blocked && !c->flag.tracking &&
-                !c->flag.tracking_broken_redir && !c->flag.tracking_bcast &&
-                !c->flag.dirty_cas && !c->flag.close_after_reply &&
-                !c->flag.unblocked && !c->flag.close_asap &&
-                !c->flag.unix_socket && !c->flag.readonly &&
-                !c->flag.no_evict && !c->flag.no_touch &&
-                !c->flag.import_source) {
-                return 1; /* Matches 'N' */
+            if (c->flag.replica || c->flag.primary || c->flag.pubsub ||
+                c->flag.multi || c->flag.blocked || c->flag.tracking ||
+                c->flag.tracking_broken_redir || c->flag.tracking_bcast ||
+                c->flag.dirty_cas || c->flag.close_after_reply ||
+                c->flag.unblocked || c->flag.close_asap ||
+                c->flag.unix_socket || c->flag.readonly ||
+                c->flag.no_evict || c->flag.no_touch ||
+                c->flag.import_source) {
+                return 0;
             }
             break;
         default:
@@ -4594,7 +4735,11 @@ void clientListCommand(client *c) {
     sds response = NULL;
 
     if (c->argc > 3) {
-        clientFilter filter = {.ids = NULL, .max_age = 0, .idle = 0, .addr = NULL, .laddr = NULL, .user = NULL, .type = -1, .skipme = 0, .db_number = -1};
+        clientFilter filter = {0};
+        filter.type = -1;
+        filter.not_type = -1;
+        filter.db_number = -1;
+        filter.not_db_number = -1;
         int i = 2;
 
         if (parseClientFiltersOrReply(c, i, &filter) != C_OK) {
@@ -4652,15 +4797,12 @@ void clientKillCommand(client *c) {
     listNode *ln;
     listIter li;
 
-    clientFilter client_filter = {.ids = NULL,
-                                  .max_age = 0,
-                                  .idle = 0,
-                                  .addr = NULL,
-                                  .laddr = NULL,
-                                  .user = NULL,
-                                  .type = -1,
-                                  .skipme = 1,
-                                  .db_number = -1};
+    clientFilter client_filter = {0};
+    client_filter.type = -1;
+    client_filter.not_type = -1;
+    client_filter.db_number = -1;
+    client_filter.not_db_number = -1;
+    client_filter.skipme = 1;
 
     int killed = 0, close_this_client = 0;
 
@@ -4738,6 +4880,31 @@ static void freeClientFilter(clientFilter *filter) {
     if (filter->lib_ver) {
         decrRefCount(filter->lib_ver);
         filter->lib_ver = NULL;
+    }
+
+    if (filter->not_ids != NULL) {
+        zfree(filter->not_ids);
+        filter->not_ids = NULL;
+    }
+    if (filter->not_flags != NULL) {
+        sdsfree(filter->not_flags);
+        filter->not_flags = NULL;
+    }
+    if (filter->not_capa != NULL) {
+        sdsfree(filter->not_capa);
+        filter->not_capa = NULL;
+    }
+    if (filter->not_ip != NULL) {
+        sdsfree(filter->not_ip);
+        filter->not_ip = NULL;
+    }
+    if (filter->not_lib_name) {
+        decrRefCount(filter->not_lib_name);
+        filter->not_lib_name = NULL;
+    }
+    if (filter->not_lib_ver) {
+        decrRefCount(filter->not_lib_ver);
+        filter->not_lib_ver = NULL;
     }
 }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -57,7 +57,6 @@ typedef struct {
      * Connections younger than this value will not match.
      * A value of 0 means no age filtering. */
     long long max_age;
-    long long not_max_age;
     /* Address/port of the client. If NULL, no address filtering is applied. */
     char *addr;
     char *not_addr;
@@ -79,7 +78,6 @@ typedef struct {
      * Connections with idle time more than this value will match.
      * A value of 0 means no idle time filtering. */
     long long idle;
-    long long not_idle;
     /* Client flags for filtering. If NULL, no filtering is applied. */
     sds flags;
     sds not_flags;
@@ -4217,19 +4215,6 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
 
             filter->max_age = maxage;
             index += 2;
-        } else if (!strcasecmp(c->argv[index]->ptr, "not-maxage") && moreargs) {
-            long long not_maxage;
-
-            if (getLongLongFromObjectOrReply(c, c->argv[index + 1], &not_maxage,
-                                             "not-maxage is not an integer or out of range") != C_OK)
-                return C_ERR;
-            if (not_maxage <= 0) {
-                addReplyError(c, "not-maxage should be greater than 0");
-                return C_ERR;
-            }
-
-            filter->not_max_age = not_maxage;
-            index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "type") && moreargs) {
             filter->type = getClientTypeByName(c->argv[index + 1]->ptr);
             if (filter->type == -1) {
@@ -4292,19 +4277,6 @@ static int parseClientFiltersOrReply(client *c, int index, clientFilter *filter)
             }
 
             filter->idle = idle_time;
-            index += 2;
-        } else if (!strcasecmp(c->argv[index]->ptr, "not-idle") && moreargs) {
-            long long not_idle_time;
-
-            if (getLongLongFromObjectOrReply(c, c->argv[index + 1], &not_idle_time,
-                                             "not-idle is not an integer or out of range") != C_OK)
-                return C_ERR;
-            if (not_idle_time <= 0) {
-                addReplyError(c, "idle should be greater than 0");
-                return C_ERR;
-            }
-
-            filter->not_idle = not_idle_time;
             index += 2;
         } else if (!strcasecmp(c->argv[index]->ptr, "flags") && moreargs) {
             filter->flags = sdsnew(c->argv[index + 1]->ptr);
@@ -4467,8 +4439,6 @@ static int clientMatchesFilter(client *client, clientFilter *client_filter) {
     if (client_filter->not_type != -1 && getClientType(client) == client_filter->not_type) return 0;
     if (client_filter->not_ids && intsetFind(client_filter->not_ids, client->id)) return 0;
     if (client_filter->not_user && client->user == client_filter->not_user) return 0;
-    if (client_filter->not_max_age != 0 && (long long)(commandTimeSnapshot() / 1000 - client->ctime) >= client_filter->not_max_age) return 0;
-    if (client_filter->not_idle != 0 && (long long)(commandTimeSnapshot() / 1000 - client->last_interaction) >= client_filter->not_idle) return 0;
     if (client_filter->not_flags && clientMatchesFlagFilter(client, client_filter->not_flags) != 0) return 0;
     if (client_filter->not_name) {
         if (client->name && client->name->ptr && strcmp(client->name->ptr, client_filter->not_name) == 0) {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -192,7 +192,7 @@ start_server {tags {"introspection"}} {
         $c3 multi
 
         # Wait 1 second to ensure idle time
-        after 1000  ;
+        after 1000
 
         # Fetch the client list filtered by name and flags
         set cl [split [r client list name client1 flags N] "\r\n"]
@@ -365,7 +365,7 @@ start_server {tags {"introspection"}} {
         $c2 client setname client2
 
         # Wait 1 second to ensure idle time
-        after 1000 ;# Wait 1 second
+        after 1000
 
         # Kill the client with name and idle time filters
         r client kill name client1 idle 1
@@ -447,7 +447,7 @@ start_server {tags {"introspection"}} {
         $c3 multi
 
         # Wait 1 second to ensure idle time
-        after 1000  ;
+        after 1000
 
         # Fetch the client list filtered by name and not-flags
         set cl [split [r client list name client1 not-flags x] "\r\n"]
@@ -512,9 +512,9 @@ start_server {tags {"introspection"}} {
         assert_error "*I/O error*" {$c1 ping}
         catch {$c1 close}
 
-        set cl [r client list]
-        assert_match "*name=client-normal*" $cl
-        assert_no_match "*name=killme-not-ip*" $cl
+        set list_reply [r client list]
+        assert_match "*name=client-normal*" $list_reply
+        assert_no_match "*name=killme-not-ip*" $list_reply
     }
 
     test {CLIENT KILL with NOT-CAPA filter} {
@@ -611,7 +611,7 @@ start_server {tags {"introspection"}} {
         catch {$c2 close}
     }
 
-    test {CLIENT KILL with multiple negative filters including idle time} {
+    test {CLIENT KILL with both positive and negative filters including idle time} {
         # Create two clients
         set c1 [valkey_client]
         set c2 [valkey_client]
@@ -619,10 +619,10 @@ start_server {tags {"introspection"}} {
         $c2 client setname client2
 
         # Wait 1 second to ensure idle time
-        after 1000 ;# Wait 1 second
+        after 1000
 
-        # Kill the client with not-name and not-idle filters
-        r client kill not-name client2 not-idle 10
+        # Kill the client with not-name and idle filters
+        r client kill not-name client2 idle 1
 
         # Assert client1 was killed
         set err1 [catch {$c1 ping} error_message1]
@@ -662,10 +662,6 @@ start_server {tags {"introspection"}} {
         assert_error "ERR Unknown client type*" {r client list not-type wrong_type}
 
         assert_error "ERR No such user*" {r client list not-user wrong_user}
-
-        assert_error "ERR *not an integer or out of range*" {r client list not-maxage str}
-        assert_error "ERR *not an integer or out of range*" {r client list not-maxage 9999999999999999999}
-        assert_error "ERR *greater than 0*" {r client list not-maxage -1}
     }
 
     proc get_field_in_client_info {info field} {
@@ -1658,7 +1654,8 @@ start_server {tags {"introspection"}} {
         r client kill not-db 0
 
         assert {[string match "*db=2*" [r client list]] == 0}
-    } {} {external:skip}
+        catch {$c1 close}
+    } {0} {external:skip}
 
     test {CLIENT KILL can filter by NOT-LIB-NAME} {
         set c1 [valkey_client]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -484,7 +484,7 @@ start_server {tags {"introspection"}} {
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
             set filtered [$c client list not-ip $ipv6only]
-            assert_equal {} $filtered
+            assert_no_match *client-ipv6* $filtered
 
             $c close
         }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -241,12 +241,14 @@ start_server {tags {"introspection"}} {
     }
 
     test {CLIENT LIST with CAPA filter} {
-        r client setname "client-with-r"
-        r client capa redirect
+        set c1 [valkey_client]
+        $c1 client setname "client-with-r"
+        $c1 client capa redirect
 
         set output [r client list capa r]
         assert_match *client-with-r* $output
-    } {}
+        catch {$c1 close}
+    }
 
     test {CLIENT KILL with IP filter} {
         set c1 [valkey_client]
@@ -380,6 +382,260 @@ start_server {tags {"introspection"}} {
         catch {$c2 close}
     }
 
+    # Test CLIENT LIST with NOT-NAME filter
+    test {CLIENT LIST with NOT-NAME filter} {
+        r client setname mytestclient
+        set c1 [valkey_client]
+        $c1 client setname client1
+        set cl [r client list not-name mytestclient]
+        assert_match "*name=client1*" $cl
+        assert_no_match "*name=mytestclient*" $cl
+        catch {$c1 close}
+    }
+
+    # Test CLIENT LIST with NOT-FLAGS filter
+    test {CLIENT LIST with NOT-FLAGS filter} {
+        set c1 [valkey_client]
+        $c1 readonly
+        set cl [r client list not-flags N]
+        assert_match "*flags=r*" $cl
+        assert_no_match "*flags=N*" $cl
+        catch {$c1 close}
+    }
+
+    # Test CLIENT LIST with NOT-TYPE filter
+    test {CLIENT LIST with NOT-TYPE filter} {
+        r client setname mytestclient
+        set c1 [valkey_client]
+        $c1 client setname client1
+        $c1 subscribe x
+        set cl [r client list not-type normal]
+        assert_match "*name=client1*" $cl
+        assert_no_match "*name=mytestclient*" $cl
+        catch {$c1 close}
+    }
+
+    # Test CLIENT LIST with multiple negative filters
+    test {CLIENT LIST with multiple negative filters} {
+        r client setname mytestclient
+        set client_info [r client info]
+        set fields [split $client_info " "]
+        foreach pair $fields {
+            lassign [split $pair "="] key val
+            if {$key eq "id"} { set myid $val }
+            if {$key eq "name"} { set myname $val }
+        }
+
+        set c1 [valkey_client]
+        $c1 client setname client1
+
+        set cl [r client list not-id $myid not-name $myname]
+
+        assert_match "*name=client1*" $cl
+        assert_no_match "*name=mytestclient*" $cl
+        catch {$c1 close}
+    }
+
+    test {CLIENT LIST with multiple negative filters} {
+        # Create multiple clients with different names and flags
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+        set c3 [valkey_client]
+        $c1 client setname client1
+        $c2 client setname client1
+        $c3 client setname client2
+        $c3 multi
+
+        # Wait 1 second to ensure idle time
+        after 1000  ;
+
+        # Fetch the client list filtered by name and not-flags
+        set cl [split [r client list name client1 not-flags x] "\r\n"]
+
+        # Assert the clients returned match the filters
+        foreach line $cl {
+            regexp {name=([^ ]+) .* flags=([^ ]+)} $line _ actual_name flags
+            assert {[string match *client1* $actual_name] || [string match *client2* $actual_name]}
+            assert {[string match *N* $flags]}
+        }
+
+        # Close clients
+        $c1 close
+        $c2 close
+        $c3 close
+    }
+
+    test {CLIENT LIST with NOT-IP filter} {
+        r client setname "not-ip"
+
+        set client_info [r client info]
+        regexp {addr=([^:]+):} $client_info -> not_ip
+
+        # Use the extracted IP for filtering.
+        r client list not-ip $not_ip
+    } {}
+
+    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+        test {CLIENT LIST with IPv6 negative filter} {
+            set c [valkey ::1 [srv 0 port] 0 $::tls]
+            $c client setname "client-ipv6"
+
+            set client_info [$c client info]
+
+            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+            set filtered [$c client list not-ip $ipv6only]
+            assert_equal {} $filtered
+
+            $c close
+        }
+    }
+
+    test {CLIENT LIST with NOT-CAPA filter} {
+        r client setname mytestclient
+        set c1 [valkey_client]
+        $c1 client setname client-with-r
+        $c1 client capa redirect
+        set cl [r client list not-capa r]
+        assert_match "*name=mytestclient*" $cl
+        assert_no_match "*name=client-with-r*" $cl
+        catch {$c1 close}
+    }
+
+    test {CLIENT KILL with NOT-IP filter} {
+        set c1 [valkey_client]
+        $c1 client setname "killme-not-ip"
+        r client setname "client-normal"
+
+        # Kill client by NOT-IP
+        r client kill not-ip "1.2.3.4" skipme yes
+
+        assert_error "*I/O error*" {$c1 ping}
+        catch {$c1 close}
+
+        set cl [r client list]
+        assert_match "*name=client-normal*" $cl
+        assert_no_match "*name=killme-not-ip*" $cl
+    }
+
+    test {CLIENT KILL with NOT-CAPA filter} {
+        set c1 [valkey_client]
+        $c1 client setname "killme-not-capa"
+        r client setname "client-normal"
+
+        # Kill using not-capa filter
+        r client kill not-capa r skipme yes
+
+        assert_error "*I/O error*" {$c1 ping}
+        catch {$c1 close}
+
+        set cl [r client list]
+        assert_match "*name=client-normal*" $cl
+        assert_no_match "*name=killme-not-capa*" $cl
+    }
+
+    test {CLIENT KILL with NOT-NAME filter} {
+        r client setname "client-normal"
+        # Create a client and set its name
+        set c1 [valkey_client]
+        $c1 client setname "killme-not-name"
+
+        # Kill the client by not-name
+        r client kill not-name client-normal
+
+        # Assert the client was killed
+        assert_error "*I/O error*" {$c1 ping}
+        catch {$c1 close}
+
+        set cl [r client list]
+        assert_match "*name=client-normal*" $cl
+        assert_no_match "*name=killme-not-name*" $cl
+    }
+
+    test {CLIENT KILL with NOT-FLAGS filter} {
+        r client setname "client-normal"
+        # Create a client and set its name
+        set c1 [valkey_client]
+        $c1 client setname "killme-not-flags"
+        $c1 readonly
+
+        # Kill the client by not-flag
+        r client kill not-flags N
+
+        # Assert the client was killed
+        assert_error "*I/O error*" {$c1 ping}
+        catch {$c1 close}
+
+        set cl [r client list]
+        assert_match "*name=client-normal*" $cl
+        assert_no_match "*name=killme-not-flags*" $cl
+    }
+
+    test {CLIENT KILL with NOT-TYPE filter} {
+        r client setname "client-normal"
+        # Create a client
+        set c1 [valkey_client]
+        $c1 client setname "killme-not-type"
+        $c1 subscribe x
+
+        # Kill the client by not-type
+        r client kill not-type normal
+
+        # Assert the client was killed
+        assert_error "*I/O error*" {$c1 ping}
+        catch {$c1 close}
+
+        set cl [r client list]
+        assert_match "*name=client-normal*" $cl
+        assert_no_match "*name=killme-not-type*" $cl
+    }
+
+    test {CLIENT KILL with multiple negative filters} {
+        # Create two clients
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+        $c1 client setname client1
+        $c2 client setname client2
+
+        # Kill the client with not-name and not-flag filters
+        r client kill not-name client2 not-flags x
+
+        # Assert client1 was killed
+        set err1 [catch {$c1 ping} error_message1]
+        assert {$err1 == 1}
+        assert {[string match "*I/O error*" $error_message1]}
+
+        # Assert client2 is still alive
+        assert {[catch {$c2 ping}] == 0}
+
+        # Cleanup
+        catch {$c2 close}
+    }
+
+    test {CLIENT KILL with multiple negative filters including idle time} {
+        # Create two clients
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+        $c1 client setname client1
+        $c2 client setname client2
+
+        # Wait 1 second to ensure idle time
+        after 1000 ;# Wait 1 second
+
+        # Kill the client with not-name and not-idle filters
+        r client kill not-name client2 not-idle 10
+
+        # Assert client1 was killed
+        set err1 [catch {$c1 ping} error_message1]
+        assert {$err1 == 1}
+        assert {[string match "*I/O error*" $error_message1]}
+
+        # Assert client2 is still alive
+        assert {[catch {$c2 ping}] == 0}
+
+        # Cleanup
+        catch {$c2 close}
+    }
+
     test {CLIENT LIST with illegal arguments} {
         assert_error "ERR syntax error" {r client list id 10 wrong_arg}
 
@@ -396,6 +652,20 @@ start_server {tags {"introspection"}} {
         assert_error "ERR *not an integer or out of range*" {r client list maxage str}
         assert_error "ERR *not an integer or out of range*" {r client list maxage 9999999999999999999}
         assert_error "ERR *greater than 0*" {r client list maxage -1}
+
+        assert_error "ERR syntax error" {r client list not-id 10 wrong_arg}
+
+        assert_error "ERR syntax error" {r client list not-id str}
+        assert_error "ERR *greater than 0*" {r client list not-id -1}
+        assert_error "ERR *greater than 0*" {r client list not-id 0}
+
+        assert_error "ERR Unknown client type*" {r client list not-type wrong_type}
+
+        assert_error "ERR No such user*" {r client list not-user wrong_user}
+
+        assert_error "ERR *not an integer or out of range*" {r client list not-maxage str}
+        assert_error "ERR *not an integer or out of range*" {r client list not-maxage 9999999999999999999}
+        assert_error "ERR *greater than 0*" {r client list not-maxage -1}
     }
 
     proc get_field_in_client_info {info field} {
@@ -1337,6 +1607,8 @@ start_server {tags {"introspection"}} {
     } {} {external:skip}
 
     test {CLIENT KILL can filter by LIB-NAME} {
+        r client setinfo lib-name ""
+        r client setinfo lib-ver ""
         set c1 [valkey_client]
         set c2 [valkey_client]
 
@@ -1355,6 +1627,58 @@ start_server {tags {"introspection"}} {
 
         $c1 client setinfo lib-ver 1.2.3
         $c2 client kill lib-ver 1.2.3
+
+        set result [$c2 client list]
+        assert {[string match {*lib-ver=1.2.3*} $result] == 0}
+
+        catch {$c2 close}
+    }
+
+    test {CLIENT LIST can filter by NOT-LIB-NAME} {
+        r CLIENT SETINFO lib-name mylib
+        r client list not-lib-name mylib
+    } {}
+
+    test {CLIENT LIST can filter by NOT-LIB-VER} {
+        r CLIENT SETINFO lib-ver 1.2.3
+        r client list not-lib-ver 1.2.3
+    } {}
+
+    test {CLIENT LIST can filter by NOT-DB number} {
+        r select 2
+        r client list not-db 2
+    } {} {external:skip}
+
+    test {CLIENT KILL can filter by NOT-DB} {
+        set c1 [valkey_client]
+
+        $c1 select 2
+        r select 0
+
+        r client kill not-db 0
+
+        assert {[string match "*db=2*" [r client list]] == 0}
+    } {} {external:skip}
+
+    test {CLIENT KILL can filter by NOT-LIB-NAME} {
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+
+        $c1 client setinfo lib-name mylib
+        $c2 client kill not-lib-name not-mylib
+
+        set result [$c2 client list]
+        assert {[string match {*lib-name=mylib*} $result] == 0}
+
+        catch {$c2 close}
+    }
+
+    test {CLIENT KILL can filter by NOT-LIB-VER} {
+        set c1 [valkey_client]
+        set c2 [valkey_client]
+
+        $c1 client setinfo lib-ver 1.2.3
+        $c2 client kill not-lib-ver 0.0.0
 
         set result [$c2 client list]
         assert {[string match {*lib-ver=1.2.3*} $result] == 0}


### PR DESCRIPTION
introduce negative filters for `CLIENT LIST` and `CLIENT KILL` commands:

1. `NOT-ID`: Excludes clients in the IDs set
2. `NOT-TYPE`: Excludes clients of the specified type
3. `NOT-ADDR`: Excludes clients of the specified address and port
4. `NOT-LADDR`: Excludes clients connected to the specified local address and port
5. `NOT-USER`: Excludes clients of the specified user
6. `NOT-FLAGS`: Excludes clients with the specified flag string
7. `NOT-NAME`: Excludes clients with the specified name
8. `NOT-LIB-NAME`: Excludes clients using the specified library name
9. `NOT-LIB-VER`: Excludes clients with the specified library version
10. `NOT-DB`: Excludes clients with the specified database ID
11. `NOT-CAPA`: Excludes clients with the specified capabilities
12. `NOT-IP`: Excludes clients with the specified IP address

close #1936

and fix the matching algorithm for flag 'N'.