### PR TITLE
Initialize rdbstate.key_type to -1 at the beginning

### DIFF
--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -866,6 +866,7 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
     gettimeofday(&tv, NULL);
     init_genrand64(((long long)tv.tv_sec * 1000000 + tv.tv_usec) ^ getpid());
 
+    rdbstate.key_type = -1;
     rdbstate.stats = initRdbStats(OBJ_TYPE_MAX);
     rdbstate.stats_num = OBJ_TYPE_MAX;
     rdbstate.databases = 1;


### PR DESCRIPTION
Otherwise this would result in a bad (key_type == 0) key type
information printing misleading error messages if there are
errors when processing other RDB_OPCODE_* type:
```
[offset 96] Unexpected EOF reading RDB file
[additional info] While doing: read-len
[additional info] Reading type 0 (string)
```