### PR TITLE
Fix and remove conflicting paths from clang-format workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,8 +7,6 @@ on:
       - '**/00-RELEASENOTES'
       - '**/COPYING'
   pull_request:
-    paths:
-      - 'src/**'
     paths-ignore:
       - '**/*.md'
       - '**/00-RELEASENOTES'


### PR DESCRIPTION
Fixes the GitHub Actions error where both `paths` and `paths-ignore` were defined for the same event, which is not allowed.

Removed the conflicting `paths` section from the `pull_request` trigger, keeping only `paths-ignore` to skip documentation changes while allowing the workflow to run on all other changes.

Tested the path filters by creating a PR to my own fork and verified that the Documentation-only changes correctly skip the unnecessary tests.

<img width="929" height="866" alt="Screenshot 2025-08-07 at 10 37 22 PM" src="https://github.com/user-attachments/assets/95a384d8-b2c7-42b6-b46a-1bc33148a6c5" />

Resolves the error: "you may only define one of `paths` and `paths-ignore` for a single event"

This is a follow-up fix to address the issue identified in the previous PR.
