### PR TITLE
Fix commandlog large-reply when using reply copy avoidance

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1391,7 +1391,17 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 
 /* Add an Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
-    if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) return;
+    if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
+        /* If copy avoidance allowed, then we explicitly maintain net_output_bytes_curr_cmd. */
+        serverAssert(obj->encoding == OBJ_ENCODING_RAW);
+        size_t str_len = sdslen(obj->ptr);
+        uint32_t num_len = digits10(str_len);
+        /* RESP encodes bulk strings as $<length>\r\n<data>\r\n */
+        c->net_output_bytes_curr_cmd += (num_len + 3); /* $<length>\r\n */
+        c->net_output_bytes_curr_cmd += str_len; /* <data> */
+        c->net_output_bytes_curr_cmd += 2; /* \r\n */
+        return;
+    }
     addReplyBulkLen(c, obj);
     addReply(c, obj);
     addReplyProto(c, "\r\n", 2);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1398,8 +1398,8 @@ void addReplyBulk(client *c, robj *obj) {
         uint32_t num_len = digits10(str_len);
         /* RESP encodes bulk strings as $<length>\r\n<data>\r\n */
         c->net_output_bytes_curr_cmd += (num_len + 3); /* $<length>\r\n */
-        c->net_output_bytes_curr_cmd += str_len; /* <data> */
-        c->net_output_bytes_curr_cmd += 2; /* \r\n */
+        c->net_output_bytes_curr_cmd += str_len;       /* <data> */
+        c->net_output_bytes_curr_cmd += 2;             /* \r\n */
         return;
     }
     addReplyBulkLen(c, obj);

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -118,10 +118,9 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         assert_equal [lindex $e 3] {set testkey {AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA... (896 more bytes)}}
         assert_equal {foobar} [lindex $e 5]
 
-        # for large-reply
-        set copy_avoid [lindex [r config get min-io-threads-avoid-copy-reply] 1]
-        r config set min-io-threads-avoid-copy-reply 0
-
+        # for large-reply - without reply copy avoidance
+        set copy_avoid [lindex [r config get min-string-size-avoid-copy-reply] 1]
+        assert_morethan $copy_avoid 1024
         r get testkey
         set e [lindex [r commandlog get -1 large-reply] 0]
         assert_equal [llength $e] 6
@@ -132,8 +131,20 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         assert_equal [lindex $e 3] {get testkey}
         assert_equal {foobar} [lindex $e 5]
 
-        # Restore min-io-threads-avoid-copy-reply value
-        r config set min-io-threads-avoid-copy-reply $copy_avoid
+        # for large-reply - with reply copy avoidance
+        # set min-string-size-avoid-copy-reply to 1 so wo will use reply copy avoidance
+        r config set min-string-size-avoid-copy-reply 1
+        r get testkey
+        set e [lindex [r commandlog get -1 large-reply] 0]
+        assert_equal [llength $e] 6
+        if {!$::external} {
+            assert_equal [lindex $e 0] 118
+        }
+        assert_equal [expr {[lindex $e 2] > 1024}] 1
+        assert_equal [lindex $e 3] {get testkey}
+        assert_equal {foobar} [lindex $e 5]
+        # Restore min-string-size-avoid-copy-reply value
+        r config set min-string-size-avoid-copy-reply $copy_avoid
     } {OK} {needs:debug}
 
     test {COMMANDLOG slow - Certain commands are omitted that contain sensitive information} {

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -120,7 +120,9 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
 
         # for large-reply - without reply copy avoidance
         set copy_avoid [lindex [r config get min-string-size-avoid-copy-reply] 1]
-        assert_morethan $copy_avoid 1024
+        if {!$::external} {
+            assert_morethan $copy_avoid 1024
+        }
         r get testkey
         set e [lindex [r commandlog get -1 large-reply] 0]
         assert_equal [llength $e] 6


### PR DESCRIPTION
In #2078, we did not report large reply when copy avoidance is allowed.
This results in replies larger than 16384 not being recorded in the
commandlog large-reply. This 16384 is controlled by the hidden config
min-string-size-avoid-copy-reply.