### PR TITLE
ARM Neon SIMD optimization for hashtable findBucket()

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -35,7 +35,7 @@
 #define __MM_MALLOC_H
 #include <immintrin.h>
 #endif
-#if defined(__aarch64__)
+#if HAVE_ARM_NEON
 #include <arm_neon.h>
 #endif
 /* -----------------------------------------------------------------------------
@@ -190,7 +190,7 @@ long long popcountScalar(void *s, long count) {
     return bits;
 }
 
-#if defined(__aarch64__)
+#if HAVE_ARM_NEON
 #include <arm_neon.h>
 
 /*  SIMD version of popcount for ARM NEON.

--- a/src/config.h
+++ b/src/config.h
@@ -374,7 +374,7 @@ void setcpuaffinity(const char *cpulist);
 #define valkey_prefetch(addr) ((void)(addr))
 #endif
 
-/* Check if we can compile SIMD code */
+/* Check if we can compile x86 SIMD code */
 #if defined(__x86_64__) && ((defined(__GNUC__) && __GNUC__ >= 5) || (defined(__clang__) && __clang_major__ >= 4)) && defined(__has_attribute) && __has_attribute(target)
 #define HAVE_X86_SIMD 1
 #else
@@ -389,6 +389,13 @@ void setcpuaffinity(const char *cpulist);
 #define ATTRIBUTE_TARGET_SSE2
 #define ATTRIBUTE_TARGET_AVX2
 #define ATTRIBUTE_TARGET_AVX512
+#endif
+
+/* Check if we can compile ARM SIMD code */
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#define HAVE_ARM_NEON 1
+#else
+#define HAVE_ARM_NEON 0
 #endif
 
 #if defined(__linux__) && defined(__GLIBC__) && (defined(__GNUC__) && (__GNUC__ > 4) || defined(__clang__) && (__clang_major__) > 5)

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -60,6 +60,9 @@
 #if HAVE_X86_SIMD
 #include <immintrin.h>
 #endif
+#if HAVE_ARM_NEON
+#include <arm_neon.h>
+#endif
 
 /* The default hashing function uses the SipHash implementation in siphash.c. */
 
@@ -719,6 +722,38 @@ static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void 
 }
 #endif
 
+#if HAVE_ARM_NEON && ENTRIES_PER_BUCKET <= 8
+/* 32 bit architectures would require a different implementation
+ * consider that even if they had Neon SIMD support,
+ * they have 12 entries per bucket and only 32-bit scalar registers */
+
+static inline __attribute__((hot, always_inline)) int popMatchBitmask(uint64_t *mask) {
+    /* one byte (8 bits) per item - either 0x80 or 0x00 */
+    int pos = __builtin_ctzll(*mask) >> 3;
+    *mask &= (*mask - 1); /* clear lowest set bit */
+    return pos;
+}
+
+static __attribute__((hot)) int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
+    const uint8x8_t hash_vector = vld1_u8(b->hashes);             /* simple load */
+    const uint8x8_t h2_vector = vdup_n_u8(h2);                    /* duplicated into every byte */
+    const uint8x8_t equal_mask = vceq_u8(hash_vector, h2_vector); /* compare: 8 bits per item, 0xFF or 0x00 */
+    uint64_t matches = vget_lane_u64(vreinterpret_u64_u8(equal_mask), 0);
+
+    /* reduce each match to one bit and zero out invalid positions */
+    const uint64_t valid_entry_mask = (1ul << (ENTRIES_PER_BUCKET << 3)) - 1ul;
+    matches = matches & 0x8080808080808080ul & valid_entry_mask;
+
+    while (matches) {
+        int pos = popMatchBitmask(&matches);
+        if ((b->presence & (1 << pos)) &&
+            checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index))
+            return 1;
+    }
+    return 0; /* No match */
+}
+#endif
+
 /* Finds an entry matching the key. If a match is found, returns a pointer to
  * the bucket containing the matching entry and points 'pos_in_bucket' to the
  * index within the bucket. Returns NULL if no matching entry was found.
@@ -746,6 +781,8 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
 #if HAVE_X86_SIMD
             /* All x86-64 CPUs have SSE2. */
             if (findKeyInBucketSSE2(ht, b, h2, key, table, pos_in_bucket, table_index)) return b;
+#elif HAVE_ARM_NEON && ENTRIES_PER_BUCKET <= 8
+            if (findKeyInBucketNeon(ht, b, h2, key, table, pos_in_bucket, table_index)) return b;
 #else
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -727,14 +727,14 @@ static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void 
  * consider that even if they had Neon SIMD support,
  * they have 12 entries per bucket and only 32-bit scalar registers */
 
