### PR TITLE
Show RPS histogram in valkey-benchmark

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1171,7 +1171,7 @@ static void showLatencyReport(void) {
             printf("\n  RPS Analysis:\n");
             printf("    Target RPS: %.0f\n", target_rps);
             printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
-            
+
             if (reqpersec < threshold_90) {
                 printf("    Status: SEVERE BOTTLENECK DETECTED\n");
                 printf("    Performance is significantly below target (< 90%%).\n");

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1140,7 +1140,8 @@ static void showLatencyReport(void) {
         }
         printf("  multi-thread: %s\n", (config.num_threads ? "yes" : "no"));
         if (config.num_threads) printf("  threads: %d\n", config.num_threads);
-
+        /* Show the RPS Report */
+        showRPSReport();
         printf("\n");
         printf("Latency by percentile distribution:\n");
         struct hdr_iter iter;
@@ -1276,9 +1277,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     } else
         startBenchmarkThreads();
     config.totlatency = mstime() - config.start;
-
     showLatencyReport();
-    showRPSReport();
     freeAllClients();
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1188,15 +1188,10 @@ static void showLatencyReport(void) {
                        rps_p50, (rps_p50 / target_rps) * 100);
 
                 /* Bottleneck analysis using P1 (99% of time achieved this or better) */ 
-                if (rps_p1 >= 0.99 * target_rps) {
-                    printf("    Status: GOOD PERFORMANCE\n");
-                    printf("    99%% of time achieved 99%% of target RPS.\n");
-                } else if (rps_p1 >= 0.90 * target_rps) {
-                    printf("    Status: BOTTLENECK DETECTED\n");
-                    printf("    99%% of time achieved 90%% of target RPS.\n");
-                } else {
+                if (rps_p1 < 0.90 * target_rps) {
                     printf("    Status: SEVERE BOTTLENECK DETECTED\n");
-                    printf("    Performance significantly below target.\n");
+                } else if (rps_p1 < 0.99 * target_rps) {
+                    printf("    Status: BOTTLENECK DETECTED\n");
                 }
             } else {
                 /* Fallback to original average-based analysis */
@@ -1204,8 +1199,6 @@ static void showLatencyReport(void) {
                     printf("    Status: SEVERE BOTTLENECK DETECTED\n");
                 } else if (reqpersec < target_rps * 0.99f) {
                     printf("    Status: BOTTLENECK DETECTED\n");
-                } else {
-                    printf("    Status: GOOD PERFORMANCE\n");
                 }
             }
         }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1088,19 +1088,12 @@ static void showRPSReport(void) {
 
         const float target_rps = (float)config.rps;
 
-        // Bottleneck detection: if 95% of the RPS < 90% of target RPS
-        bool bottleneck_detected = (p95 < 0.9f * target_rps);
-
-        if (bottleneck_detected) {
-            printf("\n");
-            printf("RPS Summary (Bottleneck Detected):\n");
-            printf("  target RPS: %.2f\n", target_rps);
-            printf("  RPS distribution (reqs/sec):\n");
-            printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
-            printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
-            printf("    Bottleneck rule: 95%% of RPS < 90%% of target RPS (%.2f)\n", 0.9f * target_rps);
-            printf("  status: BOTTLENECK DETECTED\n");
-        }
+        printf("\n");
+        printf("RPS Summary:\n");
+        printf("  target RPS: %.2f\n", target_rps);
+        printf("  RPS distribution (reqs/sec):\n");
+        printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
+        printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
     }
 }
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1160,12 +1160,12 @@ static void showLatencyReport(void) {
         printf("  latency summary (msec):\n");
         printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
         printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg, p0, p50, p95, p99, p100);
