### PR TITLE
Add RDB Version to "INFO Server"

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -5768,6 +5768,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "redis_version:%s\r\n", REDIS_VERSION,
                 "server_name:%s\r\n", SERVER_NAME,
                 "valkey_version:%s\r\n", VALKEY_VERSION,
+                "rdb_version:%i\r\n", RDB_VERSION,
                 "valkey_release_stage:%s\r\n", VALKEY_RELEASE_STAGE,
                 "redis_git_sha1:%s\r\n", serverGitSHA1(),
                 "redis_git_dirty:%i\r\n", strtol(serverGitDirty(), NULL, 10) > 0,

--- a/tests/unit/info-command.tcl
+++ b/tests/unit/info-command.tcl
@@ -65,5 +65,9 @@ start_server {tags {"info and its relative command"}} {
         # check that we didn't get the same info twice
         assert { ![string match "*used_cpu_user_children*used_cpu_user_children*" $info] }
     }
-   
+
+    test {info server section contains rdb_version} {
+        set info [r info server]
+        assert { [string match "*rdb_version*" $info] }
+    }
 }


### PR DESCRIPTION
This Pull Request introduces a new field, `rdb_version`, to the `Server` section of the `INFO` command output. This enhancement provides immediate visibility into the RDB (Redis Database) file format version that the running Valkey instance is configured to use for persistence.

**Motivation:**
- Compatibility Checks: When migrating RDB files between different Valkey (or Redis) versions, knowing the RDB version helps in assessing compatibility and potential upgrade paths. This is particularly critical as Valkey evolves independently from Redis. Future changes in either project could lead to RDB format divergences, making it impossible for a Valkey instance to load an RDB generated by a newer Redis (or vice-versa) if their RDB versions are incompatible. Explicitly exposing rdb_version provides a clear indicator of this potential incompatibility, allowing for proactive measures before data migration or recovery attempts.

- Debugging and Troubleshooting: It aids in diagnosing issues related to persistence, especially when RDB files might be corrupted or generated by an unexpected version.

- Operational Awareness: Provides operators with a quick way to verify the RDB persistence configuration without inspecting configuration files or RDB dumps directly.


**Alternatives you've considered:**
- Placing it under the Persistence section: While RDB is a persistence mechanism, the file format version is a fundamental aspect of the server's capabilities, much like the server version itself. Placing` rdb_version` in the Server section would be consistent with how `valkey_version`, `gcc_version` , `arch_bits` and `os`  is handled.

**Test Results:**
```
127.0.0.1:6379> info
# Server
redis_version:7.2.4
server_name:valkey
valkey_version:255.255.255
rdb_version:11      <--------- It's Here
valkey_release_stage:dev
redis_git_sha1:8973cdf0
redis_git_dirty:1
redis_build_id:cbbabeab1d10ce2f
server_mode:standalone
os:Darwin 24.6.0 arm64
arch_bits:64
monotonic_clock:POSIX clock_gettime
multiplexing_api:kqueue
gcc_version:4.2.1
process_id:96627
process_supervised:no
run_id:6e9df8d6ccff9bd16f36082cb777dff3299113f0
tcp_port:6379
server_time_usec:1754183545609975
uptime_in_seconds:10
uptime_in_days:0
hz:10
configured_hz:10
clients_hz:10
lru_clock:9353081
executable:./src/valkey-server
config_file:
io_threads_active:0
availability_zone:
listener0:name=tcp,bind=*,bind=-::*,port=6379

```