### PR TITLE
Make ./runtest --dump-logs dump logs for timeout tests's servers

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -408,8 +408,8 @@ proc test_server_cron {} {
             }
         }
         show_clients_state
-        kill_clients
         force_kill_all_servers
+        kill_clients
         the_end
     }
 


### PR DESCRIPTION
Kill the servers first, then kill the test clients, so that we can dump logs for timeout tests's servers easily.
Note: Technically, we need to wait a while after killing the servers. But in practice I think it's enough now.