### PR TITLE
Add --warmup and --duration parameters to valkey-benchmark

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -103,7 +103,7 @@ static struct config {
     _Atomic int liveclients;
     int requests;
     int duration;
-    _Atomic int warmup_duration;
+    int warmup_duration;
     _Atomic int current_warmup_duration;
     _Atomic int requests_issued;
     _Atomic int requests_finished;
@@ -1851,13 +1851,16 @@ usage:
         " --cert <file>      Client certificate to authenticate with.\n"
         " --key <file>       Private key file to authenticate with.\n"
         " --tls-ciphers <list> Sets the list of preferred ciphers (TLSv1.2 and below)\n"
-        "                    in order of preference from highest to lowest separated by colon (\":\").\n"
-        "                    See the ciphers(1ssl) manpage for more information about the syntax of this string.\n"
+        "                    in order of preference from highest to lowest\n"
+        "                    separated by colon (\":\"). See the ciphers(1ssl)\n"
+        "                    manpage for more information about the syntax of\n"
+        "                    this string.\n"
 #ifdef TLS1_3_VERSION
         " --tls-ciphersuites <list> Sets the list of preferred ciphersuites (TLSv1.3)\n"
-        "                    in order of preference from highest to lowest separated by colon (\":\").\n"
-        "                    See the ciphers(1ssl) manpage for more information about the syntax of this string,\n"
-        "                    and specifically for TLSv1.3 ciphersuites.\n"
+        "                    in order of preference from highest to lowest separated by\n"
+        "                    colon (\":\"). See the ciphers(1ssl) manpage for more\n"
+        "                    information about the syntax of this string, and\n"
+        "                    specifically for TLSv1.3 ciphersuites.\n"
 #endif
 #endif
         "";
@@ -1905,8 +1908,10 @@ usage:
         "                    the same or higher than the number of nodes.\n"
         " -n <requests>      Total number of requests (default 100000)\n"
         " --duration <seconds>\n"
-        "                    Run benchmark for specified number of seconds (mutually exclusive with -n)\n"
-        " --warmup <seconds> Run benchmark for specified warmup period before recording data\n"
+        "                    Run benchmark for specified number of seconds\n"
+        "                    (mutually exclusive with -n)\n"
+        " --warmup <seconds> Run benchmark for specified warmup period before\n"
+        "                    recording data\n"
         " -d <size>          Data size of SET/GET value in bytes (default 3)\n"
         " --dbnum <db>       SELECT the specified db number (default 0)\n"
         " -3                 Start session in RESP3 protocol mode.\n"
@@ -1938,9 +1943,9 @@ usage:
         "                    use the same key.\n"
         " --sequential       Modifies the -r argument to replace the string __rand_int__\n"
         "                    with 12 digit numbers sequentially instead of randomly.\n"
-        "                    __rand_1st__ through __rand_9th__ are available with independent\n"
-        "                    counters. Used to create expected number of elements with multiple\n"
-        "                    replacements.\n"
+        "                    __rand_1st__ through __rand_9th__ are available with\n"
+        "                    independent counters. Used to create expected number of\n"
+        "                    elements with multiple replacements.\n"
         "                    example: ZADD myzset __rand_int__ element:__rand_1st__\n"
         " -P <numreq>        Pipeline <numreq> requests. That is, send multiple requests\n"
         "                    before waiting for the replies. Default 1 (no pipeline).\n"
@@ -1949,7 +1954,8 @@ usage:
         "                    the number of times the command sequence is sent in each\n"
         "                    pipeline.\n",
         " -q                 Quiet. Just show query/sec values\n"
-        " --precision        Number of decimal places to display in latency output (default 0)\n"
+        " --precision        Number of decimal places to display in latency output\n"
+        "                    (default 0)\n"
         " --csv              Output in CSV format\n"
         " -l                 Loop. Run the tests forever\n"
         " -t <tests>         Only run the comma separated list of tests. The test\n"
@@ -1958,8 +1964,10 @@ usage:
         "                    on the command line.\n"
         " -I                 Idle mode. Just open N idle connections and wait.\n"
         " -x                 Read last argument from STDIN.\n"
-        " --rps <requests>   Limit the total number of requests per second. Default 0 (no limit)\n"
-        " --seed <num>       Set the seed for random number generator. Default seed is based on time.\n"
+        " --rps <requests>   Limit the total number of requests per second.\n"
+        "                    Default 0 (no limit)\n"
+        " --seed <num>       Set the seed for random number generator.\n"
+        "                    Default seed is based on time.\n"
         " --num-functions <num>\n"
         "                    Sets the number of functions present in the Lua lib that is\n"
         "                    loaded when running the 'function_load' test. (default 10).\n"

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1851,10 +1851,9 @@ usage:
         " --cert <file>      Client certificate to authenticate with.\n"
         " --key <file>       Private key file to authenticate with.\n"
         " --tls-ciphers <list> Sets the list of preferred ciphers (TLSv1.2 and below)\n"
-        "                    in order of preference from highest to lowest\n"
-        "                    separated by colon (\":\"). See the ciphers(1ssl)\n"
-        "                    manpage for more information about the syntax of\n"
-        "                    this string.\n"
+        "                    in order of preference from highest to lowest separated by\n"
+        "                    colon (\":\"). See the ciphers(1ssl) manpage for more\n"
+        "                    information about the syntax of this string.\n"
 #ifdef TLS1_3_VERSION
         " --tls-ciphersuites <list> Sets the list of preferred ciphersuites (TLSv1.3)\n"
         "                    in order of preference from highest to lowest separated by\n"

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -102,6 +102,8 @@ static struct config {
     int numclients;
     _Atomic int liveclients;
     int requests;
+    int duration;
+    _Atomic int warmup_duration;
     _Atomic int requests_issued;
     _Atomic int requests_finished;
     _Atomic int previous_requests_finished;
@@ -250,6 +252,21 @@ static long long nstime(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static bool isBenchmarkFinished(int request_count) {
+    /* don't end in warmup period */
+    int warmup_duration = atomic_load_explicit(&config.warmup_duration, memory_order_relaxed);
+    if (warmup_duration > 0) return false;
+
+    if (config.duration > 0) {
+        /* end after the specified duration */
+        if ((mstime() - config.start) >= (config.duration * 1000LL)) return true;
+    } else {
+        /* end after the specified number of requests */
+        if (request_count >= config.requests) return true;
+    }
+    return false;
 }
 
 static uint64_t dictSdsHash(const void *key) {
@@ -503,7 +520,7 @@ static void freeClient(client c) {
     aeDeleteFileEvent(el, c->context->fd, AE_READABLE);
     if (c->thread_id >= 0) {
         int requests_finished = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
-        if (requests_finished >= config.requests) {
+        if (isBenchmarkFinished(requests_finished)) {
             aeStop(el);
         }
     }
@@ -627,7 +644,7 @@ static long long acquireTokenOrWait(int tokens) {
 
 static void clientDone(client c) {
     int requests_finished = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
-    if (requests_finished >= config.requests) {
+    if (isBenchmarkFinished(requests_finished)) {
         freeClient(c);
         if (!config.num_threads && config.el) aeStop(config.el);
         return;
@@ -718,7 +735,7 @@ static void readHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                     continue;
                 }
                 int requests_finished = atomic_fetch_add_explicit(&config.requests_finished, 1, memory_order_relaxed);
-                if (requests_finished < config.requests) {
+                if (!isBenchmarkFinished(requests_finished)) {
                     if (config.num_threads == 0) {
                         hdr_record_value(config.latency_histogram, // Histogram to record to
                                          (long)c->latency <= CONFIG_LATENCY_HISTOGRAM_MAX_VALUE
@@ -836,7 +853,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
         int requests_issued = atomic_fetch_add_explicit(&config.requests_issued,
                                                         config.pipeline * c->seqlen,
                                                         memory_order_relaxed);
-        if (requests_issued >= config.requests) {
+        if (isBenchmarkFinished(requests_issued)) {
             return;
         }
 
@@ -1620,6 +1637,13 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "-n")) {
             if (lastarg) goto invalid;
             config.requests = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--duration")) {
+            if (lastarg) goto invalid;
+            config.duration = atoi(argv[++i]);
+        } else if (!strcmp(argv[i], "--warmup")) {
+            if (lastarg) goto invalid;
+            config.warmup_duration = atoi(argv[++i]);
+            
         } else if (!strcmp(argv[i], "-k")) {
             if (lastarg) goto invalid;
             config.keepalive = atoi(argv[++i]);
@@ -1870,6 +1894,9 @@ usage:
         "                    Note: If --cluster is used then number of clients has to be\n"
         "                    the same or higher than the number of nodes.\n"
         " -n <requests>      Total number of requests (default 100000)\n"
+        " --duration <seconds>\n"
+        "                    Run benchmark for specified number of seconds (overrides -n)\n"
+        " --warmup <seconds> Run benchmark for specified warmup period before recording data\n"
         " -d <size>          Data size of SET/GET value in bytes (default 3)\n"
         " --dbnum <db>       SELECT the specified db number (default 0)\n"
         " -3                 Start session in RESP3 protocol mode.\n"
@@ -1957,16 +1984,28 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
     UNUSED(eventLoop);
     UNUSED(id);
     benchmarkThread *thread = (benchmarkThread *)clientData;
-    int liveclients = atomic_load_explicit(&config.liveclients, memory_order_relaxed);
     int requests_finished = atomic_load_explicit(&config.requests_finished, memory_order_relaxed);
     int previous_requests_finished = atomic_load_explicit(&config.previous_requests_finished, memory_order_relaxed);
     long long current_tick = mstime();
 
-    if (liveclients == 0 && requests_finished != config.requests) {
+    int liveclients = atomic_load_explicit(&config.liveclients, memory_order_relaxed);
+    if (liveclients == 0 && !isBenchmarkFinished(requests_finished)) {
         fprintf(stderr, "All clients disconnected... aborting.\n");
         exit(1);
     }
-    if (config.num_threads && requests_finished >= config.requests) {
+    int warmup_duration = atomic_load_explicit(&config.warmup_duration, memory_order_relaxed);
+    if (warmup_duration > 0) {
+        if ((current_tick - config.start) >= (warmup_duration * 1000LL)) {
+            /* exit the warmup period, clear all stats */
+            atomic_store_explicit(&config.warmup_duration, 0, memory_order_relaxed);
+
+            config.start = current_tick;
+            atomic_store_explicit(&config.requests_finished, 0, memory_order_relaxed);
+            atomic_store_explicit(&config.requests_issued, 0, memory_order_relaxed);
+            atomic_store_explicit(&config.previous_requests_finished, 0, memory_order_relaxed);
+            hdr_reset(config.latency_histogram);
+        }
+    } else if (config.num_threads && isBenchmarkFinished(requests_finished)) {
         aeStop(eventLoop);
         return AE_NOMORE;
     }
@@ -1991,11 +2030,21 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
 
     config.previous_tick = current_tick;
     atomic_store_explicit(&config.previous_requests_finished, requests_finished, memory_order_relaxed);
+
     printf("%*s\r", config.last_printed_bytes, " "); /* ensure there is a clean line */
-    int printed_bytes =
-        printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)\r", config.title, instantaneous_rps, rps,
-               hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
-    config.last_printed_bytes = printed_bytes;
+    config.last_printed_bytes = 0;
+    if (warmup_duration > 0) {
+        config.last_printed_bytes += printf("Warming up ");
+    }
+    config.last_printed_bytes +=
+        printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)", config.title, instantaneous_rps, rps,
+            hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
+    if (warmup_duration > 0 || config.duration > 0) {
+        config.last_printed_bytes += printf(" %.1f seconds\r", dt);
+    } else {
+        config.last_printed_bytes += printf(" %d requests\r", requests_finished);
+    }
+
     hdr_reset(config.current_sec_latency_histogram);
     fflush(stdout);
     return SHOW_THROUGHPUT_INTERVAL;
@@ -2068,6 +2117,8 @@ int main(int argc, char **argv) {
     config.ct = VALKEY_CONN_TCP;
     config.numclients = 50;
     config.requests = 100000;
+    config.duration = -1;
+    config.warmup_duration = -1;
     config.liveclients = 0;
     config.el = aeCreateEventLoop(1024 * 10);
     aeCreateTimeEvent(config.el, 1, showThroughput, NULL, NULL);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -104,6 +104,7 @@ static struct config {
     int requests;
     int duration;
     _Atomic int warmup_duration;
+    _Atomic int current_warmup_duration;
     _Atomic int requests_issued;
     _Atomic int requests_finished;
     _Atomic int previous_requests_finished;
@@ -256,7 +257,7 @@ static long long nstime(void) {
 
 static bool isBenchmarkFinished(int request_count) {
     /* don't end in warmup period */
-    int warmup_duration = atomic_load_explicit(&config.warmup_duration, memory_order_relaxed);
+    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
     if (warmup_duration > 0) return false;
 
     if (config.duration > 0) {
@@ -1254,6 +1255,7 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
     config.requests_finished = 0;
     config.previous_requests_finished = 0;
     config.last_printed_bytes = 0;
+    config.current_warmup_duration = config.warmup_duration;
     hdr_init(CONFIG_LATENCY_HISTOGRAM_MIN_VALUE,         // Minimum value
              CONFIG_LATENCY_HISTOGRAM_MAX_VALUE,         // Maximum value
              config.precision,                           // Number of significant figures
@@ -1636,9 +1638,17 @@ int parseOptions(int argc, char **argv) {
             exit(0);
         } else if (!strcmp(argv[i], "-n")) {
             if (lastarg) goto invalid;
+            if (config.duration > 0) {
+                fprintf(stderr, "Options -n and --duration are mutually exclusive.\n");
+                exit(1);
+            }
             config.requests = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--duration")) {
             if (lastarg) goto invalid;
+            if (config.requests > 0) {
+                fprintf(stderr, "Options -n and --duration are mutually exclusive.\n");
+                exit(1);
+            }
             config.duration = atoi(argv[++i]);
         } else if (!strcmp(argv[i], "--warmup")) {
             if (lastarg) goto invalid;
@@ -1895,7 +1905,7 @@ usage:
         "                    the same or higher than the number of nodes.\n"
         " -n <requests>      Total number of requests (default 100000)\n"
         " --duration <seconds>\n"
-        "                    Run benchmark for specified number of seconds (overrides -n)\n"
+        "                    Run benchmark for specified number of seconds (mutually exclusive with -n)\n"
         " --warmup <seconds> Run benchmark for specified warmup period before recording data\n"
         " -d <size>          Data size of SET/GET value in bytes (default 3)\n"
         " --dbnum <db>       SELECT the specified db number (default 0)\n"
@@ -1993,11 +2003,11 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
         fprintf(stderr, "All clients disconnected... aborting.\n");
         exit(1);
     }
-    int warmup_duration = atomic_load_explicit(&config.warmup_duration, memory_order_relaxed);
+    int warmup_duration = atomic_load_explicit(&config.current_warmup_duration, memory_order_relaxed);
     if (warmup_duration > 0) {
         if ((current_tick - config.start) >= (warmup_duration * 1000LL)) {
             /* exit the warmup period, clear all stats */
-            atomic_store_explicit(&config.warmup_duration, 0, memory_order_relaxed);
+            atomic_store_explicit(&config.current_warmup_duration, 0, memory_order_relaxed);
 
             config.start = current_tick;
             atomic_store_explicit(&config.requests_finished, 0, memory_order_relaxed);
@@ -2116,9 +2126,10 @@ int main(int argc, char **argv) {
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
     config.ct = VALKEY_CONN_TCP;
     config.numclients = 50;
-    config.requests = 100000;
+    config.requests = -1;
     config.duration = -1;
     config.warmup_duration = -1;
+    config.current_warmup_duration = -1;
     config.liveclients = 0;
     config.el = aeCreateEventLoop(1024 * 10);
     aeCreateTimeEvent(config.el, 1, showThroughput, NULL, NULL);
@@ -2161,6 +2172,9 @@ int main(int argc, char **argv) {
     i = parseOptions(argc, argv);
     argc -= i;
     argv += i;
+
+    /* Set default for requests if not specified */
+    if (config.requests < 0) config.requests = 100000;
 
     tag = "";
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -1643,7 +1643,7 @@ int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--warmup")) {
             if (lastarg) goto invalid;
             config.warmup_duration = atoi(argv[++i]);
-            
+
         } else if (!strcmp(argv[i], "-k")) {
             if (lastarg) goto invalid;
             config.keepalive = atoi(argv[++i]);
@@ -2038,7 +2038,7 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
     }
     config.last_printed_bytes +=
         printf("%s: rps=%.1f (overall: %.1f) avg_msec=%.3f (overall: %.3f)", config.title, instantaneous_rps, rps,
-            hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
+               hdr_mean(config.current_sec_latency_histogram) / 1000.0f, hdr_mean(config.latency_histogram) / 1000.0f);
     if (warmup_duration > 0 || config.duration > 0) {
         config.last_printed_bytes += printf(" %.1f seconds\r", dt);
     } else {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -240,19 +240,41 @@ tags {"benchmark network external:skip logreqres:skip"} {
             assert {$requests >= 100 && $requests < 150}
         }
 
-        test {benchmark: duration preempts request count} {
-            set start_time [clock clicks -millisec]
+        test {benchmark: -n and --duration are mutually exclusive} {
             set cmd [valkeybenchmark $master_host $master_port "-r 5 -n 5 --duration 1 -t set"]
-            common_bench_setup $cmd
+            catch { exec {*}$cmd } error
+            assert_match "*Options -n and --duration are mutually exclusive*" $error
+        }
+
+        test {benchmark: warmup applies to all tests in multi-test run} {
+            set start_time [clock clicks -millisec]
+            set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 1 -n 50 -t set,get,incr"]
+            set output [common_bench_setup $cmd]
             set end_time [clock clicks -millisec]
 
-            # Verify duration was approximately 1 second (allow some margin)
+            # Verify total duration includes warmup for all 3 tests (at least 3 seconds)
             set elapsed [expr {($end_time - $start_time)/1000.}]
-            assert {$elapsed >= 1. && $elapsed <= 1.25}
+            assert {$elapsed >= 3}
 
-             # Verify that more than 5 requests were made (proving -n was preempted)
-            set calls [regexp -inline {calls=(\d+),} [cmdstat set]]
-            assert {$calls > 100}
+            # Verify all tests ran - with warmup, we expect more than 50 calls per command
+            # since warmup commands are also counted in server stats
+            assert_match  {*calls=*} [cmdstat set]
+            assert_match  {*calls=*} [cmdstat get]
+            assert_match  {*calls=*} [cmdstat incr]
+            
+            # Verify that each command was called more than the base 50 requests
+            # due to warmup period adding extra requests
+            set set_calls [regexp -inline {calls=(\d+)} [cmdstat set]]
+            set get_calls [regexp -inline {calls=(\d+)} [cmdstat get]]
+            set incr_calls [regexp -inline {calls=(\d+)} [cmdstat incr]]
+            
+            lassign $set_calls -> set_count
+            lassign $get_calls -> get_count
+            lassign $incr_calls -> incr_count
+            
+            assert {$set_count > 50}
+            assert {$get_count > 50}
+            assert {$incr_count > 50}
         }
 
         test {benchmark: clients idle mode should return error when reached maxclients limit} {
@@ -270,6 +292,30 @@ tags {"benchmark network external:skip logreqres:skip"} {
             common_bench_setup $cmd
             r get key
         } {arg}
+
+        test {benchmark: CSV output format} {
+            set cmd [valkeybenchmark $master_host $master_port "-c 5 -n 10 -t set,get --csv"]
+            set output [common_bench_setup $cmd]
+            # CSV output should contain comma-separated values
+            assert_match "*,*,*,*" $output
+            # Should not contain the usual formatted output
+            assert_no_match "*requests per second*" $output
+            # Should not contain carriage returns or progress indicators
+            assert_no_match "*\r*" $output
+            assert_no_match "*rps=*" $output
+            default_set_get_checks
+        }
+
+        test {benchmark: quiet mode} {
+            set cmd [valkeybenchmark $master_host $master_port "-c 5 -n 10 -t set,get -q"]
+            set output [common_bench_setup $cmd]
+            # Quiet mode should only show query/sec values (case-insensitive)
+            assert {[string match -nocase "*requests per second*" $output]}
+            # Should not contain detailed latency information (case-insensitive)
+            assert {![string match -nocase "*distribution*" $output]}
+            assert {![string match -nocase "*percentile*" $output]}
+            default_set_get_checks
+        }
 
         # tls specific tests
         if {$::tls} {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -9,11 +9,12 @@ proc cmdstat {cmd} {
 proc common_bench_setup {cmd} {
     r config resetstat
     r flushall
-    if {[catch { exec {*}$cmd } error]} {
-        set first_line [lindex [split $error "\n"] 0]
-        puts [colorstr red "valkey-benchmark non zero code, the output is: $error"]
+    if {[catch { exec {*}$cmd } output]} {
+        set first_line [lindex [split $output "\n"] 0]
+        puts [colorstr red "valkey-benchmark non zero code, the output is: $output"]
         fail "valkey-benchmark non zero code. first line: $first_line"
     }
+    return $output
 }
 
 # we use this extra asserts on a simple set,get test for features like uri parsing
@@ -206,6 +207,52 @@ tags {"benchmark network external:skip logreqres:skip"} {
             # ensure the keyspace has the desired size
             assert_equal  {keys=1} [regexp -inline {keys=[\d]*} [r info keyspace]]
             assert_match  {50} [r zcard myzset]
+        }
+
+        test {benchmark: warmup and duration are cumulative} {
+            set start_time [clock seconds]
+            set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 1 --duration 1 -t set"]
+            set output [common_bench_setup $cmd]
+            set end_time [clock seconds]
+
+            # Verify total duration was at least 2 seconds
+            set elapsed [expr {$end_time - $start_time}]
+            assert {$elapsed >= 2 && $elapsed <= 2.25}
+
+            # Check reported duration
+            lassign [regexp -inline {(\d+) requests completed in ([\d.]+) seconds} $output] -> requests duration
+            assert {$duration < 2.0 && $duration >= 1.0}
+        }
+
+        test {benchmark: warmup can be used with request count} {
+            set start_time [clock seconds]
+            set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 1 -n 100 -t set"]
+            set output [common_bench_setup $cmd]
+            set end_time [clock seconds]
+
+            # Verify total duration was at least 2 seconds
+            set elapsed [expr {$end_time - $start_time}]
+            assert {$elapsed >= 1}
+
+            # Check reported duration and command count
+            lassign [regexp -inline {(\d+) requests completed in ([\d.]+) seconds} $output] -> requests duration
+            assert {$duration < 1.0}
+            assert {$requests >= 100 && $requests < 150}
+        }
+
+        test {benchmark: duration preempts request count} {
+            set start_time [clock seconds]
+            set cmd [valkeybenchmark $master_host $master_port "-r 5 -n 5 --duration 1 -t set"]
+            common_bench_setup $cmd
+            set end_time [clock seconds]
+
+            # Verify duration was approximately 1 second (allow some margin)
+            set elapsed [expr {$end_time - $start_time}]
+            assert {$elapsed >= 1 && $elapsed <= 1.25}
+
+             # Verify that more than 5 requests were made (proving -n was preempted)
+            set calls [regexp -inline {calls=(\d+),} [cmdstat set]]
+            assert {$calls > 100}
         }
 
         test {benchmark: clients idle mode should return error when reached maxclients limit} {

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -216,7 +216,7 @@ tags {"benchmark network external:skip logreqres:skip"} {
             set end_time [clock clicks -millisec]
 
             # Verify total duration was at least 2 seconds
-            set elapsed [expr {($end_time - $start_time)/1000.}]
+            set elapsed [expr {($end_time - $start_time)/1000.0}]
             assert {$elapsed >= 2 && $elapsed <= 2.25}
 
             # Check reported duration
@@ -230,8 +230,8 @@ tags {"benchmark network external:skip logreqres:skip"} {
             set output [common_bench_setup $cmd]
             set end_time [clock clicks -millisec]
 
-            # Verify total duration was at least 2 seconds
-            set elapsed [expr {($end_time - $start_time)/1000.}]
+            # Verify total duration was at least 1 seconds
+            set elapsed [expr {($end_time - $start_time)/1000.0}]
             assert {$elapsed >= 1}
 
             # Check reported duration and command count
@@ -253,7 +253,7 @@ tags {"benchmark network external:skip logreqres:skip"} {
             set end_time [clock clicks -millisec]
 
             # Verify total duration includes warmup for all 3 tests (at least 3 seconds)
-            set elapsed [expr {($end_time - $start_time)/1000.}]
+            set elapsed [expr {($end_time - $start_time)/1000.0}]
             assert {$elapsed >= 3}
 
             # Verify all tests ran - with warmup, we expect more than 50 calls per command

--- a/tests/integration/valkey-benchmark.tcl
+++ b/tests/integration/valkey-benchmark.tcl
@@ -210,13 +210,13 @@ tags {"benchmark network external:skip logreqres:skip"} {
         }
 
         test {benchmark: warmup and duration are cumulative} {
-            set start_time [clock seconds]
+            set start_time [clock clicks -millisec]
             set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 1 --duration 1 -t set"]
             set output [common_bench_setup $cmd]
-            set end_time [clock seconds]
+            set end_time [clock clicks -millisec]
 
             # Verify total duration was at least 2 seconds
-            set elapsed [expr {$end_time - $start_time}]
+            set elapsed [expr {($end_time - $start_time)/1000.}]
             assert {$elapsed >= 2 && $elapsed <= 2.25}
 
             # Check reported duration
@@ -225,13 +225,13 @@ tags {"benchmark network external:skip logreqres:skip"} {
         }
 
         test {benchmark: warmup can be used with request count} {
-            set start_time [clock seconds]
+            set start_time [clock clicks -millisec]
             set cmd [valkeybenchmark $master_host $master_port "-r 5 --warmup 1 -n 100 -t set"]
             set output [common_bench_setup $cmd]
-            set end_time [clock seconds]
+            set end_time [clock clicks -millisec]
 
             # Verify total duration was at least 2 seconds
-            set elapsed [expr {$end_time - $start_time}]
+            set elapsed [expr {($end_time - $start_time)/1000.}]
             assert {$elapsed >= 1}
 
             # Check reported duration and command count
@@ -241,14 +241,14 @@ tags {"benchmark network external:skip logreqres:skip"} {
         }
 
         test {benchmark: duration preempts request count} {
-            set start_time [clock seconds]
+            set start_time [clock clicks -millisec]
             set cmd [valkeybenchmark $master_host $master_port "-r 5 -n 5 --duration 1 -t set"]
             common_bench_setup $cmd
-            set end_time [clock seconds]
+            set end_time [clock clicks -millisec]
 
             # Verify duration was approximately 1 second (allow some margin)
-            set elapsed [expr {$end_time - $start_time}]
-            assert {$elapsed >= 1 && $elapsed <= 1.25}
+            set elapsed [expr {($end_time - $start_time)/1000.}]
+            assert {$elapsed >= 1. && $elapsed <= 1.25}
 
              # Verify that more than 5 requests were made (proving -n was preempted)
             set calls [regexp -inline {calls=(\d+),} [cmdstat set]]


### PR DESCRIPTION
It's handy to be able to automatically do a warmup and/or test by duration rather than request count. 🙂

I changed the real-time output a bit - not sure if that's wanted or not. (Like, would it break people's weird scripts? It'll break my weird scripts, but I know the price of writing weird fragile scripts.)
```
Prepended "Warming up " when in warmup phase:
Warming up SET: rps=69211.2 (overall: 69747.5) avg_msec=0.425 (overall: 0.393) 3.8 seconds
^^^^^^^^^^

Appended running request counter when based on -n:
SET: rps=70892.0 (overall: 69878.1) avg_msec=0.385 (overall: 0.398) 612482 requests
                                                                    ^^^^^^^^^^^^^^^

Appended running second counter when in warmup or based on --duration:
SET: rps=61508.0 (overall: 61764.2) avg_msec=0.430 (overall: 0.426) 4.8 seconds
                                                                    ^^^^^^^^^^^
```
To be clear, the report at the end remains unchanged.