### PR TITLE
Fixing Slot Migration Test Failure 

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1550,6 +1550,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_match "OK" [R 2 FLUSHDB SYNC]
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16381 16381 16383 16383 NODE $node2_id]
             wait_for_migration 2 16381
+            wait_for_migration 2 16383
         }
     }
 


### PR DESCRIPTION
Make sure slot migration has finished before moving on to the next test.

Resolves #2479