### PR TITLE
Don't use AVX2 instructions if the CPU don't support it

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -242,7 +242,7 @@ long long serverPopcount(void *s, long count) {
 #if HAVE_X86_SIMD
     /* If length of s >= 256 bits and the CPU supports AVX2,
      * we prefer to use the SIMD version */
-    if (count >= 32) {
+    if (count >= 32 && __builtin_cpu_supports("avx2")) {
         return popcountAVX2(s, count);
     }
 #endif


### PR DESCRIPTION
`bitops.c`: `serverPopcount()` used `popcountAVX2()`, which as the name implies requires AVX2 support, on AVX-only machines, causing an "illegal instruction" error.

Added a `__builtin_cpu_supports("avx2")` check and falling back to the platform agnostic version if AVX2 is not supported.

Fixes #2570