### PR TITLE
Defer slot migration failover until async modules are consistent

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -14,8 +14,9 @@ typedef enum slotMigrationJobState {
     SLOT_IMPORT_WAIT_ACK,
     SLOT_IMPORT_RECEIVE_SNAPSHOT,
     SLOT_IMPORT_WAITING_FOR_PAUSED,
+    SLOT_IMPORT_WAITING_FOR_MODULES,
     SLOT_IMPORT_FAILOVER_REQUESTED,
-    SLOT_IMPORT_FAILOVER_GRANTED,
+    SLOT_IMPORT_WAITING_TO_FAILOVER,
     SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP,
 
     /* Exporting states */
@@ -76,6 +77,15 @@ typedef struct slotMigrationJob {
                                                * cleanup is done. */
     sds description;                          /* Description, used for
                                                * logging. */
+    mstime_t current_lag;                     /* Current estimated lag between
+                                               * source and target */
+    bool awaiting_lag_response;               /* True if we are currently
+                                                 waiting for a response to a
+                                                 GET-LAG command.*/
+
+    moduleAsyncProcessingReport *paused_module_report; /* Mapping of module to offset
+                                                        * accepted by that module when
+                                                        * we got the PAUSED command. */
 
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
@@ -92,7 +102,7 @@ static int connectSlotExportJob(slotMigrationJob *job);
 static const char *slotMigrationJobStateToString(slotMigrationJobState state);
 static void updateSlotMigrationJobState(slotMigrationJob *job,
                                         slotMigrationJobState state);
-static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
+static void sendSyncSlotsMessage(slotMigrationJob *job, ...);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
                                              list *slot_ranges);
@@ -373,13 +383,17 @@ void fireModuleSlotMigrationEvent(slotMigrationJob *job, int subevent) {
  *         │SLOT_IMPORT_WAITING_FOR_PAUSED┼─┤
  *         └───────────────┬──────────────┘ │
  *                   PAUSED│                │
+ *        ┌────────────────▼──────────────┐ │
+ *        │SLOT_IMPORT_WAITING_FOR_MODULES┼─┤
+ *        └────────────────┬──────────────┘ │
+ *    Modules all caught up│                │
  *         ┌───────────────▼──────────────┐ │ Error Conditions:
  *         │SLOT_IMPORT_FAILOVER_REQUESTED┼─┤  1. OOM
  *         └───────────────┬──────────────┘ │  2. Slot Ownership Change
  *         FAILOVER-GRANTED│                │  3. Demotion to replica
- *          ┌──────────────▼─────────────┐  │  4. FLUSHDB
- *          │SLOT_IMPORT_FAILOVER_GRANTED┼──┤  5. Connection Lost
- *          └──────────────┬─────────────┘  │  6. No ACK from source (timeout)
+ *       ┌─────────────────▼─────────────┐  │  4. FLUSHDB
+ *       │SLOT_IMPORT_WAITING_TO_FAILOVER┼──┤  5. Connection Lost
+ *       └─────────────────┬─────────────┘  │  6. No ACK from source (timeout)
  *       Takeover Performed│                │
  *          ┌──────────────▼───────────┐    │
  *          │SLOT_MIGRATION_JOB_SUCCESS┼──-─┤
@@ -453,7 +467,7 @@ void clusterCommandSyncSlotsEstablish(client *c) {
                 addReplyErrorObject(c, shared.syntaxerr);
                 goto cleanup;
             }
-            source_node = clusterLookupNode(c->argv[4]->ptr, CLUSTER_NAMELEN);
+            source_node = clusterLookupNode(c->argv[i + 1]->ptr, CLUSTER_NAMELEN);
             if (!source_node) {
                 addReplyError(c, "Target node does not know the source node");
                 goto cleanup;
@@ -555,32 +569,108 @@ void clusterCommandSyncSlotsSnapshotEof(client *c) {
               "Slot migration %s successfully received slot snapshot. "
               "Beginning incremental stream...",
               c->slot_migration_job->description);
-    sendSyncSlotsMessage(c->slot_migration_job, "REQUEST-PAUSE");
+    sendSyncSlotsMessage(c->slot_migration_job, "REQUEST-PAUSE", NULL);
     updateSlotMigrationJobState(c->slot_migration_job,
                                 SLOT_IMPORT_WAITING_FOR_PAUSED);
 }
 
+/* Sent by the source to the target to retrieve the current processing lag for
+ * newly enqueued commands on this connection.
+ *
+ * Since the source is pipelining lots of commands to the target, the rate at
+ * which it processes them can vary widely. By inserting the GET-LAG command, we
+ * have a marker that we can use to measure the end-to-end latency before
+ * continuing with the failover. */
+void clusterCommandSyncSlotsGetLag(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS GET-LAG should only be used "
+                         "by slot migration clients");
+        return;
+    }
+    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
+    if (job->type != SLOT_MIGRATION_IMPORT) {
+        serverLog(LL_WARNING,
+                  "Received CLUSTER SYNCSLOTS GET-LAG on exporting migration %s",
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS GET-LAG command");
+        return;
+    }
+    if (c->argc < 4) {
+        serverAssert(false);
+        serverLog(LL_WARNING,
+                  "Received malformatted SYNCSLOTS GET-LAG command on %s: "
+                  "No time argument provided",
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS GET-LAG command");
+        return;
+    }
+    /* Calculate the current lag */
+    mstime_t time;
+    if (getLongLongFromObject(c->argv[3], &time) != C_OK) {
+        serverLog(LL_WARNING,
+                  "Received malformatted SYNCSLOTS GET-LAG command on %s: "
+                  "Time argument is not an integer: %s",
+                  job->description, (sds)c->argv[3]->ptr);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS GET-LAG command");
+        return;
+    }
+    mstime_t local_time = mstime();
+    if (local_time > time) {
+        job->current_lag = mstime() - time;
+    } else {
+        job->current_lag = 0;
+    }
+
+    /* Add on any module processing lag */
+    moduleAsyncProcessingReport *report = moduleGenerateAsyncProcessingReport();
+    if (report) {
+        job->current_lag += report->maximum_lag;
+        moduleReleaseAsyncProcessingReport(report);
+    }
+
+    /* Report the lag to the source */
+    char buf[LONG_STR_SIZE];
+    ll2string(buf, sizeof(buf), job->current_lag);
+    sendSyncSlotsMessage(job, "LAG", buf, NULL);
+}
+
+
 /* Sent by the source to the target as a marker of when the pause
  * began (therefore, target is caught up once read). */
 void clusterCommandSyncSlotsPaused(client *c) {
-    if (!c->slot_migration_job) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
         addReplyError(c, "CLUSTER SYNCSLOTS PAUSED should only be used by slot "
                          "migration clients");
         return;
     }
-    serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
-    if (c->slot_migration_job->state != SLOT_IMPORT_WAITING_FOR_PAUSED) {
+    serverAssert(isSlotMigrationJobInProgress(job));
+    if (job->state != SLOT_IMPORT_WAITING_FOR_PAUSED) {
         serverLog(LL_WARNING,
                   "Received unexpected CLUSTER SYNCSLOTS PAUSED from slot "
-                  "migration %s, . Failing migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
+                  "migration %s. Failing migration.",
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                "Unexpected state machine transition");
         return;
     }
-    sendSyncSlotsMessage(c->slot_migration_job, "REQUEST-FAILOVER");
-    updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_IMPORT_FAILOVER_REQUESTED);
+
+    /* Check if any modules need to acknowledge the in-flight writes. Some
+     * modules may be configured for asynchronous processing of these changes.*/
+    job->paused_module_report = moduleGenerateAsyncProcessingReport();
+    if (job->paused_module_report &&
+        !modulesAllAppliedPreviouslyAcceptedOffset(job->paused_module_report,
+                                                   job->paused_module_report)) {
+        updateSlotMigrationJobState(job, SLOT_IMPORT_WAITING_FOR_MODULES);
+        return;
+    }
+    moduleReleaseAsyncProcessingReport(job->paused_module_report);
+    sendSyncSlotsMessage(job, "REQUEST-FAILOVER", NULL);
+    updateSlotMigrationJobState(job, SLOT_IMPORT_FAILOVER_REQUESTED);
 }
 
 /* Sent by the source to the target to grant final authorization for
@@ -603,7 +693,7 @@ void clusterCommandSyncSlotsFailoverGranted(client *c) {
         return;
     }
     updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_IMPORT_FAILOVER_GRANTED);
+                                SLOT_IMPORT_WAITING_TO_FAILOVER);
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 }
 
@@ -625,6 +715,7 @@ slotMigrationJob *createSlotImportJob(client *c,
     job->client = c;
     job->client->slot_migration_job = job;
     job->description = generateSlotMigrationJobDescription(job, source_node);
+    job->current_lag = -1;
 
     /* We treat slot imports like primaries. Primaries are expected to have a
      * dedicated query buffer and allocated replication data. */
@@ -1152,60 +1243,128 @@ void slotExportBeginStreaming(slotMigrationJob *job) {
               job->description);
 }
 
