### PR TITLE
Fix cluster test module to pass null terminated node-id to SendClusterMessage

### DIFF
--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -1,4 +1,5 @@
 #include "valkeymodule.h"
+#include <string.h>
 
 #define UNUSED(x) (void)(x)
 

--- a/tests/modules/cluster.c
+++ b/tests/modules/cluster.c
@@ -48,7 +48,11 @@ int PingallCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
 
 void DingReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {
     ValkeyModule_Log(ctx, "notice", "DING (type %d) RECEIVED from %.*s: '%.*s'", type, VALKEYMODULE_NODE_ID_LEN, sender_id, (int)len, payload);
-    ValkeyModule_SendClusterMessage(ctx, sender_id, MSGTYPE_DONG, "Message Received!", 17);
+    /* Ensure sender_id is null-terminated for cross-version compatibility */
+    char null_terminated_sender_id[VALKEYMODULE_NODE_ID_LEN + 1];
+    memcpy(null_terminated_sender_id, sender_id, VALKEYMODULE_NODE_ID_LEN);
+    null_terminated_sender_id[VALKEYMODULE_NODE_ID_LEN] = '\0';
+    ValkeyModule_SendClusterMessage(ctx, null_terminated_sender_id, MSGTYPE_DONG, "Message Received!", 17);
 }
 
 void DongReceiver(ValkeyModuleCtx *ctx, const char *sender_id, uint8_t type, const unsigned char *payload, uint32_t len) {


### PR DESCRIPTION
Fix https://github.com/valkey-io/valkey/issues/2438

Modified `DingReceiver` function in `tests/modules/cluster.c` by adding null-termination logic for cross-version compatibility