-        
+
         /* RPS bottleneck detection */
         if (config.rps > 0) {
             float target_rps = (float)config.rps;
-            float threshold = target_rps * 0.9f;  /* 90% threshold */
-            
+            float threshold = target_rps * 0.9f; /* 90% threshold */
+
             if (reqpersec < threshold) {
                 printf("\n  RPS Analysis:\n");
                 printf("    Target RPS: %.0f\n", target_rps);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1080,10 +1080,10 @@ static void createMissingClients(client c) {
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
         const float avg_rps = hdr_mean(config.rps_histogram);
-        const float p0   = (float)hdr_min(config.rps_histogram);
-        const float p50  = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
-        const float p95  = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
-        const float p99  = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+        const float p0 = (float)hdr_min(config.rps_histogram);
+        const float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+        const float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+        const float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
         const float p100 = (float)hdr_max(config.rps_histogram);
 
         const float target_rps = (float)config.rps;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1161,18 +1161,28 @@ static void showLatencyReport(void) {
         printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
         printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg, p0, p50, p95, p99, p100);
 
-        /* RPS bottleneck detection */
+        /* RPS analysis - always show when --rps is used */
         if (config.rps > 0) {
             float target_rps = (float)config.rps;
-            float threshold = target_rps * 0.9f; /* 90% threshold */
+            float threshold_99 = target_rps * 0.99f; /* 99% threshold */
+            float threshold_90 = target_rps * 0.90f; /* 90% threshold */
+            float achievement_pct = (reqpersec / target_rps) * 100.0f;
 
-            if (reqpersec < threshold) {
-                printf("\n  RPS Analysis:\n");
-                printf("    Target RPS: %.0f\n", target_rps);
-                printf("    Actual RPS: %.2f\n", reqpersec);
-                printf("    Status: BOTTLENECK DETECTED\n");
-                printf("    The benchmark could not achieve the target RPS.\n");
+            printf("\n  RPS Analysis:\n");
+            printf("    Target RPS: %.0f\n", target_rps);
+            printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
+            
+            if (reqpersec < threshold_90) {
+                printf("    Status: SEVERE BOTTLENECK DETECTED\n");
+                printf("    Performance is significantly below target (< 90%%).\n");
                 printf("    This indicates either client or server limitations.\n");
+            } else if (reqpersec < threshold_99) {
+                printf("    Status: BOTTLENECK DETECTED\n");
+                printf("    Performance is below optimal target (< 99%%).\n");
+                printf("    This indicates either client or server limitations.\n");
+            } else {
+                printf("    Status: GOOD PERFORMANCE\n");
+                printf("    Successfully achieved target RPS.\n");
             }
         }
     } else if (config.csv) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1160,6 +1160,21 @@ static void showLatencyReport(void) {
         printf("  latency summary (msec):\n");
         printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
         printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg, p0, p50, p95, p99, p100);
+        
+        /* RPS bottleneck detection */
+        if (config.rps > 0) {
+            float target_rps = (float)config.rps;
+            float threshold = target_rps * 0.9f;  /* 90% threshold */
+            
+            if (reqpersec < threshold) {
+                printf("\n  RPS Analysis:\n");
+                printf("    Target RPS: %.0f\n", target_rps);
+                printf("    Actual RPS: %.2f\n", reqpersec);
+                printf("    Status: BOTTLENECK DETECTED\n");
+                printf("    The benchmark could not achieve the target RPS.\n");
+                printf("    This indicates either client or server limitations.\n");
+            }
+        }
     } else if (config.csv) {
         printf("\"%s\",\"%.2f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\"\n", config.title, reqpersec, avg,
                p0, p50, p95, p99, p100);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1997,7 +1997,6 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
                hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
     config.last_printed_bytes = printed_bytes;
     hdr_reset(config.current_sec_latency_histogram);
-    sampleRPS();
     fflush(stdout);
     return SHOW_THROUGHPUT_INTERVAL;
 }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1268,10 +1268,10 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
              &config.current_sec_latency_histogram);     // Pointer to initialise
 
     if (config.rps > 0) {
-        hdr_init(1,                 // Min RPS: 1
-                config.rps * 2,     // Max RPS: allow headroom above target RPS
-                config.precision,
-                &config.rps_histogram);
+        hdr_init(1,
+                 config.rps * 2,
+                 config.precision,
+                 &config.rps_histogram);
         config.last_rps_sample_time = 0;
         config.last_rps_sample_requests = 0;
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1077,6 +1077,35 @@ static void createMissingClients(client c) {
     }
 }
 
+static void showRPSReport(void) {
+    if (config.rps_histogram && config.rps_histogram->total_count > 0) {
+        float avg_rps = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
+
+        float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+        float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+        float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+
+        // Bottleneck detection using target RPS
+        float target_rps = (float)config.rps;
+        const char *rps_status = NULL;
+
+        if (p99 < 0.9 * target_rps) {
+            rps_status = "SEVERE BOTTLENECK DETECTED";
+        } else if (p99 < target_rps) {
+            rps_status = "BOTTLENECK DETECTED";
+        }
+
+        if (rps_status) {
+            printf("\nRPS Percentiles:\n");
+            printf("  P50: %.0f\n", p50);
+            printf("  P95: %.0f\n", p95);
+            printf("  P99: %.0f\n", p99);
+            printf("  Average: %.0f\n", avg_rps);
+            printf("Status: %s\n", rps_status);
+        }
+    }
+}
+
 static void showLatencyReport(void) {
     const float reqpersec = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
     const float p0 = ((float)hdr_min(config.latency_histogram)) / 1000.0f;
@@ -1155,6 +1184,7 @@ static void showLatencyReport(void) {
             }
             previous_cumulative_count = cumulative_count;
         }
+        showRPSReport();
         printf("\n");
         printf("Summary:\n");
         printf("  throughput summary: %.2f requests per second\n", reqpersec);
@@ -1167,30 +1197,6 @@ static void showLatencyReport(void) {
     } else {
         printf("%*s\r", config.last_printed_bytes, " "); // ensure there is a clean line
         printf("%s: %.2f requests per second, p50=%.3f msec\n", config.title, reqpersec, p50);
-    }
-}
-
-static void showRPSReport(void) {
-    if (config.rps_histogram && config.rps_histogram->total_count > 0) {
-        float avg_rps = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
-
-        float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
-        float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
-        float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
-
-        printf("\nRPS Percentiles:\n");
-        printf("  P50: %.0f\n", p50);
-        printf("  P95: %.0f\n", p95);
-        printf("  P99: %.0f\n", p99);
-        printf("  Average: %.0f\n", avg_rps);
-
-        // Bottleneck detection using target RPS
-        float target_rps = (float)config.rps;
-        if (p99 < 0.9 * target_rps) {
-            printf("Status: SEVERE BOTTLENECK DETECTED\n");
-        } else if (p99 < target_rps) {
-            printf("Status: BOTTLENECK DETECTED\n");
-        }
     }
 }
 
