### PR TITLE
Fix dual-channel-replication test due to typo error and stabilize it

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1310,7 +1310,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         } else {
             $primary config set repl-timeout 10
             $replica config set repl-timeout 10
-            set max_tries 500
+            set max_tries 1000
         }
 
         test "Replica notice main-connection killed during rdb load callback" {; # https://github.com/valkey-io/valkey/issues/1152

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1298,10 +1298,11 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set replica_host [srv 0 host]
         set replica_port [srv 0 port]
         set replica_log [srv 0 stdout]
-        
+
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
         $replica config set repl-diskless-load flush-before-load
+        $replica config set loading-process-events-interval-bytes 1024
 
         if {$::valgrind} {
             $primary config set repl-timeout 100

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1291,7 +1291,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
     # Generating RDB will take 100 sec to generate
     $primary debug populate 1000000 primary 1
-    $primary config set rdb-key-save-delay -10
+    $primary config set rdb-key-save-delay 10
     
     start_server {} {
         set replica [srv 0 client]


### PR DESCRIPTION
It should not be a negative value, otherwise we lose the
meaning of delay and the rdb generation may finish too fast
in a fast machine and cause the test to fail.

Also, the max_tries number is increased and the
loading-process-events-interval-bytes is adjusted so that the
replica has more opportunities to process the events and can
be aware of the disconnection.