### PR TITLE
Increase TID count to accomodate valkey-search reader/writer pools

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1697,7 +1697,7 @@ static void setupStacktracePipe(void) { /* we don't need a pipe to write the sta
 #include <sys/syscall.h>
 #include <dirent.h>
 
-#define TIDS_MAX_SIZE 50
+#define TIDS_MAX_SIZE 150
 static size_t get_ready_to_signal_threads_tids(int sig_num, pid_t tids[TIDS_MAX_SIZE]);
 
 typedef struct {


### PR DESCRIPTION
The Search module creates one reader thread and one writer thread for each CPU. On large boxes (64 CPUS) the current number of TIDs are inadequate and could result in the loss of critical debugging information in the case of field failure.