@@ -1282,7 +1288,6 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     config.totlatency = mstime() - config.start;
 
     showLatencyReport();
-    showRPSReport();
     freeAllClients();
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1079,21 +1079,26 @@ static void createMissingClients(client c) {
 
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
-        const float avg_rps = hdr_mean(config.rps_histogram);
-        const float p0 = (float)hdr_min(config.rps_histogram);
-        const float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
-        const float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
-        const float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
-        const float p100 = (float)hdr_max(config.rps_histogram);
-
         const float target_rps = (float)config.rps;
+        const float threshold_rps = 0.9f * target_rps;
+        const int64_t p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
 
-        printf("\n");
-        printf("RPS Summary:\n");
-        printf("  target RPS: %.2f\n", target_rps);
-        printf("  RPS distribution (reqs/sec):\n");
-        printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
-        printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
+        if (p10 <= threshold_rps) {
+            const float avg_rps = hdr_mean(config.rps_histogram);
+            const float p0 = (float)hdr_min(config.rps_histogram);
+            const float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+            const float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+            const float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+            const float p100 = (float)hdr_max(config.rps_histogram);
+
+            printf("\n");
+            printf("RPS Summary:\n");
+            printf("  target RPS: %.2f\n", target_rps);
+            printf("  RPS distribution (reqs/sec):\n");
+            printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
+            printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
+            printf("Info: The RPS Summary is displayed if 10%% or more of the samples are below 90%% of the target RPS.\n");
+        }
     }
 }
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -136,6 +136,9 @@ static struct config {
     struct serverConfig *server_config;
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
+    struct hdr_histogram *rps_histogram;  
+    long long last_rps_sample_time;    
+    int last_rps_sample_requests;      
     _Atomic int is_fetching_slots;
     _Atomic int is_updating_slots;
     _Atomic int slots_last_update;
@@ -1164,27 +1167,51 @@ static void showLatencyReport(void) {
         /* RPS analysis - always show when --rps is used */
         if (config.rps > 0) {
             float target_rps = (float)config.rps;
-            float threshold_99 = target_rps * 0.99f; /* 99% threshold */
-            float threshold_90 = target_rps * 0.90f; /* 90% threshold */
             float achievement_pct = (reqpersec / target_rps) * 100.0f;
 
             printf("\n  RPS Analysis:\n");
             printf("    Target RPS: %.0f\n", target_rps);
             printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
 
-            if (reqpersec < threshold_90) {
-                printf("    Status: SEVERE BOTTLENECK DETECTED\n");
-                printf("    Performance is significantly below target (< 90%%).\n");
-                printf("    This indicates either client or server limitations.\n");
-            } else if (reqpersec < threshold_99) {
-                printf("    Status: BOTTLENECK DETECTED\n");
-                printf("    Performance is below optimal target (< 99%%).\n");
-                printf("    This indicates either client or server limitations.\n");
+            // ADD RPS PERCENTILE ANALYSIS
+            if (config.rps_histogram && config.rps_histogram->total_count > 0) {
+                const float rps_p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
+                const float rps_p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
+                const float rps_p50 = hdr_value_at_percentile(config.rps_histogram, 50.0);
+                // const float rps_p90 = hdr_value_at_percentile(config.rps_histogram, 90.0);
+                // const float rps_p99 = hdr_value_at_percentile(config.rps_histogram, 99.0);
+                
+                printf("    RPS Performance Guarantees:\n");
+                printf("      99%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
+                       rps_p1, (rps_p1/target_rps)*100);
+                printf("      90%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
+                       rps_p10, (rps_p10/target_rps)*100);
+                printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
+                       rps_p50, (rps_p50/target_rps)*100);
+                
+                // Bottleneck analysis using P1 (99% of time achieved this or better)
+                if (rps_p1 >= 0.99 * target_rps) {
+                    printf("    Status: GOOD PERFORMANCE\n");
+                    printf("    99%% of time achieved 99%% of target RPS.\n");
+                } else if (rps_p1 >= 0.90 * target_rps) {
+                    printf("    Status: BOTTLENECK DETECTED\n");
+                    printf("    99%% of time achieved 90%% of target RPS.\n");
+                } else {
+                    printf("    Status: SEVERE BOTTLENECK DETECTED\n");
+                    printf("    Performance significantly below target.\n");
+                }
             } else {
-                printf("    Status: GOOD PERFORMANCE\n");
-                printf("    Successfully achieved target RPS.\n");
+                // Fallback to original average-based analysis
+                if (reqpersec < target_rps * 0.90f) {
+                    printf("    Status: SEVERE BOTTLENECK DETECTED\n");
+                } else if (reqpersec < target_rps * 0.99f) {
+                    printf("    Status: BOTTLENECK DETECTED\n");
+                } else {
+                    printf("    Status: GOOD PERFORMANCE\n");
+                }
             }
         }
+
     } else if (config.csv) {
         printf("\"%s\",\"%.2f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\"\n", config.title, reqpersec, avg,
                p0, p50, p95, p99, p100);
@@ -1249,6 +1276,15 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
              config.precision,                           // Number of significant figures
              &config.current_sec_latency_histogram);     // Pointer to initialise
 
+    if (config.rps > 0) {
+        hdr_init(1,                    // Min RPS: 1
+                 1000000,              // Max RPS: 1M
+                 config.precision,
+                 &config.rps_histogram);
+        config.last_rps_sample_time = 0;
+        config.last_rps_sample_requests = 0;
+    }
+
     initPlaceholders(cmd, len);
     if (config.num_threads) initBenchmarkThreads();
 
@@ -1279,6 +1315,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);
     if (config.latency_histogram) hdr_close(config.latency_histogram);
