### PR TITLE
Back port of Defrag if slab 1/8 full to fix defrag didn't stop issue

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -29,6 +29,7 @@ Bug fixes
 * Fix client tracking memory overhead calculation (#2360)
 * Fix RDB load per slot memory pre-allocation when loading from RDB snapshot (#2466)
 * Don't use AVX2 instructions if the CPU doesn't support it (#2571)
+* Fix bug where active defrag may be unable to defrag sparsely filled pages (#2656)
 
 ================================================================================
 Valkey 8.1.3  -  Released Sun 07 July 2025

--- a/src/allocator_defrag.c
+++ b/src/allocator_defrag.c
@@ -57,7 +57,7 @@
 #define SLAB_LEN(out, i) out[(i) * BATCH_QUERY_ARGS_OUT + 2]
 #define SLAB_NUM_REGS(out, i) out[(i) * BATCH_QUERY_ARGS_OUT + 1]
 
-#define UTILIZATION_THRESHOLD_FACTOR_MILI (125) // 12.5% additional utilization
+#define UTILIZATION_THRESHOLD_FACTOR_MILLI (125) // 12.5% additional utilization
 
 /*
  * Represents a precomputed key for querying jemalloc statistics.
@@ -349,16 +349,26 @@ unsigned long allocatorDefragGetFragSmallbins(void) {
  *    defragmentation is not necessary as moving regions is guaranteed not to change the fragmentation ratio.
  * 2. If the number of non-full slabs (bin_usage->curr_nonfull_slabs) is less than 2, defragmentation is not performed
  *    because there is no other slab to move regions to.
- * 3. If slab utilization < 'avg utilization'*1.125 [code 1.125 == (1000+UTILIZATION_THRESHOLD_FACTOR_MILI)/1000]
+ * 3. Defrag if the slab is less than 1/8 full to ensure small slabs get defragmented even when average utilization is low.
+ *    This also handles the case when there are items that aren't defragmented skewing the average utilization. The 1/8
+ *    threshold (12.5%) was chosen to align with existing utilization threshold factor.
+ * 4. If slab utilization < 'avg utilization'*1.125 [code 1.125 == (1000+UTILIZATION_THRESHOLD_FACTOR_MILLI)/1000]
  *    than we should defrag. This is aligned with previous je_defrag_hint implementation.
  */
 static inline int makeDefragDecision(jeBinInfo *bin_info, jemallocBinUsageData *bin_usage, unsigned long nalloced) {
     unsigned long curr_full_slabs = bin_usage->curr_slabs - bin_usage->curr_nonfull_slabs;
     size_t allocated_nonfull = bin_usage->curr_regs - curr_full_slabs * bin_info->nregs;
-    if (bin_info->nregs == nalloced || bin_usage->curr_nonfull_slabs < 2 ||
-        1000 * nalloced * bin_usage->curr_nonfull_slabs > (1000 + UTILIZATION_THRESHOLD_FACTOR_MILI) * allocated_nonfull) {
-        return 0;
-    }
+
+    /* Don't defrag if the slab is full or if there's only 1 nonfull slab */
+    if (bin_info->nregs == nalloced || bin_usage->curr_nonfull_slabs < 2) return 0;
+
+    /* Defrag if the slab is less than 1/8 full */
+    if (1000 * nalloced < bin_info->nregs * UTILIZATION_THRESHOLD_FACTOR_MILLI) return 1;
+
+    /* Don't defrag if the slab usage is greater than the average usage (+ 12.5%) */
+    if (1000 * nalloced * bin_usage->curr_nonfull_slabs > (1000 + UTILIZATION_THRESHOLD_FACTOR_MILLI) * allocated_nonfull) return 0;
+
+    /* Otherwise, defrag! */
     return 1;
 }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -59,6 +59,15 @@ run_solo {defrag} {
         return [list $key $field]
     }
 
+    # Make a deferring client with CLIENT REPLY OFF sync with the server by
+    # temporarily setting CLIENT REPLY ON and waiting for the reply, then
+    # switching back to CLIENT REPLY OFF.
+    proc client_reply_off_wait_for_server {rd} {
+        $rd client reply on
+        assert_equal OK [$rd read]
+        $rd client reply off
+    }
+
     # Logs defragging state if ::verbose is true
     proc log_frag {title} {
         # Note, this delay is outside of the "if" so that behavior is the same, with and
@@ -238,27 +247,23 @@ run_solo {defrag} {
             perform_defrag_test $title populate {
                 # add a mass of string keys
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 for {set j 0} {$j < $n} {incr j} {
                     $rd setrange $j 250 a
                     if {$j % 3 == 0} {
                         $rd expire $j 1000 ;# put expiration on some
                     }
-                }
-                for {set j 0} {$j < $n} {incr j} {
-                    $rd read ; # Discard replies
-                    if {$j % 3 == 0} {
-                        $rd read
-                    }
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
                 assert {[scan [regexp -inline {expires\=([\d]*)} [r info keyspace]] expires=%d] > 0}
             } fragment {
                 # delete half of the keys
                 for {set j 0} {$j < $n} {incr j 2} {
                     $rd del $j
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard replies
                 $rd close
-                
+
                 # use custom slower defrag speed to start so that while_defragging has time
                 r config set active-defrag-cycle-min 2
                 r config set active-defrag-cycle-max 3
@@ -324,19 +329,19 @@ run_solo {defrag} {
                 # Populate memory with interleaving script-key pattern of same size
                 set dummy_script "--[string repeat x 450]\nreturn "
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 for {set j 0} {$j < $n} {incr j} {
                     set val "$dummy_script[format "%06d" $j]"
                     $rd script load $val
                     $rd set k$j $val
-                }
-                for {set j 0} {$j < $n} {incr j} {
-                    $rd read ; # Discard script load replies
-                    $rd read ; # Discard set replies
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
             } fragment {
                 # Delete all the keys to create fragmentation
-                for {set j 0} {$j < $n} {incr j} { $rd del k$j }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+                for {set j 0} {$j < $n} {incr j} {
+                    $rd del k$j
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
+                }
                 $rd close
             }
         }
@@ -350,22 +355,23 @@ run_solo {defrag} {
 
             perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 set val [string repeat A 250]
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j} {
                     $rd hset k$k f$f $val
                     lassign [next_exp_kf $k $f] k f
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard replies
             } fragment {
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j 2} {
                     $rd hdel k$k f$f
                     lassign [next_exp_kf $k $f 2] k f
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard replies
                 $rd close
             }
         }
@@ -380,14 +386,15 @@ run_solo {defrag} {
 
             perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 set val [string repeat A 350]
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j} {
                     $rd lpush k$k $val
                     lassign [next_exp_kf $k $f] k f
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard replies
             } fragment {
                 set k 0
                 set f 0
@@ -395,8 +402,8 @@ run_solo {defrag} {
                     $rd ltrim k$k 1 -1 ;# deletes the leftmost item
                     $rd lmove k$k k$k LEFT RIGHT ;# rotates the leftmost item to the right side
                     lassign [next_exp_kf $k $f 2] k f
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read; $rd read } ; # Discard replies
                 $rd close
             }
         }
@@ -410,22 +417,23 @@ run_solo {defrag} {
 
             perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 set val [string repeat A 300]
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j} {
                     $rd sadd k$k $val$f
                     lassign [next_exp_kf $k $f] k f
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard replies
             } fragment {
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j 2} {
                     $rd srem k$k $val$f
                     lassign [next_exp_kf $k $f 2] k f
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard replies
                 $rd close
             }
         }
@@ -439,22 +447,23 @@ run_solo {defrag} {
 
             perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 set val [string repeat A 250]
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j} {
                     $rd zadd k$k [expr rand()] $val$f
                     lassign [next_exp_kf $k $f] k f
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard replies
             } fragment {
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j 2} {
                     $rd zrem k$k $val$f
                     lassign [next_exp_kf $k $f 2] k f
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard replies
                 $rd close
             }
         }
@@ -469,16 +478,17 @@ run_solo {defrag} {
 
             perform_defrag_test $title populate {
                 set rd [valkey_deferring_client]
+                $rd client reply off
                 set val [string repeat A 50]
                 for {set j 0} {$j < $n} {incr j} {
                     $rd xadd k$j * field1 $val field2 $val
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard replies
             } fragment {
                 for {set j 0} {$j < $n} {incr j 2} {
                     $rd del k$j
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
-                for {set j 0} {$j < $n} {incr j 2} { $rd read } ; # Discard replies
                 $rd close
             }
         }


### PR DESCRIPTION
Original PR: (#2656)

**Issue History:**
1. The flaky test issue "defrag didn't stop" was originally detected in February 2025: https://github.com/valkey-io/valkey/issues/1746 Solution for 1746: https://github.com/valkey-io/valkey/pull/1762
2. Similar issue occurred recently: https://github.com/valkey-io/valkey/actions/runs/16585350083/job/46909359496#step:5:7640

**Investigation:**
1. First, the issue occurs specifically to Active Defrag stream in cluster mode.
2. After investigating `test_stream` in `memefficiency.tcl`, I found the root cause is in defrag logic rather than the test itself - There are still failed tests with the same error even if I tried different parameters for the test.
3. Then I looked at malloc-stats and identified potential defrag issues, particularly in the 80B bin where utilization only reaches ~75% after defrag instead of the expected near 100%, while other bins show proper defrag behavior - 80B actually is the size of a new stream(confirmed in `t_stream.c`) that we add during test.
4. For 80B, after adding 200000 streams and fragmenting, `curregs `= 100030, after a lot of defrag cycles, there are still 122 nonfull-slabs/511 slabs with the remaining 446 items not defragged (average 4/nonfull-slab).

**Detailed malloc-stats:**
- Total slabs: 511
- Non-full slabs: 122
- Full slabs: 511-122=389
- Theoretical maximum per slab: 256 items
- Allocated items in non-full slabs: 100030-389*256=446
- Average items per non-full slab: 446/122=3.66

**Root Cause:**
**There are some immovable items which  prevent complete defrag**

**Problems in old defrag logic:**
1. The previous condition (we don't defrag if slab utilization > 'avg utilization' * 1.125), the 12.5% threshold doesn’t work well with low utilizations.

- Let's imagine we have 446 items in 122 nonfull-slabs (avg 3.66 items/nonfull-slab), let's say, e.g. we have 81 slabs with 5 items each +41 slabs with 1 item each)
- 12.5% threshold: 3.66*1.125=4.11
- If those 41 single items are immovable, they actually lower the average, so the rest 81 slabs will be above the threshold (5>4.11) and will not be defragged - defrag didn't stop.

2. Distribution of immovable items across slabs was causing inconsistent defragmentation and flaky test outcome.

- If those 41 single items are movable, they will be moved and the avg will be 5, then 12.5% threshold: 5*1.125=5.625, so the rest 81 slabs will fall below the threshold (5<5.625) and will be defragged - defrag success.
- This can explain why we got flaky defrag tests.

**Final solution :**
1. Add one more condition before the old logic in `makeDefragDecision `to trigger defragmentation when slab is less than 1/8 full (1/8 threshold (12.5%) chosen to align with existing utilization threshold factor) - Ensures no low-utilization slabs left without defragged, and stabilize the defrag behavior.
2. The reason why we have immovable items and how to handle them is going to be investigate later.
3. Be sure to rebuild Valkey before testing it.

**Local test result:**
- Before fix: pass rate 80.8% (63/78)
- After fix: Test only stream: pass rate 100% (200/200)
Test the whole memefficiency.tcl: pass rate 100% (100/100)

Resolves #2398 , the "defrag didn't stop" issue, with help from @JimB123 @madolson

---------