### PR TITLE
Evict client only when limit is breached

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -6329,7 +6329,7 @@ void evictClients(void) {
     listRewind(server.client_mem_usage_buckets[curr_bucket].clients, &bucket_iter);
     size_t client_eviction_limit = getClientEvictionLimit();
     if (client_eviction_limit == 0) return;
-    while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] + server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >=
+    while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] + server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >
            client_eviction_limit) {
         listNode *ln = listNext(&bucket_iter);
         if (ln) {


### PR DESCRIPTION
I believe we should evict the clients when the client eviction limit is breached instead of _at_ the breach. I came across this function in the failed [daily test](https://github.com/valkey-io/valkey/actions/runs/17521272806/job/49765359298#step:6:7770), which could possibly be related.