### PR TITLE
Update automated benchmarking configs

### DIFF
--- a/.github/benchmark_configs/pr_benchmark.json
+++ b/.github/benchmark_configs/pr_benchmark.json
@@ -1,6 +1,6 @@
 [
   {
-    "requests": [1000000000],
+    "requests": [100000000],
     "keyspacelen": [10000000],
     "data_sizes": [16],
     "pipelines": [10],
@@ -13,12 +13,12 @@
     ],
     "cluster_mode": false,
     "tls_mode": false,
-    "warmup": 180,
+    "warmup": 120,
     "server_cpu_range": "0",
     "client_cpu_range": "55,95"
   },
   {
-    "requests": [1000000000],
+    "requests": [100000000],
     "keyspacelen": [10000000],
     "data_sizes": [16],
     "pipelines": [10],
@@ -29,12 +29,12 @@
     ],
     "cluster_mode": true,
     "tls_mode": false,
-    "warmup": 180,
+    "warmup": 120,
     "server_cpu_range": "0",
     "client_cpu_range": "55,95"
   },
   {
-    "requests": [1000000000],
+    "requests": [100000000],
     "keyspacelen": [3000000],
     "data_sizes": [512],
     "pipelines": [10],
@@ -45,7 +45,7 @@
     ],
     "cluster_mode": false,
     "tls_mode": false,
-    "warmup": 300,
+    "warmup": 180,
     "io-threads": 8,
     "server_cpu_range": "0-7",
     "client_cpu_range": "55,95"

--- a/.github/workflows/benchmark-on-label.yml
+++ b/.github/workflows/benchmark-on-label.yml
@@ -53,7 +53,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run benchmarks
-        timeout-minutes: 60
         working-directory: valkey-perf-benchmark
         run: |
           CONFIG_FILE="../valkey/.github/benchmark_configs/pr_benchmark.json"


### PR DESCRIPTION
reduce the req and warmup time to finish in 6 hrs as the github workflow times out after 6 hrs