### PR TITLE
Consolidate slot migration logs by grouping consecutive slot migrations into a single log entry

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2743,6 +2743,18 @@ void clusterSetNodeAsPrimary(clusterNode *n) {
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
 }
 
+static void clusterLogSlotRangeMigration(int first_slot,
+                                         int last_slot,
+                                         clusterNode *source_node,
+                                         clusterNode *target_node) {
+    serverLog(LL_NOTICE,
+              "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
+              " to node %.40s (%s) in shard %.40s.",
+              first_slot, last_slot,
+              source_node->name, source_node->human_nodename, source_node->shard_id,
+              target_node->name, target_node->human_nodename, target_node->shard_id);
+}
+
 /* This function is called when we receive a primary configuration via a
  * PING, PONG or UPDATE packet. What we receive is a node, a configEpoch of the
  * node, and the set of slots claimed under this configEpoch.
@@ -2828,13 +2840,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                     } else {
                         /* We have a gap in the range of migrated slots.
                          * Log the previous range and start a new one. */
-                        serverLog(LL_NOTICE,
-                                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
-                                  " to node %.40s (%s) in shard %.40s.",
-                                  first_migrated_slot, last_migrated_slot,
-                                  migration_source_node->name, migration_source_node->human_nodename, migration_source_node->shard_id,
-                                  sender->name, sender->human_nodename,
-                                  sender->shard_id);
+                        clusterLogSlotRangeMigration(first_migrated_slot, last_migrated_slot,
+                                                     migration_source_node, sender);
                         /* Reset the range for the next slot. */
                         first_migrated_slot = j;
                         last_migrated_slot = j;
@@ -2975,12 +2982,9 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         }
     }
 
