### PR TITLE
Attempt to fix sub-replica getting out of sync

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -140,7 +140,6 @@ static int clientMatchesIpFilter(client *c, sds ip);
 static int clientMatchesCapaFilter(client *c, sds capa_filter);
 static void freeClientFilter(clientFilter *filter);
 static bool consumeCommandQueue(client *c);
-static void discardCommandQueue(client *c);
 static int parseMultibulk(client *c,
                           int *argc,
                           robj ***argv,
@@ -3856,7 +3855,7 @@ static bool consumeCommandQueue(client *c) {
     return true;
 }
 
-static void discardCommandQueue(client *c) {
+void discardCommandQueue(client *c) {
     cmdQueue *queue = &c->cmd_queue;
     while (queue->off < queue->len) {
         parsedCommand *p = &queue->cmds[queue->off++];

--- a/src/replication.c
+++ b/src/replication.c
@@ -4543,6 +4543,10 @@ void replicationCachePrimary(client *c) {
     c->bufpos = 0;
     resetClient(c);
     resetClientIOState(c);
+    c->reqtype = 0;
+    c->multibulklen = 0;
+    c->bulklen = -1;
+    discardCommandQueue(c);
 
     /* Save the primary. Server.primary will be set to null later by
      * replicationHandlePrimaryDisconnection(). */

--- a/src/server.h
+++ b/src/server.h
@@ -2780,6 +2780,7 @@ void beforeNextClient(client *c);
 void clearClientConnectionState(client *c);
 void resetClient(client *c);
 void resetClientIOState(client *c);
+void discardCommandQueue(client *c);
 void freeClientOriginalArgv(client *c);
 void freeClientArgv(client *c);
 void sendReplyToClient(connection *conn);


### PR DESCRIPTION
Try to fix the failures seen for `test "PSYNC2 #3899 regression: verify consistency"`

* https://github.com/valkey-io/valkey/actions/runs/17224068725/job/48865204660#step:6:10445
* https://github.com/valkey-io/valkey/actions/runs/17195608962/job/48777111008#step:6:7938

This change resets the query buffer parser state in `replicationCachePrimary()` which is called when the connection to the primary is lost. Before #2092, this was done by `resetClient()`.

The solution was inspired by the discussion about the regression mentioned (discussion from 2017) and the related commits from that time: 6bc6bd4c384d2b87353c3f2bb552e3b44dd53a5b, 469d6e2b37e2913ecb673f910cdb7dbd3af18a67, c180bc7d98061fd59be54ca83b67abfd6ce65414.