+    if (config.rps_histogram) hdr_close(config.rps_histogram);
 }
 
 /* Benchmark a single RESP-encoded command of length len. */
@@ -1949,6 +1986,30 @@ usage:
     exit(exit_status);
 }
 
+static void sampleRPS(void) {
+    if (config.rps <= 0) return;
+    
+    long long current_time = mstime();
+    int current_requests = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
+    
+    // Sample every 1000ms (1 second)
+    if (current_time - config.last_rps_sample_time >= 1000) {
+        if (config.last_rps_sample_time > 0) {  // Skip first sample
+            double time_diff_sec = (current_time - config.last_rps_sample_time) / 1000.0;
+            double requests_diff = current_requests - config.last_rps_sample_requests;
+            double current_rps = requests_diff / time_diff_sec;
+            
+            if (current_rps >= 1.0) {  // Only record valid RPS values
+                hdr_record_value(config.rps_histogram, (long)current_rps);
+            }
+        }
+        
+        config.last_rps_sample_time = current_time;
+        config.last_rps_sample_requests = current_requests;
+    }
+}
+
+
 long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
     UNUSED(id);
@@ -1988,6 +2049,7 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
                hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
     config.last_printed_bytes = printed_bytes;
     hdr_reset(config.current_sec_latency_histogram);
