### PR TITLE
Print the complete log instead of just the crash log in log_crashes

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -187,17 +187,15 @@ proc log_crashes {} {
     set logs [glob */log.txt]
     foreach log $logs {
         set fd [open $log]
-        set found 0
         while {[gets $fd line] >= 0} {
             if {[string match $start_pattern $line]} {
                 puts "\n*** Crash report found in $log ***"
-                set found 1
-            }
-            if {$found} {
-                puts $line
+                puts [exec cat $log]
                 incr ::failed
+                break
             }
         }
+        close $fd
     }
 
     set logs [glob */err.txt]


### PR DESCRIPTION
We used to, for example in runtest-cluster, we will only print the crash
log since in here, when we match the pattern, we start setting found and
then print the log starting from the current line. We can print the complete
log in this case and it might help troubleshoot the crash.