### PR TITLE
Fix memory leak in deferred reply buffer

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1557,7 +1557,10 @@ inline int isDeferredReplyEnabled(client *c) {
  * callback. */
 void initDeferredReplyBuffer(client *c) {
     if (moduleNotifyKeyspaceSubscribersCnt() == 0) return;
-    if (c->deferred_reply == NULL) c->deferred_reply = listCreate();
+    if (c->deferred_reply == NULL) {
+        c->deferred_reply = listCreate();
+        listSetFreeMethod(c->deferred_reply, freeClientReplyValue);
+    }
     if (!isDeferredReplyEnabled(c)) c->deferred_reply_bytes = 0;
 }
 


### PR DESCRIPTION
Set free method for deferred_reply list to properly clean up 
ClientReplyValue objects when the list is destroyed

This was introduced in #1819.