### PR TITLE
[Backport 8.1] Fix accounting for dual channel RDB bytes in replication stats (#2602)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -11388,7 +11388,7 @@ int VM_Fork(ValkeyModuleForkDoneHandler cb, void *user_data) {
  * reported in INFO.
  * The `progress` argument should between 0 and 1, or -1 when not available. */
 void VM_SendChildHeartbeat(double progress) {
-    sendChildInfoGeneric(CHILD_INFO_TYPE_CURRENT_INFO, 0, progress, "Module fork");
+    sendChildInfoGeneric(CHILD_INFO_TYPE_CURRENT_INFO, 0, 0, progress, "Module fork");
 }
 
 /* Call from the child process when you want to terminate it.

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3652,6 +3652,9 @@ int rdbSaveToReplicasSockets(int req, rdbSaveInfo *rsi) {
 
         if (retval == C_OK) {
             sendChildCowInfo(CHILD_INFO_TYPE_RDB_COW_SIZE, "RDB");
+            if (!options.use_pipe) {
+                sendChildInfoGeneric(CHILD_INFO_TYPE_REPL_OUTPUT_BYTES, 0, rdb.processed_bytes, -1, "RDB");
+            }
         }
         if (dual_channel) {
             rioFreeConnset(&rdb);

--- a/src/server.c
+++ b/src/server.c
@@ -6603,11 +6603,11 @@ int serverFork(int purpose) {
 }
 
 void sendChildCowInfo(childInfoType info_type, char *pname) {
-    sendChildInfoGeneric(info_type, 0, -1, pname);
+    sendChildInfoGeneric(info_type, 0, 0, -1, pname);
 }
 
 void sendChildInfo(childInfoType info_type, size_t keys, char *pname) {
-    sendChildInfoGeneric(info_type, keys, -1, pname);
+    sendChildInfoGeneric(info_type, keys, 0, -1, pname);
 }
 
 /* Dismiss big chunks of memory inside a client structure, see zmadvise_dontneed() */

--- a/src/server.h
+++ b/src/server.h
@@ -1562,7 +1562,8 @@ typedef enum childInfoType {
     CHILD_INFO_TYPE_CURRENT_INFO,
     CHILD_INFO_TYPE_AOF_COW_SIZE,
     CHILD_INFO_TYPE_RDB_COW_SIZE,
-    CHILD_INFO_TYPE_MODULE_COW_SIZE
+    CHILD_INFO_TYPE_MODULE_COW_SIZE,
+    CHILD_INFO_TYPE_REPL_OUTPUT_BYTES
 } childInfoType;
 
 struct valkeyServer {
@@ -3008,7 +3009,7 @@ int aofRewriteLimited(void);
 /* Child info */
 void openChildInfoPipe(void);
 void closeChildInfoPipe(void);
-void sendChildInfoGeneric(childInfoType info_type, size_t keys, double progress, char *pname);
+void sendChildInfoGeneric(childInfoType info_type, size_t keys, size_t repl_output_bytes, double progress, char *pname);
 void sendChildCowInfo(childInfoType info_type, char *pname);
 void sendChildInfo(childInfoType info_type, size_t keys, char *pname);
 void receiveChildInfo(void);

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -95,6 +95,48 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Replicas and primary offsets were unable to match."
             }
         }
+
+        test "Dual-channel replication counts snapshot bytes" {
+            wait_for_condition 50 100 {
+                [getInfoProperty [$primary info stats] "total_net_repl_output_bytes"] > 0
+            } else {
+                fail "Replication output bytes not updated"
+            }
+        }
+    }
+}
+
+start_server {tags {"dual-channel-replication external:skip"}} {
+    set replica [srv 0 client]
+    set replica_host [srv 0 host]
+    set replica_port [srv 0 port]
+    start_server {} {
+        set primary [srv 0 client]
+        set primary_host [srv 0 host]
+        set primary_port [srv 0 port]
+
+        $primary config set repl-diskless-sync yes
+        $primary config set repl-diskless-sync-delay 0
+        $primary config set dual-channel-replication-enabled yes
+
+        $replica config set repl-diskless-sync yes
+        $replica config set repl-diskless-load swapdb
+        $replica config set dual-channel-replication-enabled yes
+
+        for {set j 0} {$j < 100} {incr j} {
+            $primary set key$j [string repeat x 100]
+        }
+        $primary config resetstat
+
+        test "dual-channel replication reports rdb transfer bytes" {
+            $replica replicaof $primary_host $primary_port
+            verify_replica_online $primary 0 700
+            wait_for_condition 50 100 {
+                [getInfoProperty [$primary info stats] "total_net_repl_output_bytes"] > 1000
+            } else {
+                fail "Replication output bytes not updated"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #2545

Followed the steps to reproduce the issue, and was able to get non-zero `total_net_repl_output_bytes`.

```
(base) ~/workspace/valkey git:[fix-bug-2545]
src/valkey-cli INFO | grep total_net_repl_output_bytes
total_net_repl_output_bytes:1788
```

---------