-static inline __attribute__((hot, always_inline)) int popMatchBitmask(uint64_t *mask) {
+static inline int popMatchBitmask(uint64_t *mask) {
     /* one byte (8 bits) per item - either 0x80 or 0x00 */
     int pos = __builtin_ctzll(*mask) >> 3;
     *mask &= (*mask - 1); /* clear lowest set bit */
     return pos;
 }
 
-static __attribute__((hot)) int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
+static int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
     const uint8x8_t hash_vector = vld1_u8(b->hashes);             /* simple load */
     const uint8x8_t h2_vector = vdup_n_u8(h2);                    /* duplicated into every byte */
     const uint8x8_t equal_mask = vceq_u8(hash_vector, h2_vector); /* compare: 8 bits per item, 0xFF or 0x00 */

--- a/src/unit/test_bitops.c
+++ b/src/unit/test_bitops.c
@@ -10,7 +10,7 @@ extern long long popcountScalar(void *s, long count);
 #if HAVE_X86_SIMD
 extern long long popcountAVX2(void *s, long count);
 #endif
-#if defined(__aarch64__)
+#if HAVE_ARM_NEON
 extern long long popcountNEON(void *s, long count);
 #endif
 
@@ -43,7 +43,7 @@ static int test_case(const char *msg, int size) {
         long long ret_avx2 = popcountAVX2(buf, size);
         TEST_ASSERT_MESSAGE(msg, expect == ret_avx2);
 #endif
-#if defined(__aarch64__)
+#if HAVE_ARM_NEON
         long long ret_neon = popcountNEON(buf, size);
         TEST_ASSERT_MESSAGE(msg, expect == ret_neon);
 #endif


### PR DESCRIPTION
This PR resolves #2519. I worked with @ahmadbelb to get a pretty good result. 😁 For `hashtableFind()` I measured 58% speed improvement on a AWS t4g.2xlarge instance, and Ahmad measured 159% speed improvement on a M1 Mac.

I'm still working on valkey-benchmark results for GET and SET throughput.

I used Google Benchmark to make micro benchmarks that test 0% 50% and 100% hit rates for hashtableFind(). You can check out the test code in this branch: https://github.com/SoftlyRaining/valkey/tree/valkey-microbench

My AWS t4g.2xlarge micro benchmark results:
```
Scalar version:
Running ./valkey-microbench
Run on (8 X 243.75 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x8)
  L1 Instruction 64 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 32768 KiB (x1)
Load Average: 6.04, 2.10, 1.14
---------------------------------------------------------------------------------------------------
Benchmark                                                         Time             CPU   Iterations
---------------------------------------------------------------------------------------------------
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                50.6 ns         50.6 ns    138342333
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                50.4 ns         50.4 ns    138342333
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                50.7 ns         50.7 ns    138342333
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                50.4 ns         50.4 ns    138342333
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                50.5 ns         50.4 ns    138342333
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_mean           50.5 ns         50.5 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_median         50.5 ns         50.4 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_stddev        0.118 ns        0.118 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_cv             0.23 %          0.23 %             5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               56.6 ns         56.6 ns    123370046
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               56.8 ns         56.8 ns    123370046
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               55.8 ns         55.8 ns    123370046
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               56.4 ns         56.4 ns    123370046
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               56.3 ns         56.3 ns    123370046
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_mean          56.4 ns         56.4 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_median        56.4 ns         56.4 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_stddev       0.363 ns        0.363 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_cv            0.64 %          0.64 %             5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              50.5 ns         50.5 ns    138420288
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              50.4 ns         50.4 ns    138420288
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              50.4 ns         50.4 ns    138420288
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              50.5 ns         50.5 ns    138420288
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              50.4 ns         50.4 ns    138420288
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_mean         50.5 ns         50.4 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_median       50.4 ns         50.4 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_stddev      0.061 ns        0.062 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_cv           0.12 %          0.12 %             5

Neon version:
Running ./valkey-microbench
Run on (8 X 243.75 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x8)
  L1 Instruction 64 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 32768 KiB (x1)
Load Average: 0.35, 0.87, 0.72
---------------------------------------------------------------------------------------------------
Benchmark                                                         Time             CPU   Iterations
---------------------------------------------------------------------------------------------------
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.7 ns         30.7 ns    226597253
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.9 ns         30.9 ns    226597253
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.7 ns         30.6 ns    226597253
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.8 ns         30.8 ns    226597253
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.6 ns         30.6 ns    226597253
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_mean           30.7 ns         30.7 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_median         30.7 ns         30.7 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_stddev        0.118 ns        0.118 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_cv             0.38 %          0.38 %             5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               36.6 ns         36.6 ns    192568222
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               35.2 ns         35.2 ns    192568222
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               34.7 ns         34.7 ns    192568222
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               36.2 ns         36.2 ns    192568222
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               36.0 ns         36.0 ns    192568222
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_mean          35.7 ns         35.7 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_median        36.0 ns         36.0 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_stddev       0.790 ns        0.789 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_cv            2.21 %          2.21 %             5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              30.5 ns         30.5 ns    229190934
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              31.4 ns         31.4 ns    229190934
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              30.7 ns         30.7 ns    229190934
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              30.4 ns         30.4 ns    229190934
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              31.1 ns         31.1 ns    229190934
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_mean         30.8 ns         30.8 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_median       30.7 ns         30.7 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_stddev      0.415 ns        0.414 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_cv           1.35 %          1.34 %             5
```

Ahmad's M1 Mac micro benchmark results:
```
Scalar version:
Running ./src/valkey-microbench
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 4.84, 8.36, 8.53
---------------------------------------------------------------------------------------------------
Benchmark                                                         Time             CPU   Iterations
---------------------------------------------------------------------------------------------------
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                29.8 ns         29.5 ns    238219371
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                30.6 ns         29.9 ns    238219371
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                29.9 ns         29.6 ns    238219371
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                29.7 ns         29.4 ns    238219371
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                29.3 ns         29.3 ns    238219371
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_mean           29.8 ns         29.5 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_median         29.8 ns         29.5 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_stddev        0.468 ns        0.250 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_cv             1.57 %          0.85 %             5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               30.8 ns         30.7 ns    228068003
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               31.3 ns         31.0 ns    228068003
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               31.3 ns         31.0 ns    228068003
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               30.9 ns         30.8 ns    228068003
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               31.4 ns         31.1 ns    228068003
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_mean          31.1 ns         30.9 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_median        31.3 ns         31.0 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_stddev       0.288 ns        0.134 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_cv            0.92 %          0.43 %             5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              29.3 ns         29.3 ns    237946966
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              29.4 ns         29.4 ns    237946966
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              29.4 ns         29.4 ns    237946966
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              29.3 ns         29.3 ns    237946966
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              29.4 ns         29.4 ns    237946966
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_mean         29.4 ns         29.4 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_median       29.4 ns         29.4 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_stddev      0.058 ns        0.061 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_cv           0.20 %          0.21 %             5

NEON version:
Running ./src/valkey-microbench
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 4.56, 5.43, 7.09
---------------------------------------------------------------------------------------------------
Benchmark                                                         Time             CPU   Iterations
---------------------------------------------------------------------------------------------------
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                11.6 ns         11.6 ns    596879005
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                11.9 ns         11.7 ns    596879005
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                11.9 ns         11.8 ns    596879005
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                11.7 ns         11.7 ns    596879005
BM_HashtableFind_0Miss/min_time:5.000/repeats:5                11.7 ns         11.7 ns    596879005
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_mean           11.8 ns         11.7 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_median         11.7 ns         11.7 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_stddev        0.119 ns        0.069 ns            5
BM_HashtableFind_0Miss/min_time:5.000/repeats:5_cv             1.01 %          0.59 %             5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               12.0 ns         11.9 ns    592642763
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               11.9 ns         11.9 ns    592642763
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               12.0 ns         12.0 ns    592642763
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               12.2 ns         12.1 ns    592642763
BM_HashtableFind_50Miss/min_time:5.000/repeats:5               11.9 ns         11.9 ns    592642763
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_mean          12.0 ns         12.0 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_median        12.0 ns         11.9 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_stddev       0.113 ns        0.069 ns            5
BM_HashtableFind_50Miss/min_time:5.000/repeats:5_cv            0.94 %          0.58 %             5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              11.9 ns         11.8 ns    590288406
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              11.9 ns         11.9 ns    590288406
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              12.0 ns         11.9 ns    590288406
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              11.9 ns         11.8 ns    590288406
BM_HashtableFind_100Miss/min_time:5.000/repeats:5              12.6 ns         12.1 ns    590288406
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_mean         12.1 ns         11.9 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_median       11.9 ns         11.9 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_stddev      0.303 ns        0.135 ns            5
BM_HashtableFind_100Miss/min_time:5.000/repeats:5_cv           2.51 %          1.14 %             5
```