-    if (migration_source_node != NULL && first_migrated_slot != -1 && last_migrated_slot != -1) {
-        serverLog(LL_NOTICE,
-                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
-                  " to node %.40s (%s) in shard %.40s.",
-                  first_migrated_slot, last_migrated_slot, migration_source_node->name, migration_source_node->human_nodename,
-                  migration_source_node->shard_id, sender->name, sender->human_nodename, sender->shard_id);
+    if (first_migrated_slot != -1) {
+        clusterLogSlotRangeMigration(first_migrated_slot, last_migrated_slot,
+                                     migration_source_node, sender);
     }
 
     /* After updating the slots configuration, don't do any actual change

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2790,8 +2790,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
 
     /* Sender and myself in the same shard? */
     int are_in_same_shard = areInSameShard(sender, myself);
-    int first_migrating_slot = -1, last_migrating_slot = -1;
-    clusterNode *from_node = NULL;
+    int first_migrated_slot = -1, last_migrated_slot = -1;
+    clusterNode *migration_source_node = NULL;
 
     for (j = 0; j < CLUSTER_SLOTS; j++) {
         if (bitmapTestBit(slots, j)) {
@@ -2817,23 +2817,28 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 server.cluster->slots[j]->configEpoch < senderConfigEpoch ||
                 clusterSlotFailoverGranted(j)) {
                 if (!isSlotUnclaimed(j) && !areInSameShard(server.cluster->slots[j], sender)) {
-                    if (from_node == NULL) from_node = server.cluster->slots[j];
-                    if (first_migrating_slot == -1) first_migrating_slot = j;
-                    if (last_migrating_slot == -1) {
-                        last_migrating_slot = j;
-                    } else if (from_node == server.cluster->slots[j] && j == last_migrating_slot + 1) {
-                        last_migrating_slot = j;
+                    if (first_migrated_slot == -1) {
+                        /* Delay-initialize the range of migrated slots. */
+                        first_migrated_slot = j;
+                        last_migrated_slot = j;
+                        migration_source_node = server.cluster->slots[j];
+                    } else if (migration_source_node == server.cluster->slots[j] && j == last_migrated_slot + 1) {
+                        /* Extend the range of migrated slots. */
+                        last_migrated_slot = j;
                     } else {
+                        /* We have a gap in the range of migrated slots.
+                         * Log the previous range and start a new one. */
                         serverLog(LL_NOTICE,
                                   "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
                                   " to node %.40s (%s) in shard %.40s.",
-                                  first_migrating_slot, last_migrating_slot,
-                                  from_node->name, from_node->human_nodename, from_node->shard_id,
+                                  first_migrated_slot, last_migrated_slot,
+                                  migration_source_node->name, migration_source_node->human_nodename, migration_source_node->shard_id,
                                   sender->name, sender->human_nodename,
                                   sender->shard_id);
-                        first_migrating_slot = -1;
-                        last_migrating_slot = -1;
-                        from_node = NULL;
+                        /* Reset the range for the next slot. */
+                        first_migrated_slot = j;
+                        last_migrated_slot = j;
+                        migration_source_node = server.cluster->slots[j];
                     }
                 }
 
@@ -2970,11 +2975,12 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
         }
     }
 
-    if (from_node != NULL && first_migrating_slot != -1 && last_migrating_slot != -1) {
+    if (migration_source_node != NULL && first_migrated_slot != -1 && last_migrated_slot != -1) {
         serverLog(LL_NOTICE,
-                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s to node %.40s (%s) in shard %.40s.",
-                  first_migrating_slot, last_migrating_slot, from_node->name, from_node->human_nodename,
-                  from_node->shard_id, sender->name, sender->human_nodename, sender->shard_id);
+                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
+                  " to node %.40s (%s) in shard %.40s.",
+                  first_migrated_slot, last_migrated_slot, migration_source_node->name, migration_source_node->human_nodename,
+                  migration_source_node->shard_id, sender->name, sender->human_nodename, sender->shard_id);
     }
 
     /* After updating the slots configuration, don't do any actual change

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2790,6 +2790,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
 
     /* Sender and myself in the same shard? */
     int are_in_same_shard = areInSameShard(sender, myself);
+    int first_migrating_slot = -1, last_migrating_slot = -1;
+    clusterNode *from_node = NULL;
 
     for (j = 0; j < CLUSTER_SLOTS; j++) {
         if (bitmapTestBit(slots, j)) {
@@ -2815,12 +2817,24 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 server.cluster->slots[j]->configEpoch < senderConfigEpoch ||
                 clusterSlotFailoverGranted(j)) {
                 if (!isSlotUnclaimed(j) && !areInSameShard(server.cluster->slots[j], sender)) {
-                    serverLog(LL_NOTICE,
-                              "Slot %d is migrated from node %.40s (%s) in shard %.40s"
-                              " to node %.40s (%s) in shard %.40s.",
-                              j, server.cluster->slots[j]->name, server.cluster->slots[j]->human_nodename,
-                              server.cluster->slots[j]->shard_id, sender->name, sender->human_nodename,
-                              sender->shard_id);
+                    if (from_node == NULL) from_node = server.cluster->slots[j];
+                    if (first_migrating_slot == -1) first_migrating_slot = j;
+                    if (last_migrating_slot == -1) {
+                        last_migrating_slot = j;
+                    } else if (from_node == server.cluster->slots[j] && j == last_migrating_slot + 1) {
+                        last_migrating_slot = j;
+                    } else {
+                        serverLog(LL_NOTICE,
+                                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s"
+                                  " to node %.40s (%s) in shard %.40s.",
+                                  first_migrating_slot, last_migrating_slot,
+                                  from_node->name, from_node->human_nodename, from_node->shard_id,
+                                  sender->name, sender->human_nodename,
+                                  sender->shard_id);
+                        first_migrating_slot = -1;
+                        last_migrating_slot = -1;
+                        from_node = NULL;
+                    }
                 }
 
                 /* Was this slot mine, and still contains keys? Mark it as
@@ -2954,6 +2968,13 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 }
             }
         }
+    }
+
+    if (from_node != NULL && first_migrating_slot != -1 && last_migrating_slot != -1) {
+        serverLog(LL_NOTICE,
+                  "Slot range [%d, %d] is migrated from node %.40s (%s) in shard %.40s to node %.40s (%s) in shard %.40s.",
+                  first_migrating_slot, last_migrating_slot, from_node->name, from_node->human_nodename,
+                  from_node->shard_id, sender->name, sender->human_nodename, sender->shard_id);
     }
 
     /* After updating the slots configuration, don't do any actual change


### PR DESCRIPTION
Previously, each slot migration was logged individually, which could lead to log spam in scenarios where many slots are migrated at once.

This commit enhances the logging mechanism to group consecutive slot migrations into a single log entry, improving log readability and reducing noise. 

Log snippets

```
1661951:S 13 Aug 2025 15:47:10.132 * Slot range [16383, 16383] is migrated from node c3926da75f7c3a0a1bcd07e088b0bde09d48024c () in shard 7746b693330c0814178b90b757e2711ebb8c6609 to node 2465c29c8afb9231525e281e5825684d0bb79f7b () in shard 39342c039d2a6c7ef0ff96314b230dfd7737d646.
1661951:S 13 Aug 2025 15:47:10.289 * Slot range [10924, 16383] is migrated from node 2465c29c8afb9231525e281e5825684d0bb79f7b () in shard 39342c039d2a6c7ef0ff96314b230dfd7737d646 to node c3926da75f7c3a0a1bcd07e088b0bde09d48024c () in shard 7746b693330c0814178b90b757e2711ebb8c6609.
1661951:S 13 Aug 2025 15:47:10.524 * Slot range [10924, 16383] is migrated from node c3926da75f7c3a0a1bcd07e088b0bde09d48024c () in shard 7746b693330c0814178b90b757e2711ebb8c6609 to node 2465c29c8afb9231525e281e5825684d0bb79f7b () in shard 39342c039d2a6c7ef0ff96314b230dfd7737d646.
```