### PR TITLE
bio.c: Organize all worker data in a struct

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -87,7 +87,7 @@ static pthread_mutex_t bio_mutex[BIO_WORKER_NUM];
 static pthread_cond_t bio_newjob_cond[BIO_WORKER_NUM];
 static list *bio_jobs[BIO_WORKER_NUM];
 static unsigned long bio_jobs_counter[BIO_NUM_OPS] = {0};
-static __thread unsigned long bio_thread_id = 0;
+static _Thread_local unsigned long bio_thread_id = 0;
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */

--- a/src/bio.c
+++ b/src/bio.c
@@ -65,15 +65,6 @@
 #include "bio.h"
 #include <stdatomic.h>
 
-static char *bio_worker_title[] = {
-    "bio_close_file",
-    "bio_aof",
-    "bio_lazy_free",
-    "bio_rdb_save",
-};
-
-#define BIO_WORKER_NUM (sizeof(bio_worker_title) / sizeof(*bio_worker_title))
-
 static unsigned int bio_job_to_worker[] = {
     [BIO_CLOSE_FILE] = 0,
     [BIO_AOF_FSYNC] = 1,
@@ -82,12 +73,31 @@ static unsigned int bio_job_to_worker[] = {
     [BIO_RDB_SAVE] = 3,
 };
 
-static pthread_t bio_threads[BIO_WORKER_NUM];
-static pthread_mutex_t bio_mutex[BIO_WORKER_NUM];
-static pthread_cond_t bio_newjob_cond[BIO_WORKER_NUM];
-static list *bio_jobs[BIO_WORKER_NUM];
+typedef struct {
+    const char *const bio_worker_title;
+    pthread_t bio_thread_id;
+    pthread_mutex_t bio_mutex;
+    pthread_cond_t bio_newjob_cond;
+    list *bio_jobs;
+} bio_worker_data;
+
+static bio_worker_data bio_workers[] = {
+    {"bio_close_file"},
+    {"bio_aof"},
+    {"bio_lazy_free"},
+    {"bio_rdb_save"},
+};
+static const bio_worker_data *const bio_worker_end = bio_workers + (sizeof bio_workers / sizeof *bio_workers);
+
+static size_t bioWorkerNum(const bio_worker_data *const bwd) {
+    /* Ensure the pointer is valid - casting to uintptr_t to not make the comparison itself UB in case
+     * the pointer is outside the valid range. It's a best effort thing anyway. */
+    serverAssert((uintptr_t)bwd >= (uintptr_t)bio_workers && (uintptr_t)bwd < (uintptr_t)bio_worker_end);
+    return (size_t)(bwd - bio_workers);
+}
+
 static unsigned long bio_jobs_counter[BIO_NUM_OPS] = {0};
-static _Thread_local unsigned long bio_thread_id = 0;
+static _Thread_local size_t bio_worker_num = 0;
 
 /* This structure represents a background Job. It is only used locally to this
  * file as the API does not expose the internals at all. */
@@ -129,15 +139,13 @@ void *bioProcessBackgroundJobs(void *arg);
 /* Initialize the background system, spawning the thread. */
 void bioInit(void) {
     pthread_attr_t attr;
-    pthread_t thread;
     size_t stacksize;
-    unsigned long j;
 
     /* Initialization of state vars and objects */
-    for (j = 0; j < BIO_WORKER_NUM; j++) {
-        pthread_mutex_init(&bio_mutex[j], NULL);
-        pthread_cond_init(&bio_newjob_cond[j], NULL);
-        bio_jobs[j] = listCreate();
+    for (bio_worker_data *bwd = bio_workers; bwd != bio_worker_end; ++bwd) {
+        pthread_mutex_init(&bwd->bio_mutex, NULL);
+        pthread_cond_init(&bwd->bio_newjob_cond, NULL);
+        bwd->bio_jobs = listCreate();
     }
 
     /* Set the stack size as by default it may be small in some system */
@@ -148,27 +156,25 @@ void bioInit(void) {
     pthread_attr_setstacksize(&attr, stacksize);
 
     /* Ready to spawn our threads. We use the single argument the thread
-     * function accepts in order to pass the job ID the thread is
-     * responsible for. */
-    for (j = 0; j < BIO_WORKER_NUM; j++) {
-        void *arg = (void *)(unsigned long)j;
-        int err = pthread_create(&thread, &attr, bioProcessBackgroundJobs, arg);
+     * function accepts in order to pass a pointer to the data that the
+     * thread is responsible for. */
+    for (bio_worker_data *bwd = bio_workers; bwd != bio_worker_end; ++bwd) {
+        int err = pthread_create(&bwd->bio_thread_id, &attr, bioProcessBackgroundJobs, (void *)bwd);
         if (err) {
             serverLog(LL_WARNING, "Fatal: Can't initialize Background Jobs. Error message: %s", strerror(err));
             exit(1);
         }
-        bio_threads[j] = thread;
     }
 }
 
 void bioSubmitJob(int type, bio_job *job) {
     job->header.type = type;
-    unsigned long worker = bio_job_to_worker[type];
-    pthread_mutex_lock(&bio_mutex[worker]);
-    listAddNodeTail(bio_jobs[worker], job);
+    bio_worker_data *const bwd = &bio_workers[bio_job_to_worker[type]];
+    pthread_mutex_lock(&bwd->bio_mutex);
+    listAddNodeTail(bwd->bio_jobs, job);
     bio_jobs_counter[type]++;
-    pthread_cond_signal(&bio_newjob_cond[worker]);
-    pthread_mutex_unlock(&bio_mutex[worker]);
+    pthread_cond_signal(&bwd->bio_newjob_cond);
+    pthread_mutex_unlock(&bwd->bio_mutex);
 }
 
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...) {
@@ -222,20 +228,17 @@ void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
 }
 
 void *bioProcessBackgroundJobs(void *arg) {
+    bio_worker_data *const bwd = arg;
     bio_job *job;
-    unsigned long worker = (unsigned long)arg;
     sigset_t sigset;
 
-    /* Check that the worker is within the right interval. */
-    serverAssert(worker < BIO_WORKER_NUM);
-
-    valkey_set_thread_title(bio_worker_title[worker]);
+    valkey_set_thread_title(bwd->bio_worker_title);
 
     serverSetCpuAffinity(server.bio_cpulist);
 
     makeThreadKillable();
 
-    pthread_mutex_lock(&bio_mutex[worker]);
+    pthread_mutex_lock(&bwd->bio_mutex);
     /* Block SIGALRM so we are sure that only the main thread will
      * receive the watchdog signal. */
     sigemptyset(&sigset);
@@ -244,22 +247,22 @@ void *bioProcessBackgroundJobs(void *arg) {
     if (err)
         serverLog(LL_WARNING, "Warning: can't mask SIGALRM in bio.c thread: %s", strerror(err));
 
-    bio_thread_id = worker;
+    bio_worker_num = bioWorkerNum(bwd);
 
     while (1) {
         listNode *ln;
 
         /* The loop always starts with the lock hold. */
-        if (listLength(bio_jobs[worker]) == 0) {
-            pthread_cond_wait(&bio_newjob_cond[worker], &bio_mutex[worker]);
+        if (listLength(bwd->bio_jobs) == 0) {
+            pthread_cond_wait(&bwd->bio_newjob_cond, &bwd->bio_mutex);
             continue;
         }
         /* Get the job from the queue. */
-        ln = listFirst(bio_jobs[worker]);
+        ln = listFirst(bwd->bio_jobs);
         job = ln->value;
         /* It is now possible to unlock the background system as we know have
          * a stand alone job structure to process.*/
-        pthread_mutex_unlock(&bio_mutex[worker]);
+        pthread_mutex_unlock(&bwd->bio_mutex);
 
         /* Process the job accordingly to its type. */
         int job_type = job->header.type;
@@ -308,33 +311,33 @@ void *bioProcessBackgroundJobs(void *arg) {
 
         /* Lock again before reiterating the loop, if there are no longer
          * jobs to process we'll block again in pthread_cond_wait(). */
-        pthread_mutex_lock(&bio_mutex[worker]);
-        listDelNode(bio_jobs[worker], ln);
+        pthread_mutex_lock(&bwd->bio_mutex);
+        listDelNode(bwd->bio_jobs, ln);
         bio_jobs_counter[job_type]--;
-        pthread_cond_signal(&bio_newjob_cond[worker]);
+        pthread_cond_signal(&bwd->bio_newjob_cond);
     }
 }
 
 /* Return the number of pending jobs of the specified type. */
 unsigned long bioPendingJobsOfType(int type) {
-    unsigned int worker = bio_job_to_worker[type];
+    bio_worker_data *const bwd = &bio_workers[bio_job_to_worker[type]];
 
-    pthread_mutex_lock(&bio_mutex[worker]);
+    pthread_mutex_lock(&bwd->bio_mutex);
     unsigned long val = bio_jobs_counter[type];
-    pthread_mutex_unlock(&bio_mutex[worker]);
+    pthread_mutex_unlock(&bwd->bio_mutex);
 
     return val;
 }
 
 /* Wait for the job queue of the worker for jobs of specified type to become empty. */
 void bioDrainWorker(int job_type) {
-    unsigned long worker = bio_job_to_worker[job_type];
+    bio_worker_data *const bwd = &bio_workers[bio_job_to_worker[job_type]];
 
-    pthread_mutex_lock(&bio_mutex[worker]);
-    while (listLength(bio_jobs[worker]) > 0) {
-        pthread_cond_wait(&bio_newjob_cond[worker], &bio_mutex[worker]);
+    pthread_mutex_lock(&bwd->bio_mutex);
+    while (listLength(bwd->bio_jobs) > 0) {
+        pthread_cond_wait(&bwd->bio_newjob_cond, &bwd->bio_mutex);
     }
-    pthread_mutex_unlock(&bio_mutex[worker]);
+    pthread_mutex_unlock(&bwd->bio_mutex);
 }
 
 /* Kill the running bio threads in an unclean way. This function should be
@@ -343,20 +346,19 @@ void bioDrainWorker(int job_type) {
  * to perform a fast memory check without other threads messing with memory. */
 void bioKillThreads(void) {
     int err;
-    unsigned long j;
 
-    for (j = 0; j < BIO_WORKER_NUM; j++) {
-        if (bio_threads[j] == pthread_self()) continue;
-        if (bio_threads[j] && pthread_cancel(bio_threads[j]) == 0) {
-            if ((err = pthread_join(bio_threads[j], NULL)) != 0) {
-                serverLog(LL_WARNING, "Bio worker thread #%lu can not be joined: %s", j, strerror(err));
+    for (bio_worker_data *bwd = bio_workers; bwd != bio_worker_end; ++bwd) {
+        if (pthread_equal(bwd->bio_thread_id, pthread_self())) continue;
+        if (bwd->bio_thread_id && pthread_cancel(bwd->bio_thread_id) == 0) {
+            if ((err = pthread_join(bwd->bio_thread_id, NULL)) != 0) {
+                serverLog(LL_WARNING, "Bio worker thread #%zu can not be joined: %s", bioWorkerNum(bwd), strerror(err));
             } else {
-                serverLog(LL_WARNING, "Bio worker thread #%lu terminated", j);
+                serverLog(LL_WARNING, "Bio worker thread #%zu terminated", bioWorkerNum(bwd));
             }
         }
     }
 }
 
 int inBioThread(void) {
-    return bio_thread_id != 0;
+    return bio_worker_num != 0;
 }

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -6,7 +6,7 @@
 
 #include "io_threads.h"
 
-static __thread int thread_id = 0; /* Thread local var */
+static _Thread_local int thread_id = 0; /* Thread local var */
 static pthread_t io_threads[IO_THREADS_MAX_NUM] = {0};
 static pthread_mutex_t io_threads_mutex[IO_THREADS_MAX_NUM];
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -149,7 +149,7 @@ static int parseMultibulk(client *c,
                           unsigned long long *net_input_bytes_curr_cmd);
 
 int ProcessingEventsWhileBlocked = 0; /* See processEventsWhileBlocked(). */
-__thread sds thread_shared_qb = NULL;
+_Thread_local sds thread_shared_qb = NULL;
 
 typedef enum {
     PARSE_OK = 0,

--- a/src/vset.c
+++ b/src/vset.c
@@ -793,7 +793,7 @@ static inline vsetBucket *vsetBucketFromRax(rax *r) {
 /* Since we do not have native posix support for qsort_r, we use this variable to help the vset
  * compare function operate entry comparison given a dynamic getExpiry function is passed to
  * different vset functions. */
-static __thread vsetGetExpiryFunc current_getter_func;
+static _Thread_local vsetGetExpiryFunc current_getter_func;
 
 static inline void vsetSetExpiryGetter(vsetGetExpiryFunc f) {
     assert(current_getter_func == NULL);


### PR DESCRIPTION
This gets rid of the need to use a void* as a carrier for the worker number. Instead a pointer to the relevant worker data is passed to the started thread.

Fixes #2529