+    sampleRPS();
     fflush(stdout);
     return SHOW_THROUGHPUT_INTERVAL;
 }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1173,7 +1173,7 @@ static void showLatencyReport(void) {
             printf("    Target RPS: %.0f\n", target_rps);
             printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
 
-            /* ADD RPS PERCENTILE ANALYSIS */ 
+            /* ADD RPS PERCENTILE ANALYSIS */
             if (config.rps_histogram && config.rps_histogram->total_count > 0) {
                 const float rps_p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
                 const float rps_p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
@@ -1187,7 +1187,7 @@ static void showLatencyReport(void) {
                 printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
                        rps_p50, (rps_p50 / target_rps) * 100);
 
-                /* Bottleneck analysis using P1 (99% of time achieved this or better) */ 
+                /* Bottleneck analysis using P1 (99% of time achieved this or better) */
                 if (rps_p1 < 0.90 * target_rps) {
                     printf("    Status: SEVERE BOTTLENECK DETECTED\n");
                 } else if (rps_p1 < 0.99 * target_rps) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1173,13 +1173,11 @@ static void showLatencyReport(void) {
             printf("    Target RPS: %.0f\n", target_rps);
             printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
 
-            // ADD RPS PERCENTILE ANALYSIS
+            /* ADD RPS PERCENTILE ANALYSIS */ 
             if (config.rps_histogram && config.rps_histogram->total_count > 0) {
                 const float rps_p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
                 const float rps_p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
                 const float rps_p50 = hdr_value_at_percentile(config.rps_histogram, 50.0);
-                // const float rps_p90 = hdr_value_at_percentile(config.rps_histogram, 90.0);
-                // const float rps_p99 = hdr_value_at_percentile(config.rps_histogram, 99.0);
 
                 printf("    RPS Performance Guarantees:\n");
                 printf("      99%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
@@ -1189,7 +1187,7 @@ static void showLatencyReport(void) {
                 printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
                        rps_p50, (rps_p50 / target_rps) * 100);
 
-                // Bottleneck analysis using P1 (99% of time achieved this or better)
+                /* Bottleneck analysis using P1 (99% of time achieved this or better) */ 
                 if (rps_p1 >= 0.99 * target_rps) {
                     printf("    Status: GOOD PERFORMANCE\n");
                     printf("    99%% of time achieved 99%% of target RPS.\n");
@@ -1201,7 +1199,7 @@ static void showLatencyReport(void) {
                     printf("    Performance significantly below target.\n");
                 }
             } else {
-                // Fallback to original average-based analysis
+                /* Fallback to original average-based analysis */
                 if (reqpersec < target_rps * 0.90f) {
                     printf("    Status: SEVERE BOTTLENECK DETECTED\n");
                 } else if (reqpersec < target_rps * 0.99f) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1098,6 +1098,7 @@ static void showRPSReport(void) {
             printf("  RPS distribution (reqs/sec):\n");
             printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
             printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
+            printf("    Bottleneck rule: 95%% of RPS < 90%% of target RPS (%.2f)\n", 0.9f * target_rps);
             printf("  status: BOTTLENECK DETECTED\n");
         }
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1079,29 +1079,26 @@ static void createMissingClients(client c) {
 
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
-        float avg_rps = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
+        const float avg_rps = hdr_mean(config.rps_histogram);
+        const float p0   = (float)hdr_min(config.rps_histogram);
+        const float p50  = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+        const float p95  = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+        const float p99  = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+        const float p100 = (float)hdr_max(config.rps_histogram);
 
-        float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
-        float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
-        float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+        const float target_rps = (float)config.rps;
 
-        // Bottleneck detection using target RPS
-        float target_rps = (float)config.rps;
-        const char *rps_status = NULL;
+        // Bottleneck detection: if 95% of the RPS < 90% of target RPS
+        bool bottleneck_detected = (p95 < 0.9f * target_rps);
 
-        if (p99 < 0.9 * target_rps) {
-            rps_status = "SEVERE BOTTLENECK DETECTED";
-        } else if (p99 < target_rps) {
-            rps_status = "BOTTLENECK DETECTED";
-        }
-
-        if (rps_status) {
-            printf("\nRPS Percentiles:\n");
-            printf("  P50: %.0f\n", p50);
-            printf("  P95: %.0f\n", p95);
-            printf("  P99: %.0f\n", p99);
-            printf("  Average: %.0f\n", avg_rps);
-            printf("Status: %s\n", rps_status);
+        if (bottleneck_detected) {
+            printf("\n");
+            printf("RPS Summary (Bottleneck Detected):\n");
+            printf("  target RPS: %.2f\n", target_rps);
+            printf("  RPS distribution (reqs/sec):\n");
+            printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
+            printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
+            printf("  status: BOTTLENECK DETECTED\n");
         }
     }
 }
@@ -1184,7 +1181,6 @@ static void showLatencyReport(void) {
             }
             previous_cumulative_count = cumulative_count;
         }
-        showRPSReport();
         printf("\n");
         printf("Summary:\n");
         printf("  throughput summary: %.2f requests per second\n", reqpersec);
@@ -1288,6 +1284,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     config.totlatency = mstime() - config.start;
 
     showLatencyReport();
+    showRPSReport();
     freeAllClients();
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -136,9 +136,9 @@ static struct config {
     struct serverConfig *server_config;
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
-    struct hdr_histogram *rps_histogram;  
-    long long last_rps_sample_time;    
-    int last_rps_sample_requests;      
+    struct hdr_histogram *rps_histogram;
+    long long last_rps_sample_time;
+    int last_rps_sample_requests;
     _Atomic int is_fetching_slots;
     _Atomic int is_updating_slots;
     _Atomic int slots_last_update;
@@ -1180,15 +1180,15 @@ static void showLatencyReport(void) {
                 const float rps_p50 = hdr_value_at_percentile(config.rps_histogram, 50.0);
                 // const float rps_p90 = hdr_value_at_percentile(config.rps_histogram, 90.0);
                 // const float rps_p99 = hdr_value_at_percentile(config.rps_histogram, 99.0);
-                
+
                 printf("    RPS Performance Guarantees:\n");
-                printf("      99%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
-                       rps_p1, (rps_p1/target_rps)*100);
-                printf("      90%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
-                       rps_p10, (rps_p10/target_rps)*100);
-                printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n", 
-                       rps_p50, (rps_p50/target_rps)*100);
-                
+                printf("      99%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
+                       rps_p1, (rps_p1 / target_rps) * 100);
+                printf("      90%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
+                       rps_p10, (rps_p10 / target_rps) * 100);
+                printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
+                       rps_p50, (rps_p50 / target_rps) * 100);
+
                 // Bottleneck analysis using P1 (99% of time achieved this or better)
                 if (rps_p1 >= 0.99 * target_rps) {
                     printf("    Status: GOOD PERFORMANCE\n");

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1268,10 +1268,10 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
              &config.current_sec_latency_histogram);     // Pointer to initialise
 
     if (config.rps > 0) {
-        hdr_init(1,       // Min RPS: 1
-                 1000000, // Max RPS: 1M
-                 config.precision,
-                 &config.rps_histogram);
+        hdr_init(1,                 // Min RPS: 1
+                config.rps * 2,     // Max RPS: allow headroom above target RPS
+                config.precision,
+                &config.rps_histogram);
         config.last_rps_sample_time = 0;
         config.last_rps_sample_requests = 0;
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1080,25 +1080,20 @@ static void createMissingClients(client c) {
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
         const float target_rps = (float)config.rps;
-        const float threshold_rps = 0.9f * target_rps;
-        const int64_t p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
 
-        if (p10 <= threshold_rps) {
-            const float avg_rps = hdr_mean(config.rps_histogram);
-            const float p0 = (float)hdr_min(config.rps_histogram);
-            const float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
-            const float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
-            const float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
-            const float p100 = (float)hdr_max(config.rps_histogram);
+        const float avg_rps = hdr_mean(config.rps_histogram);
+        const float p0 = (float)hdr_min(config.rps_histogram);
+        const float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+        const float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+        const float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+        const float p100 = (float)hdr_max(config.rps_histogram);
 
-            printf("\n");
-            printf("RPS Summary:\n");
-            printf("  target RPS: %.2f\n", target_rps);
-            printf("  RPS distribution (reqs/sec):\n");
-            printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
-            printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
-            printf("Info: The RPS Summary is displayed if 10%% or more of the samples are below 90%% of the target RPS.\n");
-        }
+        printf("\n");
+        printf("RPS Summary:\n");
+        printf("  target RPS: %.2f\n", target_rps);
+        printf("  RPS distribution (reqs/sec):\n");
+        printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
+        printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg_rps, p0, p50, p95, p99, p100);
     }
 }
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -137,8 +137,6 @@ static struct config {
     struct hdr_histogram *latency_histogram;
     struct hdr_histogram *current_sec_latency_histogram;
     struct hdr_histogram *rps_histogram;
-    long long last_rps_sample_time;
-    int last_rps_sample_requests;
     _Atomic int is_fetching_slots;
     _Atomic int is_updating_slots;
     _Atomic int slots_last_update;
@@ -1163,52 +1161,30 @@ static void showLatencyReport(void) {
         printf("  latency summary (msec):\n");
         printf("    %9s %9s %9s %9s %9s %9s\n", "avg", "min", "p50", "p95", "p99", "max");
         printf("    %9.3f %9.3f %9.3f %9.3f %9.3f %9.3f\n", avg, p0, p50, p95, p99, p100);
-
-        /* RPS analysis - always show when --rps is used */
-        if (config.rps > 0) {
-            float target_rps = (float)config.rps;
-            float achievement_pct = (reqpersec / target_rps) * 100.0f;
-
-            printf("\n  RPS Analysis:\n");
-            printf("    Target RPS: %.0f\n", target_rps);
-            printf("    Actual RPS: %.2f (%.1f%% of target)\n", reqpersec, achievement_pct);
-
-            /* ADD RPS PERCENTILE ANALYSIS */
-            if (config.rps_histogram && config.rps_histogram->total_count > 0) {
-                const float rps_p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
-                const float rps_p10 = hdr_value_at_percentile(config.rps_histogram, 10.0);
-                const float rps_p50 = hdr_value_at_percentile(config.rps_histogram, 50.0);
-
-                printf("    RPS Performance Guarantees:\n");
-                printf("      99%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
-                       rps_p1, (rps_p1 / target_rps) * 100);
-                printf("      90%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
-                       rps_p10, (rps_p10 / target_rps) * 100);
-                printf("      50%% of time: RPS ≥ %.0f (%.1f%% of target)\n",
-                       rps_p50, (rps_p50 / target_rps) * 100);
-
-                /* Bottleneck analysis using P1 (99% of time achieved this or better) */
-                if (rps_p1 < 0.90 * target_rps) {
-                    printf("    Status: SEVERE BOTTLENECK DETECTED\n");
-                } else if (rps_p1 < 0.99 * target_rps) {
-                    printf("    Status: BOTTLENECK DETECTED\n");
-                }
-            } else {
-                /* Fallback to original average-based analysis */
-                if (reqpersec < target_rps * 0.90f) {
-                    printf("    Status: SEVERE BOTTLENECK DETECTED\n");
-                } else if (reqpersec < target_rps * 0.99f) {
-                    printf("    Status: BOTTLENECK DETECTED\n");
-                }
-            }
-        }
-
     } else if (config.csv) {
         printf("\"%s\",\"%.2f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\",\"%.3f\"\n", config.title, reqpersec, avg,
                p0, p50, p95, p99, p100);
     } else {
         printf("%*s\r", config.last_printed_bytes, " "); // ensure there is a clean line
         printf("%s: %.2f requests per second, p50=%.3f msec\n", config.title, reqpersec, p50);
+    }
+}
+
+static void showRPSReport(void) {
+    if (config.rps_histogram && config.rps_histogram->total_count > 0) {
+        float target_rps = (float)config.rps;
+        printf("\nRPS Percentiles:\n");
+        printf("  P50: %lld\n", hdr_value_at_percentile(config.rps_histogram, 50.0));
+        printf("  P95: %lld\n", hdr_value_at_percentile(config.rps_histogram, 95.0));
+        printf("  P99: %lld\n", hdr_value_at_percentile(config.rps_histogram, 99.0));
+
+        // Optional bottleneck analysis
+        float p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
+        if (p1 < 0.90 * target_rps) {
+            printf("Status: SEVERE BOTTLENECK DETECTED\n");
+        } else if (p1 < 0.99 * target_rps) {
+            printf("Status: BOTTLENECK DETECTED\n");
+        }
     }
 }
 
@@ -1272,8 +1248,6 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
                  config.rps * 2,
                  config.precision,
                  &config.rps_histogram);
-        config.last_rps_sample_time = 0;
-        config.last_rps_sample_requests = 0;
     }
 
     initPlaceholders(cmd, len);
@@ -1302,6 +1276,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     config.totlatency = mstime() - config.start;
 
     showLatencyReport();
+    showRPSReport();
     freeAllClients();
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);
@@ -1977,29 +1952,6 @@ usage:
     exit(exit_status);
 }
 
