### PR TITLE
Fix check-rdb --stats crash with empty RDB

### DIFF
--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -868,7 +868,7 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp) {
 
     rdbstate.stats = initRdbStats(OBJ_TYPE_MAX);
     rdbstate.stats_num = OBJ_TYPE_MAX;
-    rdbstate.databases = 1;
+    rdbstate.databases = 0;
     rdbstate.functions_num = 0;
     rdbstate.lua_scripts = 0;
 

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -4,6 +4,21 @@ proc get_function_code {args} {
 
 tags {"check-rdb network external:skip logreqres:skip"} {
     start_server {} {
+        test "test valkey-check-rdb stats with empty RDB" {
+            r flushall
+            r save
+            set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
+            catch {
+                exec src/valkey-check-rdb $dump_rdb --stats --format info
+            } result
+            assert_match "*db.0.type.string.keys.total:0*" $result
+            assert_match "*db.0.type.list.keys.total:0*" $result
+            assert_match "*db.0.type.set.keys.total:0*" $result
+            assert_match "*db.0.type.zset.keys.total:0*" $result
+            assert_match "*db.0.type.hash.keys.total:0*" $result
+            assert_match "*db.0.type.stream.keys.total:0*" $result
+        }
+
         test "test valkey-check-rdb stats function" {
             set function_num 11
             for {set i 0} {$i < $function_num} {incr i} {


### PR DESCRIPTION
There are two problems with initializing databases to 1:
1. db0 is used by default. After printing db0, we will additionally print
   db1 with no reason.
2. Based on 1, if the RDB is an empty RDB, check-rdb will crash. Because
   there is no key data, we don't have the chance to call tryExpandRdbStats,
   and then when printting db1, we will crash on rdbstate.stats.

Introduced in #1743.