### PR TITLE
Wait for log message occurrence in module test on message received

### DIFF
--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -34,7 +34,7 @@ start_cluster 3 0 [list config_lines $modules] {
         wait_for_condition 50 100 {
             [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"] eq 2
         } else {
-            fail "node 1 didn't log 2 DONG messages"
+            fail "node 1 didn't log DONG message twice"
         }
     }
 }

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -31,7 +31,11 @@ start_cluster 3 0 [list config_lines $modules] {
         } else {
             fail "node 1 didn't receive DONG messages"
         }
-        assert_equal 2 [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"]
+        wait_for_condition 50 100 {
+            [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"] eq 2
+        } else {
+            fail "node 1 didn't log 2 DONG messages"
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
Test `Cluster module receive message API - VM_RegisterClusterMessageReceiver` fails sporadically in CI with "Expected '2' to be equal to '1'". The test failed in Daily CI 4 days ago but hasn't failed since, indicating flaky behavior that I cannot reproduce locally.


## Hypothesis
The failing line `assert_equal 2 [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"]` counts DONG message entries in node 0's log file and expects exactly 2. The failure suggests a possible race condition where there's a timing gap between when cluster statistics are updated and when the corresponding log entries become visible in the log file.


## Solution
Add `wait_for_condition` to ensure log messages are written before checking count:

```tcl
wait_for_condition 50 100 {
    [count_log_message 0 "* <cluster> DONG (type 2) RECEIVED*"] eq 2
} else {
    fail "node 1 didn't log 2 DONG messages"
}
```

Fixes #2499.
Fixes #2450.