### PR TITLE
Separate RDB snapshotting from atomic slot migration

### DIFF
--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -129,6 +129,8 @@ void updateChildInfo(childInfoType information_type, size_t cow, monotime cow_up
         server.stat_rdb_cow_bytes = server.stat_current_cow_peak;
     } else if (information_type == CHILD_INFO_TYPE_MODULE_COW_SIZE) {
         server.stat_module_cow_bytes = server.stat_current_cow_peak;
+    } else if (information_type == CHILD_INFO_TYPE_SLOT_MIGRATION_COW_SIZE) {
+        server.stat_slot_migration_cow_bytes = server.stat_current_cow_peak;
     }
 }
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -8,6 +8,7 @@
 #include "bio.h"
 #include "module.h"
 #include "functions.h"
+#include <sys/wait.h>
 
 typedef enum slotMigrationJobState {
     /* Importing states */
@@ -1219,9 +1220,8 @@ bool shouldRewriteHashtableIndex(int didx, hashtable *ht, void *privdata) {
 }
 
 /* Contains the logic run on the child process during the snapshot phase. */
-int childSnapshotForSyncSlot(int req, rio *rdb, void *privdata) {
-    UNUSED(req);
-    list *slot_ranges = privdata;
+int childSnapshotForSyncSlot(rio *rdb, slotMigrationJob *job) {
+    list *slot_ranges = job->slot_ranges;
     size_t key_count = 0;
     for (int db_num = 0; db_num < server.dbnum; db_num++) {
         listIter li;
@@ -1242,21 +1242,51 @@ int childSnapshotForSyncSlot(int req, rio *rdb, void *privdata) {
     return C_OK;
 }
 
+void killSlotMigrationChild(void) {
+    int statloc;
+    /* No slot migration child? return. */
+    if (server.child_type != CHILD_TYPE_SLOT_MIGRATION) return;
+    /* Kill slot migration child, wait for child exit. */
+    serverLog(LL_NOTICE, "Killing running slot migration child: %ld", (long)server.child_pid);
+    if (kill(server.child_pid, SIGUSR1) != -1) {
+        while (waitpid(-1, &statloc, 0) != server.child_pid);
+    }
+    resetChildState();
+    serverLog(LL_NOTICE, "Slot migration child %ld killed", (long)server.child_pid);
+    clusterHandleSlotExportBackgroundSaveDone(C_ERR);
+}
+
+
 /* Begin the snapshot for the provided job in a child process. */
 int slotExportJobBeginSnapshot(slotMigrationJob *job) {
-    connection **conns = zmalloc(sizeof(connection *));
-    *conns = job->client->conn;
-    rdbSnapshotOptions opts = {
-        .connsnum = 1,
-        .conns = conns,
-        .use_pipe = 1,
-        .req = REPLICA_REQ_NONE,
-        .skip_checksum = 1,
-        .snapshot_func = childSnapshotForSyncSlot,
-        .privdata = job->slot_ranges};
-    if (saveSnapshotToConnectionSockets(opts) != C_OK) {
+    pid_t childpid;
+    connSendTimeout(job->client->conn, server.repl_timeout * 1000);
+    connBlock(job->client->conn);
+    if ((childpid = serverFork(CHILD_TYPE_SLOT_MIGRATION)) == 0) {
+        /* Child */
+        rio rdb;
+        connection **conns = zmalloc(sizeof(connection *));
+        *conns = job->client->conn;
+        rioInitWithConnset(&rdb, conns, 1);
+        serverSetProcTitle("valkey-slot-migration-snapshot");
+        serverSetCpuAffinity(server.bgsave_cpulist);
+        int retval = childSnapshotForSyncSlot(&rdb, job);
+        if (retval == C_OK && rioFlush(&rdb) == 0) retval = C_ERR;
+        if (retval == C_OK) {
+            sendChildCowInfo(CHILD_INFO_TYPE_SLOT_MIGRATION_COW_SIZE, "slot migration");
+        }
+        rioFreeConnset(&rdb);
+        zfree(conns);
+        exitFromChild((retval == C_OK) ? 0 : 1);
+    }
+    /* Parent */
+    if (childpid == -1) {
+        closeChildInfoPipe();
         return C_ERR;
     }
+    serverLog(LL_NOTICE,
+                "Started child process %ld for slot migration %s",
+                (long)childpid, job->description);
     if (server.debug_pause_after_fork) debugPauseProcess();
     return C_OK;
 }
@@ -1275,6 +1305,7 @@ void clusterHandleSlotExportBackgroundSaveDone(int bgsaveerr) {
             continue;
         }
         if (bgsaveerr == C_OK) {
+            connNonBlock(job->client->conn);
             slotExportBeginStreaming(job);
         } else {
             serverLog(LL_WARNING,
@@ -1731,10 +1762,6 @@ void resetSlotMigrationJob(slotMigrationJob *job) {
 
     sdsfree(job->response_buf);
     job->response_buf = NULL;
-
-    /* Description is not needed once migration is finished */
-    sdsfree(job->description);
-    job->description = NULL;
 }
 
 void freeSlotMigrationJob(void *o) {
@@ -1744,6 +1771,7 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->slot_ranges_str);
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
+    sdsfree(job->description);
     zfree(o);
 }
 

--- a/src/cluster_migrateslots.h
+++ b/src/cluster_migrateslots.h
@@ -33,5 +33,6 @@ size_t clusterGetTotalSlotExportBufferMemory(void);
 bool clusterSlotFailoverGranted(int slot);
 void clusterFailAllSlotExportsWithMessage(char *message);
 void clusterHandleSlotMigrationErrorResponse(slotMigrationJob *job);
+void killSlotMigrationChild(void);
 
 #endif /* __CLUSTER_MIGRATESLOTS_H */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3569,10 +3569,6 @@ void backgroundSaveDoneHandler(int exitcode, int bysignal) {
     /* Possibly there are replicas waiting for a BGSAVE in order to be served
      * (the first stage of SYNC is a bulk transfer of dump.rdb) */
     updateReplicasWaitingBgsave((!bysignal && exitcode == 0) ? C_OK : C_ERR, type);
-
-    /* Slot export should also be notified, in case this was a export related
-     * snapshot */
-    clusterHandleSlotExportBackgroundSaveDone((!bysignal && exitcode == 0) ? C_OK : C_ERR);
 }
 
 /* Kill the RDB saving child using SIGUSR1 (so that the parent will know
@@ -3588,37 +3584,28 @@ void killRDBChild(void) {
      * - rdbRemoveTempFile */
 }
 
-/* Save snapshot to the provided connections, spawning a child process and
- * running the provided function.
- *
- * The connections array (the conns field in the rdbSnapshotOptions) is a
- * heap-allocated array that will be freed by this function and shall not be
- * freed by the caller. */
-int saveSnapshotToConnectionSockets(rdbSnapshotOptions options) {
+/* Spawn an RDB child that writes the RDB to the sockets of the replicas
+ * that are currently in REPLICA_STATE_WAIT_BGSAVE_START state. */
+int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
+    listNode *ln;
+    listIter li;
     pid_t childpid;
     int pipefds[2], rdb_pipe_write = -1, safe_to_exit_pipe = -1;
-    if (hasActiveChildProcess()) {
-        zfree(options.conns);
-        return C_ERR;
-    }
+    int dual_channel = (req & REPLICA_REQ_RDB_CHANNEL);
+
+    if (hasActiveChildProcess()) return C_ERR;
     serverAssert(server.rdb_pipe_read == -1 && server.rdb_child_exit_pipe == -1);
 
     /* Even if the previous fork child exited, don't start a new one until we
      * drained the pipe. */
-    if (server.rdb_pipe_conns) {
-        zfree(options.conns);
-        return C_ERR;
-    }
+    if (server.rdb_pipe_conns) return C_ERR;
 
-    if (options.use_pipe) {
+    if (!dual_channel) {
         /* Before to fork, create a pipe that is used to transfer the rdb bytes to
          * the parent, we can't let it write directly to the sockets, since in case
          * of TLS we must let the parent handle a continuous TLS state when the
          * child terminates and parent takes over. */
-        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) {
-            zfree(options.conns);
-            return C_ERR;
-        }
+        if (anetPipe(pipefds, O_NONBLOCK, 0) == -1) return C_ERR;
         server.rdb_pipe_read = pipefds[0]; /* read end */
         rdb_pipe_write = pipefds[1];       /* write end */
 
@@ -3627,115 +3614,11 @@ int saveSnapshotToConnectionSockets(rdbSnapshotOptions options) {
         if (anetPipe(pipefds, 0, 0) == -1) {
             close(rdb_pipe_write);
             close(server.rdb_pipe_read);
-            zfree(options.conns);
             return C_ERR;
         }
         safe_to_exit_pipe = pipefds[0];          /* read end */
         server.rdb_child_exit_pipe = pipefds[1]; /* write end */
     }
-    server.rdb_pipe_conns = NULL;
-    if (options.use_pipe) {
-        server.rdb_pipe_conns = options.conns;
-        server.rdb_pipe_numconns = options.connsnum;
-        server.rdb_pipe_numconns_writing = 0;
-    }
-    /* Create the child process. */
-    if ((childpid = serverFork(CHILD_TYPE_RDB)) == 0) {
-        /* Child */
-        int retval, dummy;
-        rio rdb;
-        if (!options.use_pipe) {
-            rioInitWithConnset(&rdb, options.conns, options.connsnum);
-        } else {
-            rioInitWithFd(&rdb, rdb_pipe_write);
-        }
-
-        /* Close the reading part, so that if the parent crashes, the child will
-         * get a write error and exit. */
-        if (options.use_pipe) close(server.rdb_pipe_read);
-        if (strstr(server.exec_argv[0], "redis-server") != NULL) {
-            serverSetProcTitle("redis-rdb-to-slaves");
-        } else {
-            serverSetProcTitle("valkey-rdb-to-replicas");
-        }
-        serverSetCpuAffinity(server.bgsave_cpulist);
-
-        if (options.skip_checksum) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
-
-        retval = options.snapshot_func(options.req, &rdb, options.privdata);
-        if (retval == C_OK && rioFlush(&rdb) == 0) retval = C_ERR;
-
-        if (retval == C_OK) {
-            sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
-        }
-        if (!options.use_pipe) {
-            rioFreeConnset(&rdb);
-        } else {
-            rioFreeFd(&rdb);
-            /* wake up the reader, tell it we're done. */
-            close(rdb_pipe_write);
-            close(server.rdb_child_exit_pipe); /* close write end so that we can detect the close on the parent. */
-        }
-        zfree(options.conns);
-        /* hold exit until the parent tells us it's safe. we're not expecting
-         * to read anything, just get the error when the pipe is closed. */
-        if (options.use_pipe) dummy = read(safe_to_exit_pipe, pipefds, 1);
-        UNUSED(dummy);
-        exitFromChild((retval == C_OK) ? 0 : 1);
-    } else {
-        /* Parent */
-        if (childpid == -1) {
-            serverLog(LL_WARNING, "Can't save in background: fork: %s", strerror(errno));
-
-            if (options.use_pipe) {
-                close(rdb_pipe_write);
-                close(server.rdb_pipe_read);
-                close(server.rdb_child_exit_pipe);
-            }
-            zfree(options.conns);
-            if (!options.use_pipe) {
-                closeChildInfoPipe();
-            } else {
-                server.rdb_pipe_conns = NULL;
-                server.rdb_pipe_numconns = 0;
-                server.rdb_pipe_numconns_writing = 0;
-            }
-        } else {
-            serverLog(LL_NOTICE, "Background RDB transfer started by pid %ld to %s%s", (long)childpid,
-                      !options.use_pipe ? "direct socket to replica" : "pipe through parent process",
-                      options.skip_checksum ? " while skipping RDB checksum for this transfer" : "");
-
-            server.rdb_save_time_start = time(NULL);
-            server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
-            if (!options.use_pipe) {
-                /* For dual channel sync, the main process no longer requires these RDB connections. */
-                zfree(options.conns);
-            } else {
-                close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
-                if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler, NULL) ==
-                    AE_ERR) {
-                    serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
-                }
-            }
-        }
-        if (options.use_pipe) close(safe_to_exit_pipe);
-        return (childpid == -1) ? C_ERR : C_OK;
-    }
-    return C_OK; /* Unreached. */
-}
-
-
-int childSnapshotUsingRDB(int req, rio *rdb, void *privdata) {
-    return rdbSaveRioWithEOFMark(req, rdb, NULL, (rdbSaveInfo *)privdata);
-}
-
-/* Spawn an RDB child that writes the RDB to the sockets of the replicas
- * that are currently in REPLICA_STATE_WAIT_BGSAVE_START state. */
-int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
-    listNode *ln;
-    listIter li;
-    int dual_channel = (req & REPLICA_REQ_RDB_CHANNEL);
-
     /*
      * For replicas with repl_state == REPLICA_STATE_WAIT_BGSAVE_END and replica_req == req:
      * Check replica capabilities, if every replica supports skipping RDB checksum, primary should also skip checksum.
@@ -3743,10 +3626,15 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
      */
     int skip_rdb_checksum = 1;
     /* Collect the connections of the replicas we want to transfer
-     * the RDB to, which are i WAIT_BGSAVE_START state. */
+     * the RDB to, which are in WAIT_BGSAVE_START state. */
     int connsnum = 0;
     connection **conns = zmalloc(sizeof(connection *) * listLength(server.replicas));
-
+    server.rdb_pipe_conns = NULL;
+    if (!dual_channel) {
+        server.rdb_pipe_conns = conns;
+        server.rdb_pipe_numconns = 0;
+        server.rdb_pipe_numconns_writing = 0;
+    }
     /* Filter replica connections pending full sync (ie. in WAIT_BGSAVE_START state). */
     listRewind(server.replicas, &li);
     while ((ln = listNext(&li))) {
@@ -3765,37 +3653,110 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
                 addRdbReplicaToPsyncWait(replica);
                 /* Put the socket in blocking mode to simplify RDB transfer. */
                 connBlock(replica->conn);
+            } else {
+                server.rdb_pipe_numconns++;
             }
             replicationSetupReplicaForFullResync(replica, getPsyncInitialOffset());
         }
 
-        /* do not skip RDB checksum on the primary if connection doesn't have integrity check or if the replica doesn't support it */
+        // do not skip RDB checksum on the primary if connection doesn't have integrity check or if the replica doesn't support it
         if (!connIsIntegrityChecked(replica->conn) || !(replica->repl_data->replica_capa & REPLICA_CAPA_SKIP_RDB_CHECKSUM))
             skip_rdb_checksum = 0;
     }
 
-    rdbSnapshotOptions options = {
-        .conns = conns,
-        .connsnum = connsnum,
-        .use_pipe = !dual_channel,
-        .req = req,
-        .skip_checksum = skip_rdb_checksum,
-        .privdata = rsi,
-        .snapshot_func = childSnapshotUsingRDB};
-    if (saveSnapshotToConnectionSockets(options) != C_OK) {
-        /* Undo the state change. The caller will perform cleanup on
-         * all the replicas in BGSAVE_START state, but an early call to
-         * replicationSetupReplicaForFullResync() turned it into BGSAVE_END */
-        listRewind(server.replicas, &li);
-        while ((ln = listNext(&li))) {
-            client *replica = ln->value;
-            if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END) {
-                replica->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
+    /* Create the child process. */
+    if ((childpid = serverFork(CHILD_TYPE_RDB)) == 0) {
+        /* Child */
+        int retval, dummy;
+        rio rdb;
+        if (dual_channel) {
+            rioInitWithConnset(&rdb, conns, connsnum);
+        } else {
+            rioInitWithFd(&rdb, rdb_pipe_write);
+        }
+
+        /* Close the reading part, so that if the parent crashes, the child will
+         * get a write error and exit. */
+        if (!dual_channel) close(server.rdb_pipe_read);
+        if (strstr(server.exec_argv[0], "redis-server") != NULL) {
+            serverSetProcTitle("redis-rdb-to-slaves");
+        } else {
+            serverSetProcTitle("valkey-rdb-to-replicas");
+        }
+        serverSetCpuAffinity(server.bgsave_cpulist);
+
+        if (skip_rdb_checksum) rdb.flags |= RIO_FLAG_SKIP_RDB_CHECKSUM;
+
+        retval = rdbSaveRioWithEOFMark(req, &rdb, NULL, rsi);
+        if (retval == C_OK && rioFlush(&rdb) == 0) retval = C_ERR;
+
+        if (retval == C_OK) {
+            sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
+        }
+        if (dual_channel) {
+            rioFreeConnset(&rdb);
+        } else {
+            rioFreeFd(&rdb);
+            /* wake up the reader, tell it we're done. */
+            close(rdb_pipe_write);
+            close(server.rdb_child_exit_pipe); /* close write end so that we can detect the close on the parent. */
+        }
+        zfree(conns);
+        /* hold exit until the parent tells us it's safe. we're not expecting
+         * to read anything, just get the error when the pipe is closed. */
+        if (!dual_channel) dummy = read(safe_to_exit_pipe, pipefds, 1);
+        UNUSED(dummy);
+        exitFromChild((retval == C_OK) ? 0 : 1);
+    } else {
+        /* Parent */
+        if (childpid == -1) {
+            serverLog(LL_WARNING, "Can't save in background: fork: %s", strerror(errno));
+
+            /* Undo the state change. The caller will perform cleanup on
+             * all the replicas in BGSAVE_START state, but an early call to
+             * replicationSetupReplicaForFullResync() turned it into BGSAVE_END */
+            listRewind(server.replicas, &li);
+            while ((ln = listNext(&li))) {
+                client *replica = ln->value;
+                if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END) {
+                    replica->repl_data->repl_state = REPLICA_STATE_WAIT_BGSAVE_START;
+                }
+            }
+            if (!dual_channel) {
+                close(rdb_pipe_write);
+                close(server.rdb_pipe_read);
+                close(server.rdb_child_exit_pipe);
+            }
+            zfree(conns);
+            if (dual_channel) {
+                closeChildInfoPipe();
+            } else {
+                server.rdb_pipe_conns = NULL;
+                server.rdb_pipe_numconns = 0;
+                server.rdb_pipe_numconns_writing = 0;
+            }
+        } else {
+            serverLog(LL_NOTICE, "Background RDB transfer started by pid %ld to %s%s", (long)childpid,
+                      dual_channel ? "direct socket to replica" : "pipe through parent process",
+                      skip_rdb_checksum ? " while skipping RDB checksum for this transfer" : "");
+
+            server.rdb_save_time_start = time(NULL);
+            server.rdb_child_type = RDB_CHILD_TYPE_SOCKET;
+            if (dual_channel) {
+                /* For dual channel sync, the main process no longer requires these RDB connections. */
+                zfree(conns);
+            } else {
+                close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
+                if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler, NULL) ==
+                    AE_ERR) {
+                    serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
+                }
             }
         }
-        return C_ERR;
+        if (!dual_channel) close(safe_to_exit_pipe);
+        return (childpid == -1) ? C_ERR : C_OK;
     }
