### PR TITLE
Simplify atomic slot migration internal communication

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1376,7 +1376,7 @@ struct client *createAOFClient(void) {
      * background processing there is a chance that the
      * command execution order will be violated.
      */
-    c->raw_flag = 0;
+    memset(c->raw_flag, 0, sizeof(c->raw_flag));
     c->flag.deny_blocking = 1;
     c->flag.fake = 1;
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1078,11 +1078,11 @@ void slotExportSendAuth(slotMigrationJob *job) {
     sds authCommand = sdsempty();
     if (server.primary_user) {
         authCommand = sdscatfmt(authCommand, "*3\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n$%i\r\n%S\r\n",
-                                   (int)sdslen(server.primary_user), server.primary_user,
-                                   (int)sdslen(server.primary_auth), server.primary_auth);
+                                (int)sdslen(server.primary_user), server.primary_user,
+                                (int)sdslen(server.primary_auth), server.primary_auth);
     } else {
         authCommand = sdscatfmt(authCommand, "*2\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n",
-                                   (int)sdslen(server.primary_auth), server.primary_auth);
+                                (int)sdslen(server.primary_auth), server.primary_auth);
     }
     setResponseCallback(job->client, slotExportReadAuthResponse);
     addReplySds(job->client, authCommand);
@@ -1186,9 +1186,9 @@ void slotExportBeginStreaming(slotMigrationJob *job) {
  * if the client output buffer is over the configured limit. */
 bool slotExportCanDoPause(slotMigrationJob *job) {
     return !server.debug_slot_migration_prevent_pause &&
-        (server.slot_migration_max_failover_repl_bytes < 0 ||
-         getClientOutputBufferMemoryUsage(job->client) <=
-             (size_t)server.slot_migration_max_failover_repl_bytes);
+           (server.slot_migration_max_failover_repl_bytes < 0 ||
+            getClientOutputBufferMemoryUsage(job->client) <=
+                (size_t)server.slot_migration_max_failover_repl_bytes);
 }
 
 /* Sent by the target to the source to pause writes to the slot for slot
@@ -1654,11 +1654,11 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 return;
             }
             serverLog(LL_NOTICE,
-                    "Pausing writes to allow slot migration %s to finalize failover.",
-                    job->description);
+                      "Pausing writes to allow slot migration %s to finalize failover.",
+                      job->description);
             job->mf_end = mstime() + server.cluster_mf_timeout * CLUSTER_MF_PAUSE_MULT;
             pauseActions(PAUSE_DURING_SLOT_MIGRATION, job->mf_end,
-                        PAUSE_ACTIONS_CLIENT_WRITE_SET);
+                         PAUSE_ACTIONS_CLIENT_WRITE_SET);
             sendSyncSlotsMessage(job, "PAUSED");
             setResponseCallback(job->client, slotMigrationJobReadPausedResponse);
             updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE);
@@ -1676,13 +1676,13 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             return;
         case SLOT_EXPORT_SEND_FAILOVER_GRANTED: {
             /* Renew our pause to help ensure we don't unpause before the gossip is
-            * propagated. If the existing pause is longer than this, it will be
-            * honored */
+             * propagated. If the existing pause is longer than this, it will be
+             * honored */
             mstime_t prop_deadline = mstime() + CLUSTER_OPERATION_TIMEOUT;
             if (job->mf_end < prop_deadline) {
                 job->mf_end = prop_deadline;
                 pauseActions(PAUSE_DURING_SLOT_MIGRATION, prop_deadline,
-                            PAUSE_ACTIONS_CLIENT_WRITE_SET);
+                             PAUSE_ACTIONS_CLIENT_WRITE_SET);
             }
 
             sendSyncSlotsMessage(job, "FAILOVER-GRANTED");
@@ -2061,14 +2061,14 @@ void clusterSlotMigrationCron(void) {
         proceedWithSlotMigration(job);
         if (canSlotMigrationJobSendAck(job)) {
             /* We send SYNCSLOTS ACK only from the source to the target, and only
-             * when we otherwise haven't enqueued some other message to write. */ 
+             * when we otherwise haven't enqueued some other message to write. */
             if (job->type == SLOT_MIGRATION_EXPORT &&
                 job->client &&
                 !job->client->flag.pending_write) {
                 run_with_period(1000) sendSyncSlotsMessage(job, "ACK");
             }
             /* For the target to ping the source, we send an out-of-band message
-            * using the pushing protocol. */
+             * using the pushing protocol. */
             if (job->type == SLOT_MIGRATION_IMPORT) {
                 run_with_period(1000) slotImportSendAck(job);
             }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -712,6 +712,16 @@ void clusterHandleFlushDuringSlotMigration(void) {
     }
 }
 
+/* The import side of the connection sends acks via out-of-band push messages.
+ * Out of band push messages can be differentiated from responses to requests
+ * and therefore simplify our response parsing for commands like SYNCSLOTS,
+ * preventing problems like:
+ *
+ * 1. Source sends SNAPSHOT-EOF
+ * 2. Target sends out of band "ack" while processing snapshot
+ * 3. Target processes SNAPSHOT-EOF and returns +OK
+ *
+ * In this case, "ack" can be processed even before the response is returned. */
 void slotImportSendAck(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_IMPORT && job->client != NULL);
     struct ClientFlags old_flags = job->client->flag;
@@ -744,7 +754,7 @@ void slotImportSendAck(slotMigrationJob *job) {
  *              ┌─────────────▼────────────────┐   │
  *              │SLOT_EXPORT_READ_AUTH_RESPONSE┼───┤
  *              └─────────────┬────────────────┘   │
- *               Authenticated│                    │
+ *    Full response read (+OK)│                    │
  *              ┌─────────────▼────────────┐       │
  *              │SLOT_EXPORT_SEND_ESTABLISH┼───────┤
  *              └─────────────┬────────────┘       │
@@ -760,19 +770,23 @@ void slotImportSendAck(slotMigrationJob *job) {
  *               ┌────────────▼───────────┐        │  4. FLUSHDB
  *               │SLOT_EXPORT_SNAPSHOTTING┼────────┤  5. Connection Lost
  *               └────────────┬───────────┘        │  6. AUTH failed
- *               Snapshot done│                    │  7. ERR from ESTABLISH command
+ *               Snapshot done│                    │  7. Any SYNCSLOTS command returns other than +OK
  *      ┌─────────────────────▼────────────────┐   │  8. Unpaused before failover completed
  *      │SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE┼───┤  9. Snapshot failed (e.g. Child OOM)
  *      └─────────────────────┬────────────────┘   │  10. No ack from target (timeout)
- *               REQUEST-PAUSE│                    │  11. Client output buffer overrun
+ *    Full response read (+OK)│                    │  11. Client output buffer overrun
  *             ┌──────────────▼─────────────┐      │
  *             │SLOT_EXPORT_WAITING_TO_PAUSE┼──────┤
  *             └──────────────┬─────────────┘      │
- *              Buffer drained│                    │
+ * Buffer drained, PAUSED sent│                    │
  *    ┌───────────────────────▼─────────────────┐  │
  *    │SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE┼──┤
  *    └───────────────────────┬─────────────────┘  │
- *    Failover request granted│                    │
+ *    Full response read (+OK)│                    │
+ *          ┌─────────────────▼───────────────┐    │
+ *          │SLOT_EXPORT_SEND_FAILOVER_GRANTED┼────┤
+ *          └─────────────────┬───────────────┘    │
+ *       FAILOVER-GRANTED sent│                    │
  *   ┌────────────────────────▼─────────────────┐  │
  *   │SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION┼──┤
  *   └────────────────────────┬─────────────────┘  │
@@ -1084,7 +1098,7 @@ void slotExportSendAuth(slotMigrationJob *job) {
         authCommand = sdscatfmt(authCommand, "*2\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n",
                                 (int)sdslen(server.primary_auth), server.primary_auth);
     }
-    setResponseCallback(job->client, slotExportReadAuthResponse);
+    addResponseCallback(job->client, slotExportReadAuthResponse);
     addReplySds(job->client, authCommand);
 }
 
@@ -1103,12 +1117,10 @@ void slotExportHandlePushMessage(client *c) {
  * connected, authenticated, and established. */
 void initSlotExportJobClient(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    job->client = createClient(job->conn);
+    job->client = createOutgoingClient(job->conn);
     job->conn = NULL;
-    job->client->flag.authenticated = 1;
     job->client->slot_migration_job = job;
-    job->client->resp = 3; /* Use RESP3 for the slot migration client. */
-    job->client->push_message_callback = slotExportHandlePushMessage;
+    job->client->outgoing_data->push_message_callback = slotExportHandlePushMessage;
     initClientReplicationData(job->client);
 }
 
@@ -1132,10 +1144,6 @@ void slotExportReadEstablishResponse(client *c) {
 
     updateSlotMigrationJobState(job, SLOT_EXPORT_WAITING_TO_SNAPSHOT);
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
-
-    /* We need to send an ACK to take the import out of WAIT_ACK state. This
-     * will kickstart the health checks, effectively taking the job online. */
-    sendSyncSlotsMessage(job, "ACK");
 }
 
 /* Generate and store the SYNCSLOTS ESTABLISH command to send to the target for
@@ -1159,7 +1167,7 @@ void slotExportSendEstablish(slotMigrationJob *job) {
                   digits10(range->start_slot), range->start_slot,
                   digits10(range->end_slot), range->end_slot);
     }
-    setResponseCallback(job->client, slotExportReadEstablishResponse);
+    addResponseCallback(job->client, slotExportReadEstablishResponse);
     addReplySds(job->client, result);
 }
 
@@ -1640,7 +1648,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             updateSlotMigrationJobState(job, SLOT_EXPORT_SNAPSHOTTING);
             /* The child process will send SNAPSHOT-EOF. We need to setup the
              * parent process to receive this response */
-            setResponseCallback(job->client, slotExportReadSnapshotEofResponse);
+            addResponseCallback(job->client, slotExportReadSnapshotEofResponse);
             return;
         case SLOT_EXPORT_SNAPSHOTTING:
             /* Waiting for child process to finish or response to SNAPSHOT-EOF
@@ -1660,7 +1668,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             pauseActions(PAUSE_DURING_SLOT_MIGRATION, job->mf_end,
                          PAUSE_ACTIONS_CLIENT_WRITE_SET);
             sendSyncSlotsMessage(job, "PAUSED");
-            setResponseCallback(job->client, slotMigrationJobReadPausedResponse);
+            addResponseCallback(job->client, slotMigrationJobReadPausedResponse);
             updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE);
             return;
         case SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE:
@@ -1687,7 +1695,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
 
             sendSyncSlotsMessage(job, "FAILOVER-GRANTED");
             updateSlotMigrationJobState(job, SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION);
-            setResponseCallback(job->client, slotExportReadFailoverGrantedResponse);
+            addResponseCallback(job->client, slotExportReadFailoverGrantedResponse);
             return;
         }
         case SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION:

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -11,11 +11,10 @@
 
 typedef enum slotMigrationJobState {
     /* Importing states */
-    SLOT_IMPORT_WAIT_ACK,
     SLOT_IMPORT_RECEIVE_SNAPSHOT,
     SLOT_IMPORT_WAITING_FOR_PAUSED,
-    SLOT_IMPORT_FAILOVER_REQUESTED,
-    SLOT_IMPORT_FAILOVER_GRANTED,
+    SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED,
+    SLOT_IMPORT_PERFORM_SLOT_FAILOVER,
     SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP,
 
     /* Exporting states */
@@ -26,10 +25,11 @@ typedef enum slotMigrationJobState {
     SLOT_EXPORT_READ_ESTABLISH_RESPONSE,
     SLOT_EXPORT_WAITING_TO_SNAPSHOT,
     SLOT_EXPORT_SNAPSHOTTING,
-    SLOT_EXPORT_STREAMING,
+    SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE,
     SLOT_EXPORT_WAITING_TO_PAUSE,
-    SLOT_EXPORT_FAILOVER_PAUSED,
-    SLOT_EXPORT_FAILOVER_GRANTED,
+    SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE,
+    SLOT_EXPORT_SEND_FAILOVER_GRANTED,
+    SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION,
 
     /* Terminal states */
     SLOT_MIGRATION_JOB_FAILED,
@@ -342,33 +342,29 @@ cleanup:
  *
  * State Machine:
  *
- *              ┌────────────────────┐
- *              │SLOT_IMPORT_WAIT_ACK┼──────┐
- *              └──────────┬─────────┘      │
- *                      ACK│                │
- *          ┌──────────────▼─────────────┐  │
- *          │SLOT_IMPORT_RECEIVE_SNAPSHOT┼──┤
- *          └──────────────┬─────────────┘  │
- *             SNAPSHOT-EOF│                │
- *         ┌───────────────▼──────────────┐ │
- *         │SLOT_IMPORT_WAITING_FOR_PAUSED┼─┤
- *         └───────────────┬──────────────┘ │
- *                   PAUSED│                │
- *         ┌───────────────▼──────────────┐ │ Error Conditions:
- *         │SLOT_IMPORT_FAILOVER_REQUESTED┼─┤  1. OOM
- *         └───────────────┬──────────────┘ │  2. Slot Ownership Change
- *         FAILOVER-GRANTED│                │  3. Demotion to replica
- *          ┌──────────────▼─────────────┐  │  4. FLUSHDB
- *          │SLOT_IMPORT_FAILOVER_GRANTED┼──┤  5. Connection Lost
- *          └──────────────┬─────────────┘  │  6. No ACK from source (timeout)
- *       Takeover Performed│                │
- *          ┌──────────────▼───────────┐    │
- *          │SLOT_MIGRATION_JOB_SUCCESS┼──-─┤
- *          └──────────────────────────┘    │
- *                                          │
- *    ┌─────────────────────────────────────▼─┐
- *    │SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP│
- *    └────────────────────┬──────────────────┘
+ *          ┌────────────────────────────┐
+ *          │SLOT_IMPORT_RECEIVE_SNAPSHOT┼────┐
+ *          └──────────────┬─────────────┘    │
+ *             SNAPSHOT-EOF│                  │
+ *         ┌───────────────▼──────────────┐   │
+ *         │SLOT_IMPORT_WAITING_FOR_PAUSED┼───┤
+ *         └───────────────┬──────────────┘   │
+ *                   PAUSED│                  │
+ * ┌───────────────────────▼────────────────┐ │ Error Conditions:
+ * │SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED┼─┤  1. OOM
+ * └───────────────────────┬────────────────┘ │  2. Slot Ownership Change
+ *         FAILOVER-GRANTED│                  │  3. Demotion to replica
+ *       ┌─────────────────▼───────────────┐  │  4. FLUSHDB
+ *       │SLOT_IMPORT_PERFORM_SLOT_FAILOVER┼──┤  5. Connection Lost
+ *       └─────────────────┬───────────────┘  │  6. No ACK from source (timeout)
+ *       Takeover Performed│.                 │
+ *          ┌──────────────▼───────────┐      │
+ *          │SLOT_MIGRATION_JOB_SUCCESS┼────-─┤
+ *          └──────────────────────────┘      │
+ *                                            │
+ *      ┌─────────────────────────────────────▼─┐
+ *      │SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP│
+ *      └──────────────────┬────────────────────┘
  * Unowned Slots Cleaned Up│
  *           ┌─────────────▼───────────┐
  *           │SLOT_MIGRATION_JOB_FAILED│
@@ -500,6 +496,7 @@ void clusterCommandSyncSlotsEstablish(client *c) {
 
     addReply(c, shared.ok);
     job->client->flag.reply_off = 1;
+    job->client->resp = 3; /* Use RESP3 for the slot migration client. */
     return;
 
 cleanup:
@@ -509,29 +506,33 @@ cleanup:
     return;
 }
 
+void slotImportHandleUnexpectedStateTransition(client *c, slotMigrationJob *job, const char *subcommand) {
+    const char *state_str = slotMigrationJobStateToString(job->state);
+    serverLog(LL_WARNING,
+              "Received CLUSTER SYNCSLOTS %s in unexpected state %s for "
+              "slot migration %s. Failing migration.",
+              subcommand, state_str, job->description);
+    addReplyErrorFormat(c, "CLUSTER SYNCSLOTS %s is unexpected in state %s", subcommand, state_str);
+    finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                           "Unexpected state machine transition");
+}
+
 /* Sent by the source to the target after dumping the snapshot in AOF format. */
 void clusterCommandSyncSlotsSnapshotEof(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c, "CLUSTER SYNCSLOTS SNAPSHOT-EOF should only be used "
-                         "by slot migration clients");
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS SNAPSHOT-EOF should only be used by slot migration clients");
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
     if (c->slot_migration_job->state != SLOT_IMPORT_RECEIVE_SNAPSHOT) {
-        serverLog(LL_WARNING,
-                  "Received CLUSTER SYNCSLOTS SNAPSHOT-EOF from slot migration "
-                  "%s, but not currently loading an AOF snapshot. Failing "
-                  "migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unexpected state machine transition");
+        slotImportHandleUnexpectedStateTransition(c, job, "SNAPSHOT-EOF");
         return;
     }
     serverLog(LL_NOTICE,
               "Slot migration %s successfully received slot snapshot. "
               "Beginning incremental stream...",
               c->slot_migration_job->description);
-    sendSyncSlotsMessage(c->slot_migration_job, "REQUEST-PAUSE");
+    addReply(c, shared.ok);
     updateSlotMigrationJobState(c->slot_migration_job,
                                 SLOT_IMPORT_WAITING_FOR_PAUSED);
 }
@@ -539,47 +540,39 @@ void clusterCommandSyncSlotsSnapshotEof(client *c) {
 /* Sent by the source to the target as a marker of when the pause
  * began (therefore, target is caught up once read). */
 void clusterCommandSyncSlotsPaused(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c, "CLUSTER SYNCSLOTS PAUSED should only be used by slot "
-                         "migration clients");
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS PAUSED should only be used by slot migration clients");
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
     if (c->slot_migration_job->state != SLOT_IMPORT_WAITING_FOR_PAUSED) {
-        serverLog(LL_WARNING,
-                  "Received unexpected CLUSTER SYNCSLOTS PAUSED from slot "
-                  "migration %s, . Failing migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unexpected state machine transition");
+        slotImportHandleUnexpectedStateTransition(c, job, "PAUSED");
         return;
     }
-    sendSyncSlotsMessage(c->slot_migration_job, "REQUEST-FAILOVER");
+    serverLog(LL_NOTICE,
+              "Slot migration %s received all incremental slot changes. "
+              "Proceeding to slot-level failover...",
+              c->slot_migration_job->description);
+    addReply(c, shared.ok);
     updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_IMPORT_FAILOVER_REQUESTED);
+                                SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED);
 }
 
 /* Sent by the source to the target to grant final authorization for
  * failover. */
 void clusterCommandSyncSlotsFailoverGranted(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c, "CLUSTER SYNCSLOTS FAILOVER-GRANTED should only be "
-                         "used by slot migration clients");
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS FAILOVER-GRANTED should only be used by slot migration clients");
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
-    if (c->slot_migration_job->state != SLOT_IMPORT_FAILOVER_REQUESTED) {
-        serverLog(LL_WARNING,
-                  "Received CLUSTER SYNCSLOTS FAILOVER-GRANTED from slot "
-                  "migration %s, but we never sent a failover request. Failing "
-                  "migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unexpected state machine transition");
+    if (c->slot_migration_job->state != SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED) {
+        slotImportHandleUnexpectedStateTransition(c, job, "FAILOVER-GRANTED");
         return;
     }
+    addReply(c, shared.ok);
     updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_IMPORT_FAILOVER_GRANTED);
