### PR TITLE
Print error context when test fails

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -403,7 +403,7 @@ proc test_server_cron {} {
                     if {[info exist ::active_clients_file($fd)]} {
                         set file $::active_clients_file($fd)
                     }
-                    lappend ::failed_tests "\[TIMEOUT]: $test_name in $file"
+                    lappend ::failed_tests "\[[colorstr red TIMEOUT]\]: $test_name in $file"
                 }
             }
         }
@@ -474,8 +474,7 @@ proc read_from_test_client fd {
     } elseif {$status eq {err}} {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
-        set test_name [lindex [split $data "\n"] 0]
-        lappend ::failed_tests $test_name
+        lappend ::failed_tests $err
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts "(Fast fail: test will exit now)"


### PR DESCRIPTION
We used to did print the context but after #2276, we lost the context.

unstable:
```
*** Extract version and sha1 details from info command and print in tests/unit/info-command.tcl
```

now:
```
*** [err]: Extract version and sha1 details from info command and print in tests/unit/info-command.tcl
Expected '0' to be equal to '1' (context: type source line 7 file /xxx/info-command.tcl cmd {assert_equal 0 1} proc ::test)
```

We can see the different, we have provided enough context when asserting fail. Otherwise we need to scroll back (which is usually a lot of server logs) to see the context.