### PR TITLE
Backport to 8.0.6

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -842,7 +842,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * - It has enough room already allocated
      * - And not too large (avoid large memmove)
      * - And the client is not in a pending I/O state */
-    if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->size - prev->used > 0 &&
+    if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->used < prev->size &&
         c->io_write_state != CLIENT_PENDING_IO) {
         size_t len_to_copy = prev->size - prev->used;
         if (len_to_copy > length) len_to_copy = length;

--- a/src/replication.c
+++ b/src/replication.c
@@ -3616,7 +3616,7 @@ void syncWithPrimary(connection *conn) {
         server.repl_rdb_transfer_s = connCreate(connTypeOfReplication());
         if (connConnect(server.repl_rdb_transfer_s, server.primary_host, server.primary_port, server.bind_source_addr,
                         fullSyncWithPrimary) == C_ERR) {
-            serverLog(LL_WARNING, "Unable to connect to Primary: %s", connGetLastError(server.repl_transfer_s));
+            serverLog(LL_WARNING, "Unable to connect to Primary: %s", connGetLastError(server.repl_rdb_transfer_s));
             connClose(server.repl_rdb_transfer_s);
             server.repl_rdb_transfer_s = NULL;
             goto error;


### PR DESCRIPTION
Just backporting two PRs to the 8.0 branch, in advance. No `release notes` label for these, so nothing added to release notes.