### PR TITLE
Add atomic slot migration test to validate DB and slot stats

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1388,6 +1388,7 @@ void clusterInit(void) {
     /* Register our own rdb aux fields */
     serverAssert(rdbRegisterAuxField("cluster-slot-states", clusterEncodeOpenSlotsAuxField,
                                      clusterDecodeOpenSlotsAuxField) == C_OK);
+    serverAssert(clusterRegisterSlotImportsAuxFields() == C_OK);
 
     /* Initialize list for slot migration jobs. */
     initClusterSlotMigrationJobList();
@@ -6385,6 +6386,9 @@ int verifyClusterConfigWithData(void) {
      * completely depend on the replication stream. */
     if (nodeIsReplica(myself)) return C_OK;
 
+    /* Allow slot migrations to clean up after reloading */
+    clusterCleanSlotImportsOnReload();
+
     /* Check that all the slots we see populated memory have a corresponding
      * entry in the cluster table. Otherwise fix the table. */
     for (j = 0; j < CLUSTER_SLOTS; j++) {
@@ -6464,7 +6468,7 @@ static void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_requ
     removeAllNotOwnedShardChannelSubscriptions();
     resetManualFailover();
 
-    /* Becoming a replica cancels all in progress imports and exports */
+    /* Perform needed slot migration state transitions */
     clusterUpdateSlotExportsOnOwnershipChange();
     clusterUpdateSlotImportsOnOwnershipChange();
 

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -501,38 +501,66 @@ int clusterRegisterSlotImportsAuxFields(void) {
  * restart the migration from the source side.
  *
  * State Machine:
+ *        SYNCSLOTS ESTABLISH│
+ *                ┌──────────▼─────────┐
+ *                │SLOT_IMPORT_WAIT_ACK┼──────┐
+ *                └──────────┬─────────┘      │
+ *              SYNCSLOTS ACK│                │
+ *            ┌──────────────▼─────────────┐  │
+ *            │SLOT_IMPORT_RECEIVE_SNAPSHOT┼──┤
+ *            └──────────────┬─────────────┘  │
+ *     SYNCSLOTS SNAPSHOT-EOF│                │
+ *           ┌───────────────▼──────────────┐ │
+ *           │SLOT_IMPORT_WAITING_FOR_PAUSED┼─┤
+ *           └───────────────┬──────────────┘ │
+ *           SYNCSLOTS PAUSED│                │
+ *           ┌───────────────▼──────────────┐ │ Error Conditions:
+ *           │SLOT_IMPORT_FAILOVER_REQUESTED┼─┤  1. OOM
+ *           └───────────────┬──────────────┘ │  2. Slot Ownership Change
+ * SYNCSLOTS FAILOVER-GRANTED│                │  3. FLUSHDB
+ *            ┌──────────────▼─────────────┐  │  4. Connection Lost
+ *            │SLOT_IMPORT_FAILOVER_GRANTED┼──┤  5. No ACK from source (timeout)
+ *            └──────────────┬─────────────┘  │  6. Demoted to replica
+ *         Takeover Performed│                │
+ *            ┌──────────────▼───────────┐    │
+ *            │SLOT_MIGRATION_JOB_SUCCESS┼────┼─────────────────┐
+ *            └──────────────────────────┘    │                 │
+ *                                            │Still primary?   │Demoted to replica?
+ *             ┌──────────────────────────────▼─┐               │
+ *             │SLOT_IMPORT_FINISHED_CLEANING_UP│               │
+ *             └─────────────┬──────────────────┘               │
+ *   Unowned Slots Cleaned Up│                                  │
+ *             ┌─────────────▼───────────┐                      │
+ *             │SLOT_MIGRATION_JOB_FAILED│                      │
+ *             └─────────────────────────┘                      │
+ *                                                              │
+ *        ┌────────────────────────────────┐                    │
+ *        │SLOT_IMPORT_OCCURRING_ON_PRIMARY◄────────────────────┘
+ *        └────────────────────────────────┘
+ *                     (see below)
+ * 
+ * State Machine (Replica):
  *
- *              ┌────────────────────┐
- *              │SLOT_IMPORT_WAIT_ACK┼──────┐
- *              └──────────┬─────────┘      │
- *                      ACK│                │
- *          ┌──────────────▼─────────────┐  │
- *          │SLOT_IMPORT_RECEIVE_SNAPSHOT┼──┤
- *          └──────────────┬─────────────┘  │
- *             SNAPSHOT-EOF│                │
- *         ┌───────────────▼──────────────┐ │
- *         │SLOT_IMPORT_WAITING_FOR_PAUSED┼─┤
- *         └───────────────┬──────────────┘ │
- *                   PAUSED│                │
- *         ┌───────────────▼──────────────┐ │ Error Conditions:
- *         │SLOT_IMPORT_FAILOVER_REQUESTED┼─┤  1. OOM
- *         └───────────────┬──────────────┘ │  2. Slot Ownership Change
- *         FAILOVER-GRANTED│                │  3. Demotion to replica
- *          ┌──────────────▼─────────────┐  │  4. FLUSHDB
- *          │SLOT_IMPORT_FAILOVER_GRANTED┼──┤  5. Connection Lost
- *          └──────────────┬─────────────┘  │  6. No ACK from source (timeout)
- *       Takeover Performed│                │
- *          ┌──────────────▼───────────┐    │
- *          │SLOT_MIGRATION_JOB_SUCCESS┼──-─┤
- *          └──────────────────────────┘    │
- *                                          │
- *           ┌──────────────────────────────▼─┐
- *           │SLOT_IMPORT_FINISHED_CLEANING_UP│
- *           └─────────────┬──────────────────┘
- * Unowned Slots Cleaned Up│
- *           ┌─────────────▼───────────┐
- *           │SLOT_MIGRATION_JOB_FAILED│
- *           └─────────────────────────┘
+ *    SYNCSLOTS ESTABLISH or │
+ *    RDB Aux field laod or  |
+ *    demotion during import |
+ *    ┌──────────────────────▼─────────┐
+ *    │SLOT_IMPORT_OCCURRING_ON_PRIMARY┼──────┐
+ *    └──────────────────────┬─────────┘      │ Error Conditions:
+ * SYNCSLOTS FINISH (SUCCESS)│                │  1. SYNCSLOTS FINISH (FAILURE)
+ *             ┌─────────────▼────────────┐   │  2. Full sync with any primary
+ *             │SLOT_MIGRATION_JOB_SUCCESS│   │  3. Promoted to primary
+ *             └──────────────────────────┘   │
+ *                                            │
+ *                      Promoted to primary?  │
+ *                           ┌────────────────┤
+ *          ┌────────────────▼───────────────┐│
+ *          │SLOT_IMPORT_FINISHED_CLEANING_UP││
+ *          └────────────────┬───────────────┘│
+ *   Unowned Slots Cleaned Up│                │ Still replica?
+ *             ┌─────────────▼───────────┐    │
+ *             │SLOT_MIGRATION_JOB_FAILED◄────┘
+ *             └─────────────────────────┘
  *
  */
 
@@ -756,7 +784,7 @@ void clusterCommandSyncSlotsFailoverGranted(client *c) {
 }
 
 /* Sent by a target primary to a replica in its shard to inform that an ongoing
- * slot import is not finished. */
+ * slot import is now finished. */
 void clusterCommandSyncSlotsFinish(client *c) {
     char *name = NULL;
     char *state = NULL;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -19,7 +19,8 @@ typedef enum slotMigrationJobState {
     SLOT_IMPORT_WAITING_FOR_PAUSED,
     SLOT_IMPORT_FAILOVER_REQUESTED,
     SLOT_IMPORT_FAILOVER_GRANTED,
-    SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP,
+    SLOT_IMPORT_FINISHED_CLEANING_UP,
+    SLOT_IMPORT_OCCURRING_ON_PRIMARY,
 
     /* Exporting states */
     SLOT_EXPORT_CONNECTING,
@@ -89,7 +90,8 @@ typedef struct slotMigrationJob {
 static bool isSlotMigrationJobFinished(slotMigrationJob *job);
 static bool isSlotMigrationJobInProgress(slotMigrationJob *job);
 static slotMigrationJob *createSlotImportJob(client *c,
-                                             clusterNode *source_node,
+                                             char *source_node_name,
+                                             char *source_node_human_name,
                                              char *name,
                                              list *slot_ranges);
 static int connectSlotExportJob(slotMigrationJob *job);
@@ -107,8 +109,11 @@ static void finishSlotMigrationJob(slotMigrationJob *job,
                                    char *message);
 static void freeSlotMigrationJob(void *o);
 static sds generateSlotMigrationJobDescription(slotMigrationJob *job,
-                                               clusterNode *node);
+                                               char *source_node_name,
+                                               char *source_node_human_name);
 static void slotExportTryUnpause(void);
+static slotMigrationJob *clusterLookupMigrationJob(sds name);
+sds generateSyncSlotsEstablishCommand(slotMigrationJob *job);
 
 /* Create an empty list of slot ranges. */
 list *createSlotRangeList(void) {
@@ -353,6 +358,138 @@ void fireModuleSlotMigrationEvent(slotMigrationJob *job, int subevent) {
     zfree(info.slot_ranges);
 }
 
+sds clusterEncodeSlotImportsAuxField(int rdbflags) {
+    if (!server.cluster_enabled) return NULL;
+
+    /* Slot imports should be persisted on RDB files to allow replicas to PSYNC
+     * with their primary during an import and not expose in progress imports to
+     * users. AOF preambles cannot be used for resynchronization - so we skip
+     * those. */
+    if ((rdbflags & RDBFLAGS_AOF_PREAMBLE) != 0) return NULL;
+    sds s = NULL;
+
+    listNode *ln;
+    listIter li;
+    listRewind(server.cluster->slot_migration_jobs, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        slotMigrationJob *job = ln->value;
+        if (isSlotMigrationJobFinished(job)) continue;
+        if (job->type != SLOT_MIGRATION_IMPORT) continue;
+        if (s == NULL) {
+            s = sdsempty();
+        } else {
+            sdscat(s, "/");
+        }
+        s = sdscatprintf(s, "%.40s:%.40s:", job->name, job->source_node_name);
+        sds slot_ranges = representSlotRangeList(job->slot_ranges);
+        s = sdscatsds(s, slot_ranges);
+        sdsfree(slot_ranges);
+    }
+    return s;
+}
+
+slotRange *decodeSlotRange(sds slot_range_str) {
+    int start_slot = atoi(slot_range_str);
+    if (start_slot < 0 || start_slot >= CLUSTER_SLOTS) return NULL;
+
+    while (*slot_range_str && *slot_range_str != '-') slot_range_str++;
+    if (*slot_range_str != '-') return NULL;
+    slot_range_str++; /* Skip '-' */
+
+    int end_slot = atoi(slot_range_str);
+    if (end_slot < 0 || end_slot >= CLUSTER_SLOTS) return NULL;
+    slotRange *slot_range = zmalloc(sizeof(slotRange));
+    slot_range->start_slot = start_slot;
+    slot_range->end_slot = end_slot;
+    return slot_range;
+}
+
+list *decodeSlotRangeList(sds slot_range_list_str) {
+    int num_slot_ranges = 0;
+    sds *slot_range_strs = sdssplitlen(slot_range_list_str, sdslen(slot_range_list_str), " ", 1, &num_slot_ranges);
+    if (num_slot_ranges < 1) {
+        sdsfreesplitres(slot_range_strs, num_slot_ranges);
+        return NULL;
+    }
+    list *slot_ranges = createSlotRangeList();
+    for (int j = 0; j < num_slot_ranges; j++) {
+        sds slot_range_str = slot_range_strs[j];
+        slotRange *slot_range = decodeSlotRange(slot_range_str);
+        if (slot_range == NULL) {
+            sdsfreesplitres(slot_range_strs, num_slot_ranges);
+            listRelease(slot_ranges);
+            return NULL;
+        }
+        listAddNodeTail(slot_ranges, slot_range);
+    }
+    sdsfreesplitres(slot_range_strs, num_slot_ranges);
+    return slot_ranges;
+}
+
+int clusterDecodeSlotImportsAuxField(int rdbflags, sds s) {
+    if (!server.cluster_enabled || s == NULL) return C_OK;
+
+    if ((rdbflags & RDBFLAGS_AOF_PREAMBLE) != 0) return C_OK;
+
+    list *new_slot_migrations = listCreate();
+    listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
+
+    int num_fields = 0;
+    sds* import_fields = NULL;
+    int num_imports = 0;
+    sds* import_strs = sdssplitlen(s, sdslen(s), "/", 1, &num_imports);
+    for (int i = 0; i < num_imports; i++) {
+        import_fields = sdssplitlen(import_strs[i], sdslen(import_strs[i]), ":", 1, &num_fields);
+
+        if (num_fields < 3) goto error;
+        sds job_name = import_fields[0];
+        sds node_name = import_fields[1];
+        sds slot_range_list_str = import_fields[2];
+
+        /* Decode the slot ranges */
+        list *slot_ranges = decodeSlotRangeList(slot_range_list_str);
+        if (!slot_ranges) goto error;
+
+        /* Try to find the corresponding node, or else just insert with no human name. */
+        char *source_node_human_name = NULL;
+        clusterNode *source_node = clusterLookupNode(node_name, CLUSTER_NAMELEN);
+        if (source_node) source_node_human_name = source_node->human_nodename;
+
+        slotMigrationJob *new_import = createSlotImportJob(NULL, node_name, source_node_human_name, job_name, slot_ranges);
+        listAddNodeTail(new_slot_migrations, new_import);
+        sdsfreesplitres(import_fields, num_fields);
+        import_fields = NULL;
+    }
+
+    listIter li;
+    listNode *ln;
+    listRewind(new_slot_migrations, &li);
+    while ((ln = listNext(&li))) {
+        slotMigrationJob *job = ln->value;
+        listAddNodeHead(server.cluster->slot_migration_jobs, job);
+        serverLog(LL_NOTICE,
+                  "Slot import discovered during snapshot load: %s",
+                  job->description);
+        fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED);
+    }
+
+    listSetFreeMethod(new_slot_migrations, NULL);
+    listRelease(new_slot_migrations);
+    sdsfreesplitres(import_strs, num_imports);
+    return C_OK;
+
+  error:
+    listRelease(new_slot_migrations);
+    sdsfreesplitres(import_strs, num_imports);
+    sdsfreesplitres(import_fields, num_fields);
+    return C_ERR;
+}
+
+int clusterRegisterSlotImportsAuxFields(void) {
+    return rdbRegisterAuxField("slot-imports", clusterEncodeSlotImportsAuxField,
+                               clusterDecodeSlotImportsAuxField);
+}
+
 /* -------------------------------- TARGET -------------------------------------
  *
  * During a slot migration, the target is informed of a migration by the source
@@ -389,9 +526,9 @@ void fireModuleSlotMigrationEvent(slotMigrationJob *job, int subevent) {
  *          │SLOT_MIGRATION_JOB_SUCCESS┼──-─┤
  *          └──────────────────────────┘    │
  *                                          │
- *    ┌─────────────────────────────────────▼─┐
- *    │SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP│
- *    └────────────────────┬──────────────────┘
+ *           ┌──────────────────────────────▼─┐
+ *           │SLOT_IMPORT_FINISHED_CLEANING_UP│
+ *           └─────────────┬──────────────────┘
  * Unowned Slots Cleaned Up│
  *           ┌─────────────▼───────────┐
  *           │SLOT_MIGRATION_JOB_FAILED│
@@ -412,6 +549,26 @@ bool clusterIsSlotImporting(int slot) {
     return false;
 }
 
+int validateSlotMigrationCanStartOrReply(client *c) {
+    if (moduleVerifyAllAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
+        return C_ERR;
+    }
+    if (!nodeIsPrimary(server.cluster->myself)) {
+        addReplyError(c, "Slot migration can only be used on primary nodes.");
+        return C_ERR;
+    }
+
+    if (isAnySlotInManualImportingState()) {
+        addReplyError(c, "Slots are being manually imported");
+        return C_ERR;
+    }
+    if (isAnySlotInManualMigratingState()) {
+        addReplyError(c, "Slots are being manually migrated");
+        return C_ERR;
+    }
+    return C_OK;
+}
+
 /* Sent by the source to the target to initiate the AOF formatted snapshot.
  * Note that if there is an error in the request, we send a fail message in
  * order to prevent infinite retry in the case of incompatibility.
@@ -423,27 +580,10 @@ void clusterCommandSyncSlotsEstablish(client *c) {
     char *name = NULL;
     clusterNode *source_node = NULL;
     clusterNode *owning_node = NULL;
+    char *source_node_name = NULL;
     list *slot_ranges = NULL;
-
-    if (moduleVerifyAllAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
-        return;
-    }
-
-    if (!nodeIsPrimary(server.cluster->myself)) {
-        addReplyError(c, "Target node is not a primary");
-        return;
-    }
-
-    if (isAnySlotInManualImportingState() ||
-        isAnySlotInManualMigratingState()) {
-        addReplyError(c, "A slot on the target node is being manually imported "
-                         "or migrated");
-        return;
-    }
-
-    if (c->slot_migration_job) {
-        addReplyError(c, "Slot migration client is already a slot migration "
-                         "job");
+    
+    if (!mustObeyClient(c) && validateSlotMigrationCanStartOrReply(c) == C_ERR) {
         return;
     }
 
@@ -457,7 +597,13 @@ void clusterCommandSyncSlotsEstablish(client *c) {
                 addReplyErrorObject(c, shared.syntaxerr);
                 goto cleanup;
             }
-            source_node = clusterLookupNode(c->argv[4]->ptr, CLUSTER_NAMELEN);
+            source_node_name = c->argv[4]->ptr;
+            source_node = clusterLookupNode(source_node_name, CLUSTER_NAMELEN);
+            i += 2;
+
+            /* If this is our primary, we don't care if we don't know the node */
+            if (mustObeyClient(c)) continue;
+
             if (!source_node) {
                 addReplyError(c, "Target node does not know the source node");
                 goto cleanup;
@@ -466,7 +612,6 @@ void clusterCommandSyncSlotsEstablish(client *c) {
                 addReplyError(c, "Source node is target node itself");
                 goto cleanup;
             }
-            i += 2;
             continue;
         }
         if (!strcasecmp(c->argv[i]->ptr, "name")) {
@@ -509,25 +654,24 @@ void clusterCommandSyncSlotsEstablish(client *c) {
         addReplyErrorObject(c, shared.syntaxerr);
         goto cleanup;
     }
-    if (!source_node || !name || !slot_ranges) {
+    if (!source_node_name || !name || !slot_ranges) {
         addReplyErrorObject(c, shared.syntaxerr);
         goto cleanup;
     }
-    if (source_node != owning_node) {
-        addReplyError(c, "Target node does not agree about current slot "
-                         "ownership");
+    if (!mustObeyClient(c) && source_node != owning_node) {
+        addReplyError(c, "Target node does not agree about current slot ownership");
         goto cleanup;
     }
 
-    slotMigrationJob *job = createSlotImportJob(c, source_node, name,
-                                                slot_ranges);
+    char *source_node_human_name = source_node ? source_node->human_nodename : NULL;
+    slotMigrationJob *job = createSlotImportJob(c, source_node_name, source_node_human_name, name, slot_ranges);
     fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED);
     listAddNodeHead(server.cluster->slot_migration_jobs, job);
 
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 
     addReply(c, shared.ok);
-    job->client->flag.reply_off = 1;
+    if (job->client) job->client->flag.reply_off = 1;
     return;
 
 cleanup:
@@ -611,34 +755,128 @@ void clusterCommandSyncSlotsFailoverGranted(client *c) {
     clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
 }
 
+/* Sent by a target primary to a replica in its shard to inform that an ongoing
+ * slot import is not finished. */
+void clusterCommandSyncSlotsFinish(client *c) {
+    char *name = NULL;
+    char *state = NULL;
+    char *message = NULL;
+    int i = 3;
+    while (i < c->argc) {
+        if (!strcasecmp(c->argv[i]->ptr, "state")) {
+            if (state || i + 1 >= c->argc) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
+            state = c->argv[i + 1]->ptr;
+            i += 2;
+            continue;
+        }
+        if (!strcasecmp(c->argv[i]->ptr, "name")) {
+            if (name || i + 1 >= c->argc ||
+                sdslen(c->argv[i + 1]->ptr) != CLUSTER_NAMELEN) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
+            name = c->argv[i + 1]->ptr;
+            i += 2;
+            continue;
+        }
+        if (!strcasecmp(c->argv[i]->ptr, "message")) {
+            if (message || i + 1 >= c->argc) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
+            message = c->argv[i + 1]->ptr;
+            i += 2;
+            continue;
+        }
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
+
+    /* Message is optional, state and name are required. */
+    if (!state || !name) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
+
+    addReply(c, shared.ok);
+    slotMigrationJob *job = clusterLookupMigrationJob(name);
+    if (!job) {
+        addReplyError(c, "No such slot migration job");
+        return;
+    }
+
+    slotMigrationJobState target_state;
+    if (!strcasecmp(state, "success")) {
+        target_state = SLOT_MIGRATION_JOB_SUCCESS;
+    } else if (!strcasecmp(state, "failed")) {
+        target_state = SLOT_MIGRATION_JOB_FAILED;
+    } else {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    }
+
+    finishSlotMigrationJob(job, target_state, message);
+}
+
 slotMigrationJob *createSlotImportJob(client *c,
-                                      clusterNode *source_node,
+                                      char *source_node_name,
+                                      char *source_node_human_name,
                                       char *name,
                                       list *slot_ranges) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
     memcpy(job->name, name, CLUSTER_NAMELEN);
-    memcpy(job->source_node_name, source_node->name, CLUSTER_NAMELEN);
-    memcpy(job->target_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
+    memcpy(job->source_node_name, source_node_name, CLUSTER_NAMELEN);
+    clusterNode *target_node = server.cluster->myself;
+    if (!clusterNodeIsPrimary(target_node)) {
+        target_node = target_node->replicaof;
+    }
+    memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     job->ctime = server.unixtime;
     job->last_update = job->ctime;
     job->last_ack = job->ctime;
     job->type = SLOT_MIGRATION_IMPORT;
     job->slot_ranges = slot_ranges;
     job->slot_ranges_str = representSlotRangeList(slot_ranges);
-    job->state = SLOT_IMPORT_WAIT_ACK;
-    job->client = c;
-    job->client->slot_migration_job = job;
-    job->description = generateSlotMigrationJobDescription(job, source_node);
-
-    /* We treat slot imports like primaries. Primaries are expected to have a
-     * dedicated query buffer and allocated replication data. */
-    initClientReplicationData(job->client);
-    job->client->querybuf = sdsempty();
+    job->description = generateSlotMigrationJobDescription(job, source_node_name, source_node_human_name);
 
     /* Mark all the slots as importing in the kvstore */
     setSlotImportingStateInAllDbs(slot_ranges, 1);
 
     serverLog(LL_NOTICE, "New slot import job created: %s.", job->description);
+
+    if (!c || c->flag.primary) {
+        /* If the client is a primary, we enter a special tracking state that 
+         * will only be used to hide the dirty keys during the import.
+         *
+         * If there is no client - it means that this is an RDB load. We create
+         * a tracking entry during RDB load in case we use this RDB to partial
+         * sync with our primary node. If we full sync the entry will be
+         * removed. If we are still a primary, or we end up being promoted, we
+         * still need this tracking entry to know to broadcast FINISH to our
+         * replicas. */
+        job->state = SLOT_IMPORT_OCCURRING_ON_PRIMARY;
+        return job;
+    }
+
+    job->state = SLOT_IMPORT_WAIT_ACK;
+    job->client = c;
+    job->client->slot_migration_job = job;
+
+    /* We treat slot imports like primaries. Primaries are expected to have a
+     * dedicated query buffer and allocated replication data.
+     *
+     * We also backfill this job's establish command (which would have been
+     * lost, as we did not have a dedicated query buffer before this point). */
+    initClientReplicationData(job->client);
+    if (!job->client->querybuf) {
+        job->client->querybuf = generateSyncSlotsEstablishCommand(job);
+        job->client->qb_pos = sdslen(job->client->querybuf);
+    }
+    job->client->repl_data->read_reploff = sdslen(job->client->querybuf);
+
     return job;
 }
 
@@ -712,8 +950,11 @@ void clusterUpdateSlotImportsOnOwnershipChange(void) {
         if (job->type != SLOT_MIGRATION_IMPORT) continue;
         if (!isSlotMigrationJobInProgress(job)) continue;
         if (!nodeIsPrimary(server.cluster->myself)) {
-            finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
-                                   "I was demoted to a replica");
+            /* All we can do is mark the slot import as occurring on primary and
+             * wait for it to do the cleanup and finish the import. */
+            if (job->state != SLOT_IMPORT_OCCURRING_ON_PRIMARY) {
+                updateSlotMigrationJobState(job, SLOT_IMPORT_OCCURRING_ON_PRIMARY);
+            }
             continue;
         }
         clusterNode *n = getClusterNodeBySlotRanges(job->slot_ranges, NULL);
@@ -746,6 +987,73 @@ void clusterHandleFlushDuringSlotMigration(void) {
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED,
                                "Data was flushed");
     }
+}
+
+/* As the final step of a slot import, once all cleanup is done (if needed), we
+ * ensure that replicas track the state transition through propagating SYNCSLOTS
+ * FINISH with the final state. */
+void propagateSyncSlotsFinish(slotMigrationJob *job) {
+    /* CLUSTER SYNCSLOTS FINISH STATE <state> NAME <name> (MESSAGE <message>) */
+    int argc = job->status_msg ? 9 : 7;
+    robj *argv[argc];
+    argv[0] = createStringObject("CLUSTER", 7);
+    argv[1] = createStringObject("SYNCSLOTS", 9);
+    argv[2] = createStringObject("FINISH", 6);
+    argv[3] = createStringObject("STATE", 5);
+    if (job->state == SLOT_MIGRATION_JOB_SUCCESS) {
+        argv[4] = createStringObject("SUCCESS", 7);
+    } else {
+        argv[4] = createStringObject("FAILED", 6);
+    }
+    argv[5] = createStringObject("NAME", 4);
+    argv[6] = createStringObject(job->name, CLUSTER_NAMELEN);
+    if (job->status_msg) {
+        argv[7] = createStringObject("MESSAGE", 7);
+        argv[8] = createStringObject(job->status_msg, sdslen(job->status_msg));
+    }
+
+    /* Perform the propagation. Notably, we may not already be in an execution
+     * unit (cron, beforeSleep). */
+    enterExecutionUnit(1, 0);
+    alsoPropagate(-1, argv, argc, PROPAGATE_REPL, -1);
+    exitExecutionUnit();
+    postExecutionUnitOperations();
+
+    for (int i = 0; i < argc; i++) decrRefCount(argv[i]);
+}
+
+void cleanupSlotImportsWithReason(char *reason) {
+    if (!server.cluster_enabled || !server.cluster) return;
+    listIter li;
+    listNode *ln = NULL;
+    listRewind(server.cluster->slot_migration_jobs, &li);
+    while ((ln = listNext(&li)) != NULL) {
+        slotMigrationJob *job = (slotMigrationJob *)ln->value;
+        if (job->type != SLOT_MIGRATION_IMPORT) continue;
+        if (!isSlotMigrationJobInProgress(job)) continue;
+        finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, reason);
+    }
+}
+
+/* Cleanup all active slot imports on becoming primary. Notably, this primary
+ * will perform any necessary key deletions in the importing slots, and only
+ * afterwards will it send a FINISH notification to its replicas. */
+void clusterCleanSlotImportsOnPromotion(void) {
+    cleanupSlotImportsWithReason("A failover occurred during slot import");
+}
+
+/* Cleanup all active imports on resyncing with a primary. */
+void clusterCleanSlotImportsOnResync(void) {
+    cleanupSlotImportsWithReason("Full resynchronization occurred");
+}
+
+/* Cleanup all active imports on reloading from disk, if I am a primary. */
+void clusterCleanSlotImportsOnReload(void) {
+    /* Only primaries should clean up slot imports when loading. Replicas may 
+     * need to know about previously ongoing slot imports in order to properly
+     * PSYNC with primaries. */
+    if (!clusterNodeIsPrimary(server.cluster->myself)) return;
+    cleanupSlotImportsWithReason("Process restarted");
 }
 
 /* ---------------------------------- SOURCE -----------------------------------
@@ -852,22 +1160,7 @@ bool clusterSlotFailoverGranted(int slot) {
  * source will attempt to migrate the slot ranges to the specified target
  * node. */
 void clusterCommandMigrateSlots(client *c) {
-    if (moduleVerifyAllAllowAtomicSlotMigrationOrReply(c) == C_ERR) {
-        return;
-    }
-    if (!nodeIsPrimary(server.cluster->myself)) {
-        addReplyError(c, "Slot migration can only be used on primary nodes.");
-        return;
-    }
-
-    if (isAnySlotInManualImportingState()) {
-        addReplyError(c, "Slots are being manually imported");
-        return;
-    }
-    if (isAnySlotInManualMigratingState()) {
-        addReplyError(c, "Slots are being manually migrated");
-        return;
-    }
+    if (validateSlotMigrationCanStartOrReply(c) == C_ERR) return;
 
     int curr_index = 2;
     list *new_slot_migrations = listCreate();
@@ -1116,14 +1409,13 @@ void initSlotExportJobClient(slotMigrationJob *job) {
 /* Generate and store the SYNCSLOTS ESTABLISH command to send to the target for
  * the job. */
 sds generateSyncSlotsEstablishCommand(slotMigrationJob *job) {
-    serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     sds result = sdscatprintf(sdsempty(),
                               "*%ld\r\n$7\r\nCLUSTER\r\n$9\r\nSYNCSLOTS\r\n"
                               "$9\r\nESTABLISH\r\n$6\r\nSOURCE\r\n$40\r\n"
                               "%.40s\r\n$4\r\nNAME\r\n$40\r\n%.40s\r\n"
                               "$10\r\nSLOTSRANGE\r\n",
                               8 + listLength(job->slot_ranges) * 2,
-                              server.cluster->myself->name,
+                              job->source_node_name,
                               job->name);
     listIter li;
     listNode *ln;
@@ -1591,7 +1883,7 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     getRandomHexChars(job->name, sizeof(job->name));
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
-    job->description = generateSlotMigrationJobDescription(job, target_node);
+    job->description = generateSlotMigrationJobDescription(job, target_node->name, target_node->human_nodename);
     return job;
 }
 
@@ -1661,8 +1953,9 @@ void slotMigrationJobReadEstablishResponse(connection *conn) {
 /* Updates the associated status message for the job, which will be seen in
  * CLUSTER GETSLOTMIGRATIONS. */
 void updateSlotMigrationJobStatusMessage(slotMigrationJob *job, char *message) {
-    if (job->status_msg) sdsfree(job->status_msg);
+    sds old_status = job->status_msg;
     job->status_msg = sdsnew(message);
+    if (old_status) sdsfree(old_status);
 }
 
 /* proceedWithSlotMigration contains the main logic for driving the slot
@@ -1695,11 +1988,14 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
                 finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_SUCCESS, NULL);
             }
             return;
-        case SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP:
+        case SLOT_IMPORT_FINISHED_CLEANING_UP:
+            serverLog(LL_NOTICE, "Cleaning up slot migration %s due to %s", job->description,
+                      job->state == SLOT_MIGRATION_JOB_CANCELLED ? "cancellation" : "failure");
             delKeysNotOwnedByMyself(job->slot_ranges);
-            setSlotImportingStateInAllDbs(job->slot_ranges, 0);
-            updateSlotMigrationJobState(job, job->post_cleanup_state);
-            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED);
+            finishSlotMigrationJob(job, job->post_cleanup_state, job->status_msg);
+            return;
+        case SLOT_IMPORT_OCCURRING_ON_PRIMARY:
+            /* Waiting for the primary to inform us of the result */
             return;
 
         /* Exporting states */
@@ -1898,7 +2194,8 @@ const char *slotMigrationJobStateToString(slotMigrationJobState state) {
     case SLOT_IMPORT_WAITING_FOR_PAUSED: return "waiting-for-paused";
     case SLOT_IMPORT_FAILOVER_REQUESTED: return "failover-requested";
     case SLOT_IMPORT_FAILOVER_GRANTED: return "failover-granted";
-    case SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP: return "cleaning-up";
+    case SLOT_IMPORT_FINISHED_CLEANING_UP: return "cleaning-up";
+    case SLOT_IMPORT_OCCURRING_ON_PRIMARY: return "occurring-on-primary";
 
     case SLOT_EXPORT_CONNECTING: return "connecting";
     case SLOT_EXPORT_SEND_AUTH: return "sending-auth-command";
@@ -1921,10 +2218,11 @@ const char *slotMigrationJobStateToString(slotMigrationJobState state) {
 }
 
 sds generateSlotMigrationJobDescription(slotMigrationJob *job,
-                                        clusterNode *node) {
+                                        char *node_name,
+                                        char *node_human_name) {
     char *other_node_desc =
         job->type == SLOT_MIGRATION_EXPORT ? "target_node" : "source_node";
-    if (sdslen(node->human_nodename) > 0) {
+    if (node_human_name && sdslen(node_human_name) > 0) {
         return sdscatprintf(sdsempty(),
                             "{name: %.40s, operation: %s, %s_id: %.40s, "
                             "%s_human_name: %s, slots: %s}",
@@ -1932,8 +2230,8 @@ sds generateSlotMigrationJobDescription(slotMigrationJob *job,
                             job->type == SLOT_MIGRATION_EXPORT
                                 ? "export"
                                 : "import",
-                            other_node_desc, node->name, other_node_desc,
-                            node->human_nodename, job->slot_ranges_str);
+                            other_node_desc, node_name, other_node_desc,
+                            node_human_name, job->slot_ranges_str);
     } else {
         return sdscatprintf(sdsempty(),
                             "{name: %.40s, operation: %s, %s_id: %.40s, "
@@ -1942,7 +2240,7 @@ sds generateSlotMigrationJobDescription(slotMigrationJob *job,
                             job->type == SLOT_MIGRATION_EXPORT
                                 ? "export"
                                 : "import",
-                            other_node_desc, node->name,
+                            other_node_desc, node_name,
                             job->slot_ranges_str);
     }
 }
@@ -2016,12 +2314,7 @@ void clusterHandleSlotMigrationClientOOM(slotMigrationJob *job) {
 void finishSlotMigrationJob(slotMigrationJob *job,
                             slotMigrationJobState state,
                             char *message) {
-    serverLog(state == SLOT_MIGRATION_JOB_FAILED ? LL_WARNING : LL_NOTICE,
-              "Slot migration %s finished. State: %s, Message: %s",
-              job->description,
-              slotMigrationJobStateToString(state), message ? message : "none");
     updateSlotMigrationJobStatusMessage(job, message);
-
     if (job->type == SLOT_MIGRATION_EXPORT) {
         /* If we finish the export, we should not remain paused */
         job->mf_end = 0;
@@ -2030,15 +2323,31 @@ void finishSlotMigrationJob(slotMigrationJob *job,
          * checkChildrenDone. */
         if (job->state == SLOT_EXPORT_SNAPSHOTTING) killSlotMigrationChild();
     }
-    if (job->type == SLOT_MIGRATION_IMPORT &&
-        state != SLOT_MIGRATION_JOB_SUCCESS) {
+    bool cleanup_needed = job->type == SLOT_MIGRATION_IMPORT &&
+                          nodeIsPrimary(server.cluster->myself) &&
+                          job->state != SLOT_IMPORT_FINISHED_CLEANING_UP;
+    if (cleanup_needed) {
         /* Defer cleanup until beforeSleep. */
         job->post_cleanup_state = state;
-        state = SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP;
+        state = SLOT_IMPORT_FINISHED_CLEANING_UP;
         clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_SLOT_MIGRATION);
     }
     updateSlotMigrationJobState(job, state);
     resetSlotMigrationJob(job);
+
+    if (cleanup_needed) return; /* Wait to do the rest until after cleanup. */
+
+    serverLog(state == SLOT_MIGRATION_JOB_FAILED ? LL_WARNING : LL_NOTICE,
+              "Slot migration %s finished. State: %s, Message: %s",
+              job->description,
+              slotMigrationJobStateToString(state),
+              job->status_msg ? job->status_msg : "none");
+
+    if (job->type == SLOT_MIGRATION_IMPORT) {
+        setSlotImportingStateInAllDbs(job->slot_ranges, 0);
+        if (nodeIsPrimary(server.cluster->myself)) propagateSyncSlotsFinish(job);
+    }
+
     if (job->type == SLOT_MIGRATION_EXPORT) {
         if (state == SLOT_MIGRATION_JOB_SUCCESS) {
             fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED);
@@ -2048,8 +2357,9 @@ void finishSlotMigrationJob(slotMigrationJob *job,
     } else {
         if (state == SLOT_MIGRATION_JOB_SUCCESS) {
             fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED);
+        } else {
+            fireModuleSlotMigrationEvent(job, VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED);
         }
-        /* Aborted notifications will be fired after cleanup completes. */
     }
 }
 
@@ -2065,7 +2375,7 @@ bool isSlotMigrationJobFinished(slotMigrationJob *job) {
  * possible that we are not trying to perform the migration, but we are not
  * finished yet, e.g. if we are still pending cleanup. */
 bool isSlotMigrationJobInProgress(slotMigrationJob *job) {
-    return job->state != SLOT_IMPORT_FINISHED_WAITING_TO_CLEANUP &&
+    return job->state != SLOT_IMPORT_FINISHED_CLEANING_UP &&
            !isSlotMigrationJobFinished(job);
 }
 
@@ -2175,7 +2485,8 @@ void clusterSlotMigrationCron(void) {
         /* Note that after granting failover, we no longer care about the
          * connection timeout, since we will use pause timeout. */
         if (isSlotMigrationJobInProgress(job) &&
-            job->state != SLOT_EXPORT_FAILOVER_GRANTED) {
+            job->state != SLOT_EXPORT_FAILOVER_GRANTED &&
+            job->state != SLOT_IMPORT_OCCURRING_ON_PRIMARY) {
             serverAssert(job->type == SLOT_MIGRATION_EXPORT || job->client);
             /* For imports, last interaction will be set to the last
              * incoming command, as replicated clients don't set
@@ -2241,45 +2552,59 @@ void clusterCommandSyncSlotsAck(client *c) {
 /* Sent by either the target or the source as a control message for progressing
  * with slot import. */
 void clusterCommandSyncSlots(client *c) {
-    if (c->flag.primary) {
-        /* Since target primaries proxy slot migration source commands to
-         * replicas through chaining replication (direct bytewise copy, not
-         * commandwise propagation), SYNCSLOTS should be ignored from our
-         * primary. */
-        return;
-    }
+    /* Commands used by primary and replica */
     if (!strcasecmp(c->argv[2]->ptr, "establish")) {
         /* CLUSTER SYNCSLOTS ESTABLISH <args> */
         clusterCommandSyncSlotsEstablish(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "snapshot-eof")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "finish")) {
+        /* CLUSTER SYNCSLOTS FINISH <args> */
+        clusterCommandSyncSlotsFinish(c);
+        return;
+    }
+
+    /* Commands only used by primary (ignored on replica) */
+    if (c->flag.primary) return;
+    if (!strcasecmp(c->argv[2]->ptr, "snapshot-eof")) {
         /* CLUSTER SYNCSLOTS SNAPSHOT-EOF */
         clusterCommandSyncSlotsSnapshotEof(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "request-pause")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "request-pause")) {
         /* CLUSTER SYNCSLOTS REQUEST-PAUSE */
         clusterCommandSyncSlotsRequestPause(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "paused")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "paused")) {
         /* CLUSTER SYNCSLOTS PAUSED */
         clusterCommandSyncSlotsPaused(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "request-failover")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "request-failover")) {
         /* CLUSTER SYNCSLOTS REQUEST-FAILOVER */
         clusterCommandSyncSlotsRequestFailover(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "failover-granted")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "failover-granted")) {
         /* CLUSTER SYNCSLOTS FAILOVER-GRANTED */
         clusterCommandSyncSlotsFailoverGranted(c);
-    } else if (!strcasecmp(c->argv[2]->ptr, "ack")) {
+        return;
+    }
+    if (!strcasecmp(c->argv[2]->ptr, "ack")) {
         /* CLUSTER SYNCSLOTS ACK */
         clusterCommandSyncSlotsAck(c);
-    } else {
-        if (c->slot_migration_job &&
-            isSlotMigrationJobInProgress(c->slot_migration_job)) {
-            serverLog(LL_WARNING, "Received unknown SYNCSLOTS subcommand from "
-                                  "slot migration %s. Failing the migration.",
-                      c->slot_migration_job->description);
-            finishSlotMigrationJob(c->slot_migration_job,
-                                   SLOT_MIGRATION_JOB_FAILED,
-                                   "Unknown SYNCSLOTS subcommand used");
-            return;
-        }
-        addReplyErrorObject(c, shared.syntaxerr);
+        return;
     }
+    if (c->slot_migration_job &&
+        isSlotMigrationJobInProgress(c->slot_migration_job)) {
+        serverLog(LL_WARNING, "Received unknown SYNCSLOTS subcommand from "
+                                "slot migration %s. Failing the migration.",
+                    c->slot_migration_job->description);
+        finishSlotMigrationJob(c->slot_migration_job,
+                                SLOT_MIGRATION_JOB_FAILED,
+                                "Unknown SYNCSLOTS subcommand used");
+        return;
+    }
+    addReplyErrorObject(c, shared.syntaxerr);
 }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -435,9 +435,9 @@ int clusterDecodeSlotImportsAuxField(int rdbflags, sds s) {
     listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
 
     int num_fields = 0;
-    sds* import_fields = NULL;
+    sds *import_fields = NULL;
     int num_imports = 0;
-    sds* import_strs = sdssplitlen(s, sdslen(s), "/", 1, &num_imports);
+    sds *import_strs = sdssplitlen(s, sdslen(s), "/", 1, &num_imports);
     for (int i = 0; i < num_imports; i++) {
         import_fields = sdssplitlen(import_strs[i], sdslen(import_strs[i]), ":", 1, &num_fields);
 
@@ -478,7 +478,7 @@ int clusterDecodeSlotImportsAuxField(int rdbflags, sds s) {
     sdsfreesplitres(import_strs, num_imports);
     return C_OK;
 
-  error:
+error:
     listRelease(new_slot_migrations);
     sdsfreesplitres(import_strs, num_imports);
     sdsfreesplitres(import_fields, num_fields);
@@ -538,11 +538,11 @@ int clusterRegisterSlotImportsAuxFields(void) {
  *        │SLOT_IMPORT_OCCURRING_ON_PRIMARY◄────────────────────┘
  *        └────────────────────────────────┘
  *                     (see below)
- * 
+ *
  * State Machine (Replica):
  *
  *    SYNCSLOTS ESTABLISH or │
- *    RDB Aux field laod or  |
+ *    RDB Aux field load or  |
  *    demotion during import |
  *    ┌──────────────────────▼─────────┐
  *    │SLOT_IMPORT_OCCURRING_ON_PRIMARY┼──────┐
@@ -610,7 +610,7 @@ void clusterCommandSyncSlotsEstablish(client *c) {
     clusterNode *owning_node = NULL;
     char *source_node_name = NULL;
     list *slot_ranges = NULL;
-    
+
     if (!mustObeyClient(c) && validateSlotMigrationCanStartOrReply(c) == C_ERR) {
         return;
     }
@@ -876,7 +876,7 @@ slotMigrationJob *createSlotImportJob(client *c,
     serverLog(LL_NOTICE, "New slot import job created: %s.", job->description);
 
     if (!c || c->flag.primary) {
-        /* If the client is a primary, we enter a special tracking state that 
+        /* If the client is a primary, we enter a special tracking state that
          * will only be used to hide the dirty keys during the import.
          *
          * If there is no client - it means that this is an RDB load. We create
@@ -1077,7 +1077,7 @@ void clusterCleanSlotImportsOnResync(void) {
 
 /* Cleanup all active imports on reloading from disk, if I am a primary. */
 void clusterCleanSlotImportsOnReload(void) {
-    /* Only primaries should clean up slot imports when loading. Replicas may 
+    /* Only primaries should clean up slot imports when loading. Replicas may
      * need to know about previously ongoing slot imports in order to properly
      * PSYNC with primaries. */
     if (!clusterNodeIsPrimary(server.cluster->myself)) return;
@@ -2627,11 +2627,11 @@ void clusterCommandSyncSlots(client *c) {
     if (c->slot_migration_job &&
         isSlotMigrationJobInProgress(c->slot_migration_job)) {
         serverLog(LL_WARNING, "Received unknown SYNCSLOTS subcommand from "
-                                "slot migration %s. Failing the migration.",
-                    c->slot_migration_job->description);
+                              "slot migration %s. Failing the migration.",
+                  c->slot_migration_job->description);
         finishSlotMigrationJob(c->slot_migration_job,
-                                SLOT_MIGRATION_JOB_FAILED,
-                                "Unknown SYNCSLOTS subcommand used");
+                               SLOT_MIGRATION_JOB_FAILED,
+                               "Unknown SYNCSLOTS subcommand used");
         return;
     }
     addReplyErrorObject(c, shared.syntaxerr);

--- a/src/cluster_migrateslots.h
+++ b/src/cluster_migrateslots.h
@@ -34,5 +34,9 @@ bool clusterSlotFailoverGranted(int slot);
 void clusterFailAllSlotExportsWithMessage(char *message);
 void clusterHandleSlotMigrationErrorResponse(slotMigrationJob *job);
 void killSlotMigrationChild(void);
+void clusterCleanSlotImportsOnPromotion(void);
+void clusterCleanSlotImportsOnResync(void);
+void clusterCleanSlotImportsOnReload(void);
+int clusterRegisterSlotImportsAuxFields(void);
 
 #endif /* __CLUSTER_MIGRATESLOTS_H */

--- a/src/replication.c
+++ b/src/replication.c
@@ -2196,6 +2196,9 @@ void replicationAttachToNewPrimary(void) {
     serverAssert(server.primary == NULL);
     replicationDiscardCachedPrimary();
 
+    /* Cancel all in progress slot imports */
+    clusterCleanSlotImportsOnResync();
+
     disconnectReplicas();     /* Force our replicas to resync with us as well. */
     freeReplicationBacklog(); /* Don't allow our chained replicas to PSYNC. */
 }
@@ -4417,6 +4420,9 @@ void replicationUnsetPrimary(void) {
     /* Restart the AOF subsystem in case we shut it down during a sync when
      * we were still a replica. */
     if (server.aof_enabled && server.aof_state == AOF_OFF) restartAOFAfterSYNC();
+
+    /* Cancel any ongoing atomic slot migrations */
+    clusterCleanSlotImportsOnPromotion();
 }
 
 /* This function is called when the replica lose the connection with the

--- a/src/server.c
+++ b/src/server.c
@@ -3578,8 +3578,15 @@ void alsoPropagate(int dbid, robj **argv, int argc, int target, int slot) {
     if (!shouldPropagate(target)) return;
 
     /* Don't propagate commands on slot migration clients, these will be proxied
-     * in replicationFeedStreamFromPrimaryStream() */
-    if (server.current_client != NULL && server.current_client->slot_migration_job) return;
+     * in replicationFeedStreamFromPrimaryStream().
+     *
+     * However, if we need to propagate to AOF, we should still do that. */
+    bool propagate_aof = (target & PROPAGATE_AOF) && server.aof_state != AOF_OFF;
+    if (server.current_client != NULL && server.current_client->slot_migration_job) {
+        if (!propagate_aof) return;
+        /* Disable propagation to replication (just do the AOF) */
+        target &= ~PROPAGATE_REPL;
+    }
 
     argvcopy = zmalloc(sizeof(robj *) * argc);
     for (j = 0; j < argc; j++) {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -625,6 +625,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         lassign $testcase source_idx target_idx source_repl_idx target_repl_idx target_id slot_to_migrate slot_to_migrate_tag slot_to_test slot_to_test_tag
         set_debug_prevent_pause 1
         test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - start migration" {
+            R $target_idx CONFIG RESETSTAT
+            R $target_repl_idx CONFIG RESETSTAT
             populate 1000 "$slot_to_migrate_tag:1:" 1000 -$source_idx false 1000
             assert_match "1" [R $source_idx HSETEX "$slot_to_migrate_tag:hfe" EX 1000 FIELDS 1 field value]
             assert_match "OK" [R $source_idx CLUSTER MIGRATESLOTS SLOTSRANGE $slot_to_migrate $slot_to_migrate NODE $target_id]
@@ -684,6 +686,17 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
                 assert_match "1" [R $target_idx DEL $slot_to_test_tag:hfe]
                 wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - slot stats" {
+                # Not visiblie in ORDERBY
+                foreach slot_stat {"key-count" "cpu-usec" "network-bytes-in" "network-bytes-out"} {
+                    foreach slot_info [R $node_idx CLUSTER SLOT-STATS ORDERBY $slot_stat LIMIT 16384 DESC] {
+                        set slot [lindex $slot_info 0]
+                        assert_not_equal $slot_to_migrate $slot
+                    }
+                }
+                # Not visible in SLOTSRANGE
+                assert_equal "" [R $node_idx CLUSTER SLOT-STATS SLOTSRANGE $slot_to_migrate $slot_to_migrate]
             }
         }
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -626,12 +626,13 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         set_debug_prevent_pause 1
         test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - start migration" {
             populate 1000 "$slot_to_migrate_tag:1:" 1000 -$source_idx false 1000
+            assert_match "1" [R $source_idx HSETEX "$slot_to_migrate_tag:hfe" EX 1000 FIELDS 1 field value]
             assert_match "OK" [R $source_idx CLUSTER MIGRATESLOTS SLOTSRANGE $slot_to_migrate $slot_to_migrate NODE $target_id]
             set jobname [get_job_name $source_idx $slot_to_migrate]
             wait_for_migration_field $source_idx $jobname state waiting-to-pause
 
-            assert_match "1000" [R $target_idx CLUSTER COUNTKEYSINSLOT $slot_to_migrate]
-            wait_for_countkeysinslot $target_repl_idx $slot_to_migrate 1000
+            assert_match "1001" [R $target_idx CLUSTER COUNTKEYSINSLOT $slot_to_migrate]
+            wait_for_countkeysinslot $target_repl_idx $slot_to_migrate 1001
         }
         foreach node_under_test [list \
             [list $target_idx "Primary"] \
@@ -672,6 +673,18 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
                 wait_for_countkeysinslot $node_idx $slot_to_test 0
             }
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - DB stats" {
+                set db_info_before [status [srv -$node_idx client] db0]
+                assert_match "" $db_info_before
+                assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value EX 1000]
+                assert_match "1" [R $target_idx HSETEX "$slot_to_test_tag:hfe" EX 1000 FIELDS 1 field value]
+                wait_for_countkeysinslot $node_idx $slot_to_test 2
+                set db_info_after [status [srv -$node_idx client] db0]
+                assert_match "keys=2,expires=1,avg_ttl=*,keys_with_volatile_items=1" $db_info_after
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:hfe]
+                wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
         }
 
         foreach eviction_policy {
@@ -697,7 +710,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                         }
                     }
                     # Validate keys are there
-                    assert_match "1000" [R $target_idx CLUSTER COUNTKEYSINSLOT $slot_to_migrate]
+                    assert_match "1001" [R $target_idx CLUSTER COUNTKEYSINSLOT $slot_to_migrate]
                 }
             }
         }

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -1937,9 +1937,20 @@ start_cluster 3 6 {tags {logreqres:skip external:skip cluster}} {
         assert_match "500" [R 8 CLUSTER COUNTKEYSINSLOT 16383]
 
         # Expect error messages
-        assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 0 $jobname] message]
+        #
+        # Depending on whether replicas can PSYNC or not, the error message
+        # changes. They may not be able to PSYNC if the primary generates enough
+        # UNLINK events when cleaning up dirty slots on promotion to fill up the
+        # replication backlog.
+        assert {
+            [string match "*A failover occurred during slot import*" [dict get [get_migration_by_name 0 $jobname] message]] ||
+            [string match "*Full resynchronization occurred*" [dict get [get_migration_by_name 0 $jobname] message]]
+        }
         assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 3 $jobname] message]
-        assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 6 $jobname] message]
+        assert {
+            [string match "*A failover occurred during slot import*" [dict get [get_migration_by_name 6 $jobname] message]] ||
+            [string match "*Full resynchronization occurred*" [dict get [get_migration_by_name 6 $jobname] message]]
+        }
         assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
         # Cleanup for the next test

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -146,6 +146,23 @@ proc assert_causes_conn_drop {node_idx body} {
     assert_match "*I/O error reading reply*" $result
 }
 
+proc is_cluster_stable {} {
+    for {set i 0} {$i < [llength $::servers]} {incr i} {
+        if {![string match "*cluster_state:ok*" [R $i CLUSTER INFO]]} {
+            return 0
+        }
+    }
+    return 1
+}
+
+proc wait_for_cluster_stable {} {
+    wait_for_condition 100 100 {
+        [is_cluster_stable]
+    } else {
+        fail "Cluster did not become stable within 10 seconds"
+    }
+}
+
 proc set_debug_prevent_pause {value} {
     for {set i 0} {$i < [llength $::servers]} {incr i} {
         assert_match "OK" [R $i DEBUG SLOTMIGRATION PREVENT-PAUSE $value]
@@ -155,6 +172,20 @@ proc set_debug_prevent_pause {value} {
 proc set_debug_prevent_failover {value} {
     for {set i 0} {$i < [llength $::servers]} {incr i} {
         assert_match "OK" [R $i DEBUG SLOTMIGRATION PREVENT-FAILOVER $value]
+    }
+}
+
+proc do_node_restart {idx} {
+    set result [catch {R $idx DEBUG RESTART 0} err]
+
+    if {$result != 0 && $err ne "I/O error reading reply"} {
+        fail "Unexpected error restarting server: $err"
+    }
+
+    wait_for_condition 100 100 {
+        [check_server_response $idx] eq 1
+    } else {
+        fail "Node didn't come back online in time"
     }
 }
 
@@ -365,7 +396,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
         set jobname [get_job_name 2 16383]
         wait_for_migration_field 2 $jobname state failed
-        assert {[string match {*A slot on the target node is being manually imported or migrated*} [dict get [get_migration_by_name 2 $jobname] message]]}
+        assert_match {*Slots are being manually imported*} [dict get [get_migration_by_name 2 $jobname] message]
         assert_match "OK" [R 0 CLUSTER SETSLOT 16383 STABLE]
 
         # Cleanup
@@ -588,10 +619,10 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
     # Test with both migrating slot < existing slot and vice versa, since a lot of the
     # kvstore logic is ordering dependent
     foreach testcase [list \
-        [list 0 2 $node2_id 0 $0_slot_tag 16383 $16383_slot_tag] \
-        [list 2 0 $node0_id 16383 $16383_slot_tag 0 $0_slot_tag] \
+        [list 0 2 3 5 $node2_id 0 $0_slot_tag 16383 $16383_slot_tag] \
+        [list 2 0 5 3 $node0_id 16383 $16383_slot_tag 0 $0_slot_tag] \
     ] {
-        lassign $testcase source_idx target_idx target_id slot_to_migrate slot_to_migrate_tag slot_to_test slot_to_test_tag
+        lassign $testcase source_idx target_idx source_repl_idx target_repl_idx target_id slot_to_migrate slot_to_migrate_tag slot_to_test slot_to_test_tag
         set_debug_prevent_pause 1
         test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - start migration" {
             populate 1000 "$slot_to_migrate_tag:1:" 1000 -$source_idx false 1000
@@ -600,34 +631,47 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_migration_field $source_idx $jobname state waiting-to-pause
 
             assert_match "1000" [R $target_idx CLUSTER COUNTKEYSINSLOT $slot_to_migrate]
+            wait_for_countkeysinslot $target_repl_idx $slot_to_migrate 1000
         }
-        test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - DBSIZE command excludes importing keys" {
-            assert_match "0" [R $target_idx DBSIZE]
-            assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
-            assert_match "1" [R $target_idx DBSIZE]
-            assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
-        }
-        test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - KEYS command excludes importing keys" {
-            assert_match "" [R $target_idx KEYS *]
-            assert_match "" [R $target_idx KEYS $slot_to_migrate_tag:*]
-            assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
-            assert_match "{$slot_to_test_tag:my_key}" [R $target_idx KEYS *]
-            assert_match "" [R $target_idx KEYS $slot_to_migrate_tag:*]
-            assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
-        }
-
-        test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - SCAN command excludes importing keys" {
-            assert_match "0 {}" [R $target_idx SCAN 0]
-            assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
-            assert_match "0 {{$slot_to_test_tag:my_key}}" [R $target_idx SCAN 0]
-            assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
-        }
-
-        test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - RANDOMKEY command excludes importing keys" {
-            assert_match "" [R $target_idx RANDOMKEY]
-            assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
-            assert_match "$slot_to_test_tag:my_key" [R $target_idx RANDOMKEY]
-            assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+        foreach node_under_test [list \
+            [list $target_idx "Primary"] \
+            [list $target_repl_idx "Replica"] \
+        ] {
+            lassign $node_under_test node_idx node_type
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - DBSIZE command excludes importing keys" {
+                assert_match "0" [R $node_idx DBSIZE]
+                assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
+                wait_for_countkeysinslot $node_idx $slot_to_test 1
+                assert_match "1" [R $node_idx DBSIZE]
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+                wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - KEYS command excludes importing keys" {
+                assert_match "" [R $node_idx KEYS *]
+                assert_match "" [R $node_idx KEYS $slot_to_migrate_tag:*]
+                assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
+                wait_for_countkeysinslot $node_idx $slot_to_test 1
+                assert_match "{$slot_to_test_tag:my_key}" [R $node_idx KEYS *]
+                assert_match "" [R $node_idx KEYS $slot_to_migrate_tag:*]
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+                wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - SCAN command excludes importing keys" {
+                assert_match "0 {}" [R $node_idx SCAN 0]
+                assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
+                wait_for_countkeysinslot $node_idx $slot_to_test 1
+                assert_match "0 {{$slot_to_test_tag:my_key}}" [R $node_idx SCAN 0]
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+                wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
+            test "$node_type importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - RANDOMKEY command excludes importing keys" {
+                assert_match "" [R $node_idx RANDOMKEY]
+                assert_match "OK" [R $target_idx SET $slot_to_test_tag:my_key my_value]
+                wait_for_countkeysinslot $node_idx $slot_to_test 1
+                assert_match "$slot_to_test_tag:my_key" [R $node_idx RANDOMKEY]
+                assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
+                wait_for_countkeysinslot $node_idx $slot_to_test 0
+            }
         }
 
         foreach eviction_policy {
@@ -639,7 +683,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             volatile-lfu
             volatile-ttl
         } {
-            test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - $eviction_policy eviction excludes importing keys" {
+            test "Primary importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - $eviction_policy eviction excludes importing keys" {
                 # Eviction should only touch non-importing keys
                 setup_eviction_test $target_idx $eviction_policy {
                     # Do 1000 evictions
@@ -658,7 +702,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             }
         }
 
-        test "Importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - active expiration excludes importing keys" {
+        test "Primary importing key containment (slot $slot_to_migrate from node $source_idx to $target_idx) - active expiration excludes importing keys" {
             # Populate 1000 keys with 1 second timeout, and do the snapshot
             assert_match "OK" [R $source_idx FLUSHALL SYNC]
             assert_match "OK" [R $target_idx FLUSHALL SYNC]
@@ -1028,8 +1072,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_countkeysinslot 3 16383 0
 
             # Migration logs shows failure on both ends
-            assert {[string match {*OOM*} [dict get [get_migration_by_name 0 $jobname] message]]}
-            assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*OOM*} [dict get [get_migration_by_name 0 $jobname] message]
+            assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for the next test
             assert_match "OK" [R 0 CONFIG SET maxmemory 0]
@@ -1066,9 +1110,13 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_match "500" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
         assert_match "500" [R 5 CLUSTER COUNTKEYSINSLOT 16383]
 
-        # Expect error messages
-        assert {[string match {*I was demoted to a replica*} [dict get [get_migration_by_name 0 $jobname] message]]}
-        assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]]}
+        # Expect error messages. Either a failover, or if the PSYNC fails, it
+        # will be a full resync message.
+        assert {
+            [string match "*A failover occurred during slot import*" [dict get [get_migration_by_name 0 $jobname] message]] ||
+            [string match "*Full resynchronization occurred*" [dict get [get_migration_by_name 0 $jobname] message]]
+        }
+        assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
         # Cleanup for the next test
         assert_match "OK" [R 2 FLUSHDB SYNC]
@@ -1128,7 +1176,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
             # Force slot takeover
             assert_match "*BUMPED*" [R 1 CLUSTER BUMPEPOCH]
-            assert_match "OK" [R 1 CLUSTER SETSLOT 0 NODE $node1_id]
+            assert_match "OK" [R 1 CLUSTER SETSLOT 0 NODE $node1_id TIMEOUT 0]
 
             # Second job should get dropped on either end
             wait_for_migration_field 0 $jobname state failed
@@ -1139,8 +1187,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_match "0" [R 5 CLUSTER COUNTKEYSINSLOT 0]
 
             # Migration logs for jobname shows failure on both ends
-            # assert {[string match {*Slots are no longer owned by myself*} [dict get [get_migration_by_name 0 $jobname] message]]}
-            # assert {[string match {*Slots are no longer owned by source node*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            # assert_match {*Slots are no longer owned by myself*} [dict get [get_migration_by_name 0 $jobname] message]
+            # assert_match {*Slots are no longer owned by source node*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for the next test
             set_debug_prevent_pause 0
@@ -1169,8 +1217,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_migration_field 2 $jobname state failed
 
             # Migration logs for job shows failure
-            assert {[string match {*Unpaused before migration completed*} [dict get [get_migration_by_name 0 $jobname] message]]}
-            assert {[string match {*Connection lost to source*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*Unpaused before migration completed*} [dict get [get_migration_by_name 0 $jobname] message]
+            assert_match {*Connection lost to source*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Validate no longer paused
             assert_match "none" [s -0 paused_reason]
@@ -1265,7 +1313,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert_error "*Target node does not agree about current slot ownership*" {R 0 CLUSTER SYNCSLOTS ESTABLISH SOURCE $node1_id NAME $fake_jobname SLOTSRANGE 16383 16383}
 
             # Not primary
-            assert_error "*Target node is not a primary*" {R 3 CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383}
+            assert_error "*Slot migration can only be used on primary nodes*" {R 3 CLUSTER SYNCSLOTS ESTABLISH SOURCE $node2_id NAME $fake_jobname SLOTSRANGE 16383 16383}
 
             # Invalid target name
             assert_error "*syntax error*" {R 0 CLUSTER SYNCSLOTS ESTABLISH SOURCE invalid NAME $fake_jobname SLOTSRANGE 16383 16383}
@@ -1321,8 +1369,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 # Target should fail the migration
                 wait_for_migration_field 2 $jobname state failed
                 wait_for_migration_field 0 $jobname state failed
-                assert {[string match {*Data was flushed*} [dict get [get_migration_by_name 0 $jobname] message]]}
-                assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]]}
+                assert_match {*Data was flushed*} [dict get [get_migration_by_name 0 $jobname] message]
+                assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
                 wait_for_countkeysinslot 0 16383 0
                 wait_for_countkeysinslot 3 16383 0
             }
@@ -1358,8 +1406,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 assert_match "OK" [eval R 2 $command]
                 wait_for_migration_field 2 $jobname state failed
                 wait_for_migration_field 0 $jobname state failed
-                assert {[string match {*Data was flushed*} [dict get [get_migration_by_name 2 $jobname] message]]}
-                assert {[string match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]]}
+                assert_match {*Data was flushed*} [dict get [get_migration_by_name 2 $jobname] message]
+                assert_match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]
                 assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
                 wait_for_countkeysinslot 0 16383 0
                 wait_for_countkeysinslot 3 16383 0
@@ -1393,12 +1441,12 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
             # The import should eventually fail due to no ACKs
             wait_for_migration_field 2 $jobname state failed
-            assert {[string match {*Timed out after too long with no interaction*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*Timed out after too long with no interaction*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # After resuming, it should be reflected on source
             resume_process $node0_pid
             wait_for_migration_field 0 $jobname state failed
-            assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 0 $jobname] message]]}
+            assert_match {*Connection lost to target*} [dict get [get_migration_by_name 0 $jobname] message]
 
             # Cleanup for the next test
             assert_match "OK" [R 0 FLUSHDB SYNC]
