### PR TITLE
Refactor scanLaterList to fix latency issue

### DIFF
--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -386,7 +386,7 @@ run_solo {defrag} {
             # number of total fields.  lists are progressively increasing sizes.
             set n 200000
 
-            perform_defrag_test $title populate {
+            perform_defrag_test $title latency 5 populate {
                 set rd [valkey_deferring_client]
                 $rd client reply off
                 set val [string repeat A 350]


### PR DESCRIPTION
This fix only addresses the big list test.

Refactor `scanLaterList` to fix latency issue:

1. Remove the `iterations `stuff and check the time every loop - The iteration optimization should be removed because the time check (19ns) is negligible compared to the actual defragmentation work (even a single 8-byte reallocation takes 43ns and the allocatorShouldDefrag function call takes 49ns per block), so the time check cost at most 30% and likely much less in practice.
2. Remove `bookmark_failed`  - Simplify control flow by handling bookmark failure inline.
3. Move` (*cursor)++` inside time check - We only increment cursor when we actually need to resume.
4. Refactor bookmark failure handling: when bookmark creation failed, break out of the loop, and return with 0 - Skip this one and continue with other quicklists.

Introduced in #2444 and #2205 