### PR TITLE
Update check times for AOF loading in memefficiency.tcl

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -308,7 +308,7 @@ run_solo {defrag} {
                 # Make sure we had defrag hits during AOF loading.  Note that we don't worry about
                 # the actual fragmentation ratio here.  It will vary based on when defrag stopped
                 # mid-cycle.  Just check that we are defragging by the number of hits.
-                assert {[s active_defrag_hits] > 100000}
+                assert {[s active_defrag_hits] > 80000}
             }
             } ;# Active defrag - AOF loading
         }


### PR DESCRIPTION
Update check times from 100k to 80k for AOF loading. 

Reason: During AOF loading, we only hit 95k items rather than 100k in one defrag test

Defrag test: https://github.com/valkey-io/valkey/actions/runs/15452801881/job/43498734253?pr=2078#step:6:7047 (line 6157)