### PR TITLE
Don't allow resize hashtable if rehashing is ongoing

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -740,7 +740,7 @@ void debugCommand(client *c) {
         }
 
         if (dbExpand(c->db, keys, 1) == C_ERR) {
-            addReplyError(c, "OOM in dictTryExpand");
+            addReplyError(c, "OOM in dbExpand");
             return;
         }
         long valsize = 0;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1250,11 +1250,11 @@ bool hashtableExpand(hashtable *ht, size_t size) {
     return expand(ht, size, NULL);
 }
 
-/* Returns false if expand failed due to memory allocation failure. */
+/* Returns true if expand was performed or if expand is not needed. Returns false if
+ * expand failed due to memory allocation failure. */
 bool hashtableTryExpand(hashtable *ht, size_t size) {
     int malloc_failed = 0;
-    expand(ht, size, &malloc_failed);
-    return malloc_failed ? false : true;
+    return expand(ht, size, &malloc_failed) || !malloc_failed;
 }
 
 /* Expanding is done automatically on insertion, but less eagerly if resize

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -617,7 +617,7 @@ static bool resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
         return false;
     }
 
-    signed char old_exp = ht->bucket_exp[hashtableIsRehashing(ht) ? 1 : 0];
+    signed char old_exp = ht->bucket_exp[0];
     size_t alloc_size = num_buckets * sizeof(bucket);
     if (exp == old_exp) {
         /* Can't resize to same size. */

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -601,6 +601,9 @@ static inline void rehashStepOnWriteIfNeeded(hashtable *ht) {
 static bool resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
     if (malloc_failed) *malloc_failed = 0;
 
+    /* We can't resize twice if rehashing is ongoing. */
+    assert(!hashtableIsRehashing(ht));
+
     /* Adjust minimum size. We don't resize to zero currently. */
     if (min_capacity == 0) min_capacity = 1;
 
@@ -618,17 +621,6 @@ static bool resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
     if (exp == old_exp) {
         /* Can't resize to same size. */
         return false;
-    }
-
-    /* We can't resize if rehashing is already ongoing. Fast-forward ongoing
-     * rehashing before we continue. This can happen only in exceptional
-     * scenarios, such as when many insertions are made while rehashing is
-     * paused. */
-    if (hashtableIsRehashing(ht)) {
-        if (hashtableIsRehashingPaused(ht)) return false;
-        while (hashtableIsRehashing(ht)) {
-            rehashStep(ht);
-        }
     }
 
     if (resize_policy == HASHTABLE_RESIZE_FORBID && ht->tables[0]) {
@@ -674,10 +666,9 @@ static bool resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
 }
 
 /* Returns true if the table is expanded, false if not expanded. If false is returned and
- * 'malloc_failed' is provided, it is set to true if malloc failed and false
- * otherwise. */
+ * 'malloc_failed' is provided, it is set to 1 if malloc failed and 0 otherwise. */
 static bool expand(hashtable *ht, size_t size, int *malloc_failed) {
-    if (size < hashtableSize(ht)) {
+    if (hashtableIsRehashing(ht) || size < hashtableSize(ht)) {
         return false;
     }
     return resize(ht, size, malloc_failed);
@@ -1259,17 +1250,22 @@ bool hashtableExpand(hashtable *ht, size_t size) {
     return expand(ht, size, NULL);
 }
 
-/* Returns true if expand was performed or if expand is not needed. Returns false if
- * expand failed due to memory allocation failure. */
+/* Returns false if expand failed due to memory allocation failure. */
 bool hashtableTryExpand(hashtable *ht, size_t size) {
     int malloc_failed = 0;
-    return expand(ht, size, &malloc_failed) || !malloc_failed;
+    expand(ht, size, &malloc_failed);
+    return malloc_failed ? false : true;
 }
 
 /* Expanding is done automatically on insertion, but less eagerly if resize
  * policy is set to AVOID and not at all if set to FORBID.
  * Returns true if expanding, false if not expanding. */
 bool hashtableExpandIfNeeded(hashtable *ht) {
+    /* Don't expand if rehashing is already in progress. */
+    if (hashtableIsRehashing(ht)) {
+        return false;
+    }
+
     size_t min_capacity = ht->used[0] + ht->used[1] + 1;
     size_t num_buckets = numBuckets(ht->bucket_exp[hashtableIsRehashing(ht) ? 1 : 0]);
     size_t current_capacity = num_buckets * ENTRIES_PER_BUCKET;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -597,7 +597,8 @@ static inline void rehashStepOnWriteIfNeeded(hashtable *ht) {
 /* Allocates a new table and initiates incremental rehashing if necessary.
  * Returns true on resize (success), false on no resize (failure). If false is returned and
  * 'malloc_failed' is provided, it is set to true if allocation failed. If
- * 'malloc_failed' is not provided, an allocation failure triggers a panic. */
+ * 'malloc_failed' is not provided, an allocation failure triggers a panic.
+ * If rehashing is in progress, resize cannot be called. */
 static bool resize(hashtable *ht, size_t min_capacity, int *malloc_failed) {
     if (malloc_failed) *malloc_failed = 0;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2030,7 +2030,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
         zs = o->ptr;
 
         if (!hashtableTryExpand(zs->ht, zsetlen)) {
-            rdbReportCorruptRDB("OOM in dictTryExpand %llu", (unsigned long long)zsetlen);
+            rdbReportCorruptRDB("OOM in hashtableTryExpand %llu", (unsigned long long)zsetlen);
             decrRefCount(o);
             return NULL;
         }

--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -236,8 +236,10 @@ int test_bucket_chain_length(int argc, char **argv, int flags) {
     for (j = 0; j < count; j++) {
         TEST_ASSERT(hashtableAdd(ht, (void *)j));
     }
-    /* If it's rehashing, add a few more until rehashing is complete. */
+    /* If it's rehashing, add a few more until rehashing is complete.
+     * We also make sure that we won't resize during the rehashing. */
     while (hashtableIsRehashing(ht)) {
+        TEST_ASSERT(!hashtableExpand(ht, count * 2));
         j++;
         TEST_ASSERT(hashtableAdd(ht, (void *)j));
     }


### PR DESCRIPTION
Similar to dicts, we disallow resizing while the hashtable is
rehashing. In the previous code, if a resize was triggered during
rehashing, like if the rehashing wasn't fast enough, we would do
a while loop until the rehashing was complete, which could be a
potential issue when doing resize.