### PR TITLE
Consistently use static_assert across code

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -54,10 +54,6 @@
 #include "monotonic.h"
 #include "config.h"
 
-#ifndef static_assert
-#define static_assert(expr, lit) _Static_assert(expr, lit)
-#endif
-
 #define UNUSED(V) ((void)V)
 
 /* Using dictSetResizeEnabled() we make possible to disable

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -191,10 +191,6 @@ void hashtableSetResizePolicy(hashtableResizePolicy policy) {
 #error "Only 64-bit or 32-bit architectures are supported"
 #endif /* 64-bit vs 32-bit version */
 
-#ifndef static_assert
-#define static_assert _Static_assert
-#endif
-
 static_assert(100 * BUCKET_DIVISOR / BUCKET_FACTOR / ENTRIES_PER_BUCKET <= MAX_FILL_PERCENT_SOFT,
               "Expand must result in a fill below the soft max fill factor");
 static_assert(MAX_FILL_PERCENT_SOFT <= MAX_FILL_PERCENT_HARD, "Soft vs hard fill factor");

--- a/src/server.h
+++ b/src/server.h
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef static_assert
-#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1 : -1]
+#define static_assert _Static_assert
 #endif
 
 #include "ae.h"         /* Event driven programming library */

--- a/src/serverassert.h
+++ b/src/serverassert.h
@@ -64,7 +64,7 @@ void _serverAssert(const char *estr, const char *file, int line);
 void _serverPanic(const char *file, int line, const char *msg, ...);
 
 #ifndef static_assert
-#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1 : -1]
+#define static_assert _Static_assert
 #endif
 
 #endif

--- a/src/vset.c
+++ b/src/vset.c
@@ -11,10 +11,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#ifndef static_assert
-#define static_assert _Static_assert
-#endif
-
 /*
  *-----------------------------------------------------------------------------
  * Volatile Set - Adaptive, Expiry-aware Set Structure


### PR DESCRIPTION
In C99, we had to use `#define static_assert(expr, lit) extern char __static_assert_failure[(expr) ? 1 : -1]` for static assertions. However, we now have native support for static_assert with _Static_assert. Previously one of the correct #defines was getting called first, setting it to _Static_assert, however after https://github.com/valkey-io/valkey/commit/65215e5378db7b47c3460567da134ab7f0bfeb58 the first import defining the symbol was "serverassert.h", which included the old style.

This change removes all unnecessary imports and always defines static_assert as _Static_assert.