### PR TITLE
fix hsetex handling of wrong number of fields

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1200,7 +1200,7 @@ void hsetexCommand(client *c) {
         }
     }
     /* Check that the parsed fields number matches the real provided number of fields */
-    if (!num_fields || (num_fields * 2) != (c->argc - fields_index)) {
+    if (!num_fields || num_fields > LLONG_MAX / 2 || (num_fields * 2) != (c->argc - fields_index)) {
         addReplyError(c, "numfields should be greater than 0 and match the provided number of fields");
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1200,7 +1200,7 @@ void hsetexCommand(client *c) {
         }
     }
     /* Check that the parsed fields number matches the real provided number of fields */
-    if (!num_fields || num_fields != (c->argc - fields_index) / 2) {
+    if (!num_fields || (num_fields * 2) != (c->argc - fields_index)) {
         addReplyError(c, "numfields should be greater than 0 and match the provided number of fields");
         return;
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -624,9 +624,8 @@ start_server {tags {"hashexpire"}} {
     } {ERR *}
 
     test {HSETEX PX - mismatched field/value count} {
-         catch {r HSETEX myhash PX 100 FIELDS 1 field1 val1 extra} e
-         set e
-    } {ERR numfields should be greater than 0 and match the provided number of fields}
+         assert_error {ERR numfields should be greater than 0 and match the provided number of fields} {r HSETEX myhash PX 100 FIELDS 1 field1 val1 extra}
+    } 
 
 
     ## FNX/FXX

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -623,10 +623,10 @@ start_server {tags {"hashexpire"}} {
         set e
     } {ERR *}
 
-    # test {HSETEX PX - mismatched field/value count} {
-    #     catch {r HSETEX myhash PX 100 FIELDS 2 field1 val1} e
-    #     set e
-    # } {ERR wrong number of arguments for 'hsetex' command}
+    test {HSETEX PX - mismatched field/value count} {
+         catch {r HSETEX myhash PX 100 FIELDS 1 field1 val1 extra} e
+         set e
+    } {ERR numfields should be greater than 0 and match the provided number of fields}
 
 
     ## FNX/FXX


### PR DESCRIPTION
currently hsetex is verifying the number of fields matches the provided number of fields by using div. instead it can match to the multiplication in order to prevent rounding the verified value down.