### PR TITLE
Throw a useful error when underlying operations failed with tls

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1040,7 +1040,8 @@ static const char *connTLSGetLastError(connection *conn_) {
     tls_connection *conn = (tls_connection *)conn_;
 
     if (conn->ssl_error) return conn->ssl_error;
-    return NULL;
+    /* If no SSL error is set, return the last errno string. */
+    return strerror(conn_->last_errno);
 }
 
 static int connTLSSetWriteHandler(connection *conn, ConnectionCallbackFunc func, int barrier) {


### PR DESCRIPTION
Right now, if a TLS connect fails, you get an unhelpful error message in the log since it prints out NULL. This change makes sure that report error always returns a string (never null) as well as tries to print out underlying errors.