### PR TITLE
Fix HGETEX to return array response when the hash object is empty

### DIFF
--- a/src/commands/hgetex.json
+++ b/src/commands/hgetex.json
@@ -49,10 +49,6 @@
                             }
                         ]
                     }
-                },
-                {
-                    "description": "Key does not exist.",
-                    "type": "null"
                 }
             ]
         },

--- a/src/commands/hgetex.json
+++ b/src/commands/hgetex.json
@@ -34,23 +34,19 @@
             }
         ],
         "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "List of values associated with the given fields, in the same order as they are requested.",
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
+            "description": "List of values associated with the given fields, in the same order as they are requested.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
                     }
-                }
-            ]
+                ]
+            }
         },
         "arguments": [
             {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -211,7 +211,7 @@ start_server {tags {"hashexpire"}} {
 
         test "HGETEX $command on non-exist key" {
             r FLUSHALL
-            assert_equal "" [r HGETEX myhash $command [get_long_expire_value $command] FIELDS 1 f2]
+            assert_equal {{} {} {}} [r HGETEX myhash $command [get_long_expire_value $command] FIELDS 3 f1 f2 f3]
         }
 
         test "HGETEX $command with duplicate field names" {


### PR DESCRIPTION
In the current implementation `HGETEX`, when applied on a non existing object, will simply return null value instead of an array (like in the `HMGET` case).