### PR TITLE
Cleanup and rename isExpiryTableValidForSamplingCb to expiryTableShouldSkipForSamplingCb

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -156,9 +156,9 @@ static inline int isExpiryTableValidForSamplingCb(hashtable *ht) {
      * space is expensive, so stop here waiting for better times...
      * The dictionary will be resized asap. */
     if (buckets > 0 && (numkeys * 100 / buckets < 1)) {
-        return C_ERR;
+        return 1;
     }
-    return C_OK;
+    return 0;
 }
 
 void activeExpireCycle(int type) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -149,7 +149,7 @@ void expireScanCallback(void *privdata, void *entry) {
     data->sampled++;
 }
 
-static inline int isExpiryTableValidForSamplingCb(hashtable *ht) {
+static inline int expiryTableShouldSkipForSamplingCb(hashtable *ht) {
     long long numkeys = hashtableSize(ht);
     unsigned long buckets = hashtableBuckets(ht);
     /* When there are less than 1% filled buckets, sampling the key
@@ -295,7 +295,7 @@ void activeExpireCycle(int type) {
 
             while (data.sampled < num && checked_buckets < max_buckets) {
                 db->expires_cursor = kvstoreScan(db->expires, db->expires_cursor, -1, expireScanCallback,
-                                                 isExpiryTableValidForSamplingCb, &data);
+                                                 expiryTableShouldSkipForSamplingCb, &data);
                 if (db->expires_cursor == 0) {
                     db_done = 1;
                     break;

--- a/src/expire.c
+++ b/src/expire.c
@@ -149,7 +149,7 @@ void expireScanCallback(void *privdata, void *entry) {
     data->sampled++;
 }
 
-static inline int expiryTableShouldSkipForSamplingCb(hashtable *ht) {
+static inline int expireShouldSkipTableForSamplingCb(hashtable *ht) {
     long long numkeys = hashtableSize(ht);
     unsigned long buckets = hashtableBuckets(ht);
     /* When there are less than 1% filled buckets, sampling the key
@@ -295,7 +295,7 @@ void activeExpireCycle(int type) {
 
             while (data.sampled < num && checked_buckets < max_buckets) {
                 db->expires_cursor = kvstoreScan(db->expires, db->expires_cursor, -1, expireScanCallback,
-                                                 expiryTableShouldSkipForSamplingCb, &data);
+                                                 expireShouldSkipTableForSamplingCb, &data);
                 if (db->expires_cursor == 0) {
                     db_done = 1;
                     break;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -363,7 +363,7 @@ size_t kvstoreMemUsage(kvstore *kvs) {
  * It's a three pronged approach.
  *
  * 1. It uses the provided cursor `cursor` to retrieve the hashtable index from it.
- * 2. If the hash table is in a valid state checked through the provided callback `hashtableScanValidFunction`,
+ * 2. If the hash table is in a valid state checked through the provided callback `kvstoreScanShouldSkipHashtable`,
  *    it performs a hashtableScan over the appropriate `keyType` hash table of `db`.
  * 3. If the hashtable is entirely scanned i.e. the cursor has reached 0, the next non empty hashtable is discovered.
  *    The hashtable information is embedded into the cursor and returned.

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -8,7 +8,9 @@ typedef struct _kvstore kvstore;
 typedef struct _kvstoreIterator kvstoreIterator;
 typedef struct _kvstoreHashtableIterator kvstoreHashtableIterator;
 
+/* Return 1 if we should skip the hashtable in scan. */
 typedef int(kvstoreScanShouldSkipHashtable)(hashtable *d);
+/* Return 1 if we should skip the hashtable in expand. */
 typedef int(kvstoreExpandShouldSkipHashtableIndex)(int didx);
 
 #define KVSTORE_ALLOCATE_HASHTABLES_ON_DEMAND (1 << 0)


### PR DESCRIPTION
We used to return C_ERR (-1) or C_OK (0), it was not that bool.
usage: int skip = !ht || (skip_cb && skip_cb(ht));

Also isExpiryTableValidForSamplingCb is actually a skip cp, rename
it to expireShouldSkipTableForSamplingCb for a better reading.