### PR TITLE
HSETEX: Support NX/XX Flags

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -4316,6 +4316,8 @@ keySpec HSETEX_Keyspecs[1] = {
 struct COMMAND_ARG HSETEX_fields_condition_Subargs[] = {
 {MAKE_ARG("fnx",ARG_TYPE_PURE_TOKEN,-1,"FNX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("fxx",ARG_TYPE_PURE_TOKEN,-1,"FXX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("nx",ARG_TYPE_PURE_TOKEN,-1,"NX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("xx",ARG_TYPE_PURE_TOKEN,-1,"XX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /* HSETEX expiration argument table */
@@ -4342,7 +4344,7 @@ struct COMMAND_ARG HSETEX_fields_Subargs[] = {
 /* HSETEX argument table */
 struct COMMAND_ARG HSETEX_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("fields-condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=HSETEX_fields_condition_Subargs},
+{MAKE_ARG("fields-condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,4,NULL),.subargs=HSETEX_fields_condition_Subargs},
 {MAKE_ARG("expiration",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,5,NULL),.subargs=HSETEX_expiration_Subargs},
 {MAKE_ARG("fields",ARG_TYPE_BLOCK,-1,"FIELDS",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=HSETEX_fields_Subargs},
 };

--- a/src/commands.def
+++ b/src/commands.def
@@ -4312,12 +4312,16 @@ keySpec HSETEX_Keyspecs[1] = {
 };
 #endif
 
+/* HSETEX key_condition argument table */
+struct COMMAND_ARG HSETEX_key_condition_Subargs[] = {
+{MAKE_ARG("nx",ARG_TYPE_PURE_TOKEN,-1,"NX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("xx",ARG_TYPE_PURE_TOKEN,-1,"XX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
+};
+
 /* HSETEX fields_condition argument table */
 struct COMMAND_ARG HSETEX_fields_condition_Subargs[] = {
 {MAKE_ARG("fnx",ARG_TYPE_PURE_TOKEN,-1,"FNX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("fxx",ARG_TYPE_PURE_TOKEN,-1,"FXX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("nx",ARG_TYPE_PURE_TOKEN,-1,"NX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("xx",ARG_TYPE_PURE_TOKEN,-1,"XX",NULL,NULL,CMD_ARG_NONE,0,NULL)},
 };
 
 /* HSETEX expiration argument table */
@@ -4344,7 +4348,8 @@ struct COMMAND_ARG HSETEX_fields_Subargs[] = {
 /* HSETEX argument table */
 struct COMMAND_ARG HSETEX_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
-{MAKE_ARG("fields-condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,4,NULL),.subargs=HSETEX_fields_condition_Subargs},
+{MAKE_ARG("key-condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=HSETEX_key_condition_Subargs},
+{MAKE_ARG("fields-condition",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,2,NULL),.subargs=HSETEX_fields_condition_Subargs},
 {MAKE_ARG("expiration",ARG_TYPE_ONEOF,-1,NULL,NULL,NULL,CMD_ARG_OPTIONAL,5,NULL),.subargs=HSETEX_expiration_Subargs},
 {MAKE_ARG("fields",ARG_TYPE_BLOCK,-1,"FIELDS",NULL,NULL,CMD_ARG_NONE,2,NULL),.subargs=HSETEX_fields_Subargs},
 };
@@ -11809,7 +11814,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 {MAKE_CMD("hrandfield","Returns one or more random fields from a hash.","O(N) where N is the number of fields returned","6.2.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HRANDFIELD_History,0,HRANDFIELD_Tips,1,hrandfieldCommand,-2,CMD_READONLY,ACL_CATEGORY_HASH,HRANDFIELD_Keyspecs,1,NULL,2),.args=HRANDFIELD_Args},
 {MAKE_CMD("hscan","Iterates over fields and values of a hash.","O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.","2.8.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSCAN_History,0,HSCAN_Tips,1,hscanCommand,-3,CMD_READONLY,ACL_CATEGORY_HASH,HSCAN_Keyspecs,1,NULL,5),.args=HSCAN_Args},
 {MAKE_CMD("hset","Creates or modifies the value of a field in a hash.","O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.","2.0.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSET_History,1,HSET_Tips,0,hsetCommand,-4,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_HASH,HSET_Keyspecs,1,NULL,2),.args=HSET_Args},
-{MAKE_CMD("hsetex","Set the value of one or more fields of a given hash key, and optionally set their expiration time.","O(1)","9.0.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSETEX_History,0,HSETEX_Tips,0,hsetexCommand,-6,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_HASH,HSETEX_Keyspecs,1,NULL,4),.args=HSETEX_Args},
+{MAKE_CMD("hsetex","Set the value of one or more fields of a given hash key, and optionally set their expiration time.","O(1)","9.0.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSETEX_History,0,HSETEX_Tips,0,hsetexCommand,-6,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_HASH,HSETEX_Keyspecs,1,NULL,5),.args=HSETEX_Args},
 {MAKE_CMD("hsetnx","Sets the value of a field in a hash only when the field doesn't exist.","O(1)","2.0.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSETNX_History,0,HSETNX_Tips,0,hsetnxCommand,4,CMD_WRITE|CMD_DENYOOM|CMD_FAST,ACL_CATEGORY_HASH,HSETNX_Keyspecs,1,NULL,3),.args=HSETNX_Args},
 {MAKE_CMD("hstrlen","Returns the length of the value of a field.","O(1)","3.2.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HSTRLEN_History,0,HSTRLEN_Tips,0,hstrlenCommand,3,CMD_READONLY|CMD_FAST,ACL_CATEGORY_HASH,HSTRLEN_Keyspecs,1,NULL,2),.args=HSTRLEN_Args},
 {MAKE_CMD("httl","Returns the remaining time to live (in seconds) of a hash key's field(s) that have an associated expiration.","O(1) for each field, so O(N) for N items when the command is called with multiple fields.","9.0.0",CMD_DOC_NONE,NULL,NULL,"hash",COMMAND_GROUP_HASH,HTTL_History,0,HTTL_Tips,0,httlCommand,-5,CMD_READONLY|CMD_FAST,ACL_CATEGORY_HASH,HTTL_Keyspecs,1,NULL,2),.args=HTTL_Args},

--- a/src/commands/hsetex.json
+++ b/src/commands/hsetex.json
@@ -53,6 +53,23 @@
                 "key_spec_index": 0
             },
             {
+                "name": "key-condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
                 "name": "fields-condition",
                 "type": "oneof",
                 "optional": true,
@@ -66,16 +83,6 @@
                         "name": "fxx",
                         "type": "pure-token",
                         "token": "FXX"
-                    },
-                    {
-                        "name": "nx",
-                        "type": "pure-token",
-                        "token": "NX"
-                    },
-                    {
-                        "name": "xx",
-                        "type": "pure-token",
-                        "token": "XX"
                     }
                 ]
             },

--- a/src/commands/hsetex.json
+++ b/src/commands/hsetex.json
@@ -66,6 +66,16 @@
                         "name": "fxx",
                         "type": "pure-token",
                         "token": "FXX"
+                    },
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "token": "XX"
                     }
                 ]
             },

--- a/src/server.c
+++ b/src/server.c
@@ -7460,12 +7460,12 @@ int parseExtendedCommandArgumentsOrReply(client *c, int *flags, int *unit, robj 
         /* clang-format off */
         if ((opt[0] == 'n' || opt[0] == 'N') &&
             (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-            !(*flags & ARGS_SET_XX || *flags & ARGS_SET_IFEQ) && (command_type == COMMAND_SET))
+            !(*flags & ARGS_SET_XX || *flags & ARGS_SET_IFEQ) && (command_type == COMMAND_SET || command_type == COMMAND_HSET))
         {
             *flags |= ARGS_SET_NX;
         } else if ((opt[0] == 'x' || opt[0] == 'X') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
-                   !(*flags & ARGS_SET_NX || *flags & ARGS_SET_IFEQ) && (command_type == COMMAND_SET))
+                   !(*flags & ARGS_SET_NX || *flags & ARGS_SET_IFEQ) && (command_type == COMMAND_SET || command_type == COMMAND_HSET))
         {
             *flags |= ARGS_SET_XX;
         } else if ((opt[0] == 'f' || opt[0] == 'F') &&

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1264,8 +1264,8 @@ void hsetexCommand(client *c) {
 
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
 
-    /* Prepare a new argv when rewriting the command. If set_expired is true, 
-     * all expired fields will be deleted. Otherwise, if rewriting is needed due to NX/XX/FNX/FXX flags, 
+    /* Prepare a new argv when rewriting the command. If set_expired is true,
+     * all expired fields will be deleted. Otherwise, if rewriting is needed due to NX/XX/FNX/FXX flags,
      * copy the command, key, and optional arguments, skipping the NX/XX/FNX/FXX flags. */
     if (set_expired) {
         new_argv = zmalloc(sizeof(robj *) * (num_fields + 2));

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1324,7 +1324,9 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
-            replaceClientCommandVector(c, new_argc, new_argv);
+            if (need_rewrite_for_nx_xx_fnx_fxx) {
+                replaceClientCommandVector(c, new_argc, new_argv);
+            }
             if (expire) {
                 /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
                  * EX/PX/EXAT flag. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1209,6 +1209,24 @@ void hsetexCommand(client *c) {
     if (checkType(c, o, OBJ_HASH))
         return;
 
+    /* Check NX/XX key-level conditions before creating a new object */
+    if ((flags & ARGS_SET_NX) && o != NULL) {
+        addReply(c, shared.czero); // NX fails if key exists
+        return;
+    }
+
+    if ((flags & ARGS_SET_XX) && o == NULL) {
+        addReply(c, shared.czero); // XX fails if key does not exist
+        return;
+    }
+
+    if (o == NULL) {
+        o = createHashObject();
+        dbAdd(c->db, c->argv[1], &o);
+    }
+
+    bool has_volatile_fields = hashTypeHasVolatileFields(o);
+
     /* Handle parsing and calculating the expiration time. */
     if (flags & ARGS_KEEPTTL)
         set_flags |= HASH_SET_KEEP_EXPIRY;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1216,13 +1216,6 @@ void hsetexCommand(client *c) {
         return;
     }
 
-    if (o == NULL) {
-        o = createHashObject();
-        dbAdd(c->db, c->argv[1], &o);
-    }
-
-    bool has_volatile_fields = hashTypeHasVolatileFields(o);
-
     /* Handle parsing and calculating the expiration time. */
     if (flags & ARGS_KEEPTTL)
         set_flags |= HASH_SET_KEEP_EXPIRY;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1190,7 +1190,7 @@ void hsetexCommand(client *c) {
     int changes = 0;
     robj **new_argv = NULL;
     int new_argc = 0;
-    int need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat = 0;
+    int need_rewrite_argv = 0;
 
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
@@ -1211,7 +1211,7 @@ void hsetexCommand(client *c) {
         return;
 
     if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX | ARGS_EX | ARGS_PX | ARGS_EXAT)) {
-        need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat = 1;
+        need_rewrite_argv = 1;
     }
 
     /* Check NX/XX key-level conditions before creating a new object */
@@ -1273,7 +1273,7 @@ void hsetexCommand(client *c) {
         incrRefCount(shared.hdel);
         new_argv[new_argc++] = c->argv[1];
         incrRefCount(c->argv[1]);
-    } else if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
+    } else if (need_rewrite_argv) {
         /* We use new_argv for rewrite */
         new_argv = zmalloc(sizeof(robj *) * c->argc);
         // Copy optional args (skip NX/XX/FNX/FXX)
@@ -1309,7 +1309,7 @@ void hsetexCommand(client *c) {
         } else {
             hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, when, set_flags);
             changes++;
-            if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
+            if (need_rewrite_argv) {
                 new_argv[new_argc++] = c->argv[i];
                 incrRefCount(c->argv[i]);
                 new_argv[new_argc++] = c->argv[i + 1];
@@ -1329,7 +1329,7 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
-            if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
+            if (need_rewrite_argv) {
                 replaceClientCommandVector(c, new_argc, new_argv);
             }
             if (expire) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1306,7 +1306,7 @@ void hsetexCommand(client *c) {
         } else {
             hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, when, set_flags);
             changes++;
-            if (need_rewrite_for_nx_xx_fnx_fxx){
+            if (need_rewrite_for_nx_xx_fnx_fxx) {
                 new_argv[new_argc++] = c->argv[i];
                 incrRefCount(c->argv[i]);
             }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1210,8 +1210,8 @@ void hsetexCommand(client *c) {
         return;
 
     /* Check NX/XX key-level conditions before creating a new object */
-    if ((flags & ARGS_SET_NX) && o != NULL ||
-        (flags & ARGS_SET_XX) && o == NULL) {
+    if (((flags & ARGS_SET_NX) && o != NULL) ||
+        ((flags & ARGS_SET_XX) && o == NULL)) {
         addReply(c, shared.czero);
         return;
     }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1276,15 +1276,8 @@ void hsetexCommand(client *c) {
     } else if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
         /* We use new_argv for rewrite */
         new_argv = zmalloc(sizeof(robj *) * c->argc);
-        int j = 0;
-        // Command
-        new_argv[j++] = c->argv[0];
-        incrRefCount(c->argv[0]);
-        // Key
-        new_argv[j++] = c->argv[1];
-        incrRefCount(c->argv[1]);
         // Copy optional args (skip NX/XX/FNX/FXX)
-        for (int i = 2; i < fields_index; i++) {
+        for (int i = 0; i < fields_index; i++) {
             if (strcmp(c->argv[i]->ptr, "NX") &&
                 strcmp(c->argv[i]->ptr, "XX") &&
                 strcmp(c->argv[i]->ptr, "FNX") &&
@@ -1293,15 +1286,14 @@ void hsetexCommand(client *c) {
                  * EX/PX/EXAT flag. */
                 if (expire && !(flags & ARGS_PXAT) && c->argv[i + 1] == expire) {
                     robj *milliseconds_obj = createStringObjectFromLongLong(when);
-                    rewriteClientCommandArgument(c, i, shared.pxat);
-                    rewriteClientCommandArgument(c, i + 1, milliseconds_obj);
-                    decrRefCount(milliseconds_obj);
+                    new_argv[new_argc++] = shared.pxat;
+                    new_argv[new_argc++] = milliseconds_obj;
+                } else {
+                    new_argv[new_argc++] = c->argv[i];
+                    incrRefCount(c->argv[i]);
                 }
-                new_argv[j++] = c->argv[i];
-                incrRefCount(c->argv[i]);
             }
         }
-        new_argc = j;
     }
 
     for (i = fields_index; i < c->argc; i += 2) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1311,6 +1311,38 @@ void hsetexCommand(client *c) {
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }
+
+        /* Rewrite command vector for replication */
+        if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
+            int rewrite_argc = 2 + num_fields * 2; // command, hash + field/value pairs
+            robj **rewrite_argv = zmalloc(sizeof(robj*) * rewrite_argc);
+            int j = 0;
+
+            // First argument: command
+            rewrite_argv[j++] = c->argv[0];
+            incrRefCount(c->argv[0]);
+
+            // Second argument: hash
+            rewrite_argv[j++] = c->argv[1];
+            incrRefCount(c->argv[1]);
+
+            // Copy all field/value pairs, skipping NX/XX/FNX/FXX flags
+            for (int i = fields_index; i < c->argc; i++) {
+                // Skip NX/XX/FNX/FXX flags
+                if (strcmp(c->argv[i]->ptr, "NX") &&
+                    strcmp(c->argv[i]->ptr, "XX") &&
+                    strcmp(c->argv[i]->ptr, "FNX") &&
+                    strcmp(c->argv[i]->ptr, "FXX")) 
+                {
+                    rewrite_argv[j++] = c->argv[i];
+                    incrRefCount(c->argv[i]);
+                }
+            }
+
+            // Replace client command vector
+            replaceClientCommandVector(c, j, rewrite_argv);
+        }
+
         signalModifiedKey(c, c->db, c->argv[1]);
         /* Delete the object in case it was left empty */
         if (hashTypeLength(o) == 0) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1311,11 +1311,10 @@ void hsetexCommand(client *c) {
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }
-
         /* Rewrite command vector for replication */
         if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
             int rewrite_argc = 2 + num_fields * 2; // command, hash + field/value pairs
-            robj **rewrite_argv = zmalloc(sizeof(robj*) * rewrite_argc);
+            robj **rewrite_argv = zmalloc(sizeof(robj *) * rewrite_argc);
             int j = 0;
 
             // First argument: command
@@ -1332,8 +1331,7 @@ void hsetexCommand(client *c) {
                 if (strcmp(c->argv[i]->ptr, "NX") &&
                     strcmp(c->argv[i]->ptr, "XX") &&
                     strcmp(c->argv[i]->ptr, "FNX") &&
-                    strcmp(c->argv[i]->ptr, "FXX")) 
-                {
+                    strcmp(c->argv[i]->ptr, "FXX")) {
                     rewrite_argv[j++] = c->argv[i];
                     incrRefCount(c->argv[i]);
                 }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1289,6 +1289,14 @@ void hsetexCommand(client *c) {
                 strcmp(c->argv[i]->ptr, "XX") &&
                 strcmp(c->argv[i]->ptr, "FNX") &&
                 strcmp(c->argv[i]->ptr, "FXX")) {
+                /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
+                 * EX/PX/EXAT flag. */
+                if (expire && !(flags & ARGS_PXAT) && c->argv[i + 1] == expire) {
+                    robj *milliseconds_obj = createStringObjectFromLongLong(when);
+                    rewriteClientCommandArgument(c, i, shared.pxat);
+                    rewriteClientCommandArgument(c, i + 1, milliseconds_obj);
+                    decrRefCount(milliseconds_obj);
+                }
                 new_argv[j++] = c->argv[i];
                 incrRefCount(c->argv[i]);
             }
@@ -1329,20 +1337,7 @@ void hsetexCommand(client *c) {
             if (need_rewrite_for_nx_xx_fnx_fxx) {
                 replaceClientCommandVector(c, new_argc, new_argv);
             }
-            if (expire) {
-                /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
-                 * EX/PX/EXAT flag. */
-                if (!(flags & ARGS_PXAT)) {
-                    for (int i = 2; i < fields_index; i++) {
-                        if (c->argv[i + 1] == expire) {
-                            robj *milliseconds_obj = createStringObjectFromLongLong(when);
-                            rewriteClientCommandArgument(c, i, shared.pxat);
-                            rewriteClientCommandArgument(c, i + 1, milliseconds_obj);
-                            decrRefCount(milliseconds_obj);
-                            break;
-                        }
-                    }
-                }
+            if (expire) {  
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1311,35 +1311,35 @@ void hsetexCommand(client *c) {
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }
-        /* Rewrite command vector for replication */
+
+        /* --- NX/XX/FNX/FXX rewrite --- */
         if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
-            int rewrite_argc = 2 + num_fields * 2; // command, hash + field/value pairs
-            robj **rewrite_argv = zmalloc(sizeof(robj *) * rewrite_argc);
-            int j = 0;
+            /* We use new_argv for rewrite */
+            if (!new_argv) {
+                int rewrite_argc = 2 + num_fields * 2;
+                new_argv = zmalloc(sizeof(robj *) * rewrite_argc);
+                int j = 0;
 
-            // First argument: command
-            rewrite_argv[j++] = c->argv[0];
-            incrRefCount(c->argv[0]);
+                new_argv[j++] = c->argv[0];
+                incrRefCount(c->argv[0]);
 
-            // Second argument: hash
-            rewrite_argv[j++] = c->argv[1];
-            incrRefCount(c->argv[1]);
+                new_argv[j++] = c->argv[1];
+                incrRefCount(c->argv[1]);
 
-            // Copy all field/value pairs, skipping NX/XX/FNX/FXX flags
-            for (int i = fields_index; i < c->argc; i++) {
-                // Skip NX/XX/FNX/FXX flags
-                if (strcmp(c->argv[i]->ptr, "NX") &&
-                    strcmp(c->argv[i]->ptr, "XX") &&
-                    strcmp(c->argv[i]->ptr, "FNX") &&
-                    strcmp(c->argv[i]->ptr, "FXX")) {
-                    rewrite_argv[j++] = c->argv[i];
-                    incrRefCount(c->argv[i]);
+                for (int i = fields_index; i < c->argc; i++) {
+                    if (strcmp(c->argv[i]->ptr, "NX") &&
+                        strcmp(c->argv[i]->ptr, "XX") &&
+                        strcmp(c->argv[i]->ptr, "FNX") &&
+                        strcmp(c->argv[i]->ptr, "FXX")) {
+                        new_argv[j++] = c->argv[i];
+                        incrRefCount(c->argv[i]);
+                    }
                 }
+                new_argc = j;
             }
-
-            // Replace client command vector
-            replaceClientCommandVector(c, j, rewrite_argv);
         }
+
+        replaceClientCommandVector(c, new_argc, new_argv);
 
         signalModifiedKey(c, c->db, c->argv[1]);
         /* Delete the object in case it was left empty */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1190,7 +1190,7 @@ void hsetexCommand(client *c) {
     int changes = 0;
     robj **new_argv = NULL;
     int new_argc = 0;
-    int need_rewrite_for_nx_xx_fnx_fxx = 0;
+    int need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat = 0;
 
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
@@ -1210,8 +1210,8 @@ void hsetexCommand(client *c) {
     if (checkType(c, o, OBJ_HASH))
         return;
 
-    if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
-        need_rewrite_for_nx_xx_fnx_fxx = 1;
+    if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX | ARGS_EX | ARGS_PX | ARGS_EXAT)) {
+        need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat = 1;
     }
 
     /* Check NX/XX key-level conditions before creating a new object */
@@ -1273,7 +1273,7 @@ void hsetexCommand(client *c) {
         incrRefCount(shared.hdel);
         new_argv[new_argc++] = c->argv[1];
         incrRefCount(c->argv[1]);
-    } else if (need_rewrite_for_nx_xx_fnx_fxx) {
+    } else if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
         /* We use new_argv for rewrite */
         new_argv = zmalloc(sizeof(robj *) * c->argc);
         int j = 0;
@@ -1316,7 +1316,7 @@ void hsetexCommand(client *c) {
         } else {
             hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, when, set_flags);
             changes++;
-            if (need_rewrite_for_nx_xx_fnx_fxx) {
+            if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
                 new_argv[new_argc++] = c->argv[i];
                 incrRefCount(c->argv[i]);
             }
@@ -1334,7 +1334,7 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
-            if (need_rewrite_for_nx_xx_fnx_fxx) {
+            if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
                 replaceClientCommandVector(c, new_argc, new_argv);
             }
             if (expire) {  

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1336,10 +1336,9 @@ void hsetexCommand(client *c) {
                     }
                 }
                 new_argc = j;
+                replaceClientCommandVector(c, new_argc, new_argv);
             }
         }
-
-        replaceClientCommandVector(c, new_argc, new_argv);
 
         signalModifiedKey(c, c->db, c->argv[1]);
         /* Delete the object in case it was left empty */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1264,7 +1264,9 @@ void hsetexCommand(client *c) {
 
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
 
-    /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
+    /* Prepare a new argv when rewritting the command. If set_expired is true, 
+     * all expired fields will be deleted. Otherwise, if rewriting is needed due to NX/XX/FNX/FXX flags, 
+     * copy the command, key, and optional arguments, skipping the NX/XX/FNX/FXX flags. */
     if (set_expired) {
         new_argv = zmalloc(sizeof(robj *) * (num_fields + 2));
         new_argv[new_argc++] = shared.hdel;
@@ -1344,7 +1346,6 @@ void hsetexCommand(client *c) {
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }
-
         signalModifiedKey(c, c->db, c->argv[1]);
         /* Delete the object in case it was left empty */
         if (hashTypeLength(o) == 0) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1312,6 +1312,8 @@ void hsetexCommand(client *c) {
             if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
                 new_argv[new_argc++] = c->argv[i];
                 incrRefCount(c->argv[i]);
+                new_argv[new_argc++] = c->argv[i + 1];
+                incrRefCount(c->argv[i + 1]);
             }
         }
     }
@@ -1330,7 +1332,7 @@ void hsetexCommand(client *c) {
             if (need_rewrite_for_nx_xx_fnx_fxx_ex_px_exat) {
                 replaceClientCommandVector(c, new_argc, new_argv);
             }
-            if (expire) {  
+            if (expire) {
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
             }
         }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1264,7 +1264,7 @@ void hsetexCommand(client *c) {
 
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
 
-    /* Prepare a new argv when rewritting the command. If set_expired is true, 
+    /* Prepare a new argv when rewriting the command. If set_expired is true, 
      * all expired fields will be deleted. Otherwise, if rewriting is needed due to NX/XX/FNX/FXX flags, 
      * copy the command, key, and optional arguments, skipping the NX/XX/FNX/FXX flags. */
     if (set_expired) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1273,8 +1273,7 @@ void hsetexCommand(client *c) {
         incrRefCount(c->argv[1]);
     } else if (need_rewrite_for_nx_xx_fnx_fxx) {
         /* We use new_argv for rewrite */
-        int rewrite_argc = 2 + (c->argc - 2); // command + key + everything else
-        new_argv = zmalloc(sizeof(robj *) * rewrite_argc);
+        new_argv = zmalloc(sizeof(robj *) * c->argc);
         int j = 0;
         // Command
         new_argv[j++] = c->argv[0];

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1288,6 +1288,7 @@ void hsetexCommand(client *c) {
                     robj *milliseconds_obj = createStringObjectFromLongLong(when);
                     new_argv[new_argc++] = shared.pxat;
                     new_argv[new_argc++] = milliseconds_obj;
+                    i++; // skip the original expire argument
                 } else {
                     new_argv[new_argc++] = c->argv[i];
                     incrRefCount(c->argv[i]);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1210,13 +1210,9 @@ void hsetexCommand(client *c) {
         return;
 
     /* Check NX/XX key-level conditions before creating a new object */
-    if ((flags & ARGS_SET_NX) && o != NULL) {
-        addReply(c, shared.czero); // NX fails if key exists
-        return;
-    }
-
-    if ((flags & ARGS_SET_XX) && o == NULL) {
-        addReply(c, shared.czero); // XX fails if key does not exist
+    if ((flags & ARGS_SET_NX) && o != NULL ||
+        (flags & ARGS_SET_XX) && o == NULL) {
+        addReply(c, shared.czero);
         return;
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1190,6 +1190,7 @@ void hsetexCommand(client *c) {
     int changes = 0;
     robj **new_argv = NULL;
     int new_argc = 0;
+    int need_rewrite_for_nx_xx_fnx_fxx = 0;
 
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(c->argv[fields_index]->ptr, "fields")) {
@@ -1208,6 +1209,10 @@ void hsetexCommand(client *c) {
     o = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, o, OBJ_HASH))
         return;
+
+    if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
+        need_rewrite_for_nx_xx_fnx_fxx = 1;
+    }
 
     /* Check NX/XX key-level conditions before creating a new object */
     if (((flags & ARGS_SET_NX) && o != NULL) ||
@@ -1266,6 +1271,28 @@ void hsetexCommand(client *c) {
         incrRefCount(shared.hdel);
         new_argv[new_argc++] = c->argv[1];
         incrRefCount(c->argv[1]);
+    } else if (need_rewrite_for_nx_xx_fnx_fxx) {
+        /* We use new_argv for rewrite */
+        int rewrite_argc = 2 + (c->argc - 2); // command + key + everything else
+        new_argv = zmalloc(sizeof(robj *) * rewrite_argc);
+        int j = 0;
+        // Command
+        new_argv[j++] = c->argv[0];
+        incrRefCount(c->argv[0]);
+        // Key
+        new_argv[j++] = c->argv[1];
+        incrRefCount(c->argv[1]);
+        // Copy optional args (skip NX/XX/FNX/FXX)
+        for (int i = 2; i < fields_index; i++) {
+            if (strcmp(c->argv[i]->ptr, "NX") &&
+                strcmp(c->argv[i]->ptr, "XX") &&
+                strcmp(c->argv[i]->ptr, "FNX") &&
+                strcmp(c->argv[i]->ptr, "FXX")) {
+                new_argv[j++] = c->argv[i];
+                incrRefCount(c->argv[i]);
+            }
+        }
+        new_argc = j;
     }
 
     for (i = fields_index; i < c->argc; i += 2) {
@@ -1280,6 +1307,10 @@ void hsetexCommand(client *c) {
         } else {
             hashTypeSet(o, c->argv[i]->ptr, c->argv[i + 1]->ptr, when, set_flags);
             changes++;
+            if (need_rewrite_for_nx_xx_fnx_fxx){
+                new_argv[new_argc++] = c->argv[i];
+                incrRefCount(c->argv[i]);
+            }
         }
     }
 
@@ -1294,6 +1325,7 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
+            replaceClientCommandVector(c, new_argc, new_argv);
             if (expire) {
                 /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
                  * EX/PX/EXAT flag. */
@@ -1309,34 +1341,6 @@ void hsetexCommand(client *c) {
                     }
                 }
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpire", c->argv[1], c->db->id);
-            }
-        }
-
-        /* --- NX/XX/FNX/FXX rewrite --- */
-        if (flags & (ARGS_SET_NX | ARGS_SET_XX | ARGS_SET_FNX | ARGS_SET_FXX)) {
-            /* We use new_argv for rewrite */
-            if (!new_argv) {
-                int rewrite_argc = 2 + num_fields * 2;
-                new_argv = zmalloc(sizeof(robj *) * rewrite_argc);
-                int j = 0;
-
-                new_argv[j++] = c->argv[0];
-                incrRefCount(c->argv[0]);
-
-                new_argv[j++] = c->argv[1];
-                incrRefCount(c->argv[1]);
-
-                for (int i = fields_index; i < c->argc; i++) {
-                    if (strcmp(c->argv[i]->ptr, "NX") &&
-                        strcmp(c->argv[i]->ptr, "XX") &&
-                        strcmp(c->argv[i]->ptr, "FNX") &&
-                        strcmp(c->argv[i]->ptr, "FXX")) {
-                        new_argv[j++] = c->argv[i];
-                        incrRefCount(c->argv[i]);
-                    }
-                }
-                new_argc = j;
-                replaceClientCommandVector(c, new_argc, new_argv);
             }
         }
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -725,6 +725,64 @@ start_server {tags {"hashexpire"}} {
         assert_equal 0 [r EXISTS myhash]
     }
 
+    ## NX/XX + FNX/FXX combinations
+
+    # NX + FNX — only set if key does not exist AND fields do not exist
+    test {HSETEX EX NX FNX - set only if key missing and fields missing} {
+        r FLUSHALL
+        set res [r HSETEX myhash EX 10 NX FNX FIELDS 2 f1 v1 f2 v2]
+        assert_equal 1 $res
+        assert_equal v1 [r HGET myhash f1]
+        assert_equal v2 [r HGET myhash f2]
+
+        # Try again — key exists now, should block
+        set res [r HSETEX myhash EX 10 NX FNX FIELDS 2 f3 v3 f4 v4]
+        assert_equal 0 $res
+        assert_equal 0 [r HEXISTS myhash f3]
+        assert_equal 0 [r HEXISTS myhash f4]
+    }
+
+    # NX + FXX — only set if key does not exist AND all fields exist (key missing → blocked)
+    test {HSETEX EX NX FXX - key missing blocks all} {
+        r FLUSHALL
+        set res [r HSETEX myhash EX 10 NX FXX FIELDS 2 f1 v1 f2 v2]
+        assert_equal 0 $res
+        assert_equal 0 [r HEXISTS myhash f1]
+        assert_equal 0 [r HEXISTS myhash f2]
+    }
+
+    # XX + FNX — only set if key exists AND none of the fields exist
+    test {HSETEX EX XX FNX - set only if key exists and fields missing} {
+        r FLUSHALL
+        r HSET myhash f1 old1
+        set res [r HSETEX myhash EX 10 XX FNX FIELDS 2 f2 v2 f3 v3]
+        assert_equal 1 $res
+        assert_equal v2 [r HGET myhash f2]
+        assert_equal v3 [r HGET myhash f3]
+
+        # Try again — fields already exist → should block
+        set res [r HSETEX myhash EX 10 XX FNX FIELDS 2 f2 x f4 y]
+        assert_equal 0 $res
+        assert_equal v2 [r HGET myhash f2]
+        assert_equal 0 [r HEXISTS myhash f4]
+    }
+
+    # XX + FXX — only set if key exists AND all fields exist
+    test {HSETEX EX XX FXX - set only if key exists and all fields exist} {
+        r FLUSHALL
+        r HSET myhash f1 old1 f2 old2
+        set res [r HSETEX myhash EX 10 XX FXX FIELDS 2 f1 new1 f2 new2]
+        assert_equal 1 $res
+        assert_equal new1 [r HGET myhash f1]
+        assert_equal new2 [r HGET myhash f2]
+
+        # Try when one field is missing → should block
+        set res [r HSETEX myhash EX 10 XX FXX FIELDS 2 f1 x f3 y]
+        assert_equal 0 $res
+        assert_equal new1 [r HGET myhash f1]
+        assert_equal 0 [r HEXISTS myhash f3]
+    }
+
     ###### Test EXPIRE #############
 
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -659,6 +659,7 @@ start_server {tags {"hashexpire"}} {
         r FLUSHALL
         set res [r HSETEX myhash XX FIELDS 2 f1 v1 f2 v2]
         assert_equal 0 $res
+        assert_equal 0 [r EXISTS myhash]
         assert_equal 0 [r HEXISTS myhash f1]
         assert_equal 0 [r HEXISTS myhash f2]
     }
@@ -747,6 +748,7 @@ start_server {tags {"hashexpire"}} {
         r FLUSHALL
         set res [r HSETEX myhash EX 10 NX FXX FIELDS 2 f1 v1 f2 v2]
         assert_equal 0 $res
+        assert_equal 0 [r EXISTS myhash]
         assert_equal 0 [r HEXISTS myhash f1]
         assert_equal 0 [r HEXISTS myhash f2]
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -627,7 +627,42 @@ start_server {tags {"hashexpire"}} {
          assert_error {ERR numfields should be greater than 0 and match the provided number of fields} {r HSETEX myhash PX 100 FIELDS 1 field1 val1 extra}
     } 
 
+    ## NX/XX key-level tests
 
+    test {HSETEX NX - non-existing key creates the key} {
+        r FLUSHALL
+        set res [r HSETEX myhash NX FIELDS 2 f1 v1 f2 v2]
+        assert_equal 1 $res
+        assert_equal v1 [r HGET myhash f1]
+        assert_equal v2 [r HGET myhash f2]
+    }
+
+    test {HSETEX NX - existing key blocked} {
+        r FLUSHALL
+        r HSET myhash f1 v1
+        set res [r HSETEX myhash NX FIELDS 2 f1 new1 f2 new2]
+        assert_equal 0 $res
+        assert_equal v1 [r HGET myhash f1]
+        assert_equal 0 [r HEXISTS myhash f2]
+    }
+
+    test {HSETEX XX - existing key updates fields} {
+        r FLUSHALL
+        r HSET myhash f1 v1 f2 v2
+        set res [r HSETEX myhash XX FIELDS 2 f1 new1 f2 new2]
+        assert_equal 1 $res
+        assert_equal new1 [r HGET myhash f1]
+        assert_equal new2 [r HGET myhash f2]
+    }
+
+    test {HSETEX XX - non-existing key blocked} {
+        r FLUSHALL
+        set res [r HSETEX myhash XX FIELDS 2 f1 v1 f2 v2]
+        assert_equal 0 $res
+        assert_equal 0 [r HEXISTS myhash f1]
+        assert_equal 0 [r HEXISTS myhash f2]
+    }
+    
     ## FNX/FXX
 
     # hsetex throws ERR *, it shouldn't


### PR DESCRIPTION
### Summary
Addresses https://github.com/valkey-io/valkey/issues/2619.  
This PR extends the `HSETEX` command to support optional key-level `NX` and `XX` flags, allowing operations conditional on the existence of the hash key.

### Changes
- Updated `hsetex.json` and regenerated `commands.def`.
- Extended argument parsing for NX/XX.
- Added key-level `NX`/`XX` support in `HSETEX`.
- Added tests covering all four NX/XX scenarios.