@@ -1430,12 +1478,12 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
             # The export should eventually fail due to no ACKs
             wait_for_migration_field 0 $jobname state failed
-            assert {[string match {*Timed out after too long with no interaction*} [dict get [get_migration_by_name 0 $jobname] message]]}
+            assert_match {*Timed out after too long with no interaction*} [dict get [get_migration_by_name 0 $jobname] message]
 
             # After resuming, it should be reflected on target
             resume_process $node2_pid
             wait_for_migration_field 2 $jobname state failed
-            assert {[string match {*Connection lost to source*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*Connection lost to source*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for the next test
             assert_match "OK" [R 0 FLUSHDB SYNC]
@@ -1512,8 +1560,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             # Migration should be failed
             wait_for_migration_field 2 $jobname state failed
             wait_for_migration_field 0 $jobname state failed
-            assert {[string match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]]}
-            assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]
+            assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for next test
             set_debug_prevent_pause 0
@@ -1551,8 +1599,8 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             # Migration should be failed
             wait_for_migration_field 2 $jobname state failed
             wait_for_migration_field 0 $jobname state failed
-            assert {[string match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]]}
-            assert {[string match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]]}
+            assert_match {*Connection lost to source*} [dict get [get_migration_by_name 0 $jobname] message]
+            assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
             # Cleanup for the next test
             assert_match "OK" [R 2 FLUSHDB SYNC]
