### PR TITLE
Fix duplicate Acks for RDMA events and fix extremely large max latency for RDMA benchmark.

### DIFF
--- a/src/rdma.c
+++ b/src/rdma.c
@@ -603,7 +603,12 @@ static int connRdmaHandleCq(rdma_connection *rdma_conn) {
             serverLog(LL_WARNING, "RDMA: get CQ event error");
             return C_ERR;
         }
-    } else if (ibv_req_notify_cq(ev_cq, 0)) {
+
+        return C_OK;
+    }
+
+    ibv_ack_cq_events(ctx->cq, 1);
+    if (ibv_req_notify_cq(ev_cq, 0)) {
         serverLog(LL_WARNING, "RDMA: notify CQ error");
         return C_ERR;
     }
@@ -616,8 +621,6 @@ pollcq:
     } else if (ret == 0) {
         return C_OK;
     }
-
-    ibv_ack_cq_events(ctx->cq, 1);
 
     if (wc.status != IBV_WC_SUCCESS) {
         if (rdma_conn->c.state == CONN_STATE_CONNECTED) {

--- a/tests/rdma/rdma-test.c
+++ b/tests/rdma/rdma-test.c
@@ -379,7 +379,12 @@ static int connRdmaHandleCq(RdmaContext *ctx) {
             rdmaFatal("RDMA: get cq event failed");
             return -1;
         }
-    } else if (ibv_req_notify_cq(ev_cq, 0)) {
+
+        return 0;
+    }
+
+    ibv_ack_cq_events(ctx->cq, 1);
+    if (ibv_req_notify_cq(ev_cq, 0)) {
         rdmaFatal("RDMA: notify cq failed");
         return -1;
     }
@@ -392,8 +397,6 @@ pollcq:
     } else if (ret == 0) {
         return 0;
     }
-
-    ibv_ack_cq_events(ctx->cq, 1);
 
     if (wc.status != IBV_WC_SUCCESS) {
         rdmaFatal("RDMA: send/recv failed");


### PR DESCRIPTION
(1) The old logic may result in the RDMA event being acknowledged unexpectly in the following two scenarios. 
* ibv_get_cq_event get an EAGAIN error. 
* ibv_get_cq_event get one event but it may ack multiple times in the pollcq loop.

(2) In the benchmark result of valkey over RDMA, the tail latency is as high as 177 milliseconds(almost 80x of TCP). This results from incorrect benchmark client setup which includes the connection setup time into the benchmark latency recording. This patch fixes this crazy tail latency issue by modifying the valkey-benchmark.c. This change only affects benchmark over RDMA as updates are regulated under Macro USE_RDMA.

There are following updates on valkey RDMA but I am willing to create separated pull requests.