### PR TITLE
HSETEX 'hset' notification should only be generated if not expired

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1268,26 +1268,28 @@ void hsetexCommand(client *c) {
         if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
             dbUpdateObjectWithVolatileItemsTracking(c->db, o);
         }
-        notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
         if (set_expired) {
             replaceClientCommandVector(c, new_argc, new_argv);
             /* We would like to reduce the number of hexpired events in case there are potential many expired fields. */
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
-        } else if (expire) {
-            /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
-             * EX/PX/EXAT flag. */
-            if (!(flags & ARGS_PXAT)) {
-                for (int i = 2; i < fields_index; i++) {
-                    if (c->argv[i + 1] == expire) {
-                        robj *milliseconds_obj = createStringObjectFromLongLong(when);
-                        rewriteClientCommandArgument(c, i, shared.pxat);
-                        rewriteClientCommandArgument(c, i + 1, milliseconds_obj);
-                        decrRefCount(milliseconds_obj);
-                        break;
+        } else {
+            notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
+            if (expire) {
+                /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
+                 * EX/PX/EXAT flag. */
+                if (!(flags & ARGS_PXAT)) {
+                    for (int i = 2; i < fields_index; i++) {
+                        if (c->argv[i + 1] == expire) {
+                            robj *milliseconds_obj = createStringObjectFromLongLong(when);
+                            rewriteClientCommandArgument(c, i, shared.pxat);
+                            rewriteClientCommandArgument(c, i + 1, milliseconds_obj);
+                            decrRefCount(milliseconds_obj);
+                            break;
+                        }
                     }
                 }
+                notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
-            notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
         /* Delete the object in case it was left empty */

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -567,7 +567,7 @@ start_server {tags {"hashexpire"}} {
             assert_equal {1} [r HSETEX myhash $command [get_past_zero_expire_value $command] FIELDS 1 f1 v1]
 
             # Verify field and keys are deleted
-            assert_keyevent_patterns $rd myhash hset hexpired del
+            assert_keyevent_patterns $rd myhash hexpired del
             assert_equal -2 [r HTTL myhash FIELDS 1 f1]
             assert_equal 0 [r HLEN myhash]
             assert_equal 0 [r EXISTS myhash]


### PR DESCRIPTION
Currently HSETEX always generate `hset` notification. In order to align with generic `set` command, it should only generate `hset` if the provided time-to-live is a valid future time.