### PR TITLE
Add auto-author-assign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.1
+      - uses: toshimaru/auto-author-assign@16f0022cf3d7970c106d8d1105f75a1165edb516 # v2.1.1

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -2,7 +2,7 @@ name: Auto Author Assign
 
 on:
   pull_request_target:
-    types: [ opened, reopened ]
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write

--- a/README.md
+++ b/README.md
@@ -370,4 +370,3 @@ Wilmington, Delaware 19802-4447
 [1]: https://github.com/valkey-io/valkey/blob/unstable/COPYING
 [2]: https://github.com/valkey-io/valkey/blob/unstable/CONTRIBUTING.md
 [3]: https://github.com/valkey-io/valkey/blob/unstable/SECURITY.md
-

--- a/README.md
+++ b/README.md
@@ -370,3 +370,4 @@ Wilmington, Delaware 19802-4447
 [1]: https://github.com/valkey-io/valkey/blob/unstable/COPYING
 [2]: https://github.com/valkey-io/valkey/blob/unstable/CONTRIBUTING.md
 [3]: https://github.com/valkey-io/valkey/blob/unstable/SECURITY.md
+


### PR DESCRIPTION
Fixes #2372

## Description

This PR adds an automated workflow that assigns PR authors to their own pull requests when opened or reopened.

## Changes

- Added `.github/workflows/auto-author-assign.yml` workflow
- Uses `toshimaru/auto-author-assign@v2.1.1` action
- Triggers on `pull_request_target` events (opened, reopened)
- Requires `pull-requests: write` permission

## Benefits

- Improves PR tracking and organization
- Automatically assigns responsibility to PR authors
- Reduces manual assignment overhead for maintainers
- Helps contributors track their own PRs more easily

## Testing

✅ **Tested on my fork before submission:**

1. Merged the workflow into my fork's unstable branch
2. Created a test PR within my fork
3. Verified that I was automatically assigned as the assignee
4. Screenshot showing successful auto-assignment:
<img width="1278" height="684" alt="Screenshot 2025-08-01 at 3 39 05 PM" src="https://github.com/user-attachments/assets/9ad643be-5eac-4ad6-bec7-184cf22e9cbd" />

The workflow executed successfully and assigned me to the test PR as expected.