+/* Enqueue a GET-LAG command with the current time and track that we are waiting
+ * for a response. */
+void slotExportRequestLag(slotMigrationJob *job) {
+    char buf[LONG_STR_SIZE];
+    ll2string(buf, sizeof(buf), mstime());
+    sendSyncSlotsMessage(job, "GET-LAG", buf, NULL);
+    job->awaiting_lag_response = true;
+}
+
 /* Attempt to pause the provided slot export job. If we can pause, the state
  * will be updated to SLOT_EXPORT_FAILOVER_PAUSED and the PAUSED subcommand is
  * sent to the target. Otherwise, there is no effect. */
 int slotExportTryDoPause(slotMigrationJob *job) {
-    serverAssert(job->type == SLOT_MIGRATION_EXPORT);
+    if (server.debug_slot_migration_prevent_pause) return C_ERR;
 
-    if (server.debug_slot_migration_prevent_pause ||
-        (server.slot_migration_max_failover_repl_bytes >= 0 &&
-         getClientOutputBufferMemoryUsage(job->client) >
-             (size_t)server.slot_migration_max_failover_repl_bytes)) {
+    /* If there is no lag indicator, we need to get one */
+    if (job->current_lag == -1) {
+        slotExportRequestLag(job);
         return C_ERR;
     }
+
+    /* If there is a lag indicator, use it to determine if we can failover */
+    if (server.slot_migration_max_lag_for_failover >= 0 &&
+        job->current_lag > server.slot_migration_max_lag_for_failover) {
+        run_with_period(5000) {
+            serverLog(LL_NOTICE,
+                      "Waiting for slot migration to have lag less than %lld. "
+                      "Current lag is %lld for migration %s",
+                      server.slot_migration_max_lag_for_failover,
+                      job->current_lag,
+                      job->description);
+        }
+        /* Request a lag indicator only if we don't already have one outbound */
+        if (!job->awaiting_lag_response) slotExportRequestLag(job);
+        return C_ERR;
+    }
+
+    /* Lag is okay, we can continue */
     serverLog(LL_NOTICE,
               "Pausing writes to allow slot migration %s to finalize failover.",
               job->description);
     job->mf_end = mstime() + server.cluster_mf_timeout * CLUSTER_MF_PAUSE_MULT;
     pauseActions(PAUSE_DURING_SLOT_MIGRATION, job->mf_end,
                  PAUSE_ACTIONS_CLIENT_WRITE_SET);
-    sendSyncSlotsMessage(job, "PAUSED");
+    sendSyncSlotsMessage(job, "PAUSED", NULL);
     return C_OK;
 }
 
-/* Sent by the target to the source to pause writes to the slot for slot
- * failover. */
-void clusterCommandSyncSlotsRequestPause(client *c) {
-    if (!c->slot_migration_job) {
-        addReplyError(c, "CLUSTER SYNCSLOTS REQUEST-PAUSE should only be used "
+/* Sent by the target to the source as a response to a previous GET-LAG request.
+ * The source uses the lag to inform when it is ready to proceed with failover.
+ */
+void clusterCommandSyncSlotsLag(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS LAG should only be used "
                          "by slot migration clients");
         return;
     }
     serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
-    /* Child process may not have closed yet, so SNAPSHOTTING is okay here */
-    if (c->slot_migration_job->state != SLOT_EXPORT_STREAMING &&
-        c->slot_migration_job->state != SLOT_EXPORT_SNAPSHOTTING) {
+    if (job->type != SLOT_MIGRATION_EXPORT) {
+        serverLog(LL_WARNING,
+                  "Received CLUSTER SYNCSLOTS LAG on importing migration %s",
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS LAG command");
+        return;
+    }
+    if (c->argc < 4) {
+        serverLog(LL_WARNING,
+                  "Received malformatted SYNCSLOTS LAG command on %s: "
+                  "No lag argument provided",
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS LAG command");
+        return;
+    }
+    /* Extract the current lag */
+    mstime_t lag;
+    if (getLongLongFromObject(c->argv[3], &lag) != C_OK) {
+        serverLog(LL_WARNING,
+                  "Received malformatted SYNCSLOTS LAG command on %s: "
+                  "Lag argument is not an integer: %s",
+                  job->description, (sds)c->argv[3]->ptr);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
+                               "Received invalid SYNCSLOTS LAG command");
+        return;
+    }
+    job->current_lag = lag;
+    job->awaiting_lag_response = false;
+
+    /* Check before sleep if we can now pause */
+    clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
+}
+
+
+/* Sent by the target to the source to pause writes to the slot for slot
+ * failover. */
+void clusterCommandSyncSlotsRequestPause(client *c) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
+        addReplyError(c, "CLUSTER SYNCSLOTS REQUEST-PAUSE should only be used "
+                         "by slot migration clients");
+        return;
+    }
+    serverAssert(isSlotMigrationJobInProgress(job));
+    /* Child process may not have closed yet, so SNAPSHOTTING state is okay here */
+    if (job->state != SLOT_EXPORT_STREAMING && job->state != SLOT_EXPORT_SNAPSHOTTING) {
         serverLog(LL_WARNING,
                   "Received CLUSTER SYNCSLOTS REQUEST-PAUSE for slot migration "
                   "%s, but the client was not streaming incremental updates. "
                   "Failing migration.",
-                  c->slot_migration_job->description);
-        finishSlotMigrationJob(c->slot_migration_job, SLOT_MIGRATION_JOB_FAILED,
+                  job->description);
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                "Unexpected state machine transition");
         return;
     }
-    if (c->slot_migration_job->state != SLOT_EXPORT_STREAMING) {
-        slotExportBeginStreaming(c->slot_migration_job);
+    if (job->state != SLOT_EXPORT_STREAMING) {
+        slotExportBeginStreaming(job);
     }
 
-    if (slotExportTryDoPause(c->slot_migration_job) == C_ERR) {
-        updateSlotMigrationJobState(c->slot_migration_job,
-                                    SLOT_EXPORT_WAITING_TO_PAUSE);
-        return;
-    }
-    updateSlotMigrationJobState(c->slot_migration_job,
-                                SLOT_EXPORT_FAILOVER_PAUSED);
+    updateSlotMigrationJobState(job, SLOT_EXPORT_WAITING_TO_PAUSE);
+    proceedWithSlotMigration(job);
 }
 
 /* Sent by the target to the source to request final authorization for
@@ -1251,7 +1410,7 @@ void clusterCommandSyncSlotsRequestFailover(client *c) {
                      PAUSE_ACTIONS_CLIENT_WRITE_SET);
     }
 
-    sendSyncSlotsMessage(c->slot_migration_job, "FAILOVER-GRANTED");
+    sendSyncSlotsMessage(c->slot_migration_job, "FAILOVER-GRANTED", NULL);
     updateSlotMigrationJobState(c->slot_migration_job,
                                 SLOT_EXPORT_FAILOVER_GRANTED);
 }
@@ -1501,6 +1660,7 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
+    job->current_lag = -1;
     return job;
 }
 
@@ -1559,7 +1719,7 @@ void slotMigrationJobReadEstablishResponse(connection *conn) {
 
     /* We need to send an ACK to take the import out of WAIT_ACK state. This
      * will kickstart the health checks, effectively taking the job online. */
-    sendSyncSlotsMessage(job, "ACK");
+    sendSyncSlotsMessage(job, "ACK", NULL);
 
     sdsfree(job->response_buf);
     job->response_buf = NULL;
@@ -1590,19 +1750,34 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
         case SLOT_IMPORT_WAITING_FOR_PAUSED:
             /* Waiting for PAUSED marker */
             return;
+        case SLOT_IMPORT_WAITING_FOR_MODULES: {
+            moduleAsyncProcessingReport *current = moduleGenerateAsyncProcessingReport();
+            if (!modulesAllAppliedPreviouslyAcceptedOffset(job->paused_module_report, current)) {
+                run_with_period(5000) {
+                    serverLog(LL_NOTICE,
+                              "Waiting for all modules to process up until PAUSED offset "
+                              "before taking over slots for %s",
+                              job->description);
+                }
+                moduleReleaseAsyncProcessingReport(current);
+                return;
+            }
+            moduleReleaseAsyncProcessingReport(current);
+            moduleReleaseAsyncProcessingReport(job->paused_module_report);
+            sendSyncSlotsMessage(job, "REQUEST-FAILOVER", NULL);
+            updateSlotMigrationJobState(job, SLOT_IMPORT_FAILOVER_REQUESTED);
+        }
         case SLOT_IMPORT_FAILOVER_REQUESTED:
             /* Waiting for FAILOVER-GRANTED response */
             return;
-        case SLOT_IMPORT_FAILOVER_GRANTED:
-            if (!server.debug_slot_migration_prevent_failover) {
-                performSlotImportJobFailover(job);
+        case SLOT_IMPORT_WAITING_TO_FAILOVER:
+            if (server.debug_slot_migration_prevent_failover) return;
+            performSlotImportJobFailover(job);
 
-                serverLog(LL_NOTICE,
-                          "Slot migration %s completed successfully. "
-                          "This node is now the owner of the slots",
-                          job->description);
-                finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_SUCCESS, NULL);
-            }
+            serverLog(LL_NOTICE,
+                      "Slot migration %s completed successfully. This node is now the owner of the slots",
+                      job->description);
+            finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_SUCCESS, NULL);
             return;
         case SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP:
             delKeysNotOwnedByMyself(job->slot_ranges);