@@ -1716,7 +1764,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
 
             # Cleanup for next test
-            assert_match "OK" [R 0 FLUSHDB SYNC]
+            assert_match "OK" [R 2 FLUSHDB SYNC]
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 0 0 NODE $node0_id]
             wait_for_migration 0 0
             R 2 CONFIG SET repl-timeout 60
@@ -1724,69 +1772,180 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         }
     }
 
-    test "Resynchronization during migration" {
+    foreach testcase [list \
+        [list 0 0 1] \
+        [list 0 1 1] \
+        [list 2 0 1] \
+        [list 2 1 1] \
+        [list 3 0 0] \
+        [list 3 1 0] \
+        [list 5 0 0] \
+        [list 5 1 0] \
+    ] {
+        lassign $testcase idx_to_restart do_save expect_fail
+        set save_condition [expr { $do_save ? "with save" : "without save" }]
+        set expectation [expr { $expect_fail ? "failure" : "success" }]
+        switch $idx_to_restart {
+            0 {set node_name "target primary"}
+            2 {set node_name "source primary"}
+            3 {set node_name "target replica"}
+            5 {set node_name "source replica"}
+        }
+        test "Restart $node_name during migration ($save_condition) causes $expectation" {
+            set_debug_prevent_pause 1
+
+            # Load data before the snapshot
+            populate 333 "$16379_slot_tag:1:" 1000 -2
+
+            # Load data while the snapshot is ongoing
+            assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16300 16300 16379 16383 NODE $node0_id]
+            set jobname [get_job_name 2 16383]
+            populate 333 "$16381_slot_tag:2:" 1000 -2
+
+            # Load data after the snapshot
+            wait_for_migration_field 2 $jobname state waiting-to-pause
+            populate 334 "$16383_slot_tag:3:" 1000 -2
+
+            # Resync the replicas on both ends
+            if {$do_save} {
+                assert_match "OK" [R $idx_to_restart SAVE]
+            }
+
+            do_node_restart $idx_to_restart
+
+            # Wait for resync
+            wait_for_condition 50 1000 {
+                [status [srv -3 client] master_link_status] == "up"
+            } else {
+                fail "Node 3 is not synced"
+            }
+            wait_for_condition 50 1000 {
+                [status [srv -5 client] master_link_status] == "up"
+            } else {
+                fail "Node 5 is not synced"
+            }
+
+            if {$expect_fail} {
+                if {$idx_to_restart != 2} {
+                    wait_for_migration_field 2 $jobname state failed
+                }
+                if {$idx_to_restart != 0} {
+                    wait_for_migration_field 0 $jobname state failed
+                }
+                set not_owning_prim 0
+                set not_owning_repl 3
+                set owning_prim 2
+                set owning_repl 5
+            } else {
+                # Replicas should get the keys again
+                wait_for_countkeysinslot 3 16379 333
+                wait_for_countkeysinslot 3 16381 333
+                wait_for_countkeysinslot 3 16383 334
+
+                # Should not be exposed to user, since the migration is not yet complete
+                assert_match "0" [R 0 DBSIZE]
+                assert_match "0" [R 3 DBSIZE]
+
+                # Allow migration to complete
+                set_debug_prevent_pause 0
+                wait_for_migration 0 16383
+
+                # Migration log shows success on both ends
+                assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
+                assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+
+                set not_owning_prim 2
+                set not_owning_repl 5
+                set owning_prim 0
+                set owning_repl 3
+            }
+
+            if {$owning_prim == $idx_to_restart && ! $do_save} {
+                assert_match "0" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16379]
+                assert_match "0" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16381]
+                assert_match "0" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16383]
+                wait_for_countkeysinslot $owning_repl 16379 0
+                wait_for_countkeysinslot $owning_repl 16381 0
+                wait_for_countkeysinslot $owning_repl 16383 0
+            } else {
+                assert_match "333" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16379]
+                assert_match "333" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16381]
+                assert_match "334" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16383]
+                wait_for_countkeysinslot $owning_repl 16379 333
+                wait_for_countkeysinslot $owning_repl 16381 333
+                wait_for_countkeysinslot $owning_repl 16383 334
+            }
+            assert_match "0" [R $not_owning_prim CLUSTER COUNTKEYSINSLOT 16379]
+            assert_match "0" [R $not_owning_prim CLUSTER COUNTKEYSINSLOT 16381]
+            assert_match "0" [R $not_owning_prim CLUSTER COUNTKEYSINSLOT 16383]
+            wait_for_countkeysinslot $not_owning_repl 16379 0
+            wait_for_countkeysinslot $not_owning_repl 16381 0
+            wait_for_countkeysinslot $not_owning_repl 16383 0
+
+            # Cleanup for the next test
+            assert_match "OK" [R $owning_prim FLUSHDB SYNC]
+            if {$expect_fail} {
+                set_debug_prevent_pause 0
+            } else {
+                assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16300 16300 16379 16383 NODE $node2_id]
+                wait_for_migration 2 16383
+            }
+            # Since we are restarting primaries, we need to ensure the cluster becomes stable
+            wait_for_cluster_stable
+        }
+    }
+}
+
+start_cluster 3 6 {tags {logreqres:skip external:skip cluster}} {
+    set node0_id [R 0 CLUSTER MYID]
+    set node1_id [R 1 CLUSTER MYID]
+    set node2_id [R 2 CLUSTER MYID]
+
+    set 16383_slot_tag "{6ZJ}"
+
+    test "Failover cancels slot migration in transferred replica" {
+        # Load some data before the snapshot
+        populate 500 "$16383_slot_tag:1:" 1000 -2
+
+        # Prepare and wait for ready
         set_debug_prevent_pause 1
-
-        # Load data before the snapshot
-        populate 333 "$16379_slot_tag:1:" 1000 -2
-
-        # Load data while the snapshot is ongoing
-        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16379 16383 NODE $node0_id]
+        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
         set jobname [get_job_name 2 16383]
-        populate 333 "$16381_slot_tag:2:" 1000 -2
-
-        # Load data after the snapshot
         wait_for_migration_field 2 $jobname state waiting-to-pause
-        populate 334 "$16383_slot_tag:3:" 1000 -2
 
-        # Resync the replicas on both ends
-        assert_match "OK" [R 0 SAVE]
-        assert_match "OK" [R 3 CLUSTER REPLICATE NO ONE]
-        assert_match "OK" [R 5 CLUSTER REPLICATE NO ONE]
-        assert_match "OK" [R 3 CLUSTER REPLICATE $node0_id]
-        assert_match "OK" [R 5 CLUSTER REPLICATE $node2_id]
-        
+        # Make sure the replicas have it
+        wait_for_countkeysinslot 3 16383 500
+        wait_for_countkeysinslot 6 16383 500
 
-        # Wait for resync
-        wait_for_condition 50 1000 {
-            [status [srv -3 client] master_link_status] == "up"
-        } else {
-            fail "Node 3 is not synced"
-        }
-        wait_for_condition 50 1000 {
-            [status [srv -5 client] master_link_status] == "up"
-        } else {
-            fail "Node 5 is not synced"
-        }
+        # Trigger failover
+        assert_match "OK" [R 3 CLUSTER FAILOVER]
 
-        # Allow migration to complete and verify
-        set_debug_prevent_pause 0
-        wait_for_migration 0 16383
-        assert_match "333" [R 0 CLUSTER COUNTKEYSINSLOT 16379]
-        assert_match "333" [R 0 CLUSTER COUNTKEYSINSLOT 16381]
-        assert_match "334" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
-        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16379]
-        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16381]
-        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+        # Jobs should be dropped on both ends
+        wait_for_migration_field 2 $jobname state failed
+        wait_for_migration_field 0 $jobname state failed
+        wait_for_migration_field 3 $jobname state failed
+        wait_for_migration_field 6 $jobname state failed
 
