### PR TITLE
Remove debug logging from cluster-flush-slot.tcl

### DIFF
--- a/tests/unit/cluster/cluster-flush-slot.tcl
+++ b/tests/unit/cluster/cluster-flush-slot.tcl
@@ -49,12 +49,6 @@ start_cluster 2 2 {tags {external:skip cluster}} {
         assert_equal [R 0 CLUSTER COUNTKEYSINSLOT $key_slot] 0
 
         # assert flush slot propagated to replica
-        for {set l 0} {$l < 4} {incr l} {
-            puts "R $l info:"
-            puts [R $l info replication]
-            puts [R $l info commandSTATS]
-        }
-
         set info [R 2 info commandSTATS]
         # not del cmd
         assert_no_match "*cmdstat_del*" $info


### PR DESCRIPTION
I believe this was a debug log at the time, and its printing
was quite annoying locally. The test is quite simple so i think
we can just remove it.