### PR TITLE
Adding testType to testRdb

### DIFF
--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -242,7 +242,7 @@ tags "modules" {
                             # 10ms per key, with 1000 keys is 10 seconds
                             $master config set rdb-key-save-delay 10000
 
-                            test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before} {
+                            test "Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling ($testType): during loading, can keep module variable same as before" {
                                 # Wait for the replica to start reading the rdb and module for acknowledgement
                                 # We wanna abort only after the temp db was populated by REDISMODULE_AUX_BEFORE_RDB
                                 wait_for_condition 100 100 {
@@ -261,7 +261,7 @@ tags "modules" {
                             # Kill the replica connection on the master
                             set killed [$master client kill type replica]
 
-                            test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: when loading aborted, can keep module variable same as before} {
+                            test "Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling ($testType): when loading aborted, can keep module variable same as before" {
                                 # Wait for loading to stop (fail) and module for acknowledgement
                                 wait_for_condition 100 100 {
                                     [s -1 async_loading] eq 0 && [$replica testrdb.async_loading.get.before] eq ""
@@ -284,7 +284,7 @@ tags "modules" {
                                 fail "Master <-> Replica didn't finish sync"
                             }
 
-                            test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: after db loaded, can set module variable with new value} {
+                            test "Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling ($testType): after db loaded, can set module variable with new value" {
                                 assert_equal [$replica dbsize] 1010
                                 assert_equal value1_master [$replica testrdb.get.before]
                             }


### PR DESCRIPTION
> @ranshid the same test runs with different test cases, and it failed for one of them.

Ah... we should probably add the testType in the test name to make it more clear then

_Originally posted by @ranshid in https://github.com/valkey-io/valkey/issues/2406#issuecomment-3172489117_

            

```
[ok]: Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling (Successful): after db loaded, can set module variable with new value (1 ms)
[ok]: Check for memory leaks (pid 81673) (1426 ms)
[ok]: Check for memory leaks (pid 81662) (1327 ms)
=== (external:skip) Starting server on 127.0.0.1:21135 ok
=== () Starting server on 127.0.0.1:21136 ok
[ok]: Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling (Aborted): during loading, can keep module variable same as before (939 ms)
[ok]: Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling (Aborted): when loading aborted, can keep module variable same as before (1 ms)
```

The testType is visible now.