### PR TITLE
Do not migrate function in new atomic slot migration

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2283,7 +2283,6 @@ int rewriteObjectRio(rio *aof, robj *o, int db_num) {
 int rewriteSlotToAppendOnlyFileRio(rio *aof, int db_num, int hashslot, size_t *key_count) {
     long long updated_time = 0;
 
-    if (rewriteFunctions(aof) == 0) return C_ERR;
     if (dbHasNoKeys(db_num)) return C_OK;
 
     serverDb *db = server.db[db_num];

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -403,6 +403,35 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
     set 16382_slot_tag "{4oi}"
     set 16383_slot_tag "{6ZJ}"
 
+    test "Slot migration won't migrate the functions" {
+        assert_does_not_resync {
+            # R 2 load a function then trigger a slot migration to R 0
+            populate 1 "$16383_slot_tag:" 1000 -2
+            R 2 function load {#!lua name=test
+                server.register_function('test', function() return 'hello1' end)
+            }
+
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            wait_for_migration 0 16383
+
+            # Make sure R 0 does not have any function.
+            assert_match {} [R 0 function list]
+
+            # R 0 load a function then migrate the slot back to R 2
+            R 0 function load {#!lua name=test
+                server.register_function('test', function() return 'hello1' end)
+            }
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 FUNCTION FLUSH SYNC]
+            assert_match "OK" [R 2 FLUSHDB SYNC]
+            assert_match "OK" [R 2 FUNCTION FLUSH SYNC]
+        }
+    }
+
     test "Single source import - one shot" {
         assert_does_not_resync {
             # Populate data before migration

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -410,7 +410,6 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             R 2 function load {#!lua name=test
                 server.register_function('test', function() return 'hello1' end)
             }
-
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
             wait_for_migration 0 16383
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -406,21 +406,42 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
     test "Slot migration won't migrate the functions" {
         assert_does_not_resync {
             # R 2 load a function then trigger a slot migration to R 0
+            set_debug_prevent_pause 1
             populate 1 "$16383_slot_tag:" 1000 -2
-            R 2 function load {#!lua name=test
-                server.register_function('test', function() return 'hello1' end)
+            R 2 function load {#!lua name=test1
+                server.register_function('test1', function() return 'hello1' end)
             }
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            set jobname [get_job_name 2 16383]
+
+            # Load a function after the snapshot
+            wait_for_migration_field 2 $jobname state waiting-to-pause
+            populate 1 "$16383_slot_tag:" 1000 -2
+            R 2 function load {#!lua name=test2
+                server.register_function('test2', function() return 'hello2' end)
+            }
+            set_debug_prevent_pause 0
             wait_for_migration 0 16383
 
             # Make sure R 0 does not have any function.
             assert_match {} [R 0 function list]
 
             # R 0 load a function then migrate the slot back to R 2
-            R 0 function load {#!lua name=test
-                server.register_function('test', function() return 'hello1' end)
+            set_debug_prevent_pause 1
+            populate 1 "$16383_slot_tag:" 1000 0
+            R 0 function load {#!lua name=test1
+                server.register_function('test1', function() return 'hello1' end)
             }
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            set jobname [get_job_name 0 16383]
+
+            # Load a function after the snapshot
+            wait_for_migration_field 0 $jobname state waiting-to-pause
+            populate 1 "$16383_slot_tag:" 1000 0
+            R 0 function load {#!lua name=test2
+                server.register_function('test2', function() return 'hello2' end)
+            }
+            set_debug_prevent_pause 0
             wait_for_migration 2 16383
 
             # Cleanup for next test


### PR DESCRIPTION
If all cluster nodes have functions, slot migration will fail
since the target will return the function already exists error
when doing the FUNCTION LOAD.

And in addition, the target's replica could panic when it executes
the FUNCTION LOAD propagated from the primary (see propagation-error-behavior).

Introduced in #1949.