### PR TITLE
Atomically update cluster and replication layer while marking self node as primary

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1453,7 +1453,6 @@ void clusterReset(int hard) {
     if (nodeIsReplica(myself)) {
         was_replica = 1;
         clusterSetNodeAsPrimary(myself);
-        replicationUnsetPrimary();
         flushAllDataAndResetRDB(server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
     }
 
@@ -5085,7 +5084,6 @@ void clusterFailoverReplaceYourPrimary(void) {
 
     /* 1) Turn this node into a primary. */
     clusterSetNodeAsPrimary(myself);
-    replicationUnsetPrimary();
 
     int remaining = old_primary->numslots;
     /* 2) Claim all the slots assigned to our primary. */
@@ -7537,13 +7535,8 @@ int clusterCommandSpecial(client *c) {
             serverLog(LL_NOTICE, "Stop replication and turning myself into empty primary (request from '%s').", client);
             sdsfree(client);
             clusterSetNodeAsPrimary(myself);
-
-            /* Flush the data before promoting myself, since promotion will try
-             * to delete data in unowned slots, and we know all data will be
-             * removed anyways. */
             flushAllDataAndResetRDB(server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
-            clusterPromoteSelfToPrimary();
-
+            verifyClusterConfigWithData();
             clusterCloseAllSlots();
             resetManualFailover();
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2731,6 +2731,8 @@ int nodeUpdateAddressIfNeeded(clusterNode *node, clusterLink *link, clusterMsg *
 void clusterSetNodeAsPrimary(clusterNode *n) {
     if (clusterNodeIsPrimary(n)) return;
 
+    serverLog(LL_NOTICE, "Reconfiguring node %.40s (%s) as primary for shard %.40s", n->name, n->human_nodename, n->shard_id);
+
     if (n->replicaof) {
         clusterNodeRemoveReplica(n->replicaof, n);
         if (n != myself) n->flags |= CLUSTER_NODE_MIGRATE_TO;
@@ -2738,6 +2740,10 @@ void clusterSetNodeAsPrimary(clusterNode *n) {
     n->flags &= ~CLUSTER_NODE_REPLICA;
     n->flags |= CLUSTER_NODE_PRIMARY;
     n->replicaof = NULL;
+
+    if (n == myself) {
+        replicationUnsetPrimary();
+    }
 
     /* Update config and state. */
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
@@ -3921,6 +3927,9 @@ int clusterProcessPacket(clusterLink *link) {
             /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
             serverAssert(nodeIsPrimary(sender));
 
+            serverLog(LL_NOTICE, "Mismatch in topology information for sender node %.40s (%s) in shard %.40s", sender->name,
+                      sender->human_nodename, sender->shard_id);
+
             /* 1) If the sender of the message is a primary, and we detected that
              *    the set of slots it claims changed, scan the slots to see if we
              *    need to update our configuration. */
@@ -4033,6 +4042,10 @@ int clusterProcessPacket(clusterLink *link) {
         n = clusterLookupNode(hdr->data.update.nodecfg.nodename, CLUSTER_NAMELEN);
         if (!n) return 1;                                    /* We don't know the reported node. */
         if (n->configEpoch >= reportedConfigEpoch) return 1; /* Nothing new. */
+
+        serverLog(LL_NOTICE, "Processing UPDATE message received from %.40s (%s) in shard %s about node %.40s (%s) in shard %s. old configEpoch %llu, new configEpoch %llu",
+                  sender->name, sender->human_nodename, sender->shard_id, n->name, n->human_nodename, n->shard_id,
+                  (unsigned long long)n->configEpoch, (unsigned long long)reportedConfigEpoch);
 
         /* If in our current config the node is a replica, set it as a primary. */
         if (nodeIsReplica(n)) clusterSetNodeAsPrimary(n);


### PR DESCRIPTION
Fixes: #2460

With this change we avoid divergence in cluster and replication layer view. I've observed node can be marked as primary in cluster while it can be marked as replica in replication layer view and have a active replication link. Without this change, we used to end up in a invalid replica chain in replication layer.