-static void sampleRPS(void) {
-    if (config.rps <= 0) return;
-
-    long long current_time = mstime();
-    int current_requests = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
-
-    // Sample every 1000ms (1 second)
-    if (current_time - config.last_rps_sample_time >= 1000) {
-        if (config.last_rps_sample_time > 0) { // Skip first sample
-            double time_diff_sec = (current_time - config.last_rps_sample_time) / 1000.0;
-            double requests_diff = current_requests - config.last_rps_sample_requests;
-            double current_rps = requests_diff / time_diff_sec;
-
-            if (current_rps >= 1.0) { // Only record valid RPS values
-                hdr_record_value(config.rps_histogram, (long)current_rps);
-            }
-        }
-
-        config.last_rps_sample_time = current_time;
-        config.last_rps_sample_requests = current_requests;
-    }
-}
-
 
 long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);
@@ -2032,6 +1984,11 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
     const float rps = (float)requests_finished / dt;
     const float instantaneous_dt = (float)(current_tick - config.previous_tick) / 1000.0;
     const float instantaneous_rps = (float)(requests_finished - previous_requests_finished) / instantaneous_dt;
+
+    if (config.rps_histogram) {
+        hdr_record_value(config.rps_histogram, (int64_t)instantaneous_rps);
+    }
+
     config.previous_tick = current_tick;
     atomic_store_explicit(&config.previous_requests_finished, requests_finished, memory_order_relaxed);
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1277,8 +1277,8 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
              &config.current_sec_latency_histogram);     // Pointer to initialise
 
     if (config.rps > 0) {
-        hdr_init(1,                    // Min RPS: 1
-                 1000000,              // Max RPS: 1M
+        hdr_init(1,       // Min RPS: 1
+                 1000000, // Max RPS: 1M
                  config.precision,
                  &config.rps_histogram);
         config.last_rps_sample_time = 0;
@@ -1988,22 +1988,22 @@ usage:
 
 static void sampleRPS(void) {
     if (config.rps <= 0) return;
-    
+
     long long current_time = mstime();
     int current_requests = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
-    
+
     // Sample every 1000ms (1 second)
     if (current_time - config.last_rps_sample_time >= 1000) {
-        if (config.last_rps_sample_time > 0) {  // Skip first sample
+        if (config.last_rps_sample_time > 0) { // Skip first sample
             double time_diff_sec = (current_time - config.last_rps_sample_time) / 1000.0;
             double requests_diff = current_requests - config.last_rps_sample_requests;
             double current_rps = requests_diff / time_diff_sec;
-            
-            if (current_rps >= 1.0) {  // Only record valid RPS values
+
+            if (current_rps >= 1.0) { // Only record valid RPS values
                 hdr_record_value(config.rps_histogram, (long)current_rps);
             }
         }
-        
+
         config.last_rps_sample_time = current_time;
         config.last_rps_sample_requests = current_requests;
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1102,7 +1102,7 @@ static void showRPSReport(void) {
     }
 }
 
-static void showLatencyReport(void) {
+static void showReport(void) {
     const float reqpersec = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
     const float p0 = ((float)hdr_min(config.latency_histogram)) / 1000.0f;
     const float p50 = hdr_value_at_percentile(config.latency_histogram, 50.0) / 1000.0f;
@@ -1282,7 +1282,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     } else
         startBenchmarkThreads();
     config.totlatency = mstime() - config.start;
-    showLatencyReport();
+    showReport();
     freeAllClients();
     if (config.threads) freeBenchmarkThreads();
     if (config.current_sec_latency_histogram) hdr_close(config.current_sec_latency_histogram);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1174,9 +1174,9 @@ static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
         float target_rps = (float)config.rps;
         printf("\nRPS Percentiles:\n");
-        printf("  P50: %lld\n", hdr_value_at_percentile(config.rps_histogram, 50.0));
-        printf("  P95: %lld\n", hdr_value_at_percentile(config.rps_histogram, 95.0));
-        printf("  P99: %lld\n", hdr_value_at_percentile(config.rps_histogram, 99.0));
+        printf("  P50: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 50.0));
+        printf("  P95: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 95.0));
+        printf("  P99: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 99.0));
 
         // Optional bottleneck analysis
         float p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
@@ -1951,7 +1951,6 @@ usage:
         "                         incr counter ';' exec\n\n");
     exit(exit_status);
 }
-
 
 long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clientData) {
     UNUSED(eventLoop);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1172,17 +1172,23 @@ static void showLatencyReport(void) {
 
 static void showRPSReport(void) {
     if (config.rps_histogram && config.rps_histogram->total_count > 0) {
-        float target_rps = (float)config.rps;
-        printf("\nRPS Percentiles:\n");
-        printf("  P50: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 50.0));
-        printf("  P95: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 95.0));
-        printf("  P99: %.0f\n", (double)hdr_value_at_percentile(config.rps_histogram, 99.0));
+        float avg_rps = (float)config.requests_finished / ((float)config.totlatency / 1000.0f);
 
-        // Optional bottleneck analysis
-        float p1 = hdr_value_at_percentile(config.rps_histogram, 1.0);
-        if (p1 < 0.90 * target_rps) {
+        float p50 = (float)hdr_value_at_percentile(config.rps_histogram, 50.0);
+        float p95 = (float)hdr_value_at_percentile(config.rps_histogram, 95.0);
+        float p99 = (float)hdr_value_at_percentile(config.rps_histogram, 99.0);
+
+        printf("\nRPS Percentiles:\n");
+        printf("  P50: %.0f\n", p50);
+        printf("  P95: %.0f\n", p95);
+        printf("  P99: %.0f\n", p99);
+        printf("  Average: %.0f\n", avg_rps);
+
+        // Bottleneck detection using target RPS
+        float target_rps = (float)config.rps;
+        if (p99 < 0.9 * target_rps) {
             printf("Status: SEVERE BOTTLENECK DETECTED\n");
-        } else if (p1 < 0.99 * target_rps) {
+        } else if (p99 < target_rps) {
             printf("Status: BOTTLENECK DETECTED\n");
         }
     }


### PR DESCRIPTION
When benchmarking with the a target thoughput using the `--rps` flag, display an RPS histogram in the benchmark report. This can help identify if there is a bottleneck.

Related to #2219.