-        # Also eventually reflected in replicas
-        wait_for_countkeysinslot 3 16379 333
-        wait_for_countkeysinslot 3 16381 333
-        wait_for_countkeysinslot 3 16383 334
-        wait_for_countkeysinslot 5 16379 0
-        wait_for_countkeysinslot 5 16381 0
-        wait_for_countkeysinslot 5 16383 0
+        # Keys should be dropped in target shard
+        assert_match "0" [R 6 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "0" [R 3 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "0" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
 
-        # Migration log shows success on both ends
-        assert {[dict get [get_migration_by_name 0 $jobname] state] eq "success"}
-        assert {[dict get [get_migration_by_name 2 $jobname] state] eq "success"}
+        # Keys on existing shard are untouched
+        assert_match "500" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "500" [R 5 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "500" [R 8 CLUSTER COUNTKEYSINSLOT 16383]
+
+        # Expect error messages
+        assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 0 $jobname] message]
+        assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 3 $jobname] message]
+        assert_match {*A failover occurred during slot import*} [dict get [get_migration_by_name 6 $jobname] message]
+        assert_match {*Connection lost to target*} [dict get [get_migration_by_name 2 $jobname] message]
 
         # Cleanup for the next test
-        assert_match "OK" [R 0 FLUSHDB SYNC]
-        assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16379 16383 NODE $node2_id]
-        wait_for_migration 2 16383
+        assert_match "OK" [R 2 FLUSHDB SYNC]
+        set_debug_prevent_pause 0
     }
