### PR TITLE
Update pong_received time via gossip only if the node is healthy from our view

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -2580,7 +2580,9 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
              * we have no pending ping for the node, nor we have failure
              * reports for this node, update the last pong time with the
              * one we see from the other nodes. */
-            if (!(flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_PFAIL)) && node->ping_sent == 0 &&
+            if (!(flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_PFAIL)) &&
+                nodeInNormalState(node) &&
+                node->ping_sent == 0 &&
                 clusterNodeFailureReportsCount(node) == 0) {
                 mstime_t pongtime = ntohl(g->pong_received);
                 pongtime *= 1000; /* Convert back to milliseconds. */


### PR DESCRIPTION
This code change aligns with the comment mentioned above.

We should let direct communication between node happen when they are not in steady state. We can use the piggybacked information from the gossip section otherwise.

Note: `pong_received` field is used to communicate with the other node within node timeout once.