### PR TITLE
Increase frequency of time check during fields active expiration

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -35,7 +35,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "expire.h"
 #include "server.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"

--- a/src/expire.c
+++ b/src/expire.c
@@ -218,7 +218,7 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
     int j, iteration = 0;
     int dbs_per_call = CRON_DBS_PER_CALL;
     int dbs_performed = 0;
-    int time_check_rate; /* Check time limit every 1/Xth of the loop. */
+    int time_check_mask; /* Check time limit when (i & mask) == 0, i.e. every (X+1)th of the loop. */
     monotime start = getMonotonicUs();
 
     if (cycleType == ACTIVE_EXPIRE_CYCLE_FAST) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -276,7 +276,7 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
             case KEYS:
                 kvs = db->expires;
                 scan_cb = expireScanCallback;
-                time_check_rate = 0xf; /* For regular keys we can check the time condition every 16 loop iterations */
+                time_check_mask = 0xf; /* For regular keys we can check the time condition every 16 loop iterations */
                 break;
             case FIELDS:
                 kvs = db->keys_with_volatile_items;
@@ -285,7 +285,7 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
                  * This is required since we might perform much more operation per single key with many fields.
                  * Limiting the number of fields we scan in each field makes the overall process less efficient.
                  * So we just perform more clock checks after each iteration. */
-                time_check_rate = 0x0;
+                time_check_mask = 0x0;
                 break;
             default:
                 serverPanic("Unknown active expiry job type %d.", jobType);
@@ -398,7 +398,7 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
                 }
             }
             /* check time limit for every FIELDS job iteration or every 16 iterations for KEYS. */
-            if ((iteration & time_check_rate) == 0) {
+            if ((iteration & time_check_mask) == 0) {
                 if (elapsedUs(start) > (uint64_t)timelimit_us) {
                     state->timelimit_exit = 1;
                     server.stat_expired_time_cap_reached_count++;

--- a/src/expire.c
+++ b/src/expire.c
@@ -281,10 +281,11 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
             case FIELDS:
                 kvs = db->keys_with_volatile_items;
                 scan_cb = fieldExpireScanCallback;
-                time_check_rate = 0x0; /* For field-level keys we check the time condition every loop iteration.
-                                        * This is required since we might perform much more operation per single key with many fields.
-                                        * Limiting the number of fields we scan in each field makes the overall process less efficient.
-                                        * So we just perform more clock checks after each iteration. */
+                /* For field-level keys we check the time condition every loop iteration.
+                 * This is required since we might perform much more operation per single key with many fields.
+                 * Limiting the number of fields we scan in each field makes the overall process less efficient.
+                 * So we just perform more clock checks after each iteration. */
+                time_check_rate = 0x0;
                 break;
             default:
                 serverPanic("Unknown active expiry job type %d.", jobType);

--- a/src/expire.c
+++ b/src/expire.c
@@ -35,6 +35,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "expire.h"
 #include "server.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
@@ -218,6 +219,7 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
     int j, iteration = 0;
     int dbs_per_call = CRON_DBS_PER_CALL;
     int dbs_performed = 0;
+    int time_check_rate; /* Check time limit every 1/Xth of the loop. */
     monotime start = getMonotonicUs();
 
     if (cycleType == ACTIVE_EXPIRE_CYCLE_FAST) {
@@ -275,10 +277,15 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
             case KEYS:
                 kvs = db->expires;
                 scan_cb = expireScanCallback;
+                time_check_rate = 0xf; /* For regular keys we can check the time condition every 16 loop iterations */
                 break;
             case FIELDS:
                 kvs = db->keys_with_volatile_items;
                 scan_cb = fieldExpireScanCallback;
+                time_check_rate = 0x0; /* For field-level keys we check the time condition every loop iteration.
+                                        * This is required since we might perform much more operation per single key with many fields.
+                                        * Limiting the number of fields we scan in each field makes the overall process less efficient.
+                                        * So we just perform more clock checks after each iteration. */
                 break;
             default:
                 serverPanic("Unknown active expiry job type %d.", jobType);
@@ -389,12 +396,13 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
                     data.ttl_sum = 0;
                     data.ttl_samples = 0;
                 }
-                if ((iteration & 0xf) == 0) { /* check time limit every 16 iterations. */
-                    if (elapsedUs(start) > (uint64_t)timelimit_us) {
-                        state->timelimit_exit = 1;
-                        server.stat_expired_time_cap_reached_count++;
-                        break;
-                    }
+            }
+            /* check time limit for every FIELDS job iteration or every 16 iterations for KEYS. */
+            if ((iteration & time_check_rate) == 0) {
+                if (elapsedUs(start) > (uint64_t)timelimit_us) {
+                    state->timelimit_exit = 1;
+                    server.stat_expired_time_cap_reached_count++;
+                    break;
                 }
             }
         } while (repeat);


### PR DESCRIPTION
When we introduced the new Hash fields expiration functionality,
we decided to combine the current active expiration job between generic keys and hash fields.
During that job we run a tight loop. In each loop iteration we scan over maximum of 20 keys (with default expire effort)  and try to "expire" them.
For hash fields expiration job, the "expire" of a hash key, means expiring maximum of 80 fields (with default expire effort).
The problem is that we might do much more work per each iteration of hash fields expiration job.
The current code is shared between the 2 jobs, and currently we only perform time check every 16 iterations.
as a result the CPU of fields active expiration can spike and consume much higher CPU% than the current 25% bound allows.

Example:

Before this PR

| Scenario                                           | AVG CPU | Time to expire all fields |
|----------------------------------------------------|---------|---------------------------|
| Expiring 10M volatile fields from a single hash    | 20.18%  | 26 seconds                |
| Expiring 10M volatile fields from 10K hash objects | 32.72%  | 7 seconds                 |


After this PR
Scenario                                                                             | AVG CPU | Time to expire all fields 
| Scenario                                           | AVG CPU | Time to expire all fields |
|----------------------------------------------------|---------|---------------------------|
| Expiring 10M volatile fields from a single hash    | 20.23%.  | 26 seconds                |
| Expiring 10M volatile fields from 10K hash objects | 20.76%.   | 11 seconds                 |

*NOTE*
The change introduced here make the field job check the time every iteration. We offer compile time option to use efficient time check using TSC (X86) or VCR (ARM) on most modern CPU, so the impact is expected to be low. Still, in order to avoid degradation for existing workloads, the code change was made so it will not impact the existing generic keys active expiration job.
 
