### PR TITLE
Update reply schema for LMOVE and BLMOVE

### DIFF
--- a/src/commands/blmove.json
+++ b/src/commands/blmove.json
@@ -60,7 +60,7 @@
                     "type": "string"
                 },
                 {
-                    "description": "Operation timed-out",
+                    "description": "Operation timed-out or the source does not exist.",
                     "type": "null"
                 }
             ]

--- a/src/commands/blmove.json
+++ b/src/commands/blmove.json
@@ -60,7 +60,7 @@
                     "type": "string"
                 },
                 {
-                    "description": "Operation timed-out or the source does not exist.",
+                    "description": "Operation timed-out or the command is issued from a transaction or a script and the source does not exist.",
                     "type": "null"
                 }
             ]

--- a/src/commands/lmove.json
+++ b/src/commands/lmove.json
@@ -53,8 +53,16 @@
             }
         ],
         "reply_schema": {
-            "description": "The element being popped and pushed.",
-            "type": "string"
+            "oneOf": [
+                {
+                    "description": "The element being popped and pushed.",
+                    "type": "string"
+                },
+                {
+                    "description": "Source does not exist.",
+                    "type": "null"
+                }
+            ]
         },
         "arguments": [
             {


### PR DESCRIPTION
Both LMOVE and BLMOVE can return null values because the source key is empty.
PR changes include 
- change the LMOVE reply_schema to include the possibility of a nil return value
- Add comment to BLMOVE reply_schema to indicate it can return nil because the source does not exist

This fixes #2532