### PR TITLE
Correct path to gen-test-certs.sh in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ line, with exactly the same name.
 
 ## Running manually
 
-To manually run a Valkey server with TLS mode (assuming `./gen-test-certs.sh` was invoked so sample certificates/keys are available):
+To manually run a Valkey server with TLS mode (assuming `./utils/gen-test-certs.sh`
+was invoked so sample certificates/keys are available):
 
 * TLS built-in mode:
     ```


### PR DESCRIPTION
Noticed a small error in the readme while looking for the script.