### PR TITLE
Attempt to fix flaky testRdb

### DIFF
--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -245,7 +245,7 @@ tags "modules" {
                             test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before} {
                                 # Wait for the replica to start reading the rdb and module for acknowledgement
                                 # We wanna abort only after the temp db was populated by REDISMODULE_AUX_BEFORE_RDB
-                                wait_for_condition 100 100 {
+                                wait_for_condition 200 100 {
                                     [s -1 async_loading] eq 1 && [$replica testrdb.async_loading.get.before] eq "value1_master"
                                 } else {
                                     fail "Module didn't receive or react to REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_STARTED"


### PR DESCRIPTION
In the daily runs, I saw macos-build failed for `testrdb.tcl`

```
 [err]: Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before in tests/unit/moduleapi/testrdb.tcl
Module didn't receive or react to REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_STARTED
[err]: Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: when loading aborted, can keep module variable same as before in tests/unit/moduleapi/testrdb.tcl
Expected '1010' to be equal to '200' (context: type source line 272 file /Users/runner/work/valkey/valkey/tests/unit/moduleapi/testrdb.tcl cmd {assert_equal [$replica dbsize] 200} proc ::test)
```

Link: https://github.com/valkey-io/valkey/actions/runs/16610259318/job/46991731591

I could pinpoint that the `wait_for_condition` would have timed out for the error. I was however unable to reproduce in the local mac, or [github macos runners](https://github.com/sarthakaggarwal97/valkey/actions/runs/16659569003/attempts/1) in my repo. I do feel we can increase the number of retries here and observe if it stabilizes the daily test. 

Please do let me know if this doesn't look like a valid fix or if there are any other ideas.