### PR TITLE
Rename trace bgsave type to rdb and aof

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -106,12 +106,12 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/lua/engine_lua.c
     ${CMAKE_SOURCE_DIR}/src/lua/debug_lua.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace.c
+    ${CMAKE_SOURCE_DIR}/src/trace/trace_rdb.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_aof.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_commands.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_db.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_cluster.c
     ${CMAKE_SOURCE_DIR}/src/trace/trace_server.c
-    ${CMAKE_SOURCE_DIR}/src/trace/trace_bgsave.c
     ${CMAKE_SOURCE_DIR}/src/commands.c
     ${CMAKE_SOURCE_DIR}/src/strl.c
     ${CMAKE_SOURCE_DIR}/src/connection.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -422,7 +422,7 @@ endif
 ENGINE_NAME=valkey
 SERVER_NAME=$(ENGINE_NAME)-server$(PROG_SUFFIX)
 ENGINE_SENTINEL_NAME=$(ENGINE_NAME)-sentinel$(PROG_SUFFIX)
-ENGINE_TRACE_OBJ=trace/trace.o trace/trace_commands.o trace/trace_db.o trace/trace_bgsave.o trace/trace_cluster.o trace/trace_server.o trace/trace_aof.o
+ENGINE_TRACE_OBJ=trace/trace.o trace/trace_commands.o trace/trace_db.o trace/trace_cluster.o trace/trace_server.o trace/trace_rdb.o trace/trace_aof.o
 ENGINE_SERVER_OBJ=threads_mngr.o adlist.o vector.o quicklist.o ae.o anet.o dict.o hashtable.o kvstore.o server.o sds.o zmalloc.o lzf_c.o lzf_d.o pqsort.o zipmap.o sha1.o ziplist.o release.o memory_prefetch.o io_threads.o networking.o util.o object.o db.o replication.o rdb.o t_string.o t_list.o t_set.o t_zset.o t_hash.o config.o aof.o pubsub.o multi.o debug.o sort.o intset.o syncio.o cluster.o cluster_legacy.o cluster_slot_stats.o crc16.o endianconv.o commandlog.o eval.o bio.o rio.o rand.o memtest.o syscheck.o crcspeed.o crccombine.o crc64.o bitops.o sentinel.o notify.o setproctitle.o blocked.o hyperloglog.o latency.o sparkline.o valkey-check-rdb.o valkey-check-aof.o geo.o lazyfree.o module.o evict.o expire.o geohash.o geohash_helper.o childinfo.o allocator_defrag.o defrag.o siphash.o rax.o t_stream.o listpack.o localtime.o lolwut.o lolwut5.o lolwut6.o acl.o tracking.o socket.o tls.o sha256.o timeout.o setcpuaffinity.o monotonic.o mt19937-64.o resp_parser.o call_reply.o script.o functions.o commands.o strl.o connection.o unix.o logreqres.o rdma.o scripting_engine.o lua/script_lua.o lua/function_lua.o lua/engine_lua.o lua/debug_lua.o
 ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3485,7 +3485,7 @@ static void backgroundSaveDoneHandlerDisk(int exitcode, int bysignal, time_t sav
         rdbRemoveTempFile(server.child_pid, 0);
         latencyEndMonitor(latency);
         latencyAddSampleIfNeeded("rdb-unlink-temp-file", latency);
-        latencyTraceIfNeeded(bgsave, rdb_unlink_temp_file, latency);
+        latencyTraceIfNeeded(rdb, rdb_unlink_temp_file, latency);
         /* SIGUSR1 is whitelisted, so we have a way to kill a child without
          * triggering an error condition. */
         if (bysignal != SIGUSR1) server.lastbgsave_status = C_ERR;

--- a/src/server.c
+++ b/src/server.c
@@ -6683,7 +6683,11 @@ int serverFork(int purpose) {
         server.stat_fork_rate =
             (double)zmalloc_used_memory() * 1000000 / server.stat_fork_time / (1024 * 1024 * 1024); /* GB per second. */
         latencyAddSampleIfNeeded("fork", server.stat_fork_time);
-        latencyTraceIfNeeded(bgsave, fork, server.stat_fork_time);
+        if (purpose == CHILD_TYPE_RDB) {
+            latencyTraceIfNeeded(rdb, fork, server.stat_fork_time);
+        } else if (purpose == CHILD_TYPE_AOF) {
+            latencyTraceIfNeeded(aof, fork, server.stat_fork_time);
+        }
 
         /* The child_pid and child_type are only for mutually exclusive children.
          * other child types should handle and store their pid's in dedicated variables.

--- a/src/trace/README.md
+++ b/src/trace/README.md
@@ -12,12 +12,11 @@ To install LTTng on your Linux system, follow the instructions provided in the [
 
 #### [Ubuntu](https://lttng.org/docs/v2.13/#doc-ubuntu)
 
-LTTng 2.13 is available on Ubuntu 22.04 LTS ​*Jammy Jellyfish*​, Ubuntu 23.04 ​*Lunar Lobster*​, and Ubuntu 23.10 ​*Mantic Minotaur*​. For previous supported releases of Ubuntu, [use the LTTng Stable 2.13 PPA](https://lttng.org/docs/v2.13/#doc-ubuntu-ppa).
+LTTng 2.13 is available on Ubuntu 22.04 LTS *Jammy Jellyfish*, Ubuntu 23.04 *Lunar Lobster*, and Ubuntu 23.10 *Mantic Minotaur*. For previous supported releases of Ubuntu, [use the LTTng Stable 2.13 PPA](https://lttng.org/docs/v2.13/#doc-ubuntu-ppa).
 
-To install LTTng 2.13 on Ubuntu 22.04 LTS ​*Jammy Jellyfish*​:
+To install LTTng 2.13 on Ubuntu 22.04 LTS *Jammy Jellyfish*:
 
 1. Install the main LTTng 2.13 packages:
-   
    ```
    apt-get install lttng-tools
    apt-get install lttng-modules-dkms
@@ -26,7 +25,7 @@ To install LTTng 2.13 on Ubuntu 22.04 LTS ​*Jammy Jellyfish*​:
 
 #### [Debian](https://lttng.org/docs/v2.13/#doc-debian)
 
-To install LTTng 2.13 on Debian 12 ​*bookworm*​:
+To install LTTng 2.13 on Debian 12 *bookworm*:
 
 1. Install the main LTTng 2.13 packages:
    ```
@@ -50,6 +49,7 @@ Enable lttng trace events dynamically:
 ~# lttng destroy valkey
 ~# lttng create valkey
 ~# lttng enable-event -u 'valkey_server:*'
+~# lttng enable-event -u 'valkey_commands:*'
 ~# lttng track -u -p `pidof valkey-server`
 ~# lttng start
 ~# lttng stop
@@ -59,14 +59,14 @@ Enable lttng trace events dynamically:
 Examples (a client run 'SET', another run 'keys'):
 ```
 ...
-[15:30:19.334467738] (+0.000001222) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
-[15:30:19.334469105] (+0.000001367) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
-[15:30:19.334470327] (+0.000001222) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
-[15:30:19.369348485] (+0.034878158) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "keys", duration = 34874 }
-[15:30:19.369698322] (+0.000349837) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 4 }
-[15:30:19.369702327] (+0.000004005) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 2 }
-[15:30:19.369704098] (+0.000001771) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
-[15:30:19.369705884] (+0.000001786) libai valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.334467738] (+0.000001222) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.334469105] (+0.000001367) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.334470327] (+0.000001222) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
+[15:30:19.369348485] (+0.034878158) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "keys", duration = 34874 }
+[15:30:19.369698322] (+0.000349837) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 4 }
+[15:30:19.369702327] (+0.000004005) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 2 }
+[15:30:19.369704098] (+0.000001771) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 1 }
+[15:30:19.369705884] (+0.000001786) xxx valkey_commands:command_call: { cpu_id = 15 }, { name = "set", duration = 0 }
 ...
 ```
 
@@ -82,31 +82,37 @@ Generally valkey-server would not run in full utilization, the overhead is accep
 
 ## Supported Events
 
-| event                      | provider          |
-| -------------------------- | ----------------- |
-| command_call               | valkey_commands   |
-| rdb_unlink_temp_file       | valkey_bgsave     |
-| fork                       | valkey_bgsave     |
-| while_blocked_cron         | valkey_server     |
-| module_acquire_gil         | valkey_server     |
-| command_unblocking         | valkey_server     |
-| expire_del                 | valkey_db         |
-| active_defrag_cycle        | valkey_db         |
-| eviction_del               | valkey_db         |
-| eviction_lazyfree          | valkey_db         |
-| eviction_cycle             | valkey_db         |
-| expire_cycle               | valkey_db         |
-| cluster_config_open        | valkey_cluster    |
-| cluster_config_write       | valkey_cluster    |
-| cluster_config_fsync       | valkey_cluster    |
-| cluster_config_rename      | valkey_cluster    |
-| cluster_config_dir_fsync   | valkey_cluster    |
-| cluster_config_close       | valkey_cluster    |
-| cluster_config_unlink      | valkey_cluster    |
-| aof_write_pending_fsync    | valkey_aof        |
-| aof_write_active_child     | valkey_aof        |
-| aof_write_alone            | valkey_aof        |
-| aof_write                  | valkey_aof        |
-| aof_fsync_always           | valkey_aof        |
-| aof_fstat                  | valkey_aof        |
-| aof_rename                 | valkey_aof        |
+| event                    | provider        |
+|--------------------------|-----------------|
+| command_call             | valkey_commands |
+| eventloop                | valkey_server   |
+| eventloop_cron           | valkey_server   |
+| while_blocked_cron       | valkey_server   |
+| module_acquire_gil       | valkey_server   |
+| command_unblocking       | valkey_server   |
+| fast_command             | valkey_server   |
+| command                  | valkey_server   |
+| expire_del               | valkey_db       |
+| active_defrag_cycle      | valkey_db       |
+| eviction_del             | valkey_db       |
+| eviction_lazyfree        | valkey_db       |
+| eviction_cycle           | valkey_db       |
+| expire_cycle             | valkey_db       |
+| cluster_config_open      | valkey_cluster  |
+| cluster_config_write     | valkey_cluster  |
+| cluster_config_fsync     | valkey_cluster  |
+| cluster_config_rename    | valkey_cluster  |
+| cluster_config_dir_fsync | valkey_cluster  |
+| cluster_config_close     | valkey_cluster  |
+| cluster_config_unlink    | valkey_cluster  |
+| fork                     | valkey_rdb      |
+| rdb_unlink_temp_file     | valkey_rdb      |
+| fork                     | valkey_aof      |
+| aof_write_pending_fsync  | valkey_aof      |
+| aof_write_active_child   | valkey_aof      |
+| aof_write_alone          | valkey_aof      |
+| aof_write                | valkey_aof      |
+| aof_fsync_always         | valkey_aof      |
+| aof_fstat                | valkey_aof      |
+| aof_rename               | valkey_aof      |
+| aof_flush                | valkey_aof      |

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -21,7 +21,7 @@
 #include "trace_cluster.h"
 #include "trace_server.h"
 #include "trace_db.h"
-#include "trace_bgsave.h"
+#include "trace_rdb.h"
 #include "trace_commands.h"
 
 #ifdef USE_LTTNG

--- a/src/trace/trace_aof.h
+++ b/src/trace/trace_aof.h
@@ -47,6 +47,16 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_class, valkey_aof, fork,
+
+    /* List of tracepoint arguments (input) */
+    LTTNG_UST_TP_ARGS(
+      uint64_t, duration
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    /* Name of the tracepoint class provider */
     valkey_aof, valkey_aof_class, valkey_aof, aof_write_pending_fsync,
 
     /* List of tracepoint arguments (input) */

--- a/src/trace/trace_rdb.c
+++ b/src/trace/trace_rdb.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 /* ==========================================================================
- * trace_sys.c - support lttng tracing for system events.
+ * trace_rdb.c - support lttng tracing for rdb events.
  * --------------------------------------------------------------------------
  * Copyright (C) 2025  zhenwei pi <zhenwei.pi@linux.dev>
  * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
@@ -17,4 +17,4 @@
 #define LTTNG_UST_TRACEPOINT_CREATE_PROBES
 #define LTTNG_UST_TRACEPOINT_DEFINE
 
-#include "trace_bgsave.h"
+#include "trace_rdb.h"

--- a/src/trace/trace_rdb.h
+++ b/src/trace/trace_rdb.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 /* ==========================================================================
- * trace_bgsave.h - support lttng tracing for background Save.
+ * trace_rdb.h - support lttng tracing for rdb events.
  * --------------------------------------------------------------------------
  * Copyright (C) 2025  zhenwei pi <zhenwei.pi@linux.dev>
  * Copyright (C) 2025  zhiqiang li <lizhiqiang.sf@bytedance.com>
@@ -17,10 +17,10 @@
 #ifdef USE_LTTNG
 
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
-#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_bgsave
+#define LTTNG_UST_TRACEPOINT_PROVIDER valkey_rdb
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
-#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_bgsave.h"
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_rdb.h"
 
 #if !defined(__VALKEY_TRACE_SYS_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
 #define __VALKEY_TRACE_SYS_H__
@@ -29,10 +29,10 @@
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
     /* Tracepoint class provider name */
-    valkey_bgsave,
+    valkey_rdb,
 
     /* Tracepoint class name */
-    valkey_bgsave_class,
+    valkey_rdb_class,
 
     /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
@@ -47,7 +47,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     /* Name of the tracepoint class provider */
-    valkey_bgsave, valkey_bgsave_class, valkey_bgsave, fork,
+    valkey_rdb, valkey_rdb_class, valkey_rdb, fork,
 
     /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
@@ -57,7 +57,7 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     /* Name of the tracepoint class provider */
-    valkey_bgsave, valkey_bgsave_class, valkey_bgsave, rdb_unlink_temp_file,
+    valkey_rdb, valkey_rdb_class, valkey_rdb, rdb_unlink_temp_file,
 
     /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
@@ -65,7 +65,7 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     )
 )
 
-#define valkey_bgsave_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
+#define valkey_rdb_trace(...) lttng_ust_tracepoint(__VA_ARGS__)
 
 #endif /* __VALKEY_TRACE_SYS_H__ */
 
@@ -77,10 +77,10 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 #define __VALKEY_TRACE_SYS_H__
 
 /* avoid compiler warning on empty source file */
-static inline void __valkey_bgsave_trace(void) {
+static inline void __valkey_rdb_trace(void) {
 }
 
-#define valkey_bgsave_trace(...) \
+#define valkey_rdb_trace(...) \
     do {                     \
     } while (0)
 


### PR DESCRIPTION
Previously, we called it the bgsave type, and it had two
events: rdb_unlink_temp_file and fork. However, the code
actually counts all forks as part of the bgsave type, such
as aof fork and module fork.

In this commit, the bgsave type was renamed to rdb type,
to align with the aof type, also adding the aof fork event.

Also doing some cleanup around the README file.
See #2070 for mode details.