@@ -1700,9 +1875,10 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             /* Waiting for PAUSE command to come in */
             return;
         case SLOT_EXPORT_WAITING_TO_PAUSE:
-            if (slotExportTryDoPause(job) == C_OK) {
-                updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_PAUSED);
+            if (slotExportTryDoPause(job) == C_ERR) {
+                return;
             }
+            updateSlotMigrationJobState(job, SLOT_EXPORT_FAILOVER_PAUSED);
             return;
         case SLOT_EXPORT_FAILOVER_PAUSED:
             if (isSlotExportPauseTimedOut(job)) {
@@ -1808,8 +1984,9 @@ const char *slotMigrationJobStateToString(slotMigrationJobState state) {
     case SLOT_IMPORT_WAIT_ACK: return "waiting-for-ack";
     case SLOT_IMPORT_RECEIVE_SNAPSHOT: return "receiving-snapshot";
     case SLOT_IMPORT_WAITING_FOR_PAUSED: return "waiting-for-paused";
+    case SLOT_IMPORT_WAITING_FOR_MODULES: return "waiting-for-modules";
     case SLOT_IMPORT_FAILOVER_REQUESTED: return "failover-requested";
-    case SLOT_IMPORT_FAILOVER_GRANTED: return "failover-granted";
+    case SLOT_IMPORT_WAITING_TO_FAILOVER: return "waiting-to-failover";
     case SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP: return "cleaning-up";
 
     case SLOT_EXPORT_CONNECTING: return "connecting";
@@ -1820,7 +1997,7 @@ const char *slotMigrationJobStateToString(slotMigrationJobState state) {
         return "reading-establish-response";
     case SLOT_EXPORT_WAITING_TO_SNAPSHOT: return "waiting-to-snapshot";
     case SLOT_EXPORT_SNAPSHOTTING: return "snapshotting";
-    case SLOT_EXPORT_STREAMING: return "replicating";
+    case SLOT_EXPORT_STREAMING: return "streaming";
     case SLOT_EXPORT_WAITING_TO_PAUSE: return "waiting-to-pause";
     case SLOT_EXPORT_FAILOVER_PAUSED: return "failover-paused";
     case SLOT_EXPORT_FAILOVER_GRANTED: return "failover-granted";
@@ -2024,8 +2201,9 @@ void clusterCommandGetSlotMigrations(client *c) {
 }
 
 
-/* Helper function to send a SYNCSLOTS subcommand for the provided job. */
-void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand) {
+/* Helper function to send a SYNCSLOTS subcommand for the provided job. The
+ * provided variardic arguments should be castable to C strings. */
+void sendSyncSlotsMessage(slotMigrationJob *job, ...) {
     serverAssert(job->client);
     ClientFlags old_flags = job->client->flag;
     if (job->type == SLOT_MIGRATION_IMPORT) {
@@ -2033,10 +2211,19 @@ void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand) {
          * flag to bypass this. */
         job->client->flag.pushing = 1;
     }
-    addReplyArrayLen(job->client, 3);
+    void *len_node = addReplyDeferredLen(job->client);
     addReplyBulkCString(job->client, "CLUSTER");
     addReplyBulkCString(job->client, "SYNCSLOTS");
-    addReplyBulkCString(job->client, subcommand);
+    size_t len = 2;
+    va_list ap;
+    va_start(ap, job);
+    char *arg;
+    while ((arg = va_arg(ap, char *))) {
+        addReplyBulkCString(job->client, arg);
+        len++;
+    }
+    va_end(ap);
+    setDeferredArrayLen(job->client, len_node, len);
     if (!old_flags.pushing) job->client->flag.pushing = 0;
 }
 
@@ -2135,7 +2322,8 @@ void slotExportTryUnpause(void) {
 
 /* Sent by either the target or the source as a liveness check. */
 void clusterCommandSyncSlotsAck(client *c) {
-    if (!c->slot_migration_job) {
+    slotMigrationJob *job = c->slot_migration_job;
+    if (!job) {
         addReplyError(c,
                       "CLUSTER SYNCSLOTS ACK should only be used by slot "
                       "migration clients");
@@ -2164,6 +2352,12 @@ void clusterCommandSyncSlots(client *c) {
     } else if (!strcasecmp(c->argv[2]->ptr, "snapshot-eof")) {
         /* CLUSTER SYNCSLOTS SNAPSHOT-EOF */
         clusterCommandSyncSlotsSnapshotEof(c);
+    } else if (!strcasecmp(c->argv[2]->ptr, "get-lag")) {
+        /* CLUSTER SYNCSLOTS GET-LAG <mstime> */
+        clusterCommandSyncSlotsGetLag(c);
+    } else if (!strcasecmp(c->argv[2]->ptr, "lag")) {
+        /* CLUSTER SYNCSLOTS LAG <mslag> */
+        clusterCommandSyncSlotsLag(c);
     } else if (!strcasecmp(c->argv[2]->ptr, "request-pause")) {
         /* CLUSTER SYNCSLOTS REQUEST-PAUSE */
         clusterCommandSyncSlotsRequestPause(c);

--- a/src/config.c
+++ b/src/config.c
@@ -3371,6 +3371,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("repl-backlog-size", NULL, MODIFIABLE_CONFIG, 1, LLONG_MAX, server.repl_backlog_size, 10 * 1024 * 1024, MEMORY_CONFIG, NULL, updateReplBacklogSize), /* Default: 10mb */
     createLongLongConfig("cluster-manual-failover-timeout", NULL, MODIFIABLE_CONFIG, 1, INT_MAX, server.cluster_mf_timeout, 5000, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("slot-migration-max-lag-for-failover", NULL, MODIFIABLE_CONFIG, -1, INT_MAX, server.slot_migration_max_lag_for_failover, 1000, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned Long Long configs */
     createULongLongConfig("maxmemory", NULL, MODIFIABLE_CONFIG, 0, ULLONG_MAX, server.maxmemory, 0, MEMORY_CONFIG, NULL, updateMaxmemory),
@@ -3390,7 +3391,6 @@ standardConfig static_configs[] = {
     createSizeTConfig("tracking-table-max-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.tracking_table_max_keys, 1000000, INTEGER_CONFIG, NULL, NULL),                                      /* Default: 1 million keys max. */
     createSizeTConfig("client-query-buffer-limit", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024 * 1024, LONG_MAX, server.client_max_querybuf_len, 1024 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Default: 1GB max query buffer. */
     createSSizeTConfig("maxmemory-clients", NULL, MODIFIABLE_CONFIG, -100, SSIZE_MAX, server.maxmemory_clients, 0, MEMORY_CONFIG | PERCENT_CONFIG, NULL, applyClientMaxMemoryUsage),
-    createSSizeTConfig("slot-migration-max-failover-repl-bytes", NULL, MODIFIABLE_CONFIG, -1, SSIZE_MAX, server.slot_migration_max_failover_repl_bytes, 0, MEMORY_CONFIG, NULL, NULL),
 
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */

--- a/src/module.c
+++ b/src/module.c
@@ -503,6 +503,11 @@ typedef struct ValkeyModuleAsyncRMCallPromise {
     ValkeyModuleCtx *ctx;
 } ValkeyModuleAsyncRMCallPromise;
 
+struct ValkeyModuleAsyncProcessingStatusCtx {
+    struct ValkeyModule *module;
+    moduleAsyncProcessingReport *report;
+};
+
 /* --------------------------------------------------------------------------
  * Prototypes
  * -------------------------------------------------------------------------- */
@@ -13989,6 +13994,157 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+/* --------------------------------------------------------------------------
+ * ## Async Keyspace Processing Status API
+ * -------------------------------------------------------------------------- */
+
+/* Registers a callback for reporting asynchronous keyspace processing status.
+ * The callback should report on the processing status by calling the
+ * `ValkeyModule_ReportAsyncProcessing*()` functions.
+ *
+ * All modules that perform asynchronous work based on keyspace notifications or
+ * command execution should register progress functions if they wish to ensure
+ * that processing is not regressed during manual failovers and slot migrations.
+ */
+int VM_RegisterAsyncProcessingStatusFunc(ValkeyModuleCtx *ctx,
+                                         ValkeyModuleAsyncProcessingStatusFunc callback) {
+    if (!ctx->module) return VALKEYMODULE_ERR;
+    ctx->module->processing_cb = callback;
+    return VALKEYMODULE_OK;
+}
+
+/* Either create or return an existing moduleAsyncProcessingStatus for this
+ * context's module from the context's report. */
+moduleAsyncProcessingStatus *moduleAddOrFindAsyncProcessingStatus(ValkeyModuleAsyncProcessingStatusCtx *ctx) {
+    dictEntry *existing, *new;
+    new = dictAddRaw(ctx->report->module_to_processing_status, ctx->module->name, &existing);
+    if (!new) return dictGetVal(existing);
+    moduleAsyncProcessingStatus *status = zcalloc(sizeof(moduleAsyncProcessingStatus));
+    dictSetVal(ctx->report->module_to_processing_status, new, status);
+    return status;
+}
+
+/* Report an estimated number of milliseconds that new changes would take to be
+ * processed by this module.
+ *
+ * Modules may track this by periodically measuring how long new changes take to
+ * be processed. This indicator will allow the engine to estimate when it is
+ * safe to execute cross-node operations that require consistency, like manual
+ * failover and atomic slot migration.
+ *
+ * If no lag is reported, the lag is assumed to be zero.
+ */
+int VM_ReportAsyncProcessingLag(ValkeyModuleAsyncProcessingStatusCtx *ctx, long long current_lag_millis) {
+    moduleAsyncProcessingStatus *status = moduleAddOrFindAsyncProcessingStatus(ctx);
+    status->current_lag = current_lag_millis;
+    if (current_lag_millis > ctx->report->maximum_lag) ctx->report->maximum_lag = current_lag_millis;
+    return C_OK;
+}
+
+/* Report on the progress of the processing by indicating up to what change this
+ * module has accepted and what change this module has applied.
+ *
+ * The offset must adhere to the following characteristics:
+ *
+ *  1. Each change that needs to be processed by the module needs to increment
+ *     the accepted offset by at least one.
+ *  2. The applied offset must eventually converge to any previously reported
+ *     accepted offset.
+ *  3. If a module reports an accepted offset N at point in time T0, and at
+ *     time T1 reports an applied offset of N, then at time T1 the module must
+ *     have processed all changes up until time T0.
+ *
+ * Note that this offset does not need to be in any way comparable to the
+ * replication offset. The offset is only used in comparison to previously
+ * reported offsets, for example to ensure the module has fully caught up during
+ * operations that require consistency like manual failover and atomic slot
+ * migration.
+ *
+ * As an example, a module may increment the accepted offset by one whenever a
+ * change is reported by the engine, and increment the applied offset by one
+ * whenever a change is processed by the module.
+ *
+ * If no offsets are reported, the module is assumed to be fully caught up to
+ * the current state of the keyspace.
+ */
+int VM_ReportAsyncProcessingOffset(ValkeyModuleAsyncProcessingStatusCtx *ctx,
+                                   uint64_t accepted_offset,
+                                   uint64_t applied_offset) {
+    moduleAsyncProcessingStatus *status = moduleAddOrFindAsyncProcessingStatus(ctx);
+    status->accepted_offset = accepted_offset;
+    status->applied_offset = applied_offset;
+    return C_OK;
+}
+
+/* Returns a combined view of all module's current processing status, for all
+ * modules that are loaded and have set a processing status callback.
+ *
+ * The returned value should be freed with moduleReleaseAsyncProcessingReport
+ */
+moduleAsyncProcessingReport *moduleGenerateAsyncProcessingReport(void) {
+    dictIterator *di = dictGetIterator(modules);
+    dictEntry *de;
+    moduleAsyncProcessingReport *result = NULL;
+
+    while ((de = dictNext(di)) != NULL) {
+        struct ValkeyModule *module = dictGetVal(de);
+        if (!module->processing_cb) continue;
+        if (!result) {
+            result = zcalloc(sizeof(moduleAsyncProcessingReport));
+            result->module_to_processing_status = dictCreate(&sdsHashDictType);
+        }
+        ValkeyModuleAsyncProcessingStatusCtx processing_ctx = {module, result};
+        module->processing_cb(&processing_ctx);
+    }
+    dictReleaseIterator(di);
+
+    return result;
+}
+
+/* Release a previously retrieved moduleCombinedProcessingStatus. */
+void moduleReleaseAsyncProcessingReport(moduleAsyncProcessingReport *status) {
+    if (!status) return;
+    if (status->module_to_processing_status) dictRelease(status->module_to_processing_status);
+    zfree(status);
+}
+
+/* Determine if all modules have caught up to the accepted offsets in a
+ * previously generated moduleAsyncProcessingReport.
+ *
+ * Any modules that do not currently have processing callbacks or that do not
+ * report an offset in their processing callback will be skipped. Any modules
+ * not present in the previous report are skipped.
+ *
+ * This can be used to ensure modules have caught up to a point in time by:
+ *
+ *   1. Generating a processing report at time T0 and storing it somewhere
+ *   2. Polling this function with the saved report and the current report
+ *
+ * Using this pattern, when this function returns true, we know all mutations
+ * up until time T0 have been processed by all modules. */
+bool modulesAllAppliedPreviouslyAcceptedOffset(moduleAsyncProcessingReport *previous_status,
+                                               moduleAsyncProcessingReport *current_status) {
+    dictIterator *di = dictGetIterator(previous_status->module_to_processing_status);
+    dictEntry *prev_entry;
+    dictEntry *curr_entry;
+
+    bool result = true;
+    while ((prev_entry = dictNext(di)) != NULL) {
+        char *module_name = dictGetKey(prev_entry);
+        moduleAsyncProcessingStatus *prev_status = dictGetVal(prev_entry);
+        if ((curr_entry = dictFind(current_status->module_to_processing_status, module_name))) {
+            moduleAsyncProcessingStatus *curr_status = dictGetVal(curr_entry);
+            if (curr_status->applied_offset < prev_status->accepted_offset) {
+                result = false;
+                break;
+            }
+        }
+    }
+
+    dictReleaseIterator(di);
+    return result;
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -14357,4 +14513,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RegisterScriptingEngine);
     REGISTER_API(UnregisterScriptingEngine);
     REGISTER_API(GetFunctionExecutionState);
+    REGISTER_API(RegisterAsyncProcessingStatusFunc);
+    REGISTER_API(ReportAsyncProcessingLag);
+    REGISTER_API(ReportAsyncProcessingOffset);
 }

--- a/src/module.h
+++ b/src/module.h
@@ -95,28 +95,42 @@ typedef struct moduleValue {
     void *value;
 } moduleValue;
 
+/* Current processing status, for modules that have asynchronous keyspace
+ * processing. */
+typedef struct moduleAsyncProcessingStatus {
+    mstime_t current_lag;
+    uint64_t accepted_offset;
+    uint64_t applied_offset;
+} moduleAsyncProcessingStatus;
+
+typedef struct moduleAsyncProcessingReport {
+    dict *module_to_processing_status; /* Dictionary from module name to moduleAsyncProcessingStatus */
+    mstime_t maximum_lag;
+} moduleAsyncProcessingReport;
+
 /* This structure represents a module inside the system. */
 typedef struct ValkeyModule {
-    void *handle;                         /* Module dlopen() handle. */
-    char *name;                           /* Module name. */
-    int ver;                              /* Module version. We use just progressive integers. */
-    int apiver;                           /* Module API version as requested during initialization.*/
-    list *types;                          /* Module data types. */
-    list *usedby;                         /* List of modules using APIs from this one. */
-    list *using;                          /* List of modules we use some APIs of. */
-    list *filters;                        /* List of filters the module has registered. */
-    list *module_configs;                 /* List of configurations the module has registered */
-    int configs_initialized;              /* Have the module configurations been initialized? */
-    int in_call;                          /* RM_Call() nesting level */
-    int in_hook;                          /* Hooks callback nesting level for this module (0 or 1). */
-    int options;                          /* Module options and capabilities. */
-    int blocked_clients;                  /* Count of ValkeyModuleBlockedClient in this module. */
-    ValkeyModuleInfoFunc info_cb;         /* Callback for module to add INFO fields. */
-    ValkeyModuleDefragFunc defrag_cb;     /* Callback for global data defrag. */
-    struct moduleLoadQueueEntry *loadmod; /* Module load arguments for config rewrite. */
-    int num_commands_with_acl_categories; /* Number of commands in this module included in acl categories */
-    int onload;                           /* Flag to identify if the call is being made from Onload (0 or 1) */
-    size_t num_acl_categories_added;      /* Number of acl categories added by this module. */
+    void *handle;                                        /* Module dlopen() handle. */
+    char *name;                                          /* Module name. */
+    int ver;                                             /* Module version. We use just progressive integers. */
+    int apiver;                                          /* Module API version as requested during initialization.*/
+    list *types;                                         /* Module data types. */
+    list *usedby;                                        /* List of modules using APIs from this one. */
+    list *using;                                         /* List of modules we use some APIs of. */
+    list *filters;                                       /* List of filters the module has registered. */
+    list *module_configs;                                /* List of configurations the module has registered */
+    int configs_initialized;                             /* Have the module configurations been initialized? */
+    int in_call;                                         /* RM_Call() nesting level */
+    int in_hook;                                         /* Hooks callback nesting level for this module (0 or 1). */
+    int options;                                         /* Module options and capabilities. */
+    int blocked_clients;                                 /* Count of ValkeyModuleBlockedClient in this module. */
+    ValkeyModuleInfoFunc info_cb;                        /* Callback for module to add INFO fields. */
+    ValkeyModuleDefragFunc defrag_cb;                    /* Callback for global data defrag. */
+    ValkeyModuleAsyncProcessingStatusFunc processing_cb; /* Callback for asynchronous keyspace processing status. */
+    struct moduleLoadQueueEntry *loadmod;                /* Module load arguments for config rewrite. */
+    int num_commands_with_acl_categories;                /* Number of commands in this module included in acl categories */
+    int onload;                                          /* Flag to identify if the call is being made from Onload (0 or 1) */
+    size_t num_acl_categories_added;                     /* Number of acl categories added by this module. */
 } ValkeyModule;
 
 /* This is a wrapper for the 'rio' streams used inside rdb.c in the server, so that
@@ -232,5 +246,9 @@ int moduleIsModuleCommand(void *module_handle, struct serverCommand *cmd);
 void freeClientModuleData(client *c);
 int checkModuleAuthentication(client *c, robj *username, robj *password, robj **err);
 void moduleFireAuthenticationEvent(uint64_t client_id, const char *username, const char *module_name, int is_granted);
+moduleAsyncProcessingReport *moduleGenerateAsyncProcessingReport(void);
+void moduleReleaseAsyncProcessingReport(moduleAsyncProcessingReport *status);
+bool modulesAllAppliedPreviouslyAcceptedOffset(moduleAsyncProcessingReport *previous_status,
+                                               moduleAsyncProcessingReport *current_status);
 
 #endif /* _MODULE_H_ */

--- a/src/server.h
+++ b/src/server.h
@@ -2215,8 +2215,9 @@ struct valkeyServer {
     unsigned long cluster_slot_migration_log_max_len;      /* Maximum count of migrations to display in the
                                                             * migration log, after which we will clear finished
                                                             * migrations. */
-    ssize_t slot_migration_max_failover_repl_bytes;        /* Maximum amount of in flight bytes for a slot migration
-                                                            * failover to be attempted. */
+    mstime_t slot_migration_max_lag_for_failover;          /* Maximum amount of acceptible lag between
+                                                            * source and target for a slot migration to
+                                                            * begin failover. */
     /* Debug config that goes along with cluster_drop_packet_filter. When set, the link is closed on packet drop. */
     uint32_t debug_cluster_close_link_on_packet_drop : 1;
     /* Debug config to control the random ping. When set, we will disable the random ping in clusterCron. */

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -538,6 +538,7 @@ typedef struct ValkeyModuleEvent {
 
 struct ValkeyModuleCtx;
 struct ValkeyModuleDefragCtx;
+struct ValkeyModuleAsyncProcessingStatusCtx;
 typedef void (*ValkeyModuleEventCallback)(struct ValkeyModuleCtx *ctx,
                                           ValkeyModuleEvent eid,
                                           uint64_t subevent,
@@ -850,11 +851,13 @@ typedef struct ValkeyModuleIO ValkeyModuleIO;
 typedef struct ValkeyModuleDigest ValkeyModuleDigest;
 typedef struct ValkeyModuleInfoCtx ValkeyModuleInfoCtx;
 typedef struct ValkeyModuleDefragCtx ValkeyModuleDefragCtx;
+typedef struct ValkeyModuleAsyncProcessingStatusCtx ValkeyModuleAsyncProcessingStatusCtx;
 
 /* Function pointers needed by both the core and modules, these needs to be
  * exposed since you can't cast a function pointer to (void *). */
 typedef void (*ValkeyModuleInfoFunc)(ValkeyModuleInfoCtx *ctx, int for_crash_report);
 typedef void (*ValkeyModuleDefragFunc)(ValkeyModuleDefragCtx *ctx);
+typedef void (*ValkeyModuleAsyncProcessingStatusFunc)(ValkeyModuleAsyncProcessingStatusCtx *ctx);
 typedef void (*ValkeyModuleUserChangedFunc)(uint64_t client_id, void *privdata);
 
 /* Type definitions for implementing scripting engines modules. */
@@ -1955,6 +1958,13 @@ VALKEYMODULE_API int (*ValkeyModule_UnregisterScriptingEngine)(ValkeyModuleCtx *
 
 VALKEYMODULE_API ValkeyModuleScriptingEngineExecutionState (*ValkeyModule_GetFunctionExecutionState)(ValkeyModuleScriptingEngineServerRuntimeCtx *server_ctx) VALKEYMODULE_ATTR;
 
+VALKEYMODULE_API void (*ValkeyModule_RegisterAsyncProcessingStatusFunc)(ValkeyModuleAsyncProcessingStatusFunc func) VALKEYMODULE_ATTR;
+
+VALKEYMODULE_API void (*ValkeyModule_ReportAsyncProcessingLag)(ValkeyModuleAsyncProcessingStatusCtx *ctx, long long current_lag_millis) VALKEYMODULE_ATTR;
+
+VALKEYMODULE_API void (*ValkeyModule_ReportAsyncProcessingOffset)(ValkeyModuleAsyncProcessingStatusCtx *ctx, uint64_t accepted_offset, uint64_t applied_offset) VALKEYMODULE_ATTR;
+
+
 #define ValkeyModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
 /* This is included inline inside each Valkey module. */
@@ -2326,6 +2336,9 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(RegisterScriptingEngine);
     VALKEYMODULE_GET_API(UnregisterScriptingEngine);
     VALKEYMODULE_GET_API(GetFunctionExecutionState);
+    VALKEYMODULE_GET_API(RegisterAsyncProcessingStatusFunc);
+    VALKEYMODULE_GET_API(ReportAsyncProcessingLag);
+    VALKEYMODULE_GET_API(ReportAsyncProcessingOffset);
 
     if (ValkeyModule_IsModuleNameBusy && ValkeyModule_IsModuleNameBusy(name)) return VALKEYMODULE_ERR;
     ValkeyModule_SetModuleAttribs(ctx, name, ver, apiver);


### PR DESCRIPTION
### **Summary**

**Problem:** Modules that perform asynchronous processing (e.g., [Valkey-search](https://github.com/valkey-io/valkey-search/)) can experience "read-your-own-write" consistency regressions during atomic slot migrations. The engine currently has no awareness of module-specific processing backlogs and can transfer slot ownership before an async module on the target node has fully processed all incoming writes, leading to data inconsistencies.

**Solution:** This PR introduces a synchronization mechanism that makes slot migration "module-aware." It defers the final `REQUEST-FAILOVER` step until all registered asynchronous modules on the target node certify they are fully consistent with the data state *at the moment the source node pauses*.

This is achieved through three core changes:

1. **New Module APIs** for modules to report their async processing status (offsets and time-based lag).  
2. **A pre-pause "Lag Probing" loop** where the source queries the target's total end-to-end lag (network + module lag) to intelligently decide *when* to pause.  
3. **A post-pause "Module Wait" period** on the target node to ensure all modules have processed data up to the pause-time checkpoint before committing the failover.

### **1. New Module APIs**

Three new module APIs are introduced to allow the engine to query the state of a module's asynchronous processing pipeline:

* `VM_RegisterAsyncProcessingStatusFunc(ValkeyModuleCtx *ctx, ValkeyModuleAsyncProcessingStatusFunc callback)` 

Modules register this callback (at most one) for the engine to poll their status. Within this callback, modules must use the following two reporting functions.  

* `VM_ReportAsyncProcessingOffset(ValkeyModuleAsyncProcessingStatusCtx *ctx, uint64_t accepted_offset, uint64_t applied_offset) ` 

Reports the module's "point-in-time" data consistency. Modules define their own offset scheme. This allows the engine to know when `applied` (fully processed) data has caught up to the last `accepted` (queued) data at a specific moment (i.e., the pause).

We don't have a canonical offset that we can use, since the engine's replication offset is only tracked when we are doing replication. Hence why modules are left to devise their own offset scheme.

* `VM_ReportAsyncProcessingLag(ValkeyModuleAsyncProcessingStatusCtx *ctx, long long current_lag_millis)`  

Reports an estimate (in milliseconds) of the module's current processing backlog. This is used by the source node to calculate the total end-to-end lag before initiating a pause.

### **2. Migration Change: Pre-Pause Lag Probing (Source Node)**

This change replaces the source node's reliance on its output buffer size as the trigger for pausing. The output buffer is blind to the module-processing backlog on the target, which could lead to pause timeouts.

We now use an active lag-probing system based on two new `SYNCSLOTS` commands:

* `SYNCSLOTS GET-LAG <mstime>`: Sent from source to target to request a lag report.  
* `SYNCSLOTS LAG <millis>`: Sent from target to source with the total calculated lag.

**Flow:**

1. Before pausing, the source enters a probing loop, sending `SYNCSLOTS GET-LAG`.  
2. The target receives this, calculates network lag (using the source `<mstime>`), and then polls its local async modules (via the new APIs) to get the maximum `module_lag_millis`.  
3. The target responds with `SYNCSLOTS LAG <total_ms>`, where `total_ms` is the sum of network and module lag.  
4. The source node will only proceed to the PAUSED state *after* this reported `total_ms` drops below a configurable threshold (default: 1 second). This ensures the target is reasonably "ready" for the final synchronization.

### **3. Migration Change: Post-Pause Module Wait (Target Node)**

This is the core consistency guarantee. Simply having low lag before the pause is not enough; we must ensure modules on the target process every write that occurred *before* the pause.

However, the target node may still be processing writes for other, non-importing slots, so we cannot simply "wait for all activity to stop." Instead, we use the new offset APIs to create a precise synchronization barrier:

1. When the target node receives SYNCSLOTS PAUSED, it immediately polls all registered modules and **records their `current accepted_offset`**. This value creates a "checkpoint" representing the exact state of each module's queue at the moment of the pause.  
2. The target node **delays sending SYNCSLOTS REQUEST-FAILOVER**.  
3. It enters an internal polling loop (via serverCron) to continuously check module status.  
4. **Only when all modules report an `applied_offset` that is equal to (or greater than) their recorded `accepted_offset` checkpoint** does the target proceed.  
5. Once this condition is met, the target is guaranteed to be fully consistent with the source's state at the pause. It then confidently sends `SYNCSLOTS REQUEST-FAILOVER` to finalize the migration.

### **New Sequence Diagram**

```
Source                                          Target  
|                                                |  
|------------ SYNCSLOTS ESTABLISH -------------->|  
|                                                |  
|<-------------------- +OK ----------------------|  
|                                                |  
|~~~~~~~~~~~~~~ snapshot as AOF ~~~~~~~~~~~~~~~~>|  
|                                                |  
|----------- SYNCSLOTS SNAPSHOT-EOF ------------>|  
|                                                |  
|~~~~~~~~~~~~ incremental changes ~~~~~~~~~~~~~~>| (Begins and continues throughout)  
|                                                |  
|                                                |  
|========== BEGIN LAG PROBING LOOP ==============|  
|                                                |  
|------------ SYNCSLOTS GET-LAG ---------------->| (Source probes readiness)  
|                                                |  
|                                       (Target calculates network lag +  
|                                        polls local modules for module_lag_ms)  
|                                                |  
|<--------------- SYNCSLOTS LAG <total_ms> ------|  
|                                                |  
|...   (Repeat until total_ms < threshold)    ...|  
|                                                |  
|========== END LAG PROBING LOOP ================|  
|                                                |  
|                                                |  
|--------------- SYNCSLOTS PAUSED -------------->| (Sent after source sees low lag)  
|                                                |  
|                                       (Target receives PAUSED,  
|                                        records current module 'accepted_offsets')  
|                                                |  
|                                       (Target waits... polls modules internally until  
|                                        all 'applied_offsets' == recorded 'accepted_offsets')  
|                                                |  
|<---------- SYNCSLOTS REQUEST-FAILOVER ---------| (Sent ONLY after modules are fully caught up)  
|                                                |  
|---------- SYNCSLOTS FAILOVER-GRANTED --------->|  
|                                                |  
|                                            (performs takeover &  
|                                             propagates topology)  
|                                                |  
(finds out about topology                        |  
change & marks migration done)                   |  
|                                                |  
```