### PR TITLE
Make modules opt-in to atomic slot migration and add server events

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -421,6 +421,10 @@ void clusterCommandSyncSlotsEstablish(client *c) {
     clusterNode *owning_node = NULL;
     list *slot_ranges = NULL;
 
+    if (moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
+        return;
+    }
+
     if (!nodeIsPrimary(server.cluster->myself)) {
         addReplyError(c, "Target node is not a primary");
         return;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -53,7 +53,9 @@ typedef struct slotMigrationJob {
     time_t last_update;                       /* Migration job last update
                                                * time. */
     time_t last_ack;                          /* Migration job last ack time. */
-    char nodename[CLUSTER_NAMELEN];           /* Name of the slot import source
+    char target_node_name[CLUSTER_NAMELEN];   /* Name of the slot import target
+                                               * node, hex string, sha1-size. */
+    char source_node_name[CLUSTER_NAMELEN];   /* Name of the slot import source
                                                * node, hex string, sha1-size. */
     char name[CLUSTER_NAMELEN];               /* Unique name for the job, hex
                                                * string, sha1-size. */
@@ -330,6 +332,23 @@ cleanup:
     return NULL;
 }
 
+void fireModuleSlotMigrationEvent(slotMigrationJob *job, int subevent) {
+    ValkeyModuleAtomicSlotMigrationInfo info = VALKEYMODULE_ATOMICSLOTMIGRATIONINFO_INITIALIZER_V1;
+    info.num_slot_ranges = job->slot_ranges->len;
+    info.slot_ranges = zmalloc(sizeof(ValkeyModuleSlotRange) * info.num_slot_ranges);
+    for (uint32_t i = 0; i < info.num_slot_ranges; i++) {
+        listNode *ln = listIndex(job->slot_ranges, i);
+        slotRange *range = (slotRange *)ln->value;
+        info.slot_ranges[i].start = range->start_slot;
+        info.slot_ranges[i].end = range->end_slot;
+    }
+    memcpy(info.source_node_id, job->source_node_name, CLUSTER_NAMELEN);
+    memcpy(info.target_node_id, job->target_node_name, CLUSTER_NAMELEN);
+    memcpy(info.job_name, job->name, CLUSTER_NAMELEN);
+    moduleFireServerEvent(VALKEYMODULE_EVENT_ATOMIC_SLOT_MIGRATION, subevent, &info);
+    zfree(info.slot_ranges);
+}
+
 /* -------------------------------- TARGET -------------------------------------
  *
  * During a slot migration, the target is informed of a migration by the source
@@ -494,6 +513,7 @@ void clusterCommandSyncSlotsEstablish(client *c) {
 
     slotMigrationJob *job = createSlotImportJob(c, source_node, name,
                                                 slot_ranges);
+    fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED);
     listAddNodeHead(server.cluster->slot_migration_jobs, job);
 
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
@@ -589,7 +609,8 @@ slotMigrationJob *createSlotImportJob(client *c,
                                       list *slot_ranges) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
     memcpy(job->name, name, CLUSTER_NAMELEN);
-    memcpy(job->nodename, source_node->name, CLUSTER_NAMELEN);
+    memcpy(job->source_node_name, source_node->name, CLUSTER_NAMELEN);
+    memcpy(job->target_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->ctime = server.unixtime;
     job->last_update = job->ctime;
     job->last_ack = job->ctime;
@@ -688,7 +709,7 @@ void clusterUpdateSlotImportsOnOwnershipChange(void) {
             continue;
         }
         clusterNode *n = getClusterNodeBySlotRanges(job->slot_ranges, NULL);
-        if (n && !memcmp(n->name, job->nodename, CLUSTER_NAMELEN)) continue;
+        if (n && !memcmp(n->name, job->source_node_name, CLUSTER_NAMELEN)) continue;
         if (n == server.cluster->myself) {
             finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                    "Slots were unexpectedly assigned to myself "
@@ -823,6 +844,9 @@ bool clusterSlotFailoverGranted(int slot) {
  * source will attempt to migrate the slot ranges to the specified target
  * node. */
 void clusterCommandMigrateSlots(client *c) {
+    if (moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
+        return;
+    }
     if (!nodeIsPrimary(server.cluster->myself)) {
         addReplyError(c, "Slot migration can only be used on primary nodes.");
         return;
@@ -925,6 +949,7 @@ void clusterCommandMigrateSlots(client *c) {
                   "Slot migration initiated through CLUSTER MIGRATESLOTS "
                   "command: %s (user request from '%s')",
                   job->description, client_info);
+        fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_STARTED);
         proceedWithSlotMigration(job);
     }
     listSetFreeMethod(new_slot_migrations, NULL);
@@ -989,7 +1014,7 @@ void slotExportConnectHandler(connection *conn) {
 /* Connect the given job to the target node. The created connection will have
  * the job as private data. */
 int connectSlotExportJob(slotMigrationJob *job) {
-    clusterNode *n = clusterLookupNode(job->nodename, CLUSTER_NAMELEN);
+    clusterNode *n = clusterLookupNode(job->target_node_name, CLUSTER_NAMELEN);
     int port = getNodeDefaultReplicationPort(n);
     serverLog(LL_NOTICE, "Connecting slot migration %s (ip: %s, port %d)",
               job->description,
@@ -1373,7 +1398,7 @@ int checkSlotExportOwnership(slotMigrationJob *job, bool *migration_done) {
     if (n) {
         if (n == server.cluster->myself) {
             return C_OK;
-        } else if (!memcmp(n->name, job->nodename, CLUSTER_NAMELEN)) {
+        } else if (!memcmp(n->name, job->target_node_name, CLUSTER_NAMELEN)) {
             *migration_done = true;
             serverLog(LL_NOTICE,
                       "Slot migration %s slots are now owned by target node.",
@@ -1469,7 +1494,8 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     job->slot_ranges = slot_ranges;
     job->slot_ranges_str = representSlotRangeList(slot_ranges);
     getRandomHexChars(job->name, sizeof(job->name));
-    memcpy(job->nodename, target_node->name, CLUSTER_NAMELEN);
+    memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
+    memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
     return job;
 }
@@ -1578,6 +1604,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             delKeysNotOwnedByMyself(job->slot_ranges);
             setSlotImportingStateInAllDbs(job->slot_ranges, 0);
             updateSlotMigrationJobState(job, job->post_cleanup_state);
+            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED);
             return;
 
         /* Exporting states */
@@ -1912,7 +1939,7 @@ void finishSlotMigrationJob(slotMigrationJob *job,
         if (job->state == SLOT_EXPORT_SNAPSHOTTING) killRDBChild();
     }
     if (job->type == SLOT_MIGRATION_IMPORT &&
-        job->state != SLOT_MIGRATION_JOB_SUCCESS) {
+        state != SLOT_MIGRATION_JOB_SUCCESS) {
         /* Defer cleanup until beforeSleep. */
         job->post_cleanup_state = state;
         state = SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP;
@@ -1920,6 +1947,18 @@ void finishSlotMigrationJob(slotMigrationJob *job,
     }
     updateSlotMigrationJobState(job, state);
     resetSlotMigrationJob(job);
+    if (job->type == SLOT_MIGRATION_EXPORT) {
+        if (state == SLOT_MIGRATION_JOB_SUCCESS) {
+            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED);
+        } else {
+            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED);
+        }
+    } else {
+        if (state == SLOT_MIGRATION_JOB_SUCCESS) {
+            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED);
+        }
+        /* Aborted notifications will be fired after cleanup completes. */
+    }
 }
 
 /* Finished means we are completely done with all work and this entry is just
@@ -1954,7 +1993,7 @@ void clusterCommandGetSlotMigrations(client *c) {
     listRewind(server.cluster->slot_migration_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
         slotMigrationJob *job = ln->value;
-        addReplyMapLen(c, 9);
+        addReplyMapLen(c, 10);
         addReplyBulkCString(c, "name");
         addReplyBulkCBuffer(c, job->name, CLUSTER_NAMELEN);
         addReplyBulkCString(c, "operation");
@@ -1963,8 +2002,10 @@ void clusterCommandGetSlotMigrations(client *c) {
                                    : "EXPORT");
         addReplyBulkCString(c, "slot_ranges");
         addReplyBulkCString(c, job->slot_ranges_str);
-        addReplyBulkCString(c, "node");
-        addReplyBulkCBuffer(c, job->nodename, CLUSTER_NAMELEN);
+        addReplyBulkCString(c, "target_node");
+        addReplyBulkCBuffer(c, job->target_node_name, CLUSTER_NAMELEN);
+        addReplyBulkCString(c, "source_node");
+        addReplyBulkCBuffer(c, job->source_node_name, CLUSTER_NAMELEN);
         addReplyBulkCString(c, "create_time");
         addReplyLongLong(c, job->ctime);
         addReplyBulkCString(c, "last_update_time");

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -421,7 +421,7 @@ void clusterCommandSyncSlotsEstablish(client *c) {
     clusterNode *owning_node = NULL;
     list *slot_ranges = NULL;
 
-    if (moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
+    if (moduleVerifyAllAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
         return;
     }
 
@@ -848,7 +848,7 @@ bool clusterSlotFailoverGranted(int slot) {
  * source will attempt to migrate the slot ranges to the specified target
  * node. */
 void clusterCommandMigrateSlots(client *c) {
-    if (moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
+    if (moduleVerifyAllAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
         return;
     }
     if (!nodeIsPrimary(server.cluster->myself)) {

--- a/src/module.c
+++ b/src/module.c
@@ -7154,7 +7154,7 @@ int moduleAllModulesHandleReplAsyncLoad(void) {
     return 1;
 }
 
-int moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(client *c) {
+int moduleVerifyAllAllowAtomicSlotMigrationOrReply(client *c) {
     dictIterator *di = dictGetIterator(modules);
     dictEntry *de;
 
@@ -7165,6 +7165,7 @@ int moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(client *c) {
                                    "Please ensure all modules have declared support for "
                                    "atomic slot migration and try again",
                                 module->name);
+            dictReleaseIterator(di);
             return C_ERR;
         }
     }
@@ -11869,8 +11870,9 @@ static uint64_t moduleEventVersions[] = {
  * * ValkeyModuleEvent_AtomicSlotMigration
  *
  *    Called when an atomic slot migration (CLUSTER MIGRATESLOTS) is started or
- *    ended in this node. This node may be a target or a source node.
- *    The following sub events are available:
+ *    ended in this node. This node may be a target or a source node, or the
+ *    target or source might be this node's primary. The following sub events
+ *    are available:
  *
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED`
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_STARTED`
@@ -11878,6 +11880,29 @@ static uint64_t moduleEventVersions[] = {
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED`
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED`
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED`
+ * 
+ *    The data pointer can be casted to ValkeyModuleAtomicSlotMigrationInfo
+ *    structure with the following fields:
+ * 
+ *         char *job_name;                     // Unique ID for the operation (40 chars)
+ *         ValkeyModuleSlotRange *slot_ranges; // Array of slot ranges involved in the operation
+ *         uint32_t num_slot_ranges;           // Number of slot ranges in slot_ranges array
+ *         char *source_node_id;               // Source node ID (40 chars)
+ *         char *target_node_id;               // Target node ID (40 chars)
+ * 
+ *    The ValkeyModuleSlotRange structure has the following fields:
+ * 
+ *          int start; // First slot in this range, inclusive
+ *          int end;   // Last slot in this range, inclusive
+ * 
+ *    Modules can use these notifications to track the start and end of slot
+ *    migrations. Slot migrations will start with a STARTED subevent and end
+ *    with a COMPLETED subevent if they are successful and ownership is
+ *    transferred, or an ABORTED subevent if they were not successful and no
+ *    ownership change was made. While a slot migration is active, modules will
+ *    see incoming commands and keyspace notifications for importing keys.
+ *    Importing keys will not be accessible to clients unless the slot migration
+ *    is COMPLETED.
  *
  * The function returns VALKEYMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event

--- a/src/module.c
+++ b/src/module.c
@@ -2588,7 +2588,7 @@ void VM_Yield(ValkeyModuleCtx *ctx, int flags, const char *busy_reply) {
  * are affected by this option, allowing them to operate without
  * command validation check.
  *
- * VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION:
+ * VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION:
  * When set, this option indicates that the module is capable of handling
  * atomic slot migration. If not set, the module is assumed to not be aware of
  * atomic slot migration and CLUSTER MIGRATESLOTS will return an error. Modules
@@ -7160,7 +7160,7 @@ int moduleVerifyAllAllowAtomicSlotMigrationOrReply(client *c) {
 
     while ((de = dictNext(di)) != NULL) {
         struct ValkeyModule *module = dictGetVal(de);
-        if (!(module->options & VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION)) {
+        if (!(module->options & VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION)) {
             addReplyErrorFormat(c, "The module %s does not support atomic slot migrations. "
                                    "Please ensure all modules have declared support for "
                                    "atomic slot migration and try again",
@@ -12774,7 +12774,7 @@ sds genModulesInfoStringRenderModuleOptions(struct ValkeyModule *module) {
         output = sdscat(output, "handle-repl-async-load|");
     if (module->options & VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED)
         output = sdscat(output, "no-implicit-signal-modified|");
-    if (module->options & VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION)
+    if (module->options & VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION)
         output = sdscat(output, "handle-atomic-slot-migration|");
     output = sdstrim(output, "|");
     output = sdscat(output, "]");

--- a/src/module.c
+++ b/src/module.c
@@ -2586,7 +2586,15 @@ void VM_Yield(ValkeyModuleCtx *ctx, int flags, const char *busy_reply) {
  * to reduce overhead or handle trusted custom command logic.
  * ValkeyModule_Replicate and ValkeyModule_EmitAOF
  * are affected by this option, allowing them to operate without
- * command validation check. */
+ * command validation check.
+ *
+ * VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION:
+ * When set, this option indicates that the module is capable of handling
+ * atomic slot migration. If not set, the module is assumed to not be aware of
+ * atomic slot migration and CLUSTER MIGRATESLOTS will return an error. Modules
+ * should set this flag if they understand keys may be loaded during the
+ * migration but before ownership is transferred.
+ */
 void VM_SetModuleOptions(ValkeyModuleCtx *ctx, int options) {
     ctx->module->options = options;
 }
@@ -7146,6 +7154,24 @@ int moduleAllModulesHandleReplAsyncLoad(void) {
     return 1;
 }
 
+int moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(client *c) {
+    dictIterator *di = dictGetIterator(modules);
+    dictEntry *de;
+
+    while ((de = dictNext(di)) != NULL) {
+        struct ValkeyModule *module = dictGetVal(de);
+        if (!(module->options & VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION)) {
+            addReplyErrorFormat(c, "The module %s does not support atomic slot migrations. "
+                                   "Please ensure all modules have declared support for "
+                                   "atomic slot migration and try again",
+                                module->name);
+            return C_ERR;
+        }
+    }
+    dictReleaseIterator(di);
+    return C_OK;
+}
+
 /* Returns true if any previous IO API failed.
  * for `Load*` APIs the VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS flag must be set with
  * ValkeyModule_SetModuleOptions first. */
@@ -11514,25 +11540,26 @@ void ModuleForkDoneHandler(int exitcode, int bysignal) {
  * a data structure associated with it. We use MAX_UINT64 on purpose,
  * in order to pass the check in ValkeyModule_SubscribeToServerEvent. */
 static uint64_t moduleEventVersions[] = {
-    VALKEYMODULE_REPLICATIONINFO_VERSION,     /* VALKEYMODULE_EVENT_REPLICATION_ROLE_CHANGED */
-    -1,                                       /* VALKEYMODULE_EVENT_PERSISTENCE */
-    VALKEYMODULE_FLUSHINFO_VERSION,           /* VALKEYMODULE_EVENT_FLUSHDB */
-    -1,                                       /* VALKEYMODULE_EVENT_LOADING */
-    VALKEYMODULE_CLIENTINFO_VERSION,          /* VALKEYMODULE_EVENT_CLIENT_CHANGE */
-    -1,                                       /* VALKEYMODULE_EVENT_SHUTDOWN */
-    -1,                                       /* VALKEYMODULE_EVENT_REPLICA_CHANGE */
-    -1,                                       /* VALKEYMODULE_EVENT_PRIMARY_LINK_CHANGE */
-    VALKEYMODULE_CRON_LOOP_VERSION,           /* VALKEYMODULE_EVENT_CRON_LOOP */
-    VALKEYMODULE_MODULE_CHANGE_VERSION,       /* VALKEYMODULE_EVENT_MODULE_CHANGE */
-    VALKEYMODULE_LOADING_PROGRESS_VERSION,    /* VALKEYMODULE_EVENT_LOADING_PROGRESS */
-    VALKEYMODULE_SWAPDBINFO_VERSION,          /* VALKEYMODULE_EVENT_SWAPDB */
-    -1,                                       /* VALKEYMODULE_EVENT_REPL_BACKUP */
-    -1,                                       /* VALKEYMODULE_EVENT_FORK_CHILD */
-    -1,                                       /* VALKEYMODULE_EVENT_REPL_ASYNC_LOAD */
-    -1,                                       /* VALKEYMODULE_EVENT_EVENTLOOP */
-    -1,                                       /* VALKEYMODULE_EVENT_CONFIG */
-    VALKEYMODULE_KEYINFO_VERSION,             /* VALKEYMODULE_EVENT_KEY */
-    VALKEYMODULE_AUTHENTICATION_INFO_VERSION, /* VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT */
+    VALKEYMODULE_REPLICATIONINFO_VERSION,          /* VALKEYMODULE_EVENT_REPLICATION_ROLE_CHANGED */
+    -1,                                            /* VALKEYMODULE_EVENT_PERSISTENCE */
+    VALKEYMODULE_FLUSHINFO_VERSION,                /* VALKEYMODULE_EVENT_FLUSHDB */
+    -1,                                            /* VALKEYMODULE_EVENT_LOADING */
+    VALKEYMODULE_CLIENTINFO_VERSION,               /* VALKEYMODULE_EVENT_CLIENT_CHANGE */
+    -1,                                            /* VALKEYMODULE_EVENT_SHUTDOWN */
+    -1,                                            /* VALKEYMODULE_EVENT_REPLICA_CHANGE */
+    -1,                                            /* VALKEYMODULE_EVENT_PRIMARY_LINK_CHANGE */
+    VALKEYMODULE_CRON_LOOP_VERSION,                /* VALKEYMODULE_EVENT_CRON_LOOP */
+    VALKEYMODULE_MODULE_CHANGE_VERSION,            /* VALKEYMODULE_EVENT_MODULE_CHANGE */
+    VALKEYMODULE_LOADING_PROGRESS_VERSION,         /* VALKEYMODULE_EVENT_LOADING_PROGRESS */
+    VALKEYMODULE_SWAPDBINFO_VERSION,               /* VALKEYMODULE_EVENT_SWAPDB */
+    -1,                                            /* VALKEYMODULE_EVENT_REPL_BACKUP */
+    -1,                                            /* VALKEYMODULE_EVENT_FORK_CHILD */
+    -1,                                            /* VALKEYMODULE_EVENT_REPL_ASYNC_LOAD */
+    -1,                                            /* VALKEYMODULE_EVENT_EVENTLOOP */
+    -1,                                            /* VALKEYMODULE_EVENT_CONFIG */
+    VALKEYMODULE_KEYINFO_VERSION,                  /* VALKEYMODULE_EVENT_KEY */
+    VALKEYMODULE_AUTHENTICATION_INFO_VERSION,      /* VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT */
+    VALKEYMODULE_ATOMICSLOTMIGRATION_INFO_VERSION, /* VALKEYMODULE_EVENT_ATOMIC_SLOT_MIGRATION */
 };
 
 /* Register to be notified, via a callback, when the specified server event
@@ -11839,6 +11866,19 @@ static uint64_t moduleEventVersions[] = {
  *                                                    // VALKEYMODULE_AUTH_RESULT_GRANTED or
  *                                                    // VALKEYMODULE_AUTH_RESULT_DENIED
  *
+ * * ValkeyModuleEvent_AtomicSlotMigration
+ *
+ *    Called when an atomic slot migration (CLUSTER MIGRATESLOTS) is started or
+ *    ended in this node. This node may be a target or a source node.
+ *    The following sub events are available:
+ *
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED`
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_STARTED`
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED`
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED`
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED`
+ *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED`
+ *
  * The function returns VALKEYMODULE_OK if the module was successfully subscribed
  * for the specified event. If the API is called from a wrong context or unsupported event
  * is given then VALKEYMODULE_ERR is returned. */
@@ -11989,6 +12029,8 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
                 moduleInitKey(&key, &ctx, info->key, info->value, info->mode);
                 moduledata = &ki;
             } else if (eid == VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT) {
+                moduledata = data;
+            } else if (eid == VALKEYMODULE_EVENT_ATOMIC_SLOT_MIGRATION) {
                 moduledata = data;
             }
 
@@ -12707,6 +12749,8 @@ sds genModulesInfoStringRenderModuleOptions(struct ValkeyModule *module) {
         output = sdscat(output, "handle-repl-async-load|");
     if (module->options & VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED)
         output = sdscat(output, "no-implicit-signal-modified|");
+    if (module->options & VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION)
+        output = sdscat(output, "handle-atomic-slot-migration|");
     output = sdstrim(output, "|");
     output = sdscat(output, "]");
     return output;

--- a/src/module.c
+++ b/src/module.c
@@ -11880,21 +11880,21 @@ static uint64_t moduleEventVersions[] = {
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED`
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED`
  *     * `VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED`
- * 
+ *
  *    The data pointer can be casted to ValkeyModuleAtomicSlotMigrationInfo
  *    structure with the following fields:
- * 
+ *
  *         char *job_name;                     // Unique ID for the operation (40 chars)
  *         ValkeyModuleSlotRange *slot_ranges; // Array of slot ranges involved in the operation
  *         uint32_t num_slot_ranges;           // Number of slot ranges in slot_ranges array
  *         char *source_node_id;               // Source node ID (40 chars)
  *         char *target_node_id;               // Target node ID (40 chars)
- * 
+ *
  *    The ValkeyModuleSlotRange structure has the following fields:
- * 
+ *
  *          int start; // First slot in this range, inclusive
  *          int end;   // Last slot in this range, inclusive
- * 
+ *
  *    Modules can use these notifications to track the start and end of slot
  *    migrations. Slot migrations will start with a STARTED subevent and end
  *    with a COMPLETED subevent if they are successful and ownership is

--- a/src/module.h
+++ b/src/module.h
@@ -211,6 +211,7 @@ int TerminateModuleForkChild(int child_pid, int wait);
 ssize_t rdbSaveModulesAux(rio *rdb, int when);
 int moduleAllDatatypesHandleErrors(void);
 int moduleAllModulesHandleReplAsyncLoad(void);
+int moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(client *c);
 sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int sections);
 void moduleFireServerEvent(uint64_t eid, int subid, void *data);
 void processModuleLoadingProgressEvent(int is_aof);

--- a/src/module.h
+++ b/src/module.h
@@ -211,7 +211,7 @@ int TerminateModuleForkChild(int child_pid, int wait);
 ssize_t rdbSaveModulesAux(rio *rdb, int when);
 int moduleAllDatatypesHandleErrors(void);
 int moduleAllModulesHandleReplAsyncLoad(void);
-int moduleVerifyAllModulesAllowAtomicSlotMigrationOrReply(client *c);
+int moduleVerifyAllAllowAtomicSlotMigrationOrReply(client *c);
 sds modulesCollectInfo(sds info, dict *sections_dict, int for_crash_report, int sections);
 void moduleFireServerEvent(uint64_t eid, int subid, void *data);
 void processModuleLoadingProgressEvent(int is_aof);

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1907,7 +1907,7 @@ int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
         return VALKEYMODULE_ERR;
     }
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION);
 
     if (connTypeRegister(&CT_RDMA) != C_OK) return VALKEYMODULE_ERR;
 

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1907,7 +1907,7 @@ int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
         return VALKEYMODULE_ERR;
     }
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
 
     if (connTypeRegister(&CT_RDMA) != C_OK) return VALKEYMODULE_ERR;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -1305,7 +1305,7 @@ int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
         return VALKEYMODULE_ERR;
     }
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION);
 
     if (connTypeRegister(&CT_TLS) != C_OK) return VALKEYMODULE_ERR;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -1305,7 +1305,7 @@ int ValkeyModule_OnLoad(void *ctx, ValkeyModuleString **argv, int argc) {
         return VALKEYMODULE_ERR;
     }
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
 
     if (connTypeRegister(&CT_TLS) != C_OK) return VALKEYMODULE_ERR;
 

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -333,7 +333,7 @@ typedef uint64_t ValkeyModuleTimerID;
 /* Declare that the module can handle atomic slot migration. When not set,
  * CLUSTER MIGRATESLOTS will return an error, and the CLUSTER SETSLOTS based
  * slot migration must be used. */
-#define VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION (1 << 5)
+#define VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION (1 << 5)
 
 /* Next option flag, must be updated when adding new module flags above!
  * This flag should not be used directly by the module.

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -330,10 +330,15 @@ typedef uint64_t ValkeyModuleTimerID;
  * are already pre-validated or trusted. */
 #define VALKEYMODULE_OPTIONS_SKIP_COMMAND_VALIDATION (1 << 4)
 
+/* Declare that the module can handle atomic slot migration. When not set,
+ * CLUSTER MIGRATESLOTS will return an error, and the CLUSTER SETSLOTS based
+ * slot migration must be used. */
+#define VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION (1 << 5)
+
 /* Next option flag, must be updated when adding new module flags above!
  * This flag should not be used directly by the module.
  * Use ValkeyModule_GetModuleOptionsAll instead. */
-#define _VALKEYMODULE_OPTIONS_FLAGS_NEXT (1 << 5)
+#define _VALKEYMODULE_OPTIONS_FLAGS_NEXT (1 << 6)
 
 /* Definitions for ValkeyModule_SetCommandInfo. */
 
@@ -523,7 +528,8 @@ typedef void (*ValkeyModuleEventLoopOneShotFunc)(void *user_data);
 #define VALKEYMODULE_EVENT_CONFIG 16
 #define VALKEYMODULE_EVENT_KEY 17
 #define VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT 18
-#define _VALKEYMODULE_EVENT_NEXT 19 /* Next event flag, should be updated if a new event added. */
+#define VALKEYMODULE_EVENT_ATOMIC_SLOT_MIGRATION 19
+#define _VALKEYMODULE_EVENT_NEXT 20 /* Next event flag, should be updated if a new event added. */
 
 typedef struct ValkeyModuleEvent {
     uint64_t id;      /* VALKEYMODULE_EVENT_... defines. */
@@ -581,7 +587,8 @@ static const ValkeyModuleEvent ValkeyModuleEvent_ReplicationRoleChanged = {VALKE
                                ValkeyModuleEvent_EventLoop = {VALKEYMODULE_EVENT_EVENTLOOP, 1},
                                ValkeyModuleEvent_Config = {VALKEYMODULE_EVENT_CONFIG, 1},
                                ValkeyModuleEvent_Key = {VALKEYMODULE_EVENT_KEY, 1},
-                               ValkeyModuleEvent_AuthenticationAttempt = {VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT, 1};
+                               ValkeyModuleEvent_AuthenticationAttempt = {VALKEYMODULE_EVENT_AUTHENTICATION_ATTEMPT, 1},
+                               ValkeyModuleEvent_AtomicSlotMigration = {VALKEYMODULE_EVENT_ATOMIC_SLOT_MIGRATION, 1};
 
 /* Those are values that are used for the 'subevent' callback argument. */
 #define VALKEYMODULE_SUBEVENT_PERSISTENCE_RDB_START 0
@@ -652,6 +659,14 @@ static const ValkeyModuleEvent ValkeyModuleEvent_ReplicationRoleChanged = {VALKE
 #define _VALKEYMODULE_SUBEVENT_SHUTDOWN_NEXT 0
 #define _VALKEYMODULE_SUBEVENT_CRON_LOOP_NEXT 0
 #define _VALKEYMODULE_SUBEVENT_SWAPDB_NEXT 0
+
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED 0
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_STARTED 1
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED 2
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED 3
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED 4
+#define VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED 5
+#define _VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_NEXT 6
 
 /* ValkeyModuleClientInfo flags. */
 #define VALKEYMODULE_CLIENTINFO_FLAG_SSL (1 << 0)
@@ -801,6 +816,26 @@ typedef struct ValkeyModuleAuthenticationInfo {
 #define ValkeyModuleAuthenticationInfo ValkeyModuleAuthenticationInfoV1
 
 #define VALKEYMODULE_AUTHENTICATIONINFO_INITIALIZER_V1 {.version = 1}
+
+#define VALKEYMODULE_ATOMICSLOTMIGRATION_INFO_VERSION 1
+
+typedef struct ValkeyModuleSlotRange {
+    int start; /* Start slot, inclusive. */
+    int end;   /* End slot, inclusive. */
+} ValkeyModuleSlotRange;
+
+typedef struct ValkeyModuleAtomicSlotMigrationInfo {
+    uint64_t version;                                  /* Version of this structure for ABI compat. */
+    char job_name[VALKEYMODULE_NODE_ID_LEN + 1];       /* Unique ID for the migration operation. */
+    ValkeyModuleSlotRange *slot_ranges;                /* Array of slot ranges involved in the migration. */
+    uint32_t num_slot_ranges;                          /* Number of slot ranges in the array. */
+    char source_node_id[VALKEYMODULE_NODE_ID_LEN + 1]; /* Node ID of the source node. */
+    char target_node_id[VALKEYMODULE_NODE_ID_LEN + 1]; /* Node ID of the target node. */
+} ValkeyModuleAtomicSlotMigrationInfoV1;
+
+#define ValkeyModuleAtomicSlotMigrationInfo ValkeyModuleAtomicSlotMigrationInfoV1
+
+#define VALKEYMODULE_ATOMICSLOTMIGRATIONINFO_INITIALIZER_V1 {.version = 1}
 
 typedef enum {
     VALKEYMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -67,7 +67,8 @@ TEST_MODULES = \
     rdbloadsave.so \
     crash.so \
     cluster.so \
-    helloscripting.so
+    helloscripting.so \
+    unsupported_features.so
 
 .PHONY: all
 

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -567,7 +567,7 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         }
     }
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION);
 
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -378,6 +378,73 @@ void authAttemptCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent e, uint64_t sub
     LogNumericEvent(ctx, "auth-attempt-success", ai->result == VALKEYMODULE_AUTH_RESULT_GRANTED);
 }
 
+void logAtomicSlotMigrationInfo(ValkeyModuleCtx *ctx, const char *prefix, ValkeyModuleAtomicSlotMigrationInfo *asmi) {
+    ValkeyModuleString *target_keyname = ValkeyModule_CreateStringPrintf(ctx, "%s-target", prefix);
+    LogStringEvent(ctx, ValkeyModule_StringPtrLen(target_keyname, NULL), asmi->target_node_id);
+    ValkeyModule_FreeString(ctx, target_keyname);
+
+    ValkeyModuleString *source_keyname = ValkeyModule_CreateStringPrintf(ctx, "%s-source", prefix);
+    LogStringEvent(ctx, ValkeyModule_StringPtrLen(source_keyname, NULL), asmi->source_node_id);
+    ValkeyModule_FreeString(ctx, source_keyname);
+
+    ValkeyModuleString *job_keyname = ValkeyModule_CreateStringPrintf(ctx, "%s-jobname", prefix);
+    LogStringEvent(ctx, ValkeyModule_StringPtrLen(job_keyname, NULL), asmi->job_name);
+    ValkeyModule_FreeString(ctx, job_keyname);
+
+    ValkeyModuleString *numslotranges_keyname = ValkeyModule_CreateStringPrintf(ctx, "%s-numslotranges", prefix);
+    LogNumericEvent(ctx, ValkeyModule_StringPtrLen(numslotranges_keyname, NULL), asmi->num_slot_ranges);
+    ValkeyModule_FreeString(ctx, numslotranges_keyname);
+
+    ValkeyModuleString *joined_range_str = NULL;
+    for (size_t i = 0; i < asmi->num_slot_ranges; i++) {
+        ValkeyModuleString *range_str = ValkeyModule_CreateStringPrintf(ctx, "%d-%d",
+            asmi->slot_ranges[i].start, asmi->slot_ranges[i].end);
+        if (joined_range_str) {
+            ValkeyModule_StringAppendBuffer(ctx, range_str, " ", 1);
+            size_t range_str_len;
+            const char *range_buf = ValkeyModule_StringPtrLen(range_str, &range_str_len);
+            ValkeyModule_StringAppendBuffer(ctx, joined_range_str, range_buf, range_str_len);
+            ValkeyModule_FreeString(ctx, range_str);
+        } else {
+            joined_range_str = range_str;
+        }
+    }
+    if (!joined_range_str) {
+        joined_range_str = ValkeyModule_CreateString(ctx, "", 0);
+    }
+    ValkeyModuleString *slotranges_keyname = ValkeyModule_CreateStringPrintf(ctx, "%s-slotranges", prefix);
+    LogStringEvent(ctx, ValkeyModule_StringPtrLen(slotranges_keyname, NULL), ValkeyModule_StringPtrLen(joined_range_str, NULL));
+    ValkeyModule_FreeString(ctx, slotranges_keyname);
+    ValkeyModule_FreeString(ctx, joined_range_str);
+}
+
+void atomicSlotMigrationCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent e, uint64_t sub, void *data)
+{
+    VALKEYMODULE_NOT_USED(e);
+
+    ValkeyModuleAtomicSlotMigrationInfo *asmi = data;
+    switch (sub) {
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-import-start", asmi);
+            break;
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-import-complete", asmi);
+            break;
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-import-abort", asmi);
+            break;
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_STARTED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-export-start", asmi);
+            break;
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-export-complete", asmi);
+            break;
+        case VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_ABORTED:
+            logAtomicSlotMigrationInfo(ctx, "atomic-slot-migration-export-abort", asmi);
+            break;
+    }
+}
+
 static int cmdIsKeyRemoved(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
     if(argc != 2){
         return ValkeyModule_WrongArity(ctx);
@@ -469,6 +536,9 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     ValkeyModule_SubscribeToServerEvent(ctx,
         ValkeyModuleEvent_AuthenticationAttempt, authAttemptCallback);
 
+    ValkeyModule_SubscribeToServerEvent(ctx,
+        ValkeyModuleEvent_AtomicSlotMigration, atomicSlotMigrationCallback);
+
     event_log = ValkeyModule_CreateDict(ctx);
     removed_event_log = ValkeyModule_CreateDict(ctx);
     removed_subevent_type = ValkeyModule_CreateDict(ctx);
@@ -496,6 +566,8 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
             return VALKEYMODULE_ERR;
         }
     }
+
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
 
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/testrdb.c
+++ b/tests/modules/testrdb.c
@@ -314,7 +314,7 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_Init(ctx,"testrdb",1,VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS | VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS | VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
 
     if (argc > 0)
         ValkeyModule_StringToLongLong(argv[0], &conf_aux_count);

--- a/tests/modules/testrdb.c
+++ b/tests/modules/testrdb.c
@@ -314,7 +314,7 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     if (ValkeyModule_Init(ctx,"testrdb",1,VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
 
-    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS | VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_ALLOW_ATOMIC_SLOT_MIGRATION);
+    ValkeyModule_SetModuleOptions(ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS | VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD | VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION);
 
     if (argc > 0)
         ValkeyModule_StringToLongLong(argv[0], &conf_aux_count);

--- a/tests/modules/unsupported_features.c
+++ b/tests/modules/unsupported_features.c
@@ -1,0 +1,15 @@
+
+#include "valkeymodule.h"
+
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    if (ValkeyModule_Init(ctx,"unsupported_features",1,VALKEYMODULE_APIVER_1)== VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    /* This module does not set any options, meaning it will not opt-in to
+     * features like Atomic Slot Migration and Async Loading */
+
+    return VALKEYMODULE_OK;
+}

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -266,8 +266,10 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_equal [dict get $import_migration slot_ranges] 16383-16383
         assert_equal [dict get $export_migration slot_ranges] 16383-16383
 
-        assert_equal [dict get $import_migration node] [R 2 CLUSTER MYID]
-        assert_equal [dict get $export_migration node] [R 0 CLUSTER MYID]
+        assert_equal [dict get $import_migration source_node] [R 2 CLUSTER MYID]
+        assert_equal [dict get $import_migration target_node] [R 0 CLUSTER MYID]
+        assert_equal [dict get $export_migration source_node] [R 2 CLUSTER MYID]
+        assert_equal [dict get $export_migration target_node] [R 0 CLUSTER MYID]
 
         set import_create_time [dict get $import_migration create_time]
         assert {$import_create_time ne ""}

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -384,4 +384,74 @@ tags "modules" {
             r ping
         }
     }
+
+    start_cluster 3 0 [list tags [list logreqres:skip external:skip cluster] overrides [list loadmodule "$testmodule"]] {
+        test {Test atomic slot migration hooks} {
+            assert_match "OK" [R 2 DEBUG SLOTMIGRATION PREVENT-PAUSE 1]
+            set node0_id [R 0 CLUSTER MYID]
+            set node2_id [R 2 CLUSTER MYID]
+
+            # Start a migration
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            set job_name [dict get [lindex [R 2 CLUSTER GETSLOTMIGRATIONS] 0] name]
+
+            wait_for_condition 50 100 {
+                [R 0 hooks.event_last atomic-slot-migration-import-start-target] ne ""
+            } else {
+                fail "Import start event never triggered"
+            }
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-target] $node0_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-source] $node2_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-target] $node0_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-source] $node2_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-numslotranges] "1"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-slotranges] "16383-16383"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-numslotranges] "1"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-jobname] $job_name
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-jobname] $job_name
+
+            # Abort the migration
+            assert_match "OK" [R 2 CLUSTER CANCELSLOTMIGRATIONS]
+
+            wait_for_condition 50 100 {
+                [R 0 hooks.event_last atomic-slot-migration-import-abort-target] ne ""
+            } else {
+                fail "Import abort event never triggered"
+            }
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-target] $node0_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-source] $node2_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-target] $node0_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-source] $node2_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-numslotranges] "1"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-slotranges] "16383-16383"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-numslotranges] "1"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-jobname] $job_name
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-jobname] $job_name
+
+            # Allow migration to complete
+            assert_match "OK" [R 2 DEBUG SLOTMIGRATION PREVENT-PAUSE 0]
+
+            # Start a migration again
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            set job_name [dict get [lindex [R 2 CLUSTER GETSLOTMIGRATIONS] 0] name]
+
+            wait_for_condition 50 100 {
+                [R 0 hooks.event_last atomic-slot-migration-import-complete-target] ne ""
+            } else {
+                fail "Import complete event never triggered"
+            }
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-target] $node0_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-source] $node2_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-target] $node0_id
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-source] $node2_id
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-numslotranges] "1"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-slotranges] "16383-16383"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-numslotranges] "1"
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-jobname] $job_name
+            assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-jobname] $job_name
+        }
+    }
 }

--- a/tests/unit/moduleapi/unsupported_features.tcl
+++ b/tests/unit/moduleapi/unsupported_features.tcl
@@ -1,0 +1,31 @@
+start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {enable-module-command yes}} {
+    set testmodule [file normalize tests/modules/unsupported_features.so]
+
+    set node0_id [R 0 CLUSTER MYID]
+    set node1_id [R 1 CLUSTER MYID]
+    set node2_id [R 2 CLUSTER MYID]
+
+    test "ASM blocked by module source" {
+        assert_match "OK" [R 2 MODULE LOAD $testmodule]
+
+        assert_error "ERR The module unsupported_features does not support atomic slot migrations*" {R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id}
+
+        assert_match "OK" [R 2 MODULE UNLOAD unsupported_features]
+    }
+
+    test "ASM blocked by module target" {
+        assert_match "OK" [R 0 MODULE LOAD $testmodule]
+
+        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+
+        wait_for_condition 50 100 {
+            [dict get [lindex [R 2 CLUSTER GETSLOTMIGRATIONS] 0] state] eq "failed"
+        } else {
+            fail "Slot migration did not fail despite target having module that did not support it"
+        }
+
+        assert_match "Received error during handshake to target: -ERR The module unsupported_features does not support atomic slot migrations*" [dict get [lindex [R 2 CLUSTER GETSLOTMIGRATIONS] 0] message]
+
+        assert_match "OK" [R 0 MODULE UNLOAD unsupported_features]
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/valkey-io/valkey/issues/2579

Notably, I am exposing this feature as "Atomic Slot Migration" to modules. If we want to call it something else, we should consider that now (e.g.. "Replication-Based Slot Migration"?)

Also note: I am exposing both target and source node in the event. It is not guaranteed that either target or source would be the node the event fires on (e.g. replicas will fire the event after replica containment is introduced). Even though it could be potentially inferred from CLUSTER SLOTS, it should help modules parse it this way. Modules should be able to infer whether it is occurring on primary/replica from `ctx` flags, so not duplicating that here.

Closes #2579