### PR TITLE
Remove the unused value duplicate API from dict of libvalkey

### DIFF
--- a/deps/libvalkey/src/dict.c
+++ b/deps/libvalkey/src/dict.c
@@ -289,10 +289,8 @@ void dictSetKey(dict *d, dictEntry *de, void *key) {
 }
 
 void dictSetVal(dict *d, dictEntry *de, void *val) {
-    if (d->type->valDup)
-        de->val = d->type->valDup(val);
-    else
-        de->val = val;
+    UNUSED(d);
+    de->val = val;
 }
 
 void *dictGetKey(const dictEntry *de) {

--- a/deps/libvalkey/src/dict.h
+++ b/deps/libvalkey/src/dict.h
@@ -46,7 +46,6 @@ typedef struct dictEntry dictEntry; /* opaque */
 typedef struct dictType {
     uint64_t (*hashFunction)(const void *key);
     void *(*keyDup)(const void *key);
-    void *(*valDup)(const void *obj);
     int (*keyCompare)(const void *key1, const void *key2);
     void (*keyDestructor)(void *key);
     void (*valDestructor)(void *obj);


### PR DESCRIPTION
The commit (https://github.com/valkey-io/valkey/commit/0700c441c60dc150157a82af057e71b6a6234326) removes the unused value duplicate API from dict, and libvalkey's dict needs to remain consistent with it.