### PR TITLE
Update swapdb command comment to mention why cluster mode is not allowed

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1740,7 +1740,7 @@ void swapMainDbWithTempDb(serverDb **tempDb) {
 void swapdbCommand(client *c) {
     int id1, id2;
 
-    /* Not allowed in cluster mode: we have just DB 0 there. */
+    /* Not allowed in cluster mode: atomicity cross shards is challenging in cluster mode. */
     if (server.cluster_enabled) {
         addReplyError(c, "SWAPDB is not allowed in cluster mode");
         return;


### PR DESCRIPTION
The comment has been outdated since #1671, update it.