### PR TITLE
Fix cluster slot allocation test flakiness

### DIFF
--- a/tests/cluster/cluster.tcl
+++ b/tests/cluster/cluster.tcl
@@ -133,6 +133,9 @@ proc create_cluster {masters slaves} {
 }
 
 proc cluster_allocate_with_continuous_slots {n} {
+    for {set j 0} {$j < $n} {incr j} {
+        unset -nocomplain slots_$j
+    }
     set slot 16383
     set avg [expr ($slot+1) / $n]
     while {$slot >= 0} {


### PR DESCRIPTION
There was a failure in the [daily run](https://github.com/valkey-io/valkey/actions/runs/17142308322/job/48631952015#step:11:286) for `ERR Slot 3275 is already busy`.

This change ensures previous allocations are cleared so slots aren't appended multiple times when this helper is invoked repeatedly in the same test run. So each run starts with a clean state.

The test is passing after this change in the 7 [CI](https://github.com/sarthakaggarwal97/valkey/actions/runs/17163027093) of my local repository

```
00:55:14> Create a 5 nodes cluster: FAILED: caught an error in the test ERR Slot 3275 is already busy
ERR Slot 3275 is already busy
    while executing
"[Rn $n] {*}$args"
    (procedure "R" line 2)
    invoked from within
"R $j cluster addslots {*}[set slots_${j}]"
    (procedure "cluster_allocate_with_continuous_slots" line 10)
    invoked from within
"cluster_allocate_with_continuous_slots $masters"
    (procedure "cluster_create_with_continuous_slots" line 2)
    invoked from within
"cluster_create_with_continuous_slots 5 15"
    ("uplevel" body line 2)
    invoked from within
"uplevel 1 $code"
    (procedure "test" line 6)
    invoked from within
"test "Create a 5 nodes cluster" {
    cluster_create_with_continuous_slots 5 15
}"
    (file "../tests/12.1-replica-migration-3.tcl" line 11)
    invoked from within
"source $test "
```