### PR TITLE
Fix slot range lists overlap to rewind the nested list again 

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -182,10 +182,10 @@ bool doSlotRangeListsOverlap(list *ranges1, list *ranges2) {
     listIter li1, li2;
     listNode *ln1, *ln2;
     listRewind(ranges1, &li1);
-    listRewind(ranges2, &li2);
     while ((ln1 = listNext(&li1)) != NULL) {
+        slotRange *range1 = ln1->value;
+        listRewind(ranges2, &li2);
         while ((ln2 = listNext(&li2)) != NULL) {
-            slotRange *range1 = ln1->value;
             slotRange *range2 = ln2->value;
             if (doSlotRangesOverlap(range1, range2)) {
                 return true;

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -183,7 +183,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_error "*syntax error*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE}
         assert_error "*Invalid node name*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE blah}
         assert_error "*Unknown node name*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $fake_jobname}
-        assert_error "*Slot ranges in migrations overlap*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 1 1 NODE $node1_id SLOTSRANGE 0 2 NODE $node2_id} 
+        assert_error "*Slot ranges in migrations overlap*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 1 1 NODE $node1_id SLOTSRANGE 0 2 NODE $node2_id}
+        assert_error "*Slot ranges in migrations overlap*" {R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 2 2 NODE $node1_id SLOTSRANGE 2 2 NODE $node2_id}
 
         set source_node_id [R 0 CLUSTER MYID]
         set target_node_id [R 1 CLUSTER MYID]


### PR DESCRIPTION
In the current implementation, the second list was never rewound again once it was iterated. So for the first element of `ranges1`, `ranges2` was iterated fully. But when the second element of `ranges1` was processed, the `ranges2` was not rewound again.

With this change, for every element of `ranges1`, we start from the beginning for `ranges2`