### PR TITLE
Implement new Module API to test client readonly flag

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -13862,6 +13862,11 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+/* Returns if the current client is readonly */
+int VM_IsReadOnlyCtx(ValkeyModuleCtx *ctx) {
+    return ctx->client->flag.readonly;
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -14230,4 +14235,5 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RegisterScriptingEngine);
     REGISTER_API(UnregisterScriptingEngine);
     REGISTER_API(GetFunctionExecutionState);
+    REGISTER_API(IsReadOnlyCtx);
 }

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1898,6 +1898,8 @@ VALKEYMODULE_API int (*ValkeyModule_UnregisterScriptingEngine)(ValkeyModuleCtx *
 
 VALKEYMODULE_API ValkeyModuleScriptingEngineExecutionState (*ValkeyModule_GetFunctionExecutionState)(ValkeyModuleScriptingEngineServerRuntimeCtx *server_ctx) VALKEYMODULE_ATTR;
 
+VALKEYMODULE_API int (*ValkeyModule_IsReadOnlyCtx)(ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+
 #define ValkeyModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
 /* This is included inline inside each Valkey module. */
@@ -2269,6 +2271,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(RegisterScriptingEngine);
     VALKEYMODULE_GET_API(UnregisterScriptingEngine);
     VALKEYMODULE_GET_API(GetFunctionExecutionState);
+    VALKEYMODULE_GET_API(IsReadOnlyCtx);
 
     if (ValkeyModule_IsModuleNameBusy && ValkeyModule_IsModuleNameBusy(name)) return VALKEYMODULE_ERR;
     ValkeyModule_SetModuleAttribs(ctx, name, ver, apiver);

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -540,6 +540,10 @@ int test_keyslot(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     return ValkeyModule_ReplyWithLongLong(ctx, slot);
 }
 
+int test_readonly(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    return ValkeyModule_ReplyWithLongLong(ctx, ValkeyModule_IsReadOnlyCtx(ctx));
+}
+
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
@@ -606,6 +610,8 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_CreateCommand(ctx, "test.malloc_api", test_malloc_api,"", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
     if (ValkeyModule_CreateCommand(ctx, "test.keyslot", test_keyslot, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx, "test.readonly", test_readonly, "", 0, 0, 0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
     return VALKEYMODULE_OK;

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -493,6 +493,12 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         r set x y
     } {OK}
 
+    test "IsReadOnlyCtx API" {
+        assert_equal [r test.readonly] 0
+        r readonly
+        assert_equal [r test.readonly] 1
+    } {OK}
+
     test "malloc API" {
         assert_equal {OK} [r test.malloc_api 0]
     }


### PR DESCRIPTION
Search module wants to dispatch cross-shard query operations in accordance with requesting connection readonly flag. This module API exposes the state of the readonly flag for the current client.