### PR TITLE
Skip sorting empty lists in sortCommandGeneric to prevent undefined behavior when calling pqsort

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -506,7 +506,7 @@ void sortCommandGeneric(client *c, int readonly) {
         server.sort_alpha = alpha;
         server.sort_bypattern = sortby ? 1 : 0;
         server.sort_store = storekey ? 1 : 0;
-        /* If the source keys are empty, we have will have a vector length of zero,
+        /* If the source keys are empty, we will have a vector length of zero,
          * so no need to sort. */
         if (vectorlen != 0) {   
             if (sortby && (start != 0 || end != vectorlen - 1))

--- a/src/sort.c
+++ b/src/sort.c
@@ -508,7 +508,7 @@ void sortCommandGeneric(client *c, int readonly) {
         server.sort_store = storekey ? 1 : 0;
         /* If the source keys are empty, we will have a vector length of zero,
          * so no need to sort. */
-        if (vectorlen != 0) {   
+        if (vectorlen != 0) {
             if (sortby && (start != 0 || end != vectorlen - 1))
                 pqsort(vector, vectorlen, sizeof(serverSortObject), sortCompare, start, end);
             else

--- a/src/sort.c
+++ b/src/sort.c
@@ -302,13 +302,27 @@ void sortCommandGeneric(client *c, int readonly) {
         return;
     }
 
+    /* If we have nothing to sort (the specified key doesn't exist), we return
+     * an empty array, or, if STORE is used, delete the target key and return 0. */
+    if (!sortval) {
+        listRelease(operations);
+        if (storekey == NULL) {
+            addReplyArrayLen(c, 0);
+        } else {
+            if (dbDelete(c->db, storekey)) {
+                signalModifiedKey(c, c->db, storekey);
+                notifyKeyspaceEvent(NOTIFY_GENERIC, "del", storekey, c->db->id);
+                server.dirty++;
+            }
+            addReplyLongLong(c, 0);
+        }
+        return;
+    }
+
     /* Now we need to protect sortval incrementing its count, in the future
      * SORT may have options able to overwrite/delete keys during the sorting
      * and the sorted key itself may get destroyed */
-    if (sortval)
-        incrRefCount(sortval);
-    else
-        sortval = createQuicklistObject(server.list_max_listpack_size, server.list_compress_depth);
+    incrRefCount(sortval);
 
     /* When sorting a set with no sort specified, we must sort the output
      * so the result is consistent across scripting and replication.

--- a/src/sort.c
+++ b/src/sort.c
@@ -302,27 +302,13 @@ void sortCommandGeneric(client *c, int readonly) {
         return;
     }
 
-    /* If we have nothing to sort (the specified key doesn't exist), we return
-     * an empty array, or, if STORE is used, delete the target key and return 0. */
-    if (!sortval) {
-        listRelease(operations);
-        if (storekey == NULL) {
-            addReplyArrayLen(c, 0);
-        } else {
-            if (dbDelete(c->db, storekey)) {
-                signalModifiedKey(c, c->db, storekey);
-                notifyKeyspaceEvent(NOTIFY_GENERIC, "del", storekey, c->db->id);
-                server.dirty++;
-            }
-            addReplyLongLong(c, 0);
-        }
-        return;
-    }
-
     /* Now we need to protect sortval incrementing its count, in the future
      * SORT may have options able to overwrite/delete keys during the sorting
      * and the sorted key itself may get destroyed */
-    incrRefCount(sortval);
+    if (sortval)
+        incrRefCount(sortval);
+    else
+        sortval = createQuicklistObject(server.list_max_listpack_size, server.list_compress_depth);
 
     /* When sorting a set with no sort specified, we must sort the output
      * so the result is consistent across scripting and replication.
@@ -520,10 +506,14 @@ void sortCommandGeneric(client *c, int readonly) {
         server.sort_alpha = alpha;
         server.sort_bypattern = sortby ? 1 : 0;
         server.sort_store = storekey ? 1 : 0;
-        if (sortby && (start != 0 || end != vectorlen - 1))
-            pqsort(vector, vectorlen, sizeof(serverSortObject), sortCompare, start, end);
-        else
-            qsort(vector, vectorlen, sizeof(serverSortObject), sortCompare);
+        /* If the source keys are empty, we have will have a vector length of zero,
+         * so no need to sort. */
+        if (vectorlen != 0) {   
+            if (sortby && (start != 0 || end != vectorlen - 1))
+                pqsort(vector, vectorlen, sizeof(serverSortObject), sortCompare, start, end);
+            else
+                qsort(vector, vectorlen, sizeof(serverSortObject), sortCompare);
+        }
     }
 
     /* Send command output to the output buffer, performing the specified

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -204,6 +204,11 @@ foreach command {SORT SORT_RO} {
         assert_equal [lsort -real $floats] [r sort mylist]
     }
 
+    test "SORT returns an empty array if the list is empty" {
+        r flushdb
+        r sort mylist
+    } {}
+
     test "SORT with STORE returns zero if result is empty (github issue 224)" {
         r flushdb
         r sort foo{t} store bar{t}


### PR DESCRIPTION
This one was found by [afl++](https://github.com/AFLplusplus/AFLplusplus). Executing `sort key by *` with a non-existing key, `vectorlen` gets initially set to `0` and then set to `-1` at `vectorlen = end - start + 1;` which then gets passed to `pqsort` as a `size_t` causing an underflow. Since we're operating on an empty list here, we can just skip the entire sorting step altogether and either return the expected zero-length array or unlink the store key in the database.