-
 }
 
 start_cluster 3 0 {tags {logreqres:skip external:skip cluster}} {
@@ -1852,4 +2011,57 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster}} {
         assert_match "*Unable to connect to target node: Connection refused*" [dict get [get_migration_by_name 0 $jobname] message]
     }
 
+}
+
+start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {appendonly yes auto-aof-rewrite-percentage 0}} {
+    set node0_id [R 0 CLUSTER MYID]
+    set node1_id [R 1 CLUSTER MYID]
+    set node2_id [R 2 CLUSTER MYID]
+
+    set 16383_slot_tag "{6ZJ}"
+
+    test "Replica PSYNC after loading AOF does not lose migration" {
+        # Load some data before the snapshot
+        populate 500 "$16383_slot_tag:1:" 1000 -2
+
+        # Prepare and wait for ready
+        set_debug_prevent_pause 1
+        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+        set jobname [get_job_name 2 16383]
+        wait_for_migration_field 2 $jobname state waiting-to-pause
+
+        # Make sure the replicas have it
+        wait_for_countkeysinslot 3 16383 500
+
+        # Restart the replica
+        do_node_restart 3
+
+        # Replica should still see the migration. Note that since AOF does not
+        # persist the replication ID, this is because of a full resync.
+        wait_for_migration_field 3 $jobname state occurring-on-primary
+        assert_match "0" [R 3 DBSIZE]
+    }
+
+    test "Importing keys are persisted through AOF" {
+        set_debug_prevent_pause 0
+
+        wait_for_migration 0 16383
+
+        assert_match "500" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+        wait_for_countkeysinslot 3 16383 500
+        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+        wait_for_countkeysinslot 5 16383 0
+
+        assert_match "1 *" [R 0 WAITAOF 1 0 0]
+
+        # Reload the data on the primary
+        R 0 DEBUG LOADAOF
+
+        assert_match "500" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+
+        # Cleanup for next test
+        assert_match "OK" [R 0 FLUSHDB SYNC]
+        assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+        wait_for_migration 2 16383
+    }
 }

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -385,7 +385,7 @@ tags "modules" {
         }
     }
 