-    return C_OK;
+    return C_OK; /* Unreached. */
 }
 
 void saveCommand(client *c) {

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -117,17 +117,6 @@ enum RdbType {
 };
 /* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdb_type_string[] */
 
-typedef int (*ChildSnapshotFunc)(int req, rio *rdb, void *privdata);
-typedef struct rdbSnapshotOptions {
-    int connsnum;                    /* Number of connections. */
-    connection **conns;              /* A heap-allocated array of connections to send the snapshot to. */
-    int use_pipe;                    /* Use pipe to send the snapshot. */
-    int req;                         /* See REPLICA_REQ_* in server.h. */
-    int skip_checksum;               /* Skip checksum when sending the snapshot. */
-    ChildSnapshotFunc snapshot_func; /* Function to call to take the snapshot. */
-    void *privdata;                  /* Private data to pass to snapshot_func. */
-} rdbSnapshotOptions;
-
 /* Test if a type is an object type. */
 #define rdbIsObjectType(t) (((t) >= 0 && (t) <= 7) || ((t) >= 9 && (t) < RDB_TYPE_LAST))
 
@@ -209,6 +198,5 @@ int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, s
 int rdbSaveRio(int req, rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi);
 ssize_t rdbSaveFunctions(rio *rdb);
 rdbSaveInfo *rdbPopulateSaveInfo(rdbSaveInfo *rsi);
-int saveSnapshotToConnectionSockets(rdbSnapshotOptions options);
 
 #endif

--- a/src/replication.c
+++ b/src/replication.c
@@ -1719,11 +1719,7 @@ void rdbPipeWriteHandler(struct connection *conn) {
         return;
     } else {
         replica->repl_data->repldboff += nwritten;
-        if (getClientType(replica) == CLIENT_TYPE_SLOT_EXPORT) {
-            server.stat_net_cluster_slot_export_bytes += nwritten;
-        } else {
-            server.stat_net_repl_output_bytes += nwritten;
-        }
+        server.stat_net_repl_output_bytes += nwritten;
         if (replica->repl_data->repldboff < server.rdb_pipe_bufflen) {
             replica->repl_data->repl_last_partial_write = server.unixtime;
             return; /* more data to write.. */
@@ -1797,11 +1793,7 @@ void rdbPipeReadHandler(struct aeEventLoop *eventLoop, int fd, void *clientData,
                 /* Note: when use diskless replication, 'repldboff' is the offset
                  * of 'rdb_pipe_buff' sent rather than the offset of entire RDB. */
                 replica->repl_data->repldboff = nwritten;
-                if (getClientType(replica) == CLIENT_TYPE_SLOT_EXPORT) {
-                    server.stat_net_cluster_slot_export_bytes += nwritten;
-                } else {
-                    server.stat_net_repl_output_bytes += nwritten;
-                }
+                server.stat_net_repl_output_bytes += nwritten;
             }
             /* If we were unable to write all the data to one of the replicas,
              * setup write handler (and disable pipe read handler, below) */

--- a/src/server.c
+++ b/src/server.c
@@ -824,6 +824,7 @@ const char *strChildType(int type) {
     case CHILD_TYPE_AOF: return "AOF";
     case CHILD_TYPE_LDB: return "LDB";
     case CHILD_TYPE_MODULE: return "MODULE";
+    case CHILD_TYPE_SLOT_MIGRATION: return "SLOT_MIGRATION";
     default: return "Unknown";
     }
 }
@@ -850,7 +851,7 @@ void resetChildState(void) {
 
 /* Return if child type is mutually exclusive with other fork children */
 int isMutuallyExclusiveChildType(int type) {
-    return type == CHILD_TYPE_RDB || type == CHILD_TYPE_AOF || type == CHILD_TYPE_MODULE;
+    return type == CHILD_TYPE_RDB || type == CHILD_TYPE_AOF || type == CHILD_TYPE_MODULE || type == CHILD_TYPE_SLOT_MIGRATION;
 }
 
 /* Returns true when we're inside a long command that yielded to the event loop. */
@@ -1396,6 +1397,8 @@ void checkChildrenDone(void) {
                 backgroundRewriteDoneHandler(exitcode, bysignal);
             } else if (server.child_type == CHILD_TYPE_MODULE) {
                 ModuleForkDoneHandler(exitcode, bysignal);
+            } else if (server.child_type == CHILD_TYPE_SLOT_MIGRATION) {
+                clusterHandleSlotExportBackgroundSaveDone((!bysignal && exitcode == 0) ? C_OK : C_ERR);
             } else {
                 serverPanic("Unknown child type %d for child pid %d", server.child_type, server.child_pid);
                 exit(1);
@@ -2938,6 +2941,7 @@ void initServer(void) {
     server.stat_rdb_cow_bytes = 0;
     server.stat_aof_cow_bytes = 0;
     server.stat_module_cow_bytes = 0;
+    server.stat_slot_migration_cow_bytes = 0;
     server.stat_module_progress = 0;
     for (int j = 0; j < CLIENT_TYPE_COUNT; j++) server.stat_clients_type_memory[j] = 0;
     server.stat_cluster_links_memory = 0;
@@ -4721,6 +4725,11 @@ int finishShutdown(void) {
         }
     }
 
+    if (server.child_type == CHILD_TYPE_SLOT_MIGRATION) {
+        serverLog(LL_WARNING, "There is a slot migration child. Killing it!");
+        killSlotMigrationChild();
+    }
+
     /* Create a new RDB file before exiting. */
     if ((server.saveparamslen > 0 && !nosave) || save) {
         serverLog(LL_NOTICE, "Saving the final RDB snapshot before exiting.");
@@ -6029,7 +6038,9 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "aof_last_write_status:%s\r\n", (server.aof_last_write_status == C_OK && aof_bio_fsync_status == C_OK) ? "ok" : "err",
                 "aof_last_cow_size:%zu\r\n", server.stat_aof_cow_bytes,
                 "module_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_MODULE,
-                "module_fork_last_cow_size:%zu\r\n", server.stat_module_cow_bytes));
+                "module_fork_last_cow_size:%zu\r\n", server.stat_module_cow_bytes,
+                "slot_migration_fork_in_progress:%d\r\n", server.child_type == CHILD_TYPE_SLOT_MIGRATION,
+                "slot_migration_fork_last_cow_size:%zu\r\n", server.stat_slot_migration_cow_bytes));
 
         if (server.aof_enabled) {
             info = sdscatprintf(

--- a/src/server.h
+++ b/src/server.h
@@ -1631,12 +1631,14 @@ typedef struct {
 #define CHILD_TYPE_AOF 2
 #define CHILD_TYPE_LDB 3
 #define CHILD_TYPE_MODULE 4
+#define CHILD_TYPE_SLOT_MIGRATION 5
 
 typedef enum childInfoType {
     CHILD_INFO_TYPE_CURRENT_INFO,
     CHILD_INFO_TYPE_AOF_COW_SIZE,
     CHILD_INFO_TYPE_RDB_COW_SIZE,
-    CHILD_INFO_TYPE_MODULE_COW_SIZE
+    CHILD_INFO_TYPE_MODULE_COW_SIZE,
+    CHILD_INFO_TYPE_SLOT_MIGRATION_COW_SIZE
 } childInfoType;
 
 struct valkeyServer {
@@ -1812,6 +1814,7 @@ struct valkeyServer {
     size_t stat_rdb_cow_bytes;                          /* Copy on write bytes during RDB saving. */
     size_t stat_aof_cow_bytes;                          /* Copy on write bytes during AOF rewrite. */
     size_t stat_module_cow_bytes;                       /* Copy on write bytes during module fork. */
+    size_t stat_slot_migration_cow_bytes;               /* Copy on write bytes during slot migration fork. */
     double stat_module_progress;                        /* Module save progress. */
     size_t stat_clients_type_memory[CLIENT_TYPE_COUNT]; /* Mem usage by type */
     size_t stat_cluster_links_memory;                   /* Mem usage by cluster links */


### PR DESCRIPTION
TBD

we now re-using CHILD_TYPE_RDB and reuse a lot of RDB saving code, it was an easier way to implement in the first time, but it mess up the logs and some info fileds. Also we need to rewrite it so that we can support one fork with multiple target in the same time in the next step.

@murphyjacob4 and me are working on it.