+                                SLOT_IMPORT_PERFORM_SLOT_FAILOVER);
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 }
 
@@ -596,7 +589,7 @@ slotMigrationJob *createSlotImportJob(client *c,
     job->type = SLOT_MIGRATION_IMPORT;
     job->slot_ranges = slot_ranges;
     job->slot_ranges_str = representSlotRangeList(slot_ranges);
-    job->state = SLOT_IMPORT_WAIT_ACK;
+    job->state = SLOT_IMPORT_RECEIVE_SNAPSHOT;
     job->client = c;
     job->client->slot_migration_job = job;
     job->description = generateSlotMigrationJobDescription(job, source_node);
@@ -719,6 +712,15 @@ void clusterHandleFlushDuringSlotMigration(void) {
     }
 }
 
+void slotImportSendAck(slotMigrationJob *job) {
+    serverAssert(job->type == SLOT_MIGRATION_IMPORT && job->client != NULL);
+    struct ClientFlags old_flags = job->client->flag;
+    job->client->flag.pushing = 1;
+    addReplyPushLen(job->client, 1);
+    addReplyBulkCBuffer(job->client, "ack", 3);
+    job->client->flag.pushing = old_flags.pushing;
+}
+
 /* ---------------------------------- SOURCE -----------------------------------
  *
  * During a slot import, the source node tracks ongoing export operations as
@@ -759,21 +761,21 @@ void clusterHandleFlushDuringSlotMigration(void) {
  *               │SLOT_EXPORT_SNAPSHOTTING┼────────┤  5. Connection Lost
  *               └────────────┬───────────┘        │  6. AUTH failed
  *               Snapshot done│                    │  7. ERR from ESTABLISH command
- *                ┌───────────▼─────────┐          │  8. Unpaused before failover completed
- *                │SLOT_EXPORT_STREAMING┼──────────┤  9. Snapshot failed (e.g. Child OOM)
- *                └───────────┬─────────┘          │  10. No ack from target (timeout)
+ *      ┌─────────────────────▼────────────────┐   │  8. Unpaused before failover completed
+ *      │SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE┼───┤  9. Snapshot failed (e.g. Child OOM)
+ *      └─────────────────────┬────────────────┘   │  10. No ack from target (timeout)
  *               REQUEST-PAUSE│                    │  11. Client output buffer overrun
  *             ┌──────────────▼─────────────┐      │
  *             │SLOT_EXPORT_WAITING_TO_PAUSE┼──────┤
  *             └──────────────┬─────────────┘      │
  *              Buffer drained│                    │
- *             ┌──────────────▼────────────┐       │
- *             │SLOT_EXPORT_FAILOVER_PAUSED┼───────┤
- *             └──────────────┬────────────┘       │
+ *    ┌───────────────────────▼─────────────────┐  │
+ *    │SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE┼──┤
+ *    └───────────────────────┬─────────────────┘  │
  *    Failover request granted│                    │
- *            ┌───────────────▼────────────┐       │
- *            │SLOT_EXPORT_FAILOVER_GRANTED┼───────┤
- *            └───────────────┬────────────┘       │
+ *   ┌────────────────────────▼─────────────────┐  │
+ *   │SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION┼──┤
+ *   └────────────────────────┬─────────────────┘  │
  *       New topology received│                    │
  *             ┌──────────────▼───────────┐        │
  *             │SLOT_MIGRATION_JOB_SUCCESS│        │
@@ -814,7 +816,7 @@ bool clusterSlotFailoverGranted(int slot) {
         if (job->type != SLOT_MIGRATION_EXPORT) continue;
         if (!isSlotMigrationJobInProgress(job)) continue;
         if (!isSlotInSlotRanges(slot, job->slot_ranges)) continue;
-        return job->state == SLOT_EXPORT_FAILOVER_GRANTED;
+        return job->state == SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION;
     }
     return false;
 }
@@ -1050,14 +1052,14 @@ int slotMigrationJobReadOkResponse(slotMigrationJob *job, sds *err_out) {
 /* Read a response to the AUTH command, moving to the next stage of the migration
  * if the response is a success. If there is an error, fail the migration with the
  * error message. */
