### PR TITLE
Fix atomic slot migration snapshot never proceeding with hz 1

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -520,6 +520,41 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         }
     }
 
+    test "Import with hz set to 1" {
+        assert_does_not_resync {
+            set old_hz [lindex [R 0 CONFIG GET hz] 1]
+            R 0 CONFIG SET hz 1
+            R 2 CONFIG SET hz 1
+
+            # Populate data before migration
+            populate 1000 "$16383_slot_tag:" 1000 -2
+
+            # Perform one-shot import
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            set jobname [get_job_name 2 16383]
+            wait_for_migration 0 16383
+
+            # Keys successfully migrated
+            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+            # Also eventually reflected in replicas
+            wait_for_countkeysinslot 3 16383 1000
+            wait_for_countkeysinslot 5 16383 0
+
+            # Migration log shows success on both ends
+            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+            # Cleanup for next test
+            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            wait_for_migration 2 16383
+            R 0 CONFIG SET hz $old_hz
+            R 2 CONFIG SET hz $old_hz
+        }
+    }
+
     # Catch-all test for covering commands sent during incremental replication
     test "Single source import - Incremental Command Coverage" {
         assert_does_not_resync {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -530,25 +530,25 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             populate 1000 "$16383_slot_tag:" 1000 -2
 
             # Perform one-shot import
-            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+            assert_equal "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
             set jobname [get_job_name 2 16383]
             wait_for_migration 0 16383
 
             # Keys successfully migrated
-            assert_match "1000" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
-            assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_equal 1000 [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+            assert_equal 0 [R 2 CLUSTER COUNTKEYSINSLOT 16383]
 
             # Also eventually reflected in replicas
             wait_for_countkeysinslot 3 16383 1000
             wait_for_countkeysinslot 5 16383 0
 
             # Migration log shows success on both ends
-            assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
-            assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+            assert_equal [dict get [get_migration_by_name 0 $jobname] state] "success"
+            assert_equal [dict get [get_migration_by_name 2 $jobname] state] "success"
 
             # Cleanup for next test
-            assert_match "OK" [R 0 FLUSHDB SYNC]
-            assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+            assert_equal "OK" [R 0 FLUSHDB SYNC]
+            assert_equal "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
             wait_for_migration 2 16383
             R 0 CONFIG SET hz $old_hz
             R 2 CONFIG SET hz $old_hz


### PR DESCRIPTION
The problem is that ACKs run on a set loop (once every second) and this will happen every loop with hz 1.

Instead, we can do the ACK after running the main logic. We can also do an additional optimization where we don't send an ACK from source to target if we already sent some data this cron loop, since the target will reset the ack timer on any data over the connection.