-    start_cluster 3 0 [list tags [list logreqres:skip external:skip cluster] overrides [list loadmodule "$testmodule"]] {
+    start_cluster 3 3 [list tags [list logreqres:skip external:skip cluster] overrides [list loadmodule "$testmodule"]] {
         test {Test atomic slot migration hooks} {
             assert_match "OK" [R 2 DEBUG SLOTMIGRATION PREVENT-PAUSE 1]
             set node0_id [R 0 CLUSTER MYID]
@@ -398,17 +398,27 @@ tags "modules" {
             wait_for_condition 50 100 {
                 [R 0 hooks.event_last atomic-slot-migration-import-start-target] ne ""
             } else {
-                fail "Import start event never triggered"
+                fail "Import start event never triggered on primary"
+            }
+            wait_for_condition 50 100 {
+                [R 3 hooks.event_last atomic-slot-migration-import-start-target] ne ""
+            } else {
+                fail "Import start event never triggered on replica"
             }
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-target] $node0_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-source] $node2_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-target] $node0_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-source] $node2_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-target] $node0_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-source] $node2_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-numslotranges] "1"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-slotranges] "16383-16383"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-numslotranges] "1"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-slotranges] "16383-16383"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-slotranges] "16383-16383"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-jobname] $job_name
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-jobname] $job_name
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-jobname] $job_name
 
             # Abort the migration
