### PR TITLE
Increase latency for big list test in defrag

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -172,6 +172,8 @@ run_solo {defrag} {
     #    while_defragging {code} - optional, code executed after defrag has started
     #    latency <ms> - optional, verifies the latency to a ms target (default 5)
     proc perform_defrag_test {name args} {
+        # This value should be 5 ms, but it was flaky in github runners. The issue 
+        # https://github.com/valkey-io/valkey/issues/2444 is tracking if we can raise the limit again.
         set opts(latency) 40
         set opts(while_defragging) {}
         array set opts $args

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -172,7 +172,7 @@ run_solo {defrag} {
     #    while_defragging {code} - optional, code executed after defrag has started
     #    latency <ms> - optional, verifies the latency to a ms target (default 5)
     proc perform_defrag_test {name args} {
-        set opts(latency) 5
+        set opts(latency) 40
         set opts(while_defragging) {}
         array set opts $args
         assert {[info exists opts(populate)]}
@@ -378,7 +378,7 @@ run_solo {defrag} {
             # number of total fields.  lists are progressively increasing sizes.
             set n 200000
 
-            perform_defrag_test $title latency 30 populate {
+            perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
                 set val [string repeat A 350]
                 set k 0

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -378,7 +378,7 @@ run_solo {defrag} {
             # number of total fields.  lists are progressively increasing sizes.
             set n 200000
 
-            perform_defrag_test $title populate {
+            perform_defrag_test $title latency 30 populate {
                 set rd [valkey_deferring_client]
                 set val [string repeat A 350]
                 set k 0


### PR DESCRIPTION
Across multiple runs of the big list test in defrag, the latency check is tripping because the maximum observed defrag cycle latency occasionally spikes above our 5 ms limit. While most cycles complete in just a few milliseconds, rare slowdowns push some cycles into the double digit millisecond range, so a 5 ms hard cap is too aggressive for stable testing.

```
/runtest --verbose --tls --single unit/memefficiency --only '/big list' --accurate --loop --fastfail
```

```
[err]: Active Defrag big list: standalone in tests/unit/memefficiency.tcl
Expected 12 <= 5 (context: type proc line 18 cmd {assert {$max_latency <= $limit_ms}} proc ::validate_latency level 1)
(Fast fail: test will exit now)

[err]: Active Defrag big list: standalone in tests/unit/memefficiency.tcl
Expected 21 <= 5 (context: type proc line 18 cmd {assert {$max_latency <= $limit_ms}} proc ::validate_latency level 1)
(Fast fail: test will exit now)

[err]: Active Defrag big list: standalone in tests/unit/memefficiency.tcl
Expected 25 <= 5 (context: type proc line 18 cmd {assert {$max_latency <= $limit_ms}} proc ::validate_latency level 1)
(Fast fail: test will exit now)

[err]: Active Defrag big list: standalone in tests/unit/memefficiency.tcl
Expected 17 <= 5 (context: type proc line 18 cmd {assert {$max_latency <= $limit_ms}} proc ::validate_latency level 1)
(Fast fail: test will exit now)

```