### PR TITLE
Don't allow slot migration to myself node

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -893,7 +893,7 @@ void clusterCommandMigrateSlots(client *c) {
             goto cleanup;
         }
         if (target_node == server.cluster->myself) {
-            addReplyError(c, "Slots are served by this node.");
+            addReplyError(c, "Target node can not be this node.");
             goto cleanup;
         }
         curr_index++;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -847,7 +847,7 @@ void clusterCommandMigrateSlots(client *c) {
             goto cleanup;
         }
         if (source_node != server.cluster->myself) {
-            addReplyError(c, "Slots are not served by myself.");
+            addReplyError(c, "Slots are not served by this node.");
             goto cleanup;
         }
 
@@ -893,7 +893,7 @@ void clusterCommandMigrateSlots(client *c) {
             goto cleanup;
         }
         if (target_node == server.cluster->myself) {
-            addReplyError(c, "Slots are served by myself.");
+            addReplyError(c, "Slots are served by this node.");
             goto cleanup;
         }
         curr_index++;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -892,6 +892,10 @@ void clusterCommandMigrateSlots(client *c) {
                                 (sds)c->argv[curr_index]->ptr);
             goto cleanup;
         }
+        if (target_node == server.cluster->myself) {
+            addReplyErrorFormat(c, "Slots are served by myself.");
+            goto cleanup;
+        }
         curr_index++;
 
         slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges);

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -847,7 +847,7 @@ void clusterCommandMigrateSlots(client *c) {
             goto cleanup;
         }
         if (source_node != server.cluster->myself) {
-            addReplyErrorFormat(c, "Slots are not served by myself.");
+            addReplyError(c, "Slots are not served by myself.");
             goto cleanup;
         }
 
@@ -893,7 +893,7 @@ void clusterCommandMigrateSlots(client *c) {
             goto cleanup;
         }
         if (target_node == server.cluster->myself) {
-            addReplyErrorFormat(c, "Slots are served by myself.");
+            addReplyError(c, "Slots are served by myself.");
             goto cleanup;
         }
         curr_index++;

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -200,7 +200,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
         assert_error "*Slot migration can only be used on primary nodes*" {R 3 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0}
         assert_error "*Slots are not served by this node*" {R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
-        assert_error "*Slots are served by this node*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
+        assert_error "*Target node can not be this node*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
 
         assert_error "*wrong number of arguments*" {R 0 CLUSTER CANCELSLOTMIGRATIONS ARG}
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -200,6 +200,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
         assert_error "*Slot migration can only be used on primary nodes*" {R 3 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0}
         assert_error "*Slots are not served by myself*" {R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
+        assert_error "*Slots are served by myself*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
 
         assert_error "*wrong number of arguments*" {R 0 CLUSTER CANCELSLOTMIGRATIONS ARG}
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -199,8 +199,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         R 0 CLUSTER ADDSLOTS 0
 
         assert_error "*Slot migration can only be used on primary nodes*" {R 3 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0}
-        assert_error "*Slots are not served by myself*" {R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
-        assert_error "*Slots are served by myself*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
+        assert_error "*Slots are not served by this node*" {R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
+        assert_error "*Slots are served by this node*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id}
 
         assert_error "*wrong number of arguments*" {R 0 CLUSTER CANCELSLOTMIGRATIONS ARG}
         assert_error "*No migrations ongoing*" {R 0 CLUSTER CANCELSLOTMIGRATIONS}


### PR DESCRIPTION
This may result in meaningless slot migration job, we should
return an error to user in advance to avoid operation error.
Also `by myself` is not correct English grammar and `myself`
is a internal code terminology, changed to `by this node`.

Was introduced in #1949.