@@ -417,17 +427,27 @@ tags "modules" {
             wait_for_condition 50 100 {
                 [R 0 hooks.event_last atomic-slot-migration-import-abort-target] ne ""
             } else {
-                fail "Import abort event never triggered"
+                fail "Import abort event never triggered on primary"
+            }
+            wait_for_condition 50 100 {
+                [R 3 hooks.event_last atomic-slot-migration-import-abort-target] ne ""
+            } else {
+                fail "Import abort event never triggered on replica"
             }
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-target] $node0_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-source] $node2_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-target] $node0_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-source] $node2_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-target] $node0_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-source] $node2_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-numslotranges] "1"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-slotranges] "16383-16383"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-numslotranges] "1"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-slotranges] "16383-16383"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-slotranges] "16383-16383"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-jobname] $job_name
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-jobname] $job_name
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-jobname] $job_name
 
             # Allow migration to complete
@@ -440,17 +460,27 @@ tags "modules" {
             wait_for_condition 50 100 {
                 [R 0 hooks.event_last atomic-slot-migration-import-complete-target] ne ""
             } else {
-                fail "Import complete event never triggered"
+                fail "Import complete event never triggered on primary"
+            }
+            wait_for_condition 50 100 {
+                [R 3 hooks.event_last atomic-slot-migration-import-complete-target] ne ""
+            } else {
+                fail "Import complete event never triggered on replica"
             }
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-target] $node0_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-source] $node2_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-target] $node0_id
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-source] $node2_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-target] $node0_id
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-source] $node2_id
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-numslotranges] "1"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-slotranges] "16383-16383"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-numslotranges] "1"
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-slotranges] "16383-16383"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-slotranges] "16383-16383"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-jobname] $job_name
+            assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-jobname] $job_name
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-jobname] $job_name
         }
     }


### PR DESCRIPTION
This is just adds one more additional test, based on https://github.com/valkey-io/valkey/pull/2635 (will rebase onto unstable once that one is submitted)