### PR TITLE
CONFIG GET command return sorted output

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -997,29 +997,30 @@ void configGetCommand(client *c) {
     }
 
     di = dictGetIterator(matches);
-    unsigned long matchesSize = dictSize(matches);
-    addReplyMapLen(c, matchesSize);
+    int n = dictSize(matches);
+    addReplyMapLen(c, n);
 
     struct {
         const char *key;
         sds value;
-    } *sorted = zmalloc(sizeof(*sorted) * matchesSize);
-    unsigned long sortedIndex = 0;
+    } *sorted = zmalloc(sizeof(*sorted) * n);
+
+    i = 0;
     while ((de = dictNext(di)) != NULL) {
         standardConfig *config = (standardConfig *)dictGetVal(de);
-        sorted[sortedIndex].key = dictGetKey(de);
-        sorted[sortedIndex].value = config->interface.get(config);
-        sortedIndex++;
+        sorted[i].key = dictGetKey(de);
+        sorted[i].value = config->interface.get(config);
+        i++;
     }
-    qsort(sorted, matchesSize, sizeof(*sorted), configKeyCompare);
-
-    for (sortedIndex = 0; sortedIndex < matchesSize; sortedIndex++) {
-        addReplyBulkCString(c, sorted[sortedIndex].key);
-        addReplyBulkSds(c, sorted[sortedIndex].value);
-    }
-    zfree(sorted);
     dictReleaseIterator(di);
     dictRelease(matches);
+
+    qsort(sorted, n, sizeof(*sorted), configKeyCompare);
+    for (i = 0; i < n; i++) {
+        addReplyBulkCString(c, sorted[i].key);
+        addReplyBulkSds(c, sorted[i].value);
+    }
+    zfree(sorted);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -948,6 +948,13 @@ end:
     listRelease(module_configs_apply);
 }
 
+/* Used by configGetCommand */
+static int configKeyCompare(const void *a, const void *b) {
+    const char *key_a = *(const char **)a;
+    const char *key_b = *(const char **)b;
+    return strcmp(key_a, key_b);
+}
+
 /*-----------------------------------------------------------------------------
  * CONFIG GET implementation
  *----------------------------------------------------------------------------*/
@@ -990,12 +997,27 @@ void configGetCommand(client *c) {
     }
 
     di = dictGetIterator(matches);
-    addReplyMapLen(c, dictSize(matches));
+    unsigned long matchesSize = dictSize(matches);
+    addReplyMapLen(c, matchesSize);
+
+    struct {
+        const char *key;
+        sds value;
+    } *sorted = zmalloc(sizeof(*sorted) * matchesSize);
+    unsigned long sortedIndex = 0;
     while ((de = dictNext(di)) != NULL) {
         standardConfig *config = (standardConfig *)dictGetVal(de);
-        addReplyBulkCString(c, dictGetKey(de));
-        addReplyBulkSds(c, config->interface.get(config));
+        sorted[sortedIndex].key = dictGetKey(de);
+        sorted[sortedIndex].value = config->interface.get(config);
+        sortedIndex++;
     }
+    qsort(sorted, matchesSize, sizeof(*sorted), configKeyCompare);
+
+    for (sortedIndex = 0; sortedIndex < matchesSize; sortedIndex++) {
+        addReplyBulkCString(c, sorted[sortedIndex].key);
+        addReplyBulkSds(c, sorted[sortedIndex].value);
+    }
+    zfree(sorted);
     dictReleaseIterator(di);
     dictRelease(matches);
 }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1143,6 +1143,15 @@ start_server {tags {"introspection"}} {
         r client info
     } {*lib-name= *}
 
+    test {CONFIG get should return sorted output} {
+        set config [r config get *]
+        set keys {}
+        foreach {key value} $config {
+            lappend keys $key
+        }
+        assert_equal [lsort $keys] $keys
+    }
+
     test {CONFIG save params special case handled properly} {
         # No "save" keyword - defaults should apply
         start_server {config "minimal.conf"} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1143,7 +1143,7 @@ start_server {tags {"introspection"}} {
         r client info
     } {*lib-name= *}
 
-    test {CONFIG get should return sorted output} {
+    test {CONFIG GET should return sorted output} {
         set config [r config get *]
         set keys {}
         foreach {key value} $config {


### PR DESCRIPTION
Previously, the config names and values were stored in a temporary dict. This ensures that no duplicates are returned, but it also makes the order random.

In this PR, the config names and values still stored in the temporary dict, but then they are copied to an array, which is sorted, before the reply is sent.

Resolves #2042