### PR TITLE
Reduce active defrag test latency by lowering hit threshold

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -847,7 +847,7 @@ static doneStatus defragLaterStep(monotime endtime, void *privdata) {
             listDelNode(defrag_later, head);
         }
 
-        if (++iterations > 16 || server.stat_active_defrag_hits - prev_defragged > 0 ||
+        if (++iterations > 16 || server.stat_active_defrag_hits > prev_defragged ||
             server.stat_active_defrag_scanned - prev_scanned > 64) {
             if (getMonotonicUs() > endtime) break;
             iterations = 0;
@@ -895,7 +895,7 @@ static doneStatus defragStageKvstoreHelper(monotime endtime,
     }
 
     while (true) {
-        if (++iterations > 16 || server.stat_active_defrag_hits - prev_defragged > 512 || server.stat_active_defrag_scanned - prev_scanned > 64) {
+        if (++iterations > 16 || server.stat_active_defrag_hits > prev_defragged || server.stat_active_defrag_scanned - prev_scanned > 64) {
             if (getMonotonicUs() >= endtime) break;
             iterations = 0;
             prev_defragged = server.stat_active_defrag_hits;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -847,7 +847,7 @@ static doneStatus defragLaterStep(monotime endtime, void *privdata) {
             listDelNode(defrag_later, head);
         }
 
-        if (++iterations > 16 || server.stat_active_defrag_hits - prev_defragged > 512 ||
+        if (++iterations > 16 || server.stat_active_defrag_hits - prev_defragged > 0 ||
             server.stat_active_defrag_scanned - prev_scanned > 64) {
             if (getMonotonicUs() > endtime) break;
             iterations = 0;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -822,7 +822,7 @@ static doneStatus defragLaterStep(monotime endtime, void *privdata) {
     defragKeysCtx *ctx = privdata;
 
     unsigned int iterations = 0;
-    unsigned long long prev_defragged = server.stat_active_defrag_hits;
+    long long prev_defragged = server.stat_active_defrag_hits;
     unsigned long long prev_scanned = server.stat_active_defrag_scanned;
 
     while (defrag_later && listLength(defrag_later) > 0) {
@@ -882,7 +882,7 @@ static doneStatus defragStageKvstoreHelper(monotime endtime,
     }
 
     unsigned int iterations = 0;
-    unsigned long long prev_defragged = server.stat_active_defrag_hits;
+    long long prev_defragged = server.stat_active_defrag_hits;
     unsigned long long prev_scanned = server.stat_active_defrag_scanned;
 
     if (state.slot == KVS_SLOT_DEFRAG_LUT) {

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -183,7 +183,7 @@ run_solo {defrag} {
     proc perform_defrag_test {name args} {
         # This value should be 5 ms, but it was flaky in github runners. The issue 
         # https://github.com/valkey-io/valkey/issues/2444 is tracking if we can raise the limit again.
-        set opts(latency) 40
+        set opts(latency) 5
         set opts(while_defragging) {}
         array set opts $args
         assert {[info exists opts(populate)]}


### PR DESCRIPTION
Changed the defrag hit threshold from 512 to 1 in the `defragLaterStep` & `defragStageKvstoreHelper` function to reduce defrag latency. (idea from Jim)

1. Previously, the defrag loop would continue processing up to 512 successful defragmentations before checking if the time limit was exceeded. Now it checks after every single successful allocation move.
2. The trade-off is slightly more frequent time checks, but the time check (~19ns) is negligible compared to the actual defragmentation work (even a single 8-byte reallocation takes ~43ns and the allocatorShouldDefrag function call takes ~49ns per block). This overhead is minimal compared to the latency improvement gained from better time management during active defragmentation.
3. Also revert the change from https://github.com/valkey-io/valkey/pull/2421/files to test.
4. Solved compilation issue with unsigned by changing the type of the local variable `prev_defragged `to match the type of `server.stat_active_defrag_hits`

Closes #2444