### PR TITLE
Add test failure template to contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-failure.md
+++ b/.github/ISSUE_TEMPLATE/test-failure.md
@@ -20,3 +20,5 @@ A short description of the failure.
 **Error stack trace**
 
 A relevant stack trace for the test failure.
+
+> **Tip:** Copy and paste the full stack trace from the CI output into your issue, as CI links may expire over time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ The Valkey project is led by a Technical Steering Committee, whose responsibilit
 * Found a bug? [Report it here](https://github.com/valkey-io/valkey/issues/new?template=bug_report.md&title=%5BBUG%5D)
 * Valkey crashed? [Submit a crash report here](https://github.com/valkey-io/valkey/issues/new?template=crash_report.md&title=%5BCRASH%5D+%3Cshort+description%3E)
 * Suggest a new feature? [Post your detailed feature request here](https://github.com/valkey-io/valkey/issues/new?template=feature_request.md&title=%5BNEW%5D)
+* Report a test failure? [Report it here](https://github.com/valkey-io/valkey/issues/new?template=test-failure.md)
 * Want to help with documentation? [Move on to valkey-doc](https://github.com/valkey-io/valkey-doc)
 * Report a vulnerability? See [SECURITY.md](SECURITY.md)
 


### PR DESCRIPTION
We recently introduced a new template to create `test failures` issues from a template. This change makes this template visible in the `CONTRIBUTING.md` file. Also, added a tip to paste the stack trace since outputs of CI links can expire.