### PR TITLE
Fix out-of-bound memory access when num-fields is not provided

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1191,7 +1191,7 @@ void hsetexCommand(client *c) {
     robj **new_argv = NULL;
     int new_argc = 0;
 
-    for (; fields_index < c->argc; fields_index++) {
+    for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
             /* checking optional flags */
             if (parseExtendedCommandArgumentsOrReply(c, &flags, &unit, &expire, &comparison, COMMAND_HSET, fields_index++) != C_OK) return;
@@ -1358,7 +1358,7 @@ void hgetexCommand(client *c) {
     int new_argc = 0;
     int milliseconds_index = -1, numitems_index = -1;
 
-    for (; fields_index < c->argc; fields_index++) {
+    for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
             /* checking optional flags */
             if (parseExtendedCommandArgumentsOrReply(c, &flags, &unit, &expire, &comparison, COMMAND_HGET, fields_index++) != C_OK) return;
@@ -1611,7 +1611,7 @@ void hexpireGenericCommand(client *c, long long basetime, int unit) {
     robj **new_argv = NULL;
     int new_argc = 0;
 
-    for (; fields_index < c->argc; fields_index++) {
+    for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
             /* checking optional flags */
             if (parseExtendedExpireArgumentsOrReply(c, &flag, fields_index++) != C_OK) return;

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -2053,6 +2053,16 @@ start_server {tags {"hashexpire"}} {
         assert_morethan [r HTTL myhash FIELDS 1 f1] 0
         assert_equal 1 [get_keys_with_volatile_items r]
     }
+
+    test {Verify error when hash expire commands num fields is not provided} {
+        r FLUSHALL
+        catch {r hsetex myhash KEEPTTL KEEPTTL KEEPTTL FIELDS} e
+        assert_match $e {ERR numfields should be greater than 0 and match the provided number of fields}
+        catch {r hexpire myhash 10 NX NX FIELDS} e
+        assert_match $e {ERR numfields should be greater than 0 and match the provided number of fields}
+        catch {r hgetex myhash PERSIST PERSIST FIELDS} e
+        assert_match $e {ERR numfields should be greater than 0 and match the provided number of fields}
+    }
 }
 
 ####### Test info


### PR DESCRIPTION
Following new API presented in https://github.com/valkey-io/valkey/pull/2089, we might access out of bound memory in case of some illegal command input