### PR TITLE
Don't call SSL_write() with num=0

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -2337,7 +2337,7 @@ static void writeToReplica(client *c) {
         len -= start;
 
         /* For TLS, we should not call SSL_write() with num=0 */
-        if (len == 0) {
+        if (unlikely(len == 0)) {
             continue;
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -2336,6 +2336,11 @@ static void writeToReplica(client *c) {
         size_t len = (cur_node == last_node) ? bufpos : cur_block->used;
         len -= start;
 
+        /* For TLS, we should not call SSL_write() with num=0 */
+        if (len == 0) {
+            continue;
+        }
+
         iov[iovcnt].iov_base = cur_block->buf + start;
         iov[iovcnt].iov_len = len;
         total_bytes += len;


### PR DESCRIPTION
https://github.com/valkey-io/valkey/blob/aefed3d363d1c7d7cb391d3f605484c78c9a88f2/src/networking.c#L2279-L2293
From above code, we can see that `c->repl_data->ref_block_pos` could be equal to `o->used`.
When `o->used == o->size`, we may call SSL_write() with num=0 which does not comply with the openSSL specification. 
(ref: https://docs.openssl.org/master/man3/SSL_write/#warnings)

What's worse is that it's still the case after the reconnection. See https://github.com/valkey-io/valkey/blob/aefed3d363d1c7d7cb391d3f605484c78c9a88f2/src/replication.c#L756-L769. So in this case the replica will keep reconnecting again and again until it doesn't meet the requirements for partial synchronization.

Resolves #2119