### PR TITLE
deflake test: relax time requirement in hash ttl test

### DIFF
--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1487,9 +1487,11 @@ start_server {tags {"hashexpire"}} {
         for {set i 1} {$i <= 600} {incr i} {
             assert_equal "v$i" [r HGET myhash "f$i"]
             if {$i == 1 || $i == 10 || $i == 100 || $i == 200 || $i == 300} {
-                assert_equal 3 [r HTTL myhash FIELDS 1 "f$i"]
+                # nonzero time has passed so we should check for a range
+                assert_morethan [r HTTL myhash FIELDS 1 "f$i"] 1
+                assert_lessthan_equal [r HTTL myhash FIELDS 1 "f$i"] 3
             } else {
-                assert_equal -1 [r HTTL myhash FIELDS 1 "f$i"]
+                assert_equal [r HTTL myhash FIELDS 1 "f$i"] -1
             }
         }
         # Re-enable active expiry

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1478,7 +1478,9 @@ start_server {tags {"hashexpire"}} {
             lappend pairs "f$i" "v$i"
         }
         r HSET myhash {*}$pairs
-        r HEXPIRE myhash 3 FIELDS 5 f1 f10 f100 f200 f300
+        
+        set expire_time [get_long_expire_value HEXPIREAT]
+        r HEXPIREAT myhash $expire_time FIELDS 5 f1 f10 f100 f200 f300
         
         # Verify encoding changed to hashtable
         set "hashtable" [r OBJECT ENCODING myhash]
@@ -1487,9 +1489,7 @@ start_server {tags {"hashexpire"}} {
         for {set i 1} {$i <= 600} {incr i} {
             assert_equal "v$i" [r HGET myhash "f$i"]
             if {$i == 1 || $i == 10 || $i == 100 || $i == 200 || $i == 300} {
-                # nonzero time has passed so we should check for a range
-                assert_morethan [r HTTL myhash FIELDS 1 "f$i"] 1
-                assert_lessthan_equal [r HTTL myhash FIELDS 1 "f$i"] 3
+                assert_equal [r HEXPIRETIME myhash FIELDS 1 "f$i"] $expire_time
             } else {
                 assert_equal [r HTTL myhash FIELDS 1 "f$i"] -1
             }


### PR DESCRIPTION
tiny change. It failed once for me (a little time passed and it returned 2 seconds instead of 3), so I figured it's probably a little flaky for others too