### PR TITLE
Free field and value for invalid item expiry

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2198,7 +2198,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
             long long itemexpiry = EXPIRY_NONE;
             if (rdbtype == RDB_TYPE_HASH_2) {
                 itemexpiry = rdbLoadMillisecondTime(rdb, RDB_VERSION);
-                if (itemexpiry < EXPIRY_NONE || rioGetReadError(rdb)) return NULL;
+                if (itemexpiry < EXPIRY_NONE || rioGetReadError(rdb)) {
+                    sdsfree(field);
+                    sdsfree(value);
+                    decrRefCount(o);
+                    return NULL;
+                }
             }
 
             /* Add pair to hash table */


### PR DESCRIPTION
I think we should safely deallocate field and value here, and this change should address this leak: https://github.com/valkey-io/valkey/actions/runs/17027650597/job/48265126023#step:6:7325


```
 ==91949==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 70 byte(s) in 1 object(s) allocated from:
    #0 0x5635911e4d73 in malloc (/home/runner/work/valkey/valkey/src/valkey-server+0x206d73) (BuildId: f147b90893504c0f834b306808efaa79c850a2fe)
    #1 0x56359128a2d7 in ztrymalloc_usable_internal /home/runner/work/valkey/valkey/src/zmalloc.c:156:17
    #2 0x56359128a2d7 in ztrymalloc_usable /home/runner/work/valkey/valkey/src/zmalloc.c:175:17
    #3 0x56359127851e in _sdsnewlen /home/runner/work/valkey/valkey/src/sds.c:112:22
    #4 0x563591333b97 in rdbLoadLzfStringObject /home/runner/work/valkey/valkey/src/rdb.c:444:15
    #5 0x5635913352da in rdbGenericLoadStringObject /home/runner/work/valkey/valkey/src/rdb.c:568:34
    #6 0x563591345fda in rdbLoadObject /home/runner/work/valkey/valkey/src/rdb.c:2191:26
    #7 0x5635913eaaa3 in restoreCommand /home/runner/work/valkey/valkey/src/cluster.c:261:17
    #8 0x563591264ceb in call /home/runner/work/valkey/valkey/src/server.c:3804:5
    #9 0x563591267ffc in processCommand /home/runner/work/valkey/valkey/src/server.c:4471:9
    #10 0x5635912c5221 in processCommandAndResetClient /home/runner/work/valkey/valkey/src/networking.c:3632:9
    #11 0x5635912c5221 in processInputBuffer /home/runner/work/valkey/valkey/src/networking.c:3763:13
    #12 0x5635912a87ae in readQueryFromClient /home/runner/work/valkey/valkey/src/networking.c:3873:17
    #13 0x563591551c2f in callHandler /home/runner/work/valkey/valkey/src/./connhelpers.h:79:18
    #14 0x563591551c2f in connSocketEventHandler /home/runner/work/valkey/valkey/src/socket.c:301:14
    #15 0x5635912322f0 in aeProcessEvents /home/runner/work/valkey/valkey/src/ae.c:486:17
    #16 0x563591232d6c in aeMain /home/runner/work/valkey/valkey/src/ae.c:543:9
    #17 0x563591276910 in main /home/runner/work/valkey/valkey/src/server.c:7375:5
    #18 0x7fb88ce2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #19 0x7fb88ce2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #20 0x563591149f24 in _start (/home/runner/work/valkey/valkey/src/valkey-server+0x16bf24) (BuildId: f147b90893504c0f834b306808efaa79c850a2fe)
```

