### PR TITLE
Increase wait time condition for New Master down consecutively test

### DIFF
--- a/tests/unit/cluster/slave-selection.tcl
+++ b/tests/unit/cluster/slave-selection.tcl
@@ -186,7 +186,7 @@ test "New Master down consecutively" {
 
         set paused_pid [srv [expr $master_id * -1] pid]
         pause_process $paused_pid
-        wait_for_condition 1000 50 {
+        wait_for_condition 2000 50 {
             [master_detected $instances]
         } else {
             fail "No failover detected when master $master_id fails"


### PR DESCRIPTION
With #2604 merged, the `Node #10 should eventually replicate node #5` started passing successfully with valgrind, but I guess we are seeing a new daily [failure](https://github.com/valkey-io/valkey/actions/runs/17718547607/job/50346909032#step:6:12990) from a `New Master down consecutively` test that runs shortly after. 