### PR TITLE
Fix memory leak in saveSnapshotToConnectionSockets

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3586,8 +3586,9 @@ void killRDBChild(void) {
 /* Save snapshot to the provided connections, spawning a child process and
  * running the provided function.
  *
- * Connections array provided will be freed after the save is completed, and
- * should not be freed by the caller. */
+ * The connections array (the conns field in the rdbSnapshotOptions) is a
+ * heap-allocated array that will be freed by this function and shall not be
+ * freed by the caller. */
 int saveSnapshotToConnectionSockets(rdbSnapshotOptions options) {
     pid_t childpid;
     int pipefds[2], rdb_pipe_write = -1, safe_to_exit_pipe = -1;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3591,19 +3591,28 @@ void killRDBChild(void) {
 int saveSnapshotToConnectionSockets(rdbSnapshotOptions options) {
     pid_t childpid;
     int pipefds[2], rdb_pipe_write = -1, safe_to_exit_pipe = -1;
-    if (hasActiveChildProcess()) return C_ERR;
+    if (hasActiveChildProcess()) {
+        zfree(options.conns);
+        return C_ERR;
+    }
     serverAssert(server.rdb_pipe_read == -1 && server.rdb_child_exit_pipe == -1);
 
     /* Even if the previous fork child exited, don't start a new one until we
      * drained the pipe. */
-    if (server.rdb_pipe_conns) return C_ERR;
+    if (server.rdb_pipe_conns) {
+        zfree(options.conns);
+        return C_ERR;
+    }
 
     if (options.use_pipe) {
         /* Before to fork, create a pipe that is used to transfer the rdb bytes to
          * the parent, we can't let it write directly to the sockets, since in case
          * of TLS we must let the parent handle a continuous TLS state when the
          * child terminates and parent takes over. */
-        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) return C_ERR;
+        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) {
+            zfree(options.conns);
+            return C_ERR;
+        }
         server.rdb_pipe_read = pipefds[0]; /* read end */
         rdb_pipe_write = pipefds[1];       /* write end */
 
@@ -3612,6 +3621,7 @@ int saveSnapshotToConnectionSockets(rdbSnapshotOptions options) {
         if (anetPipe(pipefds, 0, 0) == -1) {
             close(rdb_pipe_write);
             close(server.rdb_pipe_read);
+            zfree(options.conns);
             return C_ERR;
         }
         safe_to_exit_pipe = pipefds[0];          /* read end */

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -120,7 +120,7 @@ enum RdbType {
 typedef int (*ChildSnapshotFunc)(int req, rio *rdb, void *privdata);
 typedef struct rdbSnapshotOptions {
     int connsnum;                    /* Number of connections. */
-    connection **conns;              /* Connections to send the snapshot to. */
+    connection **conns;              /* A heap-allocated array of connections to send the snapshot to. */
     int use_pipe;                    /* Use pipe to send the snapshot. */
     int req;                         /* See REPLICA_REQ_* in server.h. */
     int skip_checksum;               /* Skip checksum when sending the snapshot. */


### PR DESCRIPTION
We now pass in rdbSnapshotOptions options in this function, and options.conns
is now malloc'ed in the caller side, so we need to zfree it when returning early
due to an error. Previously, conns was malloc'ed after the error handling, so we
don't have this.

Introduced in #1949.