### PR TITLE
Module API: Add READONLY flag to ClientInfo.flags output structure

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3789,7 +3789,7 @@ int modulePopulateClientInfoStructure(void *ci, client *client, int structver) {
     if (client->flag.tracking) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_TRACKING;
     if (client->flag.blocked) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_BLOCKED;
     if (client->conn->type == connectionTypeTls()) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_SSL;
-    if (client->flag.readonly) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_READONLY;    
+    if (client->flag.readonly) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_READONLY;
 
     int port;
     connAddrPeerName(client->conn, ci1->addr, sizeof(ci1->addr), &port);
@@ -3863,9 +3863,9 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *      }
  */
 int VM_GetClientInfoById(void *ci, uint64_t id) {
-    client *client = 
+    client *client =
         (server.executing_client && server.executing_client->id == id)
-            ? server.executing_client 
+            ? server.executing_client
             : lookupClientByID(id);
     if (client == NULL) return VALKEYMODULE_ERR;
     if (ci == NULL) return VALKEYMODULE_OK;

--- a/src/module.c
+++ b/src/module.c
@@ -3849,6 +3849,7 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *     VALKEYMODULE_CLIENTINFO_FLAG_TRACKING     Client with keys tracking on.
  *     VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET   Client using unix domain socket.
  *     VALKEYMODULE_CLIENTINFO_FLAG_MULTI        Client in MULTI state.
+ *     VALKEYMODULE_CLIENTINFO_FLAG_READONLY     Client in ReadOnly state.
  *
  * However passing NULL is a way to just check if the client exists in case
  * we are not interested in any additional information.

--- a/src/module.c
+++ b/src/module.c
@@ -3789,6 +3789,7 @@ int modulePopulateClientInfoStructure(void *ci, client *client, int structver) {
     if (client->flag.tracking) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_TRACKING;
     if (client->flag.blocked) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_BLOCKED;
     if (client->conn->type == connectionTypeTls()) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_SSL;
+    if (client->flag.readonly) ci1->flags |= VALKEYMODULE_CLIENTINFO_FLAG_READONLY;    
 
     int port;
     connAddrPeerName(client->conn, ci1->addr, sizeof(ci1->addr), &port);
@@ -3862,7 +3863,10 @@ int modulePopulateReplicationInfoStructure(void *ri, int structver) {
  *      }
  */
 int VM_GetClientInfoById(void *ci, uint64_t id) {
-    client *client = lookupClientByID(id);
+    client *client = 
+        (server.executing_client && server.executing_client->id == id)
+            ? server.executing_client 
+            : lookupClientByID(id);
     if (client == NULL) return VALKEYMODULE_ERR;
     if (ci == NULL) return VALKEYMODULE_OK;
 

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -658,6 +658,7 @@ static const ValkeyModuleEvent ValkeyModuleEvent_ReplicationRoleChanged = {VALKE
 #define VALKEYMODULE_CLIENTINFO_FLAG_TRACKING (1 << 3)
 #define VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1 << 4)
 #define VALKEYMODULE_CLIENTINFO_FLAG_MULTI (1 << 5)
+#define VALKEYMODULE_CLIENTINFO_FLAG_READONLY (1 << 6)
 
 /* Here we take all the structures that the module pass to the core
  * and the other way around. Notably the list here contains the structures

--- a/tests/modules/misc.c
+++ b/tests/modules/misc.c
@@ -306,13 +306,14 @@ int test_clientinfo(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
 
     ValkeyModule_ReplyWithArray(ctx, 10);
     char flags[512];
-    snprintf(flags, sizeof(flags) - 1, "%s:%s:%s:%s:%s:%s",
+    snprintf(flags, sizeof(flags) - 1, "%s:%s:%s:%s:%s:%s:%s",
         ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_SSL ? "ssl" : "",
         ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_PUBSUB ? "pubsub" : "",
         ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_BLOCKED ? "blocked" : "",
         ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_TRACKING ? "tracking" : "",
         ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET ? "unixsocket" : "",
-        ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_MULTI ? "multi" : "");
+        ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_MULTI ? "multi" : "",
+        ci.flags & VALKEYMODULE_CLIENTINFO_FLAG_READONLY ? "readonly" : "");
 
     ValkeyModule_ReplyWithCString(ctx, "flags");
     ValkeyModule_ReplyWithCString(ctx, flags);

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -103,19 +103,25 @@ start_server {overrides {save {900 1}} tags {"modules"}} {
         set ssl_flag [expr $::tls ? {"ssl:"} : {":"}]
 
         assert { [dict get $info db] == 9 }
-        assert { [dict get $info flags] == "${ssl_flag}::::" }
+        assert { [dict get $info flags] == "${ssl_flag}:::::" }
 
         # Test MULTI flag
         r multi
         r test.clientinfo
         set info [lindex [r exec] 0]
-        assert { [dict get $info flags] == "${ssl_flag}::::multi" }
+        assert { [dict get $info flags] == "${ssl_flag}::::multi:" }
 
         # Test TRACKING flag
         r client tracking on
         set info [r test.clientinfo]
-        assert { [dict get $info flags] == "${ssl_flag}::tracking::" }
+        assert { [dict get $info flags] == "${ssl_flag}::tracking:::" }
         r CLIENT TRACKING off
+        r readonly
+        set info [r test.clientinfo]
+        assert { [dict get $info flags] == "${ssl_flag}:::::readonly" }
+        r readwrite
+        set info [r test.clientinfo]
+        assert { [dict get $info flags] == "${ssl_flag}:::::" }
     }
 
     test {tracking with rm_call sanity} {


### PR DESCRIPTION
* Add a flag `VALKEYMODULE_CLIENTINFO_FLAG_READONLY` to `ValkeyModuleClientInfo.flags` and set it in `ValkeyModule_GetClientInfoById()`.
* Add an optimization for accessing the current client by ID, to avoid looking it up in a radix tree.

Closes #2487