-void slotMigrationJobReadAuthResponse(client *c) {
+void slotExportReadAuthResponse(client *c) {
     slotMigrationJob *job = c->slot_migration_job;
     if (c->flag.close_asap || !isSlotMigrationJobInProgress(job)) {
         return;
     }
     sds err;
     if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
-        sds status = sdscatfmt(sdsempty(), "Failed to AUTH to target node: %S", err);
+        sds status = sdscatfmt(sdsempty(), "Target node AUTH response error: %S", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
         sdsfree(status);
         sdsfree(err);
@@ -1070,7 +1072,7 @@ void slotMigrationJobReadAuthResponse(client *c) {
 
 /* Perform the authentication steps needed to authenticate a slot migration
  * job's connection. */
-void slotMigrationJobSendAuth(slotMigrationJob *job) {
+void slotExportSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     serverAssert(server.primary_auth);
     sds authCommand = sdsempty();
@@ -1082,9 +1084,19 @@ void slotMigrationJobSendAuth(slotMigrationJob *job) {
         authCommand = sdscatfmt(authCommand, "*2\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n",
                                    (int)sdslen(server.primary_auth), server.primary_auth);
     }
-    job->client->flag2.reading_response = 1;
-    job->client->read_response_callback = slotMigrationJobReadAuthResponse;
+    setResponseCallback(job->client, slotExportReadAuthResponse);
     addReplySds(job->client, authCommand);
+}
+
+void slotExportHandlePushMessage(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job || !isSlotMigrationJobInProgress(job)) {
+        return;
+    }
+    if (c->argv_len == 1 && !strcasecmp(c->argv[0]->ptr, "ack")) {
+        job->last_ack = server.unixtime;
+        return;
+    }
 }
 
 /* Initialize the client for the slot migration job, which should already be
@@ -1095,20 +1107,22 @@ void initSlotExportJobClient(slotMigrationJob *job) {
     job->conn = NULL;
     job->client->flag.authenticated = 1;
     job->client->slot_migration_job = job;
+    job->client->resp = 3; /* Use RESP3 for the slot migration client. */
+    job->client->push_message_callback = slotExportHandlePushMessage;
     initClientReplicationData(job->client);
 }
 
 /* Read a response to the SYNCSLOTS ESTABLISH response, accumulating it in a
  * buffer, and moving to the next stage of the migration if the response is a
  * success. If there is an error, fail the migration with the error message. */
-void slotMigrationJobReadEstablishResponse(client *c) {
+void slotExportReadEstablishResponse(client *c) {
     slotMigrationJob *job = c->slot_migration_job;
     if (c->flag.close_asap || !isSlotMigrationJobInProgress(job)) {
         return;
     }
     sds err;
     if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
-        sds status = sdscatfmt(sdsempty(), "Failed to SYNCSLOTS ESTABLISH for slot migration: %S", err);
+        sds status = sdscatfmt(sdsempty(), "Target node SYNCSLOTS ESTABLISH response error: %S", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
         sdsfree(status);
         sdsfree(err);
@@ -1126,7 +1140,7 @@ void slotMigrationJobReadEstablishResponse(client *c) {
 
 /* Generate and store the SYNCSLOTS ESTABLISH command to send to the target for
  * the job. */
-void slotMigrationJobSendEstablish(slotMigrationJob *job) {
+void slotExportSendEstablish(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     sds result = sdscatprintf(sdsempty(),
                               "*%ld\r\n$7\r\nCLUSTER\r\n$9\r\nSYNCSLOTS\r\n"
@@ -1145,8 +1159,7 @@ void slotMigrationJobSendEstablish(slotMigrationJob *job) {
                   digits10(range->start_slot), range->start_slot,
                   digits10(range->end_slot), range->end_slot);
     }
-    job->client->flag2.reading_response = 1;
-    job->client->read_response_callback = slotMigrationJobReadEstablishResponse;
+    setResponseCallback(job->client, slotExportReadEstablishResponse);
     addReplySds(job->client, result);
 }
 
@@ -1156,7 +1169,7 @@ void slotMigrationJobSendEstablish(slotMigrationJob *job) {
  */
 void slotExportBeginStreaming(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    updateSlotMigrationJobState(job, SLOT_EXPORT_STREAMING);
+    updateSlotMigrationJobState(job, SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE);
 
     /* When the slot export is not ready, it will skip adding the client to the
      * pending write queue (creating a backlog of pending commands). If any
@@ -1169,108 +1182,91 @@ void slotExportBeginStreaming(slotMigrationJob *job) {
               job->description);
 }
 
-/* Attempt to pause the provided slot export job. If we can pause, the state
- * will be updated to SLOT_EXPORT_FAILOVER_PAUSED and the PAUSED subcommand is
- * sent to the target. Otherwise, there is no effect. */
-int slotExportTryDoPause(slotMigrationJob *job) {
-    serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-
-    if (server.debug_slot_migration_prevent_pause ||
-        (server.slot_migration_max_failover_repl_bytes >= 0 &&
-         getClientOutputBufferMemoryUsage(job->client) >
-             (size_t)server.slot_migration_max_failover_repl_bytes)) {
-        return C_ERR;
-    }
-    serverLog(LL_NOTICE,
-              "Pausing writes to allow slot migration %s to finalize failover.",
-              job->description);
-    job->mf_end = mstime() + server.cluster_mf_timeout * CLUSTER_MF_PAUSE_MULT;
-    pauseActions(PAUSE_DURING_SLOT_MIGRATION, job->mf_end,
-                 PAUSE_ACTIONS_CLIENT_WRITE_SET);
-    sendSyncSlotsMessage(job, "PAUSED");
-    return C_OK;
+/* Return whether or not we can do the pause at this time. We may not be able
+ * if the client output buffer is over the configured limit. */
+bool slotExportCanDoPause(slotMigrationJob *job) {
+    return !server.debug_slot_migration_prevent_pause &&
+        (server.slot_migration_max_failover_repl_bytes < 0 ||
+         getClientOutputBufferMemoryUsage(job->client) <=
+             (size_t)server.slot_migration_max_failover_repl_bytes);
 }
 
 /* Sent by the target to the source to pause writes to the slot for slot
  * failover. */
-void clusterCommandSyncSlotsRequestPause(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c, "CLUSTER SYNCSLOTS REQUEST-PAUSE should only be used "
-                         "by slot migration clients");
+void slotExportReadSnapshotEofResponse(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job || !isSlotMigrationJobInProgress(job)) {
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
-    /* Child process may not have closed yet, so SNAPSHOTTING is okay here */
-    if (c->slot_migration_job->state != SLOT_EXPORT_STREAMING &&
-        c->slot_migration_job->state != SLOT_EXPORT_SNAPSHOTTING) {
-        serverLog(LL_WARNING,
-                  "Received CLUSTER SYNCSLOTS REQUEST-PAUSE for slot migration "
-                  "%s, but the client was not streaming incremental updates. "
-                  "Failing migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unexpected state machine transition");
+    serverAssert(c->slot_migration_job->state == SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE ||
+                 c->slot_migration_job->state == SLOT_EXPORT_SNAPSHOTTING);
+
+    sds err;
+    if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
+        sds status = sdscatfmt(sdsempty(), "Target node SNAPSHOT-EOF response error: %S", err);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
+        sdsfree(status);
+        sdsfree(err);
         return;
     }
-    if (c->slot_migration_job->state != SLOT_EXPORT_STREAMING) {
+
+    if (c->slot_migration_job->state != SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE) {
         slotExportBeginStreaming(c->slot_migration_job);
     }
 
-    if (slotExportTryDoPause(c->slot_migration_job) == C_ERR) {
-        updateSlotMigrationJobState(c->slot_migration_job,
-                                    SLOT_EXPORT_WAITING_TO_PAUSE);
-        return;
-    }
-    updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_EXPORT_FAILOVER_PAUSED);
+    updateSlotMigrationJobState(c->slot_migration_job, SLOT_EXPORT_WAITING_TO_PAUSE);
+    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 }
 
 /* Sent by the target to the source to request final authorization for
  * failover. Authorization could be denied if the source has unpaused itself by
  * now. */
-void clusterCommandSyncSlotsRequestFailover(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c,
-                      "CLUSTER SYNCSLOTS REQUEST-FAILOVER should only be used "
-                      "by slot migration clients");
+void slotMigrationJobReadPausedResponse(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job || !isSlotMigrationJobInProgress(job)) {
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
-    if (c->slot_migration_job->state != SLOT_EXPORT_FAILOVER_PAUSED) {
-        serverLog(LL_WARNING,
-                  "Received CLUSTER SYNCSLOTS REQUEST-FAILOVER for slot "
-                  "migration %s, but the client was not in the paused state. "
-                  "Failing migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unexpected state machine transition");
-        return;
-    }
+    serverAssert(c->slot_migration_job->state == SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE);
 
     /* Do one last check, since we could have unpaused in the background. */
     if (isSlotExportPauseTimedOut(c->slot_migration_job)) {
-        serverLog(LL_WARNING,
-                  "Received CLUSTER SYNCSLOTS REQUEST-FAILOVER on slot "
-                  "migration %s, but we are not paused. Denying failover.",
-                  c->slot_migration_job->description);
         finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
-                               "Unpaused before failover completed");
+                               "Timed out before streaming completed");
         return;
     }
 
-    /* Renew our pause to help ensure we don't unpause before the gossip is
-     * propagated. If the existing pause is longer than this, it will be
-     * honored */
-    mstime_t prop_deadline = mstime() + CLUSTER_OPERATION_TIMEOUT;
-    if (c->slot_migration_job->mf_end < prop_deadline) {
-        c->slot_migration_job->mf_end = prop_deadline;
-        pauseActions(PAUSE_DURING_SLOT_MIGRATION, prop_deadline,
-                     PAUSE_ACTIONS_CLIENT_WRITE_SET);
+    sds err;
+    if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
+        sds status = sdscatfmt(sdsempty(), "Target node PAUSED response error: %S", err);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
+        sdsfree(status);
+        sdsfree(err);
+        return;
     }
 
-    sendSyncSlotsMessage(c->slot_migration_job, "FAILOVER-GRANTED");
-    updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_EXPORT_FAILOVER_GRANTED);
+    updateSlotMigrationJobState(c->slot_migration_job, SLOT_EXPORT_SEND_FAILOVER_GRANTED);
+    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
+}
+
+void slotExportReadFailoverGrantedResponse(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job || !isSlotMigrationJobInProgress(job)) {
+        return;
+    }
+    serverAssert(c->slot_migration_job->state == SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION);
+
+    sds err;
+    if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
+        sds status = sdscatfmt(sdsempty(), "Target node FAILOVER-GRANTED response error: %S", err);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
+        sdsfree(status);
+        sdsfree(err);
+        return;
+    }
+
+    /* Notably there is no state transition. If we get an OK response, we still
+     * need to wait for the topology update before we will finish the migration
+     * on this end. */
 }
 
 /* Predicate function supplied to rewriteAppendOnlyFileRio to filter to only
@@ -1536,19 +1532,16 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
     while (1) {
         switch (job->state) {
         /* Importing states */
-        case SLOT_IMPORT_WAIT_ACK:
-            /* Waiting for ACK */
-            return;
         case SLOT_IMPORT_RECEIVE_SNAPSHOT:
-            /* Waiting for SNAPSHOT-EOF marker */
+            /* Waiting for SNAPSHOT-EOF command */
             return;
         case SLOT_IMPORT_WAITING_FOR_PAUSED:
-            /* Waiting for PAUSED marker */
+            /* Waiting for PAUSED command */
             return;
-        case SLOT_IMPORT_FAILOVER_REQUESTED:
-            /* Waiting for FAILOVER-GRANTED response */
+        case SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED:
+            /* Waiting for FAILOVER-GRANTED command */
             return;
-        case SLOT_IMPORT_FAILOVER_GRANTED:
+        case SLOT_IMPORT_PERFORM_SLOT_FAILOVER:
             if (!server.debug_slot_migration_prevent_failover) {
                 performSlotImportJobFailover(job);
 
@@ -1596,14 +1589,14 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             continue;
         }
         case SLOT_EXPORT_SEND_AUTH:
-            slotMigrationJobSendAuth(job);
+            slotExportSendAuth(job);
             updateSlotMigrationJobState(job, SLOT_EXPORT_READ_AUTH_RESPONSE);
             return;
         case SLOT_EXPORT_READ_AUTH_RESPONSE:
             /* We are still reading back the response, nothing to do in cron */
             return;
         case SLOT_EXPORT_SEND_ESTABLISH:
-            slotMigrationJobSendEstablish(job);
+            slotExportSendEstablish(job);
             updateSlotMigrationJobState(job,
                                         SLOT_EXPORT_READ_ESTABLISH_RESPONSE);
             return;
@@ -1645,19 +1638,32 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 return;
             }
             updateSlotMigrationJobState(job, SLOT_EXPORT_SNAPSHOTTING);
+            /* The child process will send SNAPSHOT-EOF. We need to setup the
+             * parent process to receive this response */
+            setResponseCallback(job->client, slotExportReadSnapshotEofResponse);
             return;
         case SLOT_EXPORT_SNAPSHOTTING:
-            /* Waiting for child process to finish */
+            /* Waiting for child process to finish or response to SNAPSHOT-EOF
+             * to be received. */
             return;
-        case SLOT_EXPORT_STREAMING:
-            /* Waiting for PAUSE command to come in */
+        case SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE:
+            /* Child process is done, but waiting for response to SNAPSHOT-EOF */
             return;
         case SLOT_EXPORT_WAITING_TO_PAUSE:
-            if (slotExportTryDoPause(job) == C_OK) {
-                updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_PAUSED);
+            if (!slotExportCanDoPause(job)) {
+                return;
             }
+            serverLog(LL_NOTICE,
+                    "Pausing writes to allow slot migration %s to finalize failover.",
+                    job->description);
+            job->mf_end = mstime() + server.cluster_mf_timeout * CLUSTER_MF_PAUSE_MULT;
+            pauseActions(PAUSE_DURING_SLOT_MIGRATION, job->mf_end,
+                        PAUSE_ACTIONS_CLIENT_WRITE_SET);
+            sendSyncSlotsMessage(job, "PAUSED");
+            setResponseCallback(job->client, slotMigrationJobReadPausedResponse);
+            updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE);
             return;
-        case SLOT_EXPORT_FAILOVER_PAUSED:
+        case SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE:
             if (isSlotExportPauseTimedOut(job)) {
                 serverLog(LL_WARNING, "Slot migration %s timed out during slot "
                                       "failover.",
@@ -1668,7 +1674,23 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                                        "Timed out before streaming completed");
             }
             return;
-        case SLOT_EXPORT_FAILOVER_GRANTED:
+        case SLOT_EXPORT_SEND_FAILOVER_GRANTED: {
+            /* Renew our pause to help ensure we don't unpause before the gossip is
+            * propagated. If the existing pause is longer than this, it will be
+            * honored */
+            mstime_t prop_deadline = mstime() + CLUSTER_OPERATION_TIMEOUT;
+            if (job->mf_end < prop_deadline) {
+                job->mf_end = prop_deadline;
+                pauseActions(PAUSE_DURING_SLOT_MIGRATION, prop_deadline,
+                            PAUSE_ACTIONS_CLIENT_WRITE_SET);
+            }
+
+            sendSyncSlotsMessage(job, "FAILOVER-GRANTED");
+            updateSlotMigrationJobState(job, SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION);
+            setResponseCallback(job->client, slotExportReadFailoverGrantedResponse);
+            return;
+        }
+        case SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION:
             if (isSlotExportPauseTimedOut(job)) {
                 /* Although we make strong efforts to ensure all data is
                  * transferred, we do need to eventually unpause if the target
@@ -1758,11 +1780,10 @@ void initClusterSlotMigrationJobList(void) {
 /* Convert a slotMigrationJobState enum to a user presentable string. */
 const char *slotMigrationJobStateToString(slotMigrationJobState state) {
     switch (state) {
-    case SLOT_IMPORT_WAIT_ACK: return "waiting-for-ack";
     case SLOT_IMPORT_RECEIVE_SNAPSHOT: return "receiving-snapshot";
     case SLOT_IMPORT_WAITING_FOR_PAUSED: return "waiting-for-paused";
-    case SLOT_IMPORT_FAILOVER_REQUESTED: return "failover-requested";
-    case SLOT_IMPORT_FAILOVER_GRANTED: return "failover-granted";
+    case SLOT_IMPORT_WAITING_FOR_FAILOVER_GRANTED: return "waiting-for-failover-granted";
+    case SLOT_IMPORT_PERFORM_SLOT_FAILOVER: return "failover-granted";
     case SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP: return "cleaning-up";
 
     case SLOT_EXPORT_CONNECTING: return "connecting";
@@ -1773,10 +1794,11 @@ const char *slotMigrationJobStateToString(slotMigrationJobState state) {
         return "reading-establish-response";
     case SLOT_EXPORT_WAITING_TO_SNAPSHOT: return "waiting-to-snapshot";
     case SLOT_EXPORT_SNAPSHOTTING: return "snapshotting";
-    case SLOT_EXPORT_STREAMING: return "replicating";
+    case SLOT_EXPORT_READ_SNAPSHOT_EOF_RESPONSE: return "reading-snapshot-eof-response";
     case SLOT_EXPORT_WAITING_TO_PAUSE: return "waiting-to-pause";
-    case SLOT_EXPORT_FAILOVER_PAUSED: return "failover-paused";
-    case SLOT_EXPORT_FAILOVER_GRANTED: return "failover-granted";
+    case SLOT_EXPORT_FAILOVER_READ_PAUSED_RESPONSE: return "reading-paused-response";
+    case SLOT_EXPORT_SEND_FAILOVER_GRANTED: return "sending-failover-granted";
+    case SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION: return "waiting-for-topology-finalization";
 
     case SLOT_MIGRATION_JOB_SUCCESS: return "success";
     case SLOT_MIGRATION_JOB_CANCELLED: return "cancelled";
@@ -1846,7 +1868,7 @@ void clusterHandleSlotMigrationClientClose(slotMigrationJob *job) {
      * find out about the takeover (or until the pause times out).
      *
      * Otherwise, we can mark it failed. */
-    if (job->state != SLOT_EXPORT_FAILOVER_GRANTED) {
+    if (job->state != SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION) {
         if (job->type == SLOT_MIGRATION_EXPORT) {
             finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                    "Connection lost to target. Check CLUSTER "
@@ -1962,21 +1984,13 @@ void clusterCommandGetSlotMigrations(client *c) {
     }
 }
 
-
 /* Helper function to send a SYNCSLOTS subcommand for the provided job. */
 void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand) {
     serverAssert(job->client);
-    ClientFlags old_flags = job->client->flag;
-    if (job->type == SLOT_MIGRATION_IMPORT) {
-        /* Since the slot migration import has replies off, we use the pushing
-         * flag to bypass this. */
-        job->client->flag.pushing = 1;
-    }
     addReplyArrayLen(job->client, 3);
     addReplyBulkCString(job->client, "CLUSTER");
     addReplyBulkCString(job->client, "SYNCSLOTS");
     addReplyBulkCString(job->client, subcommand);
-    if (!old_flags.pushing) job->client->flag.pushing = 0;
 }
 
 /* Cleanup any finished slot migrations when we are over the max log length. */
@@ -1998,13 +2012,10 @@ void clusterCleanupSlotMigrationLog(void) {
  * false otherwise. */
 bool canSlotMigrationJobSendAck(slotMigrationJob *job) {
     /* 1. We cannot send ACK from parent process while child is snapshotting
-     * 2. We don't send an ACK from the import side until the export has first
-     *    sent one (thus taking us out of SLOT_IMPORT_WAIT_ACK). This simplifies
-     *    parsing of the response to CLUSTER SYNCSLOTS ESTABLISH.
-     * 3. We can't send ACK if we are still connecting or sending establish
-     *    job. */
-    return job->state != SLOT_EXPORT_SNAPSHOTTING &&
-           job->state != SLOT_IMPORT_WAIT_ACK &&
+     * 2. We can't send ACK if we are still connecting or performing SYNCSLOTS
+     *    ESTABLISH */
+    return isSlotMigrationJobInProgress(job) &&
+           job->state != SLOT_EXPORT_SNAPSHOTTING &&
            job->state != SLOT_EXPORT_CONNECTING &&
            job->state != SLOT_EXPORT_SEND_AUTH &&
            job->state != SLOT_EXPORT_READ_AUTH_RESPONSE &&
@@ -2024,7 +2035,7 @@ void clusterSlotMigrationCron(void) {
         /* Note that after granting failover, we no longer care about the
          * connection timeout, since we will use pause timeout. */
         if (isSlotMigrationJobInProgress(job) &&
-            job->state != SLOT_EXPORT_FAILOVER_GRANTED) {
+            job->state != SLOT_EXPORT_WAIT_FOR_TOPOLOGY_FINALIZATION) {
             serverAssert(job->type == SLOT_MIGRATION_EXPORT || job->client);
             /* For imports, last interaction will be set to the last
              * incoming command, as replicated clients don't set
@@ -2046,12 +2057,22 @@ void clusterSlotMigrationCron(void) {
                     "Timed out after too long with no interaction");
                 continue;
             }
-            /* Send acks only when the child process isn't writing to it. */
-            if (canSlotMigrationJobSendAck(job)) {
-                run_with_period(1000) sendSyncSlotsMessage(job, "ACK");
-            }
         }
         proceedWithSlotMigration(job);
+        if (canSlotMigrationJobSendAck(job)) {
+            /* We send SYNCSLOTS ACK only from the source to the target, and only
+             * when we otherwise haven't enqueued some other message to write. */ 
+            if (job->type == SLOT_MIGRATION_EXPORT &&
+                job->client &&
+                !job->client->flag.pending_write) {
+                run_with_period(1000) sendSyncSlotsMessage(job, "ACK");
+            }
+            /* For the target to ping the source, we send an out-of-band message
+            * using the pushing protocol. */
+            if (job->type == SLOT_MIGRATION_IMPORT) {
+                run_with_period(1000) slotImportSendAck(job);
+            }
+        }
     }
 
     clusterCleanupSlotMigrationLog();
@@ -2072,19 +2093,13 @@ void slotExportTryUnpause(void) {
     unpauseActions(PAUSE_DURING_SLOT_MIGRATION);
 }
 
-/* Sent by either the target or the source as a liveness check. */
+/* Sent by source to the target as a liveness check. */
 void clusterCommandSyncSlotsAck(client *c) {
     if (!c->slot_migration_job) {
-        addReplyError(c,
-                      "CLUSTER SYNCSLOTS ACK should only be used by slot "
-                      "migration clients");
+        addReplyError(c, "CLUSTER SYNCSLOTS ACK should only be used by slot migration clients");
         return;
     }
     c->slot_migration_job->last_ack = server.unixtime;
-    if (c->slot_migration_job->state == SLOT_IMPORT_WAIT_ACK) {
-        updateSlotMigrationJobState(c->slot_migration_job,
-                                    SLOT_IMPORT_RECEIVE_SNAPSHOT);
-    }
 }
 
 /* Sent by either the target or the source as a control message for progressing
@@ -2097,21 +2112,21 @@ void clusterCommandSyncSlots(client *c) {
          * primary. */
         return;
     }
+    int was_pushing = c->flag.pushing;
+    if (isReplicatedClient(c)) {
+        /* To allow replies even when the client is a replicated client, we set
+         * pushing to true for this response */
+        c->flag.pushing = 1;
+    }
     if (!strcasecmp(c->argv[2]->ptr, "establish")) {
         /* CLUSTER SYNCSLOTS ESTABLISH <args> */
         clusterCommandSyncSlotsEstablish(c);
     } else if (!strcasecmp(c->argv[2]->ptr, "snapshot-eof")) {
         /* CLUSTER SYNCSLOTS SNAPSHOT-EOF */
         clusterCommandSyncSlotsSnapshotEof(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "request-pause")) {
-        /* CLUSTER SYNCSLOTS REQUEST-PAUSE */
-        clusterCommandSyncSlotsRequestPause(c);
     } else if (!strcasecmp(c->argv[2]->ptr, "paused")) {
         /* CLUSTER SYNCSLOTS PAUSED */
         clusterCommandSyncSlotsPaused(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "request-failover")) {
-        /* CLUSTER SYNCSLOTS REQUEST-FAILOVER */
-        clusterCommandSyncSlotsRequestFailover(c);
     } else if (!strcasecmp(c->argv[2]->ptr, "failover-granted")) {
         /* CLUSTER SYNCSLOTS FAILOVER-GRANTED */
         clusterCommandSyncSlotsFailoverGranted(c);
@@ -2119,16 +2134,7 @@ void clusterCommandSyncSlots(client *c) {
         /* CLUSTER SYNCSLOTS ACK */
         clusterCommandSyncSlotsAck(c);
     } else {
-        if (c->slot_migration_job &&
-            isSlotMigrationJobInProgress(c->slot_migration_job)) {
-            serverLog(LL_WARNING, "Received unknown SYNCSLOTS subcommand from "
-                                  "slot migration %s. Failing the migration.",
-                      c->slot_migration_job->description);
-            finishSlotMigrationJob(c->slot_migration_job,
-                                   SLOT_MIGRATION_JOB_FAILED,
-                                   "Unknown SYNCSLOTS subcommand used");
-            return;
-        }
         addReplyErrorObject(c, shared.syntaxerr);
     }
+    c->flag.pushing = was_pushing;
 }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1025,29 +1025,47 @@ int proceedWithSlotExportJobConnecting(slotMigrationJob *job, bool *completed) {
     }
 }
 
+int slotMigrationJobReadOkResponse(slotMigrationJob *job, sds *err_out) {
+    client *c = job->client;
+    if (c->argv_len < 1) {
+        *err_out = sdsnew("No response received");
+        return C_ERR;
+    }
+    if (c->argv_len > 1) {
+        *err_out = sdsnew("Expected +OK, got:");
+        for (int i = 0; i < c->argv_len; i++) {
+            robj *dec = getDecodedObject(c->argv[i]);
+            *err_out = sdscatfmt(*err_out, " %S", dec->ptr);
+            decrRefCount(dec);
+        }
+        return C_ERR;
+    }
+    if (memcmp(c->argv[0]->ptr, "+OK", 4) != 0) {
+        *err_out = sdscatfmt(sdsempty(), "Expected +OK, got: %S", c->argv[0]->ptr);
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /* Read a response to the AUTH command, moving to the next stage of the migration
  * if the response is a success. If there is an error, fail the migration with the
  * error message. */
-void slotMigrationJobReadAuthResponse(connection *conn) {
-    slotMigrationJob *job = (slotMigrationJob *)connGetPrivateData(conn);
-
-    sds err = receiveSynchronousResponse(job->conn);
-    if (err == NULL) {
-        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, "Target node did not respond to AUTH command");
+void slotMigrationJobReadAuthResponse(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (c->flag.close_asap || !isSlotMigrationJobInProgress(job)) {
         return;
     }
-    if (err[0] == '-') {
-        sds status_msg = sdscatfmt(sdsempty(), "Failed to AUTH to target node: %s", err);
-        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
+    sds err;
+    if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
+        sds status = sdscatfmt(sdsempty(), "Failed to AUTH to target node: %S", err);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
+        sdsfree(status);
         sdsfree(err);
-        sdsfree(status_msg);
         return;
     }
-
-    sdsfree(err);
     serverLog(LL_NOTICE, "Successfully authenticated slot migration %s", job->description);
     updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
-    proceedWithSlotMigration(job);
+    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 }
 
 /* Perform the authentication steps needed to authenticate a slot migration
@@ -1055,18 +1073,18 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     serverAssert(server.primary_auth);
-
-    sds err = replicationSendAuth(job->conn);
-    if (err) {
-        sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
-        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
-        sdsfree(err);
-        sdsfree(status_msg);
-        return;
+    sds authCommand = sdsempty();
+    if (server.primary_user) {
+        authCommand = sdscatfmt(authCommand, "*3\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n$%i\r\n%S\r\n",
+                                   (int)sdslen(server.primary_user), server.primary_user,
+                                   (int)sdslen(server.primary_auth), server.primary_auth);
+    } else {
+        authCommand = sdscatfmt(authCommand, "*2\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n",
+                                   (int)sdslen(server.primary_auth), server.primary_auth);
     }
-
-    connSetReadHandler(job->conn, slotMigrationJobReadAuthResponse);
-    updateSlotMigrationJobState(job, SLOT_EXPORT_READ_AUTH_RESPONSE);
+    job->client->flag2.reading_response = 1;
+    job->client->read_response_callback = slotMigrationJobReadAuthResponse;
+    addReplySds(job->client, authCommand);
 }
 
 /* Initialize the client for the slot migration job, which should already be
@@ -1080,9 +1098,35 @@ void initSlotExportJobClient(slotMigrationJob *job) {
     initClientReplicationData(job->client);
 }
 
+/* Read a response to the SYNCSLOTS ESTABLISH response, accumulating it in a
+ * buffer, and moving to the next stage of the migration if the response is a
+ * success. If there is an error, fail the migration with the error message. */
+void slotMigrationJobReadEstablishResponse(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (c->flag.close_asap || !isSlotMigrationJobInProgress(job)) {
+        return;
+    }
+    sds err;
+    if (slotMigrationJobReadOkResponse(job, &err) == C_ERR) {
+        sds status = sdscatfmt(sdsempty(), "Failed to SYNCSLOTS ESTABLISH for slot migration: %S", err);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status);
+        sdsfree(status);
+        sdsfree(err);
+        return;
+    }
+    serverLog(LL_NOTICE, "Successfully established outgoing slot migration client for %s", job->description);
+
+    updateSlotMigrationJobState(job, SLOT_EXPORT_WAITING_TO_SNAPSHOT);
+    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
+
+    /* We need to send an ACK to take the import out of WAIT_ACK state. This
+     * will kickstart the health checks, effectively taking the job online. */
+    sendSyncSlotsMessage(job, "ACK");
+}
+
 /* Generate and store the SYNCSLOTS ESTABLISH command to send to the target for
  * the job. */
-sds generateSyncSlotsEstablishCommand(slotMigrationJob *job) {
+void slotMigrationJobSendEstablish(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     sds result = sdscatprintf(sdsempty(),
                               "*%ld\r\n$7\r\nCLUSTER\r\n$9\r\nSYNCSLOTS\r\n"
@@ -1101,7 +1145,9 @@ sds generateSyncSlotsEstablishCommand(slotMigrationJob *job) {
                   digits10(range->start_slot), range->start_slot,
                   digits10(range->end_slot), range->end_slot);
     }
-    return result;
+    job->client->flag2.reading_response = 1;
+    job->client->read_response_callback = slotMigrationJobReadEstablishResponse;
+    addReplySds(job->client, result);
 }
 
 /* There are two potential triggers for streaming (whichever happens first):
@@ -1474,67 +1520,6 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     return job;
 }
 
-/* Read a response to the SYNCSLOTS ESTABLISH response, accumulating it in a
- * buffer, and moving to the next stage of the migration if the response is a
- * success. If there is an error, fail the migration with the error message. */
-void slotMigrationJobReadEstablishResponse(connection *conn) {
-    client *c = (client *)connGetPrivateData(conn);
-    slotMigrationJob *job = c->slot_migration_job;
-    if (c->flag.close_asap || !isSlotMigrationJobInProgress(job)) {
-        return;
-    }
-    if (!job->response_buf) {
-        job->response_buf = sdsempty();
-        job->response_buf = sdsMakeRoomForNonGreedy(job->response_buf,
-                                                    PROTO_IOBUF_LEN);
-    }
-
-    int result;
-    result = connRead(conn,
-                      ((char *)job->response_buf) + sdslen(job->response_buf),
-                      sdsavail(job->response_buf));
-    if (result > 0) {
-        sdsIncrLen(job->response_buf, result);
-    }
-    if (conn->state != CONN_STATE_CONNECTED) {
-        freeClientAsync(c);
-        return;
-    }
-    if (sdslen(job->response_buf) < 2 ||
-        job->response_buf[sdslen(job->response_buf) - 2] != '\r' ||
-        job->response_buf[sdslen(job->response_buf) - 1] != '\n') {
-        if (sdsavail(job->response_buf) == 0) {
-            /* We filled up the buffer, and we still have no response. Only
-             * choice is to stop the migration. */
-            finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
-                                   "Response to establish job is larger than "
-                                   "buffer limit");
-            return;
-        }
-        connSetReadHandler(conn, slotMigrationJobReadEstablishResponse);
-        return;
-    }
-    if (job->response_buf[0] == '-') {
-        sds err_msg = sdscatfmt(sdsempty(), "Received error during handshake "
-                                            "to target: %S",
-                                job->response_buf);
-        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, err_msg);
-        sdsfree(err_msg);
-        return;
-    }
-
-    updateSlotMigrationJobState(job, SLOT_EXPORT_WAITING_TO_SNAPSHOT);
-    connSetReadHandler(conn, readQueryFromClient);
-    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
-
-    /* We need to send an ACK to take the import out of WAIT_ACK state. This
-     * will kickstart the health checks, effectively taking the job online. */
-    sendSyncSlotsMessage(job, "ACK");
-
-    sdsfree(job->response_buf);
-    job->response_buf = NULL;
-}
-
 /* ----------------------------- TARGET & SOURCE ---------------------------- */
 
 /* Updates the associated status message for the job, which will be seen in
@@ -1607,19 +1592,18 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             } else {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
             }
+            initSlotExportJobClient(job);
             continue;
         }
         case SLOT_EXPORT_SEND_AUTH:
             slotMigrationJobSendAuth(job);
-            continue;
+            updateSlotMigrationJobState(job, SLOT_EXPORT_READ_AUTH_RESPONSE);
+            return;
         case SLOT_EXPORT_READ_AUTH_RESPONSE:
             /* We are still reading back the response, nothing to do in cron */
             return;
         case SLOT_EXPORT_SEND_ESTABLISH:
-            initSlotExportJobClient(job);
-            addReplySds(job->client, generateSyncSlotsEstablishCommand(job));
-            connSetReadHandler(job->client->conn,
-                               slotMigrationJobReadEstablishResponse);
+            slotMigrationJobSendEstablish(job);
             updateSlotMigrationJobState(job,
                                         SLOT_EXPORT_READ_ESTABLISH_RESPONSE);
             return;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1098,7 +1098,6 @@ void slotExportSendAuth(slotMigrationJob *job) {
         authCommand = sdscatfmt(authCommand, "*2\r\n$4\r\nAUTH\r\n$%i\r\n%S\r\n",
                                 (int)sdslen(server.primary_auth), server.primary_auth);
     }
-    addResponseCallback(job->client, slotExportReadAuthResponse);
     addReplySds(job->client, authCommand);
 }
 
@@ -1167,7 +1166,6 @@ void slotExportSendEstablish(slotMigrationJob *job) {
                   digits10(range->start_slot), range->start_slot,
                   digits10(range->end_slot), range->end_slot);
     }
-    addResponseCallback(job->client, slotExportReadEstablishResponse);
     addReplySds(job->client, result);
 }
 
@@ -1598,6 +1596,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
         }
         case SLOT_EXPORT_SEND_AUTH:
             slotExportSendAuth(job);
+            addResponseCallback(job->client, slotExportReadAuthResponse);
             updateSlotMigrationJobState(job, SLOT_EXPORT_READ_AUTH_RESPONSE);
             return;
         case SLOT_EXPORT_READ_AUTH_RESPONSE:
@@ -1605,8 +1604,8 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             return;
         case SLOT_EXPORT_SEND_ESTABLISH:
             slotExportSendEstablish(job);
-            updateSlotMigrationJobState(job,
-                                        SLOT_EXPORT_READ_ESTABLISH_RESPONSE);
+            addResponseCallback(job->client, slotExportReadEstablishResponse);
+            updateSlotMigrationJobState(job, SLOT_EXPORT_READ_ESTABLISH_RESPONSE);
             return;
         case SLOT_EXPORT_READ_ESTABLISH_RESPONSE:
             /* We are still reading back the response, nothing to do in cron */

--- a/src/debug.c
+++ b/src/debug.c
@@ -1103,7 +1103,9 @@ void _serverAssertPrintClientInfo(const client *c) {
 
     bugReportStart();
     serverLog(LL_WARNING, "=== ASSERTION FAILED CLIENT CONTEXT ===");
-    serverLog(LL_WARNING, "client->flags = %llu", (unsigned long long)c->raw_flag);
+    for (size_t i = 0; i < sizeof(c->raw_flag) / sizeof(c->raw_flag[0]); i++) {
+        serverLog(LL_WARNING, "client->flags[%ld] = %llu", i, (unsigned long long)c->raw_flag[i]);
+    }
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);
     for (j = 0; j < c->argc; j++) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -1104,7 +1104,7 @@ void _serverAssertPrintClientInfo(const client *c) {
     bugReportStart();
     serverLog(LL_WARNING, "=== ASSERTION FAILED CLIENT CONTEXT ===");
     for (size_t i = 0; i < sizeof(c->raw_flag) / sizeof(c->raw_flag[0]); i++) {
-        serverLog(LL_WARNING, "client->flags[%ld] = %llu", i, (unsigned long long)c->raw_flag[i]);
+        serverLog(LL_WARNING, "client->flags[%lu] = %llu", (unsigned long)i, (unsigned long long)c->raw_flag[i]);
     }
     serverLog(LL_WARNING, "client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING, "client->argc = %d", c->argc);

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -372,8 +372,6 @@ int trySendReadToIOThreads(client *c) {
     /* For simplicity let the main-thread handle the blocked clients */
     if (c->flag.blocked || c->flag.unblocked) return C_ERR;
     if (c->flag.close_asap) return C_ERR;
-    /* For simplicity, let the main-thread handle responses to outgoing requests */
-    if (c->flag.reading_response) return C_ERR;
     size_t tid = (c->id % (server.active_io_threads_num - 1)) + 1;
 
     /* Handle case where client has a pending IO write job on a different thread:
@@ -392,6 +390,7 @@ int trySendReadToIOThreads(client *c) {
     c->read_flags = canParseCommand(c) ? 0 : READ_FLAGS_DONT_PARSE;
     c->read_flags |= authRequired(c) ? READ_FLAGS_AUTH_REQUIRED : 0;
     c->read_flags |= isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
+    c->read_flags |= c->flag.outgoing ? READ_FLAGS_RESPONSE : 0;
 
     c->io_read_state = CLIENT_PENDING_IO;
     connSetPostponeUpdateState(c->conn, 1);

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -373,7 +373,7 @@ int trySendReadToIOThreads(client *c) {
     if (c->flag.blocked || c->flag.unblocked) return C_ERR;
     if (c->flag.close_asap) return C_ERR;
     /* For simplicity, let the main-thread handle responses to outgoing requests */
-    if (c->flag2.reading_response) return C_ERR;
+    if (c->flag.reading_response) return C_ERR;
     size_t tid = (c->id % (server.active_io_threads_num - 1)) + 1;
 
     /* Handle case where client has a pending IO write job on a different thread:

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -372,6 +372,8 @@ int trySendReadToIOThreads(client *c) {
     /* For simplicity let the main-thread handle the blocked clients */
     if (c->flag.blocked || c->flag.unblocked) return C_ERR;
     if (c->flag.close_asap) return C_ERR;
+    /* For simplicity, let the main-thread handle responses to outgoing requests */
+    if (c->flag2.reading_response) return C_ERR;
     size_t tid = (c->id % (server.active_io_threads_num - 1)) + 1;
 
     /* Handle case where client has a pending IO write job on a different thread:

--- a/src/module.c
+++ b/src/module.c
@@ -736,6 +736,7 @@ void moduleReleaseTempClient(client *c) {
     resetClient(c);
     c->bufpos = 0;
     c->raw_flag = 0;
+    c->raw_flag2 = 0;
     c->flag.module = 1;
     c->flag.fake = 1;
     c->user = NULL; /* Root user */

--- a/src/module.c
+++ b/src/module.c
@@ -735,8 +735,7 @@ void moduleReleaseTempClient(client *c) {
     c->duration = 0;
     resetClient(c);
     c->bufpos = 0;
-    c->raw_flag = 0;
-    c->raw_flag2 = 0;
+    memset(c->raw_flag, 0, sizeof(c->raw_flag));
     c->flag.module = 1;
     c->flag.fake = 1;
     c->user = NULL; /* Root user */

--- a/src/networking.c
+++ b/src/networking.c
@@ -282,6 +282,13 @@ void initClientOutgoingData(client *c) {
     c->outgoing_data->push_message_callback = NULL;
 }
 
+void freeClientOutgoingData(client *c) {
+    if (!c->outgoing_data) return;
+    listRelease(c->outgoing_data->response_callbacks);
+    zfree(c->outgoing_data);
+    c->outgoing_data = NULL;
+}
+
 client *createOutgoingClient(connection *conn) {
     client *c = createClient(conn);
     c->flag.outgoing = 1;
@@ -2092,6 +2099,7 @@ void freeClient(client *c) {
 
     freeClientBlockingState(c);
     freeClientPubSubData(c);
+    freeClientOutgoingData(c);
 
     /* Free data structures. */
     releaseReplyReferences(c);

--- a/src/networking.c
+++ b/src/networking.c
@@ -267,6 +267,33 @@ static int isCopyAvoidPreferred(client *c, robj *obj) {
     return server.min_string_size_copy_avoid_threaded && sdslen(obj->ptr) >= (size_t)server.min_string_size_copy_avoid_threaded;
 }
 
+void addResponseCallback(client *c, ClientResponseCallback cb) {
+    serverAssert(c->flag.outgoing && c->outgoing_data);
+    ClientResponseCallback *val = zmalloc(sizeof(ClientResponseCallback));
+    *val = cb;
+    listAddNodeTail(c->outgoing_data->response_callbacks, val);
+}
+
+void initClientOutgoingData(client *c) {
+    if (c->outgoing_data) return;
+    c->outgoing_data = zmalloc(sizeof(outgoingClientData));
+    c->outgoing_data->response_callbacks = listCreate();
+    listSetFreeMethod(c->outgoing_data->response_callbacks, zfree);
+    c->outgoing_data->push_message_callback = NULL;
+}
+
+client *createOutgoingClient(connection *conn) {
+    client *c = createClient(conn);
+    c->flag.outgoing = 1;
+
+    /* Outgoing clients are by default authenticated since we are starting them. */
+    c->flag.authenticated = 1;
+    c->resp = 3; /* Use RESP3 to support things like out-of-band pushes. */
+
+    initClientOutgoingData(c);
+    return c;
+}
+
 client *createClient(connection *conn) {
     client *c = zmalloc(sizeof(client));
 
@@ -360,8 +387,7 @@ client *createClient(connection *conn) {
     c->io_last_written.buf = NULL;
     c->io_last_written.bufpos = 0;
     c->io_last_written.data_len = 0;
-    c->response_callback = NULL;
-    c->push_message_callback = NULL;
+    c->outgoing_data = NULL;
     return c;
 }
 
@@ -3355,7 +3381,7 @@ void parseInlineBuffer(client *c) {
  * CLIENT_PROTOCOL_ERROR. */
 #define PROTO_DUMP_LEN 128
 static void setProtocolError(const char *errstr, client *c) {
-    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c) || c->flag.reading_response) {
+    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c) || c->flag.outgoing) {
         sds client = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
 
         /* Sample some protocol to given an idea about what was inside. */
@@ -3380,7 +3406,7 @@ static void setProtocolError(const char *errstr, client *c) {
             }
         }
         /* Log all the client and protocol info. */
-        int loglevel = (isReplicatedClient(c) || c->flag.reading_response) ? LL_WARNING : LL_VERBOSE;
+        int loglevel = (isReplicatedClient(c) || c->flag.outgoing) ? LL_WARNING : LL_VERBOSE;
         serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client, buf);
         sdsfree(client);
     }
@@ -3419,7 +3445,7 @@ void parseMultibulkBuffer(client *c) {
     while ((flag & READ_FLAGS_PARSING_COMPLETED) &&
            sdslen(c->querybuf) > c->qb_pos &&
            (c->querybuf[c->qb_pos] == '*' ||
-            (c->querybuf[c->qb_pos] == '>' && c->push_message_callback))) {
+            (c->querybuf[c->qb_pos] == '>' && c->flag.outgoing))) {
         c->reqtype = PROTO_REQ_MULTIBULK;
         /* Push a new parser state to the command queue */
         if (queue->len == queue->cap) {
@@ -3770,10 +3796,9 @@ void parseInputBuffer(client *c) {
     if (!c->reqtype) {
         if (c->querybuf[c->qb_pos] == '*') {
             c->reqtype = PROTO_REQ_MULTIBULK;
-        } else if (c->querybuf[c->qb_pos] == '>' && c->push_message_callback != NULL) {
-            /* We only handle pushes if there is a callback configured for them.
-             * Otherwise, we treat these as if they are inline for backwards
-             * compatibility. */
+        } else if (c->querybuf[c->qb_pos] == '>' && c->flag.outgoing) {
+            /* We only handle pushes if this is an outgoing client, otherwise it
+             * has no meaning */
             c->reqtype = PROTO_REQ_MULTIBULK;
         } else {
             c->reqtype = PROTO_REQ_INLINE;
@@ -3786,12 +3811,6 @@ void parseInputBuffer(client *c) {
         parseMultibulkBuffer(c);
     } else {
         serverPanic("Unknown request type");
-    }
-    if (c->flag.reading_response) {
-        /* If any commands were processed into the command queue, they will not
-         * have the response read flag, since it only applies to the first
-         * response.*/
-        c->read_flags |= READ_FLAGS_RESPONSE;
     }
 }
 
@@ -3982,29 +4001,18 @@ static void prefetchCommandQueueKeys(client *c) {
     }
 }
 
-/* Register for a response callback. The callback will be triggered after the
- * next response is parsed. The parsed response will be set in c->argv. While
- * waiting for a response, normal command parsing and execution will not be
- * performed. */
-void setResponseCallback(client *c, ClientResponseCallback cb) {
-    c->flag.reading_response = 1;
-    c->response_callback = cb;
-}
-
-void processResponse(client *c) {
-    serverAssert(c->flag.reading_response && c->response_callback != NULL);
-    c->response_callback(c);
-    c->flag.reading_response = 0;
-    c->response_callback = NULL;
-
-    /* Ensure the client is reset for the next command */
-    resetClient(c);
-}
-
-void processPushMessage(client *c) {
-    serverAssert(c->push_message_callback != NULL);
-    c->push_message_callback(c);
-    resetClient(c);
+void processOutgoingCommandResponse(client *c) {
+    if (c->read_flags & READ_FLAGS_PUSH_MESSAGE) {
+        if (c->outgoing_data->push_message_callback) c->outgoing_data->push_message_callback(c);
+        return;
+    }
+    if (listLength(c->outgoing_data->response_callbacks) == 0) {
+        return;
+    }
+    listNode *ln = listFirst(c->outgoing_data->response_callbacks);
+    ClientResponseCallback *cb = ln->value;
+    (*cb)(c);
+    listDelNode(c->outgoing_data->response_callbacks, ln);
 }
 
 int processInputBuffer(client *c) {
@@ -4017,18 +4025,19 @@ int processInputBuffer(client *c) {
 
         c->read_flags = isReplicatedClient(c) ? READ_FLAGS_REPLICATED : 0;
         c->read_flags |= authRequired(c) ? READ_FLAGS_AUTH_REQUIRED : 0;
+        c->read_flags |= c->flag.outgoing ? READ_FLAGS_RESPONSE : 0;
 
         /* If commands are queued up, pop from the queue first */
         if (!consumeCommandQueue(c)) {
             parseInputBuffer(c);
             prepareCommandQueue(c);
         }
-        if (c->read_flags & READ_FLAGS_PUSH_MESSAGE) {
-            processPushMessage(c);
-            continue;
-        }
-        if (c->read_flags & READ_FLAGS_RESPONSE) {
-            processResponse(c);
+
+        /* Responses don't require any additional parsing, fire the callbacks
+         * and continue to the next one. */
+        if (c->flag.outgoing) {
+            processOutgoingCommandResponse(c);
+            resetClient(c);
             continue;
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3420,7 +3420,7 @@ void parseMultibulkBuffer(client *c) {
     while ((flag & READ_FLAGS_PARSING_COMPLETED) &&
            sdslen(c->querybuf) > c->qb_pos &&
            (c->querybuf[c->qb_pos] == '*' ||
-           (c->querybuf[c->qb_pos] == '>' && c->push_message_callback))) {
+            (c->querybuf[c->qb_pos] == '>' && c->push_message_callback))) {
         c->reqtype = PROTO_REQ_MULTIBULK;
         /* Push a new parser state to the command queue */
         if (queue->len == queue->cap) {
@@ -3997,7 +3997,7 @@ void processResponse(client *c) {
     c->response_callback(c);
     c->flag2.reading_response = 0;
     c->response_callback = NULL;
-    
+
     /* Ensure the client is reset for the next command */
     resetClient(c);
 }

--- a/src/networking.c
+++ b/src/networking.c
@@ -317,6 +317,7 @@ client *createClient(connection *conn) {
     c->multibulklen = 0;
     c->bulklen = -1;
     c->raw_flag = 0;
+    c->raw_flag2 = 0;
     c->capa = 0;
     c->slot = -1;
     c->ctime = c->last_interaction = server.unixtime;
@@ -360,6 +361,7 @@ client *createClient(connection *conn) {
     c->io_last_written.buf = NULL;
     c->io_last_written.bufpos = 0;
     c->io_last_written.data_len = 0;
+    c->read_response_callback = NULL;
     return c;
 }
 
@@ -3171,6 +3173,8 @@ void resetClient(client *c) {
     c->flag.buffered_reply = 0;
     c->flag.keyspace_notified = 0;
     c->net_output_bytes_curr_cmd = 0;
+    c->flag2.reading_response = 0;
+    c->read_response_callback = NULL;
 
     /* Make sure the duration has been recorded to some command. */
     serverAssert(c->duration == 0);
@@ -3353,7 +3357,7 @@ void parseInlineBuffer(client *c) {
  * CLIENT_PROTOCOL_ERROR. */
 #define PROTO_DUMP_LEN 128
 static void setProtocolError(const char *errstr, client *c) {
-    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c)) {
+    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c) || c->flag2.reading_response) {
         sds client = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
 
         /* Sample some protocol to given an idea about what was inside. */
@@ -3378,7 +3382,7 @@ static void setProtocolError(const char *errstr, client *c) {
             }
         }
         /* Log all the client and protocol info. */
-        int loglevel = (isReplicatedClient(c)) ? LL_WARNING : LL_VERBOSE;
+        int loglevel = (isReplicatedClient(c) || c->flag2.reading_response) ? LL_WARNING : LL_VERBOSE;
         serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client, buf);
         sdsfree(client);
     }
@@ -3980,6 +3984,11 @@ int processInputBuffer(client *c) {
         /* If commands are queued up, pop from the queue first */
         if (!consumeCommandQueue(c)) {
             parseInputBuffer(c);
+            if (c->flag2.reading_response) {
+                c->read_response_callback(c);
+                resetClient(c);
+                continue;
+            }
             prepareCommandQueue(c);
         }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -316,8 +316,7 @@ client *createClient(connection *conn) {
     c->cur_script = NULL;
     c->multibulklen = 0;
     c->bulklen = -1;
-    c->raw_flag = 0;
-    c->raw_flag2 = 0;
+    memset(c->raw_flag, 0, sizeof(c->raw_flag));
     c->capa = 0;
     c->slot = -1;
     c->ctime = c->last_interaction = server.unixtime;
@@ -3356,7 +3355,7 @@ void parseInlineBuffer(client *c) {
  * CLIENT_PROTOCOL_ERROR. */
 #define PROTO_DUMP_LEN 128
 static void setProtocolError(const char *errstr, client *c) {
-    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c) || c->flag2.reading_response) {
+    if (server.verbosity <= LL_VERBOSE || isReplicatedClient(c) || c->flag.reading_response) {
         sds client = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
 
         /* Sample some protocol to given an idea about what was inside. */
@@ -3381,7 +3380,7 @@ static void setProtocolError(const char *errstr, client *c) {
             }
         }
         /* Log all the client and protocol info. */
-        int loglevel = (isReplicatedClient(c) || c->flag2.reading_response) ? LL_WARNING : LL_VERBOSE;
+        int loglevel = (isReplicatedClient(c) || c->flag.reading_response) ? LL_WARNING : LL_VERBOSE;
         serverLog(loglevel, "Protocol error (%s) from client: %s. Query buffer: %s", errstr, client, buf);
         sdsfree(client);
     }
@@ -3788,7 +3787,7 @@ void parseInputBuffer(client *c) {
     } else {
         serverPanic("Unknown request type");
     }
-    if (c->flag2.reading_response) {
+    if (c->flag.reading_response) {
         /* If any commands were processed into the command queue, they will not
          * have the response read flag, since it only applies to the first
          * response.*/
@@ -3988,14 +3987,14 @@ static void prefetchCommandQueueKeys(client *c) {
  * waiting for a response, normal command parsing and execution will not be
  * performed. */
 void setResponseCallback(client *c, ClientResponseCallback cb) {
-    c->flag2.reading_response = 1;
+    c->flag.reading_response = 1;
     c->response_callback = cb;
 }
 
 void processResponse(client *c) {
-    serverAssert(c->flag2.reading_response && c->response_callback != NULL);
+    serverAssert(c->flag.reading_response && c->response_callback != NULL);
     c->response_callback(c);
-    c->flag2.reading_response = 0;
+    c->flag.reading_response = 0;
     c->response_callback = NULL;
 
     /* Ensure the client is reset for the next command */

--- a/src/networking.c
+++ b/src/networking.c
@@ -361,7 +361,8 @@ client *createClient(connection *conn) {
     c->io_last_written.buf = NULL;
     c->io_last_written.bufpos = 0;
     c->io_last_written.data_len = 0;
-    c->read_response_callback = NULL;
+    c->response_callback = NULL;
+    c->push_message_callback = NULL;
     return c;
 }
 
@@ -3173,8 +3174,6 @@ void resetClient(client *c) {
     c->flag.buffered_reply = 0;
     c->flag.keyspace_notified = 0;
     c->net_output_bytes_curr_cmd = 0;
-    c->flag2.reading_response = 0;
-    c->read_response_callback = NULL;
 
     /* Make sure the duration has been recorded to some command. */
     serverAssert(c->duration == 0);
@@ -3420,7 +3419,8 @@ void parseMultibulkBuffer(client *c) {
     serverAssert(queue->len == 0);
     while ((flag & READ_FLAGS_PARSING_COMPLETED) &&
            sdslen(c->querybuf) > c->qb_pos &&
-           c->querybuf[c->qb_pos] == '*') {
+           (c->querybuf[c->qb_pos] == '*' ||
+           (c->querybuf[c->qb_pos] == '>' && c->push_message_callback))) {
         c->reqtype = PROTO_REQ_MULTIBULK;
         /* Push a new parser state to the command queue */
         if (queue->len == queue->cap) {
@@ -3467,6 +3467,7 @@ static int parseMultibulk(client *c,
     long long ll;
     int is_replicated = c->read_flags & READ_FLAGS_REPLICATED;
     int auth_required = c->read_flags & READ_FLAGS_AUTH_REQUIRED;
+    int additional_flags = 0;
 
     if (c->multibulklen == 0) {
         /* The client (argc) should have been reset */
@@ -3476,7 +3477,7 @@ static int parseMultibulk(client *c,
         newline = memchr(c->querybuf + c->qb_pos, '\r', sdslen(c->querybuf) - c->qb_pos);
         if (newline == NULL) {
             if (sdslen(c->querybuf) - c->qb_pos > PROTO_INLINE_MAX_SIZE) {
-                return READ_FLAGS_ERROR_BIG_MULTIBULK;
+                return READ_FLAGS_ERROR_BIG_MULTIBULK | additional_flags;
             }
             return 0;
         }
@@ -3486,19 +3487,20 @@ static int parseMultibulk(client *c,
 
         /* We know for sure there is a whole line since newline != NULL,
          * so go ahead and find out the multi bulk length. */
-        serverAssertWithInfo(c, NULL, c->querybuf[c->qb_pos] == '*');
+        serverAssertWithInfo(c, NULL, c->querybuf[c->qb_pos] == '*' || c->querybuf[c->qb_pos] == '>');
+        if (c->querybuf[c->qb_pos] == '>') additional_flags |= READ_FLAGS_PUSH_MESSAGE;
         size_t multibulklen_slen = newline - (c->querybuf + 1 + c->qb_pos);
         ok = string2ll(c->querybuf + 1 + c->qb_pos, multibulklen_slen, &ll);
         if (!ok || ll > INT_MAX) {
-            return READ_FLAGS_ERROR_INVALID_MULTIBULK_LEN;
+            return READ_FLAGS_ERROR_INVALID_MULTIBULK_LEN | additional_flags;
         } else if (ll > 10 && auth_required) {
-            return READ_FLAGS_ERROR_UNAUTHENTICATED_MULTIBULK_LEN;
+            return READ_FLAGS_ERROR_UNAUTHENTICATED_MULTIBULK_LEN | additional_flags;
         }
 
         c->qb_pos = (newline - c->querybuf) + 2;
 
         if (ll <= 0) {
-            return READ_FLAGS_PARSING_NEGATIVE_MBULK_LEN;
+            return READ_FLAGS_PARSING_NEGATIVE_MBULK_LEN | additional_flags;
         }
 
         c->multibulklen = ll;
@@ -3551,7 +3553,7 @@ static int parseMultibulk(client *c,
             newline = memchr(c->querybuf + c->qb_pos, '\r', sdslen(c->querybuf) - c->qb_pos);
             if (newline == NULL) {
                 if (sdslen(c->querybuf) - c->qb_pos > PROTO_INLINE_MAX_SIZE) {
-                    return READ_FLAGS_ERROR_BIG_BULK_COUNT;
+                    return READ_FLAGS_ERROR_BIG_BULK_COUNT | additional_flags;
                 }
                 break;
             }
@@ -3560,15 +3562,15 @@ static int parseMultibulk(client *c,
             if (newline - (c->querybuf + c->qb_pos) > (ssize_t)(sdslen(c->querybuf) - c->qb_pos - 2)) return 0;
 
             if (c->querybuf[c->qb_pos] != '$') {
-                return READ_FLAGS_ERROR_MBULK_UNEXPECTED_CHARACTER;
+                return READ_FLAGS_ERROR_MBULK_UNEXPECTED_CHARACTER | additional_flags;
             }
 
             size_t bulklen_slen = newline - (c->querybuf + c->qb_pos + 1);
             ok = string2ll(c->querybuf + c->qb_pos + 1, bulklen_slen, &ll);
             if (!ok || ll < 0 || (!(is_replicated) && ll > server.proto_max_bulk_len)) {
-                return READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN;
+                return READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN | additional_flags;
             } else if (ll > 16384 && auth_required) {
-                return READ_FLAGS_ERROR_UNAUTHENTICATED_BULK_LEN;
+                return READ_FLAGS_ERROR_UNAUTHENTICATED_BULK_LEN | additional_flags;
             }
 
             c->qb_pos = newline - c->querybuf + 2;
@@ -3645,9 +3647,9 @@ static int parseMultibulk(client *c,
         /* Per-slot network bytes-in calculation, 3rd and 4th components. */
         *net_input_bytes_curr_cmd += (*argv_len_sum + (*argc * 2));
         c->reqtype = 0;
-        return READ_FLAGS_PARSING_COMPLETED;
+        return READ_FLAGS_PARSING_COMPLETED | additional_flags;
     }
-    return 0;
+    return additional_flags;
 }
 
 /* Perform necessary tasks after a command was executed:
@@ -3769,6 +3771,11 @@ void parseInputBuffer(client *c) {
     if (!c->reqtype) {
         if (c->querybuf[c->qb_pos] == '*') {
             c->reqtype = PROTO_REQ_MULTIBULK;
+        } else if (c->querybuf[c->qb_pos] == '>' && c->push_message_callback != NULL) {
+            /* We only handle pushes if there is a callback configured for them.
+             * Otherwise, we treat these as if they are inline for backwards
+             * compatibility. */
+            c->reqtype = PROTO_REQ_MULTIBULK;
         } else {
             c->reqtype = PROTO_REQ_INLINE;
         }
@@ -3780,6 +3787,12 @@ void parseInputBuffer(client *c) {
         parseMultibulkBuffer(c);
     } else {
         serverPanic("Unknown request type");
+    }
+    if (c->flag2.reading_response) {
+        /* If any commands were processed into the command queue, they will not
+         * have the response read flag, since it only applies to the first
+         * response.*/
+        c->read_flags |= READ_FLAGS_RESPONSE;
     }
 }
 
@@ -3970,6 +3983,31 @@ static void prefetchCommandQueueKeys(client *c) {
     }
 }
 
+/* Register for a response callback. The callback will be triggered after the
+ * next response is parsed. The parsed response will be set in c->argv. While
+ * waiting for a response, normal command parsing and execution will not be
+ * performed. */
+void setResponseCallback(client *c, ClientResponseCallback cb) {
+    c->flag2.reading_response = 1;
+    c->response_callback = cb;
+}
+
+void processResponse(client *c) {
+    serverAssert(c->flag2.reading_response && c->response_callback != NULL);
+    c->response_callback(c);
+    c->flag2.reading_response = 0;
+    c->response_callback = NULL;
+    
+    /* Ensure the client is reset for the next command */
+    resetClient(c);
+}
+
+void processPushMessage(client *c) {
+    serverAssert(c->push_message_callback != NULL);
+    c->push_message_callback(c);
+    resetClient(c);
+}
+
 int processInputBuffer(client *c) {
     /* Parse the query buffer and/or execute already parsed commands. */
     while ((c->querybuf && c->qb_pos < sdslen(c->querybuf)) ||
@@ -3984,12 +4022,15 @@ int processInputBuffer(client *c) {
         /* If commands are queued up, pop from the queue first */
         if (!consumeCommandQueue(c)) {
             parseInputBuffer(c);
-            if (c->flag2.reading_response) {
-                c->read_response_callback(c);
-                resetClient(c);
-                continue;
-            }
             prepareCommandQueue(c);
+        }
+        if (c->read_flags & READ_FLAGS_PUSH_MESSAGE) {
+            processPushMessage(c);
+            continue;
+        }
+        if (c->read_flags & READ_FLAGS_RESPONSE) {
+            processResponse(c);
+            continue;
         }
 
         /* Prefetch keys for the next commands in queue, if not already done. */

--- a/src/server.c
+++ b/src/server.c
@@ -4094,6 +4094,7 @@ uint64_t getCommandFlags(client *c) {
  * done by I/O threads to offload the main-thread. */
 static void prepareCommandGeneric(robj **argv, int argc, int *read_flags, struct serverCommand **cmd, int *slot) {
     if (!(*read_flags & READ_FLAGS_PARSING_COMPLETED) || argc == 0) return;
+    if (*read_flags & READ_FLAGS_PUSH_MESSAGE || *read_flags & READ_FLAGS_RESPONSE) return;
     /* Make sure we don't do this twice. */
     debugServerAssert(*cmd == NULL && !(*read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
     *cmd = lookupCommand(argv, argc);

--- a/src/server.h
+++ b/src/server.h
@@ -1168,9 +1168,9 @@ typedef struct ClientFlags {
                                               or client::buf. */
     uint64_t keyspace_notified : 1;        /* Indicates that a keyspace notification was triggered during the execution of the
                                               current command. */
-    uint64_t reading_response : 1;         /* The client has sent a command over this client and is expecting a response. The next
-                                              command from this client is expected to be a response to the previous request and
-                                              will not be processed as a command. */
+    uint64_t outgoing : 1;                 /* The client represents an outgoing connection. As opposed to other connections, we
+                                            * send commands to other nodes through this client, and parse the query buffer as
+                                            * responses. */
 } ClientFlags;
 
 typedef struct ClientPubSubData {
@@ -1237,6 +1237,15 @@ typedef struct ClientModuleData {
                                                 * unloaded for cleanup. Opaque for the Server Core.*/
 } ClientModuleData;
 
+typedef void (*ClientResponseCallback)(struct client *c);
+
+typedef struct outgoingClientData {
+    list *response_callbacks;                     /* Queue of callbacks for outgoing requests. As responses come in,
+                                                   * the front of the queue will be popped and notified. This allows
+                                                   * for pipelining outgoing requests. */
+    ClientResponseCallback push_message_callback; /* Callback to handle RESP3 out-of-band push messages. */
+} outgoingClientData;
+
 /* Parser state and parse result of a command from a client's input buffer. */
 typedef struct parsedCommand {
     int read_flags; /* complete, error or 0 (parsing not complete) */
@@ -1268,8 +1277,6 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
-typedef void (*ClientResponseCallback)(struct client *c);
-
 typedef struct client {
     /* Basic client information and connection. */
     uint64_t id; /* Client incremental unique ID. */
@@ -1300,6 +1307,7 @@ typedef struct client {
     multiState *mstate;                   /* MULTI/EXEC state, lazily initialized when first needed */
     blockingState *bstate;                /* Blocking state, lazily initialized when first needed */
     slotMigrationJob *slot_migration_job; /* Pointer to the slot migration job, or NULL. */
+    outgoingClientData *outgoing_data;    /* Required for: outgoing connections that need to perform request/response parsing. */
     /* Output buffer and reply handling */
     long duration;                       /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
     char *buf;                           /* Output buffer */
@@ -1358,19 +1366,16 @@ typedef struct client {
     dictEntry *cur_script;             /* Cached pointer to the dictEntry of the script being executed. */
     user *user;                        /* User associated with this connection */
     time_t obuf_soft_limit_reached_time;
-    list *deferred_reply_errors;                  /* Used for module thread safe contexts. */
-    robj *name;                                   /* As set by CLIENT SETNAME. */
-    robj *lib_name;                               /* The client library name as set by CLIENT SETINFO. */
-    robj *lib_ver;                                /* The client library version as set by CLIENT SETINFO. */
-    sds peerid;                                   /* Cached peer ID. */
-    sds sockname;                                 /* Cached connection target address. */
-    time_t ctime;                                 /* Client creation time. */
-    list *deferred_reply;                         /* List of reply objects to be sent to the client, typically after
-                                                     the client has been unblocked. */
-    unsigned long long deferred_reply_bytes;      /* Total bytes of objects in the blocked client pending list.*/
-    ClientResponseCallback response_callback;     /* Callback to handle the response when the client is in
-                                                   * reading_response state. */
-    ClientResponseCallback push_message_callback; /* Callback to handle RESP3 out-of-band push messages. */
+    list *deferred_reply_errors;             /* Used for module thread safe contexts. */
+    robj *name;                              /* As set by CLIENT SETNAME. */
+    robj *lib_name;                          /* The client library name as set by CLIENT SETINFO. */
+    robj *lib_ver;                           /* The client library version as set by CLIENT SETINFO. */
+    sds peerid;                              /* Cached peer ID. */
+    sds sockname;                            /* Cached connection target address. */
+    time_t ctime;                            /* Client creation time. */
+    list *deferred_reply;                    /* List of reply objects to be sent to the client, typically after
+                                                the client has been unblocked. */
+    unsigned long long deferred_reply_bytes; /* Total bytes of objects in the blocked client pending list.*/
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
@@ -2783,6 +2788,7 @@ void dictVanillaFree(void *val);
 #define WRITE_FLAGS_IS_REPLICA (1 << 1)
 
 client *createClient(connection *conn);
+client *createOutgoingClient(connection *conn);
 void freeClient(client *c);
 void freeClientAsync(client *c);
 void logInvalidUseAndFreeClientAsync(client *c, const char *fmt, ...);
@@ -2920,7 +2926,7 @@ int processIOThreadsReadDone(void);
 int processIOThreadsWriteDone(void);
 void releaseReplyReferences(client *c);
 void resetLastWrittenBuf(client *c);
-void setResponseCallback(client *c, ClientResponseCallback cb);
+void addResponseCallback(client *c, ClientResponseCallback cb);
 
 int parseExtendedCommandArgumentsOrReply(client *c, int *flags, int *unit, robj **expire, robj **compare_val, int command_type, int max_args);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1170,6 +1170,12 @@ typedef struct ClientFlags {
                                               current command. */
 } ClientFlags;
 
+typedef struct ClientFlags2 {
+    uint64_t reading_response : 1;         /* The client has sent a command over this client and is expecting a response. The next
+                                            command from this client is expected to be a response to the previous request and
+                                            will not be processed as a command. */
+} ClientFlags2;
+
 typedef struct ClientPubSubData {
     hashtable *pubsub_channels;      /* channels a client is interested in (SUBSCRIBE) */
     hashtable *pubsub_patterns;      /* patterns a client is interested in (PSUBSCRIBE) */
@@ -1265,6 +1271,8 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
+typedef void (*ClientReadResponseCallback)(struct client *c);
+
 typedef struct client {
     /* Basic client information and connection. */
     uint64_t id; /* Client incremental unique ID. */
@@ -1313,6 +1321,10 @@ typedef struct client {
     union {
         uint64_t raw_flag;
         struct ClientFlags flag;
+    };
+    union {
+        uint64_t raw_flag2;
+        struct ClientFlags2 flag2;
     };
     uint16_t write_flags;            /* Client Write flags - used to communicate the client write state. */
     volatile uint8_t io_read_state;  /* Indicate the IO read state of the client */
@@ -1363,6 +1375,8 @@ typedef struct client {
     list *deferred_reply;                    /* List of reply objects to be sent to the client, typically after
                                                 the client has been unblocked. */
     unsigned long long deferred_reply_bytes; /* Total bytes of objects in the blocked client pending list.*/
+    ClientReadResponseCallback read_response_callback; /* Callback to handle the response when the client is in
+                                                        * reading_response state. */
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -1171,9 +1171,9 @@ typedef struct ClientFlags {
 } ClientFlags;
 
 typedef struct ClientFlags2 {
-    uint64_t reading_response : 1;         /* The client has sent a command over this client and is expecting a response. The next
-                                            command from this client is expected to be a response to the previous request and
-                                            will not be processed as a command. */
+    uint64_t reading_response : 1; /* The client has sent a command over this client and is expecting a response. The next
+                                    command from this client is expected to be a response to the previous request and
+                                    will not be processed as a command. */
 } ClientFlags2;
 
 typedef struct ClientPubSubData {
@@ -1365,18 +1365,18 @@ typedef struct client {
     dictEntry *cur_script;             /* Cached pointer to the dictEntry of the script being executed. */
     user *user;                        /* User associated with this connection */
     time_t obuf_soft_limit_reached_time;
-    list *deferred_reply_errors;             /* Used for module thread safe contexts. */
-    robj *name;                              /* As set by CLIENT SETNAME. */
-    robj *lib_name;                          /* The client library name as set by CLIENT SETINFO. */
-    robj *lib_ver;                           /* The client library version as set by CLIENT SETINFO. */
-    sds peerid;                              /* Cached peer ID. */
-    sds sockname;                            /* Cached connection target address. */
-    time_t ctime;                            /* Client creation time. */
-    list *deferred_reply;                    /* List of reply objects to be sent to the client, typically after
-                                                the client has been unblocked. */
-    unsigned long long deferred_reply_bytes; /* Total bytes of objects in the blocked client pending list.*/
-    ClientResponseCallback response_callback; /* Callback to handle the response when the client is in
-                                               * reading_response state. */
+    list *deferred_reply_errors;                  /* Used for module thread safe contexts. */
+    robj *name;                                   /* As set by CLIENT SETNAME. */
+    robj *lib_name;                               /* The client library name as set by CLIENT SETINFO. */
+    robj *lib_ver;                                /* The client library version as set by CLIENT SETINFO. */
+    sds peerid;                                   /* Cached peer ID. */
+    sds sockname;                                 /* Cached connection target address. */
+    time_t ctime;                                 /* Client creation time. */
+    list *deferred_reply;                         /* List of reply objects to be sent to the client, typically after
+                                                     the client has been unblocked. */
+    unsigned long long deferred_reply_bytes;      /* Total bytes of objects in the blocked client pending list.*/
+    ClientResponseCallback response_callback;     /* Callback to handle the response when the client is in
+                                                   * reading_response state. */
     ClientResponseCallback push_message_callback; /* Callback to handle RESP3 out-of-band push messages. */
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;

--- a/src/server.h
+++ b/src/server.h
@@ -1271,7 +1271,7 @@ typedef struct LastWrittenBuf {
 /* Forward declaration of slotMigrationJob */
 typedef struct slotMigrationJob slotMigrationJob;
 
-typedef void (*ClientReadResponseCallback)(struct client *c);
+typedef void (*ClientResponseCallback)(struct client *c);
 
 typedef struct client {
     /* Basic client information and connection. */
@@ -1375,8 +1375,9 @@ typedef struct client {
     list *deferred_reply;                    /* List of reply objects to be sent to the client, typically after
                                                 the client has been unblocked. */
     unsigned long long deferred_reply_bytes; /* Total bytes of objects in the blocked client pending list.*/
-    ClientReadResponseCallback read_response_callback; /* Callback to handle the response when the client is in
-                                                        * reading_response state. */
+    ClientResponseCallback response_callback; /* Callback to handle the response when the client is in
+                                               * reading_response state. */
+    ClientResponseCallback push_message_callback; /* Callback to handle RESP3 out-of-band push messages. */
 #ifdef LOG_REQ_RES
     clientReqResInfo reqres;
 #endif
@@ -2781,6 +2782,8 @@ void dictVanillaFree(void *val);
 #define READ_FLAGS_NO_KEYS (1 << 19)
 #define READ_FLAGS_CROSSSLOT (1 << 20)
 #define READ_FLAGS_PREFETCHED (1 << 21)
+#define READ_FLAGS_RESPONSE (1 << 22)
+#define READ_FLAGS_PUSH_MESSAGE (1 << 23)
 
 /* Write flags for various write errors and states */
 #define WRITE_FLAGS_WRITE_ERROR (1 << 0)
@@ -2924,6 +2927,7 @@ int processIOThreadsReadDone(void);
 int processIOThreadsWriteDone(void);
 void releaseReplyReferences(client *c);
 void resetLastWrittenBuf(client *c);
+void setResponseCallback(client *c, ClientResponseCallback cb);
 
 int parseExtendedCommandArgumentsOrReply(client *c, int *flags, int *unit, robj **expire, robj **compare_val, int command_type, int max_args);
 

--- a/src/server.h
+++ b/src/server.h
@@ -1168,13 +1168,10 @@ typedef struct ClientFlags {
                                               or client::buf. */
     uint64_t keyspace_notified : 1;        /* Indicates that a keyspace notification was triggered during the execution of the
                                               current command. */
+    uint64_t reading_response : 1;         /* The client has sent a command over this client and is expecting a response. The next
+                                              command from this client is expected to be a response to the previous request and
+                                              will not be processed as a command. */
 } ClientFlags;
-
-typedef struct ClientFlags2 {
-    uint64_t reading_response : 1; /* The client has sent a command over this client and is expecting a response. The next
-                                    command from this client is expected to be a response to the previous request and
-                                    will not be processed as a command. */
-} ClientFlags2;
 
 typedef struct ClientPubSubData {
     hashtable *pubsub_channels;      /* channels a client is interested in (SUBSCRIBE) */
@@ -1319,12 +1316,8 @@ typedef struct client {
     robj **original_argv;       /* Arguments of original command if arguments were rewritten. */
     /* Client flags and state indicators */
     union {
-        uint64_t raw_flag;
+        uint64_t raw_flag[2];
         struct ClientFlags flag;
-    };
-    union {
-        uint64_t raw_flag2;
-        struct ClientFlags2 flag2;
     };
     uint16_t write_flags;            /* Client Write flags - used to communicate the client write state. */
     volatile uint8_t io_read_state;  /* Indicate the IO read state of the client */

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1222,16 +1222,16 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_error "*syntax error*" {R 0 CLUSTER SYNCSLOTS UNKNOWN}
 
             assert_causes_conn_drop 0 {
-                $client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383
-                $client CLUSTER SYNCSLOTS SNAPSHOT-EOF
+                assert_match "OK" [$client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383]
+                assert_match "OK" [$client CLUSTER SYNCSLOTS SNAPSHOT-EOF]
                 $client CLUSTER SYNCSLOTS SNAPSHOT-EOF
             }
             assert_causes_conn_drop 0 {
-                $client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383
+                assert_match "OK" [$client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383]
                 $client CLUSTER SYNCSLOTS PAUSED
             }
             assert_causes_conn_drop 0 {
-                $client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383
+                assert_match "OK" [$client CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383]
                 $client CLUSTER SYNCSLOTS FAILOVER-GRANTED
             }
         }

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1158,7 +1158,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             set_debug_prevent_failover 1
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]
             set jobname [get_job_name 0 0]
-            wait_for_migration_field 0 $jobname state failover-granted
+            wait_for_migration_field 0 $jobname state waiting-for-topology-finalization
 
             assert_match "slot_migration_in_progress" [s -0 paused_reason]
 
@@ -1192,7 +1192,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             set_debug_prevent_failover 1
             assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node2_id]
             set jobname [get_job_name 0 0]
-            wait_for_migration_field 0 $jobname state failover-granted
+            wait_for_migration_field 0 $jobname state waiting-for-topology-finalization
 
             assert_match "slot_migration_in_progress" [s -0 paused_reason]
             assert_match "write" [s -0 paused_actions]
@@ -1215,8 +1215,6 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
     test "CLUSTER SYNCSLOTS invalid state machine traversal" {
         assert_does_not_resync {
-            assert_error "*ERR CLUSTER SYNCSLOTS REQUEST-PAUSE should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS REQUEST-PAUSE}
-            assert_error "*ERR CLUSTER SYNCSLOTS REQUEST-FAILOVER should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS REQUEST-FAILOVER}
             assert_error "*ERR CLUSTER SYNCSLOTS SNAPSHOT-EOF should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS SNAPSHOT-EOF}
             assert_error "*ERR CLUSTER SYNCSLOTS PAUSED should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS PAUSED}
             assert_error "*ERR CLUSTER SYNCSLOTS FAILOVER-GRANTED should only be used by slot migration clients*" {R 0 CLUSTER SYNCSLOTS FAILOVER-GRANTED}
@@ -1487,7 +1485,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
             # Should be denied
             wait_for_migration_field 2 $jobname state failed
-            assert_match {*Failed to AUTH to target node*} [dict get [get_migration_by_name 2 $jobname] message]
+            assert_match {*Target node AUTH response error*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for next test
             R 0 CONFIG SET requirepass ""


### PR DESCRIPTION
# Summary

Previously, it looked like:

```
Source                                          Target
       |                                                |
       |------------ SYNCSLOTS ESTABLISH -------------->|
       |                                                |
       |<-------------------- +OK ----------------------|
       |                                                |
       |~~~~~~~~~~~~~~ snapshot as AOF ~~~~~~~~~~~~~~~~>|
       |                                                |
       |----------- SYNCSLOTS SNAPSHOT-EOF ------------>|
       |                                                |
       |<----------- SYNCSLOTS REQUEST-PAUSE -----------|
       |                                                |
       |~~~~~~~~~~~~ incremental changes ~~~~~~~~~~~~~~>|
       |                                                |
       |--------------- SYNCSLOTS PAUSED -------------->|
       |                                                |
       |<---------- SYNCSLOTS REQUEST-FAILOVER ---------|
       |                                                |
       |---------- SYNCSLOTS FAILOVER-GRANTED --------->|
       |                                                |
       |                                            (performs takeover &
       |                                             propagates topology)
       |                                                |
 (finds out about topology                              |
  change & marks migration done)                        |
       |                                                |
```

Now, instead of both ends of the migration sending SYNCSLOTS, we will only send SYNCSLOTS from the source to the target, and the target will only ever respond to the source:

```
Source                                          Target
       |                                                |
       |------------ SYNCSLOTS ESTABLISH -------------->|
       |                                                |
       |<-------------------- +OK ----------------------|
       |                                                |
       |~~~~~~~~~~~~~~ snapshot as AOF ~~~~~~~~~~~~~~~~>|
       |                                                |
       |----------- SYNCSLOTS SNAPSHOT-EOF ------------>|
       |                                                |
       |<-------------------- +OK ----------------------|
       |                                                |
       |~~~~~~~~~~~~ incremental changes ~~~~~~~~~~~~~~>|
       |                                                |
       |--------------- SYNCSLOTS PAUSED -------------->|
       |                                                |
       |<-------------------- +OK ----------------------|
       |                                                |
       |---------- SYNCSLOTS FAILOVER-GRANTED --------->|
       |                                                |
       |                                            (performs takeover &
       |                                             propagates topology)
       |                                                |
       |<-------------------- +OK ----------------------|
       |                                                |
 (finds out about topology                              |
  change & marks migration done)                        |
       |                                                |
```

Benefits of this approach:

1. Less SYNCSLOTS commands to maintain and support
2. Forwards and backwards compatibility is trivial since we can detect when -ERR is returned for newly added SYNCSLOTS commands
3. Allows for errors to be sent back to the source node, which will improve operator troubleshooting
4. By ensuring a single direction of command flow (from source to target), we can more easily implement replica key containment by simply replicating the SYNCSLOTS commands downwards

# Support for outgoing clients

We don't currently have a formal concept for an "outgoing" client (a client we initiate to another node, that we send commands over and expect response back on). The closest thing we have is replication links - however we use synchronous writes and reads which are not performant and won't be acceptable for slot migration (where both nodes are actively serving primary traffic).

To accommodate for this, I added a new concept for this "outgoing" client. Outgoing clients are created from an already established connection via the `createOutgoingClient` function. An outgoing client supports registering response callbacks into a queue. Response processing goes through our normal inline/multibulk parsing (storing the contents in c->argv, c->argv, etc). For each response, we fire the next response callback in the queue. This design should allow for trivial offloading to IO threads and pipelining of many requests for low latency handshakes.

# Rethinking slot migration ACKs

One problem with the new SYNCSLOTS request/response model is that both ends were periodically sending SYNCSLOTS ACK to one another as a liveness check.

Luckily, in RESP3, we have support for out-of-band messages. Using this, ACKs work differently on either end of the migration:

* Sources send ACKs to targets via the existing SYNCSLOTS ACK command. The SYNCSLOTS ACK command does not return a response
* Targets send ACKs to sources via out-of-band messages. After SYNCSLOTS ESTABLISH, the target will periodically send `>1\r\n$3\r\nack\r\n` back to the source as a liveness check.

# Out of band message callbacks

Finally, to handle the ACK messages from target -> source, this PR introduces a second callback for push messages that can be set on outgoing clients. The multibulk processing was extended to support parsing of push message types, so they become encoded into c->argv and can be read and handled by the registered callback.

# Sidenote: We ran out of client->flags

When making the change, I noticed we had exactly 64 client->flag entries. I needed to extend the client->raw_flag value so that the bitfield could be expanded safely.