### PR TITLE
Optimize skiplist random level generation logic

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -520,7 +520,6 @@ typedef enum {
 #define SUPERVISED_UPSTART 3
 
 #define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-#define ZSKIPLIST_P 0.25      /* Skiplist P = 1/4 */
 #define ZSKIPLIST_MAX_SEARCH 10
 
 /* Append only defines */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -171,7 +171,7 @@ static int zslRandomLevel(void) {
     uint64_t rand = genrand64_int64();
 
     /* The probability of gaining 2 additional leading zeros is 0.25.
-     * This matches the level calculation logic perfectly: each 
+     * This matches the level calculation logic perfectly: each
      * iteration has a 0.25 probability of increasing the level by 1.
      * Note: __builtin_clzll has undefined behavior when the input is 0. */
     int level = rand == 0 ? ZSKIPLIST_MAXLEVEL : (__builtin_clzll(rand) / 2 + 1);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -168,10 +168,13 @@ void zslFree(zskiplist *zsl) {
  * (both inclusive), with a powerlaw-alike distribution where higher
  * levels are less likely to be returned. */
 static int zslRandomLevel(void) {
-    static const int threshold = ZSKIPLIST_P * RAND_MAX;
-    int level = 1;
-    while (random() < threshold) level += 1;
-    return (level < ZSKIPLIST_MAXLEVEL) ? level : ZSKIPLIST_MAXLEVEL;
+    uint64_t rand = genrand64_int64();
+
+    /* The probability of gaining 2 additional leading zeros is 0.25.
+     * This matches the level calculation logic perfectly: each iteration
+     * has a 0.25 probability of increasing the level by 1. */
+    int level = rand == 0 ? ZSKIPLIST_MAXLEVEL : (__builtin_clzll(rand) / 2 + 1);
+    return level;
 }
 
 /* Compares node and score/ele; defines zset ordering. Return value:

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -171,8 +171,9 @@ static int zslRandomLevel(void) {
     uint64_t rand = genrand64_int64();
 
     /* The probability of gaining 2 additional leading zeros is 0.25.
-     * This matches the level calculation logic perfectly: each iteration
-     * has a 0.25 probability of increasing the level by 1. */
+     * This matches the level calculation logic perfectly: each 
+     * iteration has a 0.25 probability of increasing the level by 1.
+     * Note: __builtin_clzll has undefined behavior when the input is 0. */
     int level = rand == 0 ? ZSKIPLIST_MAXLEVEL : (__builtin_clzll(rand) / 2 + 1);
     return level;
 }


### PR DESCRIPTION
###  Description
Each insertion of a skiplist node requires generating a random level (via the `zslRandomLevel` function), and some commands (such as `zunionstore`) call the `zslRandomLevel` function multiple times. Therefore, optimizing `zslRandomLevel` can significantly improve the performance of these commands.

The main optimization approach is as follows:

1. Original logic: Each iteration called the `random` function, with a 0.25 probability of continuing to call `random` again. In the worst-case scenario, it required up to 32 calls (though the probability of this occurring is extremely low).
2. Optimized logic: We only need to call the `genrand64_int64` function once. Each iteration uses only 2 bits of randomness, effectively achieving the equivalent of 32 iterations in the original algorithm.
3. Additionally, the introduction of `__builtin_clzll` significantly reduces CPU usage,  which compiles into a single, highly efficient CPU instruction (e.g., LZCNT on x86, CLZ on ARM) on supported hardware platforms
4. Although I've explained a lot, the actual code changes are quite minimal, so just look at the code directly.


### Benchmark

The benchmark steps are as follows:
```
step 1: Start valkey-sever
valkey-server  --save '' --appendonly no

step 2: Initialize two sorted sets, zset1 and zset2, each with a size of 129 (the default threshold beyond which a skip list is used is 128).
valkey-benchmark -r 129 -n 100000 -P 32 zadd zset1 __rand_int__ ele:__rand_int__  && valkey-benchmark -r 129 -n 100000 -P 32 zadd zset2 __rand_int__ ele:__rand_int__

step 3: Run benchmark command
valkey-benchmark -n 3000000 zunionstore zset 2 zset1 zset2
```

The benchmark result
The QPS before optimization was 24354.80, and the QPS after optimization reached 25396.61, representing a **4.3% performance improvement.**

Test benchmark  Env
OS: 	Ubuntu Server 24.04 LTS 64bit
CPU: AMD EPYC 9754 128-Core Processor * 4