### PR TITLE
Fix hfe no malloc size unit

### DIFF
--- a/src/unit/test_vset.c
+++ b/src/unit/test_vset.c
@@ -401,7 +401,7 @@ int expire_mock_entries(vset *set, mstime_t now) {
 }
 
 void *mock_defragfn(void *ptr) {
-    size_t size = zmalloc_size(ptr);
+    size_t size = zmalloc_usable_size(ptr);
     void *newptr = zmalloc(size);
     memcpy(newptr, ptr, size);
     zfree(ptr);

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -58,7 +58,7 @@
 #error "Newer version of jemalloc required"
 #endif
 
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && !defined(NO_MALLOC_USABLE_SIZE)
 #include <malloc/malloc.h>
 #define HAVE_MALLOC_SIZE 1
 #define zmalloc_size(p) malloc_size(p)


### PR DESCRIPTION
test_vest uses a mock_defrag function in order to simulate defrag flow.
In the scenario of no system malloc_size we need to use zmalloc_usable_size in order to prevent stepping over the "to-be-replaced" buffer

will partially fix: https://github.com/valkey-io/valkey/issues/2435