### PR TITLE
Add config for maximum random field count for HRANDFIELD/ZRANDMEMBER/SRANDMEMBER

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3344,6 +3344,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 10 * 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 10mb */
     createLongLongConfig("cluster-manual-failover-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.cluster_mf_timeout, 5000, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("max-rand-count", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX/2, server.max_rand_count, LONG_MAX/2, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),

--- a/src/config.c
+++ b/src/config.c
@@ -3344,7 +3344,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 10 * 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 10mb */
     createLongLongConfig("cluster-manual-failover-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.cluster_mf_timeout, 5000, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("max-rand-count", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX/2, server.max_rand_count, LONG_MAX/2, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("max-rand-count", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX / 2, server.max_rand_count, LONG_MAX / 2, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),

--- a/src/server.h
+++ b/src/server.h
@@ -1850,6 +1850,7 @@ struct valkeyServer {
                                                  invocation of the event loop. */
     unsigned int max_new_conns_per_cycle;     /* The maximum number of tcp connections that will be accepted during each
                                                  invocation of the event loop. */
+    long long max_rand_count;                 /* The maximum number of random values to retrieve. */
     /* AOF persistence */
     int aof_enabled;                    /* AOF configuration */
     int aof_state;                      /* AOF_(ON|OFF|WAIT_REWRITE) */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1316,16 +1316,13 @@ void hrandfieldCommand(client *c) {
     listpackEntry ele;
 
     if (c->argc >= 3) {
-        if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
-        if (l < -server.max_rand_count || l > server.max_rand_count) {
-            addReplyError(c, "value is out of range");
-            return;
-        }
+        if (getRangeLongFromObjectOrReply(c, c->argv[2], -server.max_rand_count, server.max_rand_count, &l, NULL) != C_OK) return;
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withvalues"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4)
+        } else if (c->argc == 4) {
             withvalues = 1;
+        }
         hrandfieldWithCountCommand(c, l, withvalues);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1317,16 +1317,14 @@ void hrandfieldCommand(client *c) {
 
     if (c->argc >= 3) {
         if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
+        if (l < -server.max_rand_count || l > server.max_rand_count) {
+            addReplyError(c, "value is out of range");
+            return;
+        }
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withvalues"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4) {
-            withvalues = 1;
-            if (l < -LONG_MAX / 2 || l > LONG_MAX / 2) {
-                addReplyError(c, "value is out of range");
-                return;
-            }
-        }
+        } else if (c->argc == 4) withvalues = 1;
         hrandfieldWithCountCommand(c, l, withvalues);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1324,7 +1324,8 @@ void hrandfieldCommand(client *c) {
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withvalues"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4) withvalues = 1;
+        } else if (c->argc == 4)
+            withvalues = 1;
         hrandfieldWithCountCommand(c, l, withvalues);
         return;
     }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1008,11 +1008,7 @@ void srandmemberWithCountCommand(client *c) {
     size_t len;
     int64_t llele;
 
-    if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
-    if (l < -server.max_rand_count || l > server.max_rand_count) {
-        addReplyError(c, "value is out of range");
-        return;
-    }
+    if (getRangeLongFromObjectOrReply(c, c->argv[2], -server.max_rand_count, server.max_rand_count, &l, NULL) != C_OK) return;
     if (l >= 0) {
         count = (unsigned long)l;
     } else {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1009,6 +1009,10 @@ void srandmemberWithCountCommand(client *c) {
     int64_t llele;
 
     if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
+    if (l < -server.max_rand_count || l > server.max_rand_count) {
+        addReplyError(c, "value is out of range");
+        return;
+    }
     if (l >= 0) {
         count = (unsigned long)l;
     } else {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4253,7 +4253,8 @@ void zrandmemberCommand(client *c) {
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withscores"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4) withscores = 1;
+        } else if (c->argc == 4)
+            withscores = 1;
         zrandmemberWithCountCommand(c, l, withscores);
         return;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4245,16 +4245,13 @@ void zrandmemberCommand(client *c) {
     listpackEntry ele;
 
     if (c->argc >= 3) {
-        if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
-        if (l < -server.max_rand_count || l > server.max_rand_count) {
-            addReplyError(c, "value is out of range");
-            return;
-        }
+        if (getRangeLongFromObjectOrReply(c, c->argv[2], -server.max_rand_count, server.max_rand_count, &l, NULL) != C_OK) return;
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withscores"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4)
+        } else if (c->argc == 4) {
             withscores = 1;
+        }
         zrandmemberWithCountCommand(c, l, withscores);
         return;
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4246,16 +4246,14 @@ void zrandmemberCommand(client *c) {
 
     if (c->argc >= 3) {
         if (getRangeLongFromObjectOrReply(c, c->argv[2], -LONG_MAX, LONG_MAX, &l, NULL) != C_OK) return;
+        if (l < -server.max_rand_count || l > server.max_rand_count) {
+            addReplyError(c, "value is out of range");
+            return;
+        }
         if (c->argc > 4 || (c->argc == 4 && strcasecmp(c->argv[3]->ptr, "withscores"))) {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
-        } else if (c->argc == 4) {
-            withscores = 1;
-            if (l < -LONG_MAX / 2 || l > LONG_MAX / 2) {
-                addReplyError(c, "value is out of range");
-                return;
-            }
-        }
+        } else if (c->argc == 4) withscores = 1;
         zrandmemberWithCountCommand(c, l, withscores);
         return;
     }

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -77,6 +77,28 @@ start_server {tags {"hash"}} {
         assert_error {*value is out of range*} {r hrandfield myhash -9223372036854775808 withvalues}
         assert_error {*value is out of range*} {r hrandfield myhash -9223372036854775808}
     } {}
+    
+    test "HRANDFIELD count max-rand-count config is handled correctly" {
+        r hmset testhash a 1 b 2
+        r config set max-rand-count 10
+
+        assert_error {*value is out of range*} {r hrandfield testhash 11}
+        assert_error {*value is out of range*} {r hrandfield testhash -11}
+        assert_error {*value is out of range*} {r hrandfield testhash 11 withvalues}
+        assert_error {*value is out of range*} {r hrandfield testhash -11 withvalues}
+
+        set res [r hrandfield testhash 10 withvalues]
+        assert_equal [llength $res] 4
+
+        set res [r hrandfield testhash -10 withvalues]
+        assert_equal [llength $res] 20
+        
+        set res [r hrandfield testhash 10]
+        assert_equal [llength $res] 2
+
+        set res [r hrandfield testhash -10]
+        assert_equal [llength $res] 10
+    }
 
     test "HRANDFIELD with <count> against non existing key" {
         r hrandfield nonexisting_key 100

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -80,6 +80,7 @@ start_server {tags {"hash"}} {
     
     test "HRANDFIELD count max-rand-count config is handled correctly" {
         r hmset testhash a 1 b 2
+        set orig_max_rand_count [lindex [r config get max-rand-count] 1]
         r config set max-rand-count 10
 
         assert_error {*value is out of range*} {r hrandfield testhash 11}
@@ -98,6 +99,8 @@ start_server {tags {"hash"}} {
 
         set res [r hrandfield testhash -10]
         assert_equal [llength $res] 10
+
+        r config set max-rand-count $orig_max_rand_count
     }
 
     test "HRANDFIELD with <count> against non existing key" {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -827,6 +827,20 @@ foreach type {single multiple single_multiple} {
         assert_error {*value is out of range*} {r srandmember myset -9223372036854775808}
     } {}
 
+    test "SRANDMEMBER count max-rand-count config is handled correctly" {
+        r sadd testset a b
+        r config set max-rand-count 10
+
+        assert_error {*value is out of range*} {r srandmember testset 11}
+        assert_error {*value is out of range*} {r srandmember testset -11}
+        
+        set res [r srandmember testset 10]
+        assert_equal [llength $res] 2
+
+        set res [r srandmember testset -10]
+        assert_equal [llength $res] 10
+    }
+
     # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -829,6 +829,7 @@ foreach type {single multiple single_multiple} {
 
     test "SRANDMEMBER count max-rand-count config is handled correctly" {
         r sadd testset a b
+        set orig_max_rand_count [lindex [r config get max-rand-count] 1]
         r config set max-rand-count 10
 
         assert_error {*value is out of range*} {r srandmember testset 11}
@@ -839,6 +840,8 @@ foreach type {single multiple single_multiple} {
 
         set res [r srandmember testset -10]
         assert_equal [llength $res] 10
+
+        r config set max-rand-count $orig_max_rand_count
     }
 
     # Make sure we can distinguish between an empty array and a null response

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2463,6 +2463,28 @@ start_server {tags {"zset"}} {
         assert_error {*value is out of range*} {r zrandmember myzset -9223372036854775808}
     } {}
 
+    test "ZRANDMEMBER count max-rand-count config is handled correctly" {
+        r zadd testzset 1 a 2 b
+        r config set max-rand-count 10
+
+        assert_error {*value is out of range*} {r zrandmember testzset 11}
+        assert_error {*value is out of range*} {r zrandmember testzset -11}
+        assert_error {*value is out of range*} {r zrandmember testzset 11 withscores}
+        assert_error {*value is out of range*} {r zrandmember testzset -11 withscores}
+
+        set res [r zrandmember testzset 10 withscores]
+        assert_equal [llength $res] 4
+
+        set res [r zrandmember testzset -10 withscores]
+        assert_equal [llength $res] 20
+        
+        set res [r zrandmember testzset 10]
+        assert_equal [llength $res] 2
+
+        set res [r zrandmember testzset -10]
+        assert_equal [llength $res] 10
+    }
+
     # Make sure we can distinguish between an empty array and a null response
     r readraw 1
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2465,6 +2465,7 @@ start_server {tags {"zset"}} {
 
     test "ZRANDMEMBER count max-rand-count config is handled correctly" {
         r zadd testzset 1 a 2 b
+        set orig_max_rand_count [lindex [r config get max-rand-count] 1]
         r config set max-rand-count 10
 
         assert_error {*value is out of range*} {r zrandmember testzset 11}
@@ -2483,6 +2484,8 @@ start_server {tags {"zset"}} {
 
         set res [r zrandmember testzset -10]
         assert_equal [llength $res] 10
+
+        r config set max-rand-count $orig_max_rand_count
     }
 
     # Make sure we can distinguish between an empty array and a null response


### PR DESCRIPTION
This PR is meant to resolve #844, I got inspiration from https://github.com/Snapchat/KeyDB/pull/639


**Description**

This PR adds a new configuration parameter max-rand-count to limit the maximum number of random elements that can be retrieved using the following commands:

- HRANDFIELD
- SRANDMEMBER
- ZRANDMEMBER

Changes include:

- Added new config parameter max-rand-count with default value of LONG_MAX/2
- Added validation checks in hash, set and zset random field commands
- Added corresponding test cases to verify the new configuration
- Error message "value is out of range" will be returned if count exceeds the configured limit

The default `max_rand_count` of `LONG_MAX/2` is because when using the `withscores` or `withvalues` arguments for `zrandmember` and `hrandfield`, the number of outputs will double. Meaning if a count of less than `-LONG_MAX/2` is entered, it causes the server to crash since it overflows. Either way though, from the issue it sounded like it's reasonable to expect the user to be able to call the command multiple times if they really need more values.