### PR TITLE
Use unsigned long for `maxiterations`, fixing undefined behavior in scan with extremely large count

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1199,7 +1199,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
          * COUNT, so if the hash table is in a pathological state (very
          * sparsely populated) we avoid to block too much time at the cost
          * of returning no or very few elements. */
-        long maxiterations = count * 10;
+        unsigned long maxiterations = (unsigned long)count * 10UL;
 
         /* We pass scanData which have three pointers to the callback:
          * 1. data.keys: the list to which it will add new elements;


### PR DESCRIPTION
This one was found by [afl++](https://github.com/AFLplusplus/AFLplusplus). Executing `scan 0 count n` with a count that is within 10% of `LONG_MAX`, `count * 10` would cause `maxiterations` to overflow. This is technically not a real problem since the way `maxiterations` is used would eventually cause it to underflow back to `LONG_MAX` again and continue counting down from there but I figured we may want to fix this regardless for expected behavior correctness?