### PR TITLE
Add IPv6 availability check to skip tests when unavailable

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -268,6 +268,11 @@ proc tags_acceptable {tags err_return} {
         return 0
     }
 
+    if {!$::require_ipv6 && ![is_ipv6_available]} {
+        lappend ::denytags "ipv6"
+        set err "IPv6 not available on this system, skipping IPv6 tests"
+    }
+
     return 1
 }
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -268,9 +268,9 @@ proc tags_acceptable {tags err_return} {
         return 0
     }
 
-    if {!$::require_ipv6 && ![is_ipv6_available]} {
-        lappend ::denytags "ipv6"
-        set err "IPv6 not available on this system, skipping IPv6 tests"
+    if {[lsearch $tags "ipv6"] >= 0 && ![is_ipv6_available]} {
+        set err "IPv6 not available on this system"
+        return 0
     }
 
     return 1

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -499,48 +499,6 @@ proc roundFloat f {
     format "%.10g" $f
 }
 
-#IPv6 detection utilities
-#for this detaction there are 3 different attempts
-#1) running ifconfig and filter on 'inet6*::1' 
-#2) netstat -an and filter on '*::1*'
-#3) in the and if both of tham fail, the last is the socket connection on ::1 address
-proc is_ipv6_available {} {
-    if {[catch {exec ifconfig lo0} result] == 0} {
-        if {[string match "*inet6*::1*" $result]} {
-            return 1
-        }
-    }
-    
-    if {[catch {exec netstat -an} result] == 0} {
-        if {[string match "*::1*" $result]} {
-            return 1
-        }
-    }
-    
-    if {[catch {
-        set sock [socket -async ::1 22]
-        close $sock
-        return 1
-    }]} {
-        return 0
-    }
-    
-    return 0
-}
-
-#Check the presence of env variable VALKEY_REQUIRE_IPV6 to decide if run the tests or not
-proc should_skip_ipv6_tests {} {
-    if {[info exists ::env(VALKEY_REQUIRE_IPV6)] && $::env(VALKEY_REQUIRE_IPV6) == "1"} {
-        return 0
-    }
-    
-    if {![is_ipv6_available]} {
-        puts "Warning: IPv6 not available, skipping IPv6 tests"
-        return 1
-    }
-    return 0
-}
-
 set ::last_port_attempted 0
 proc find_available_port {start count} {
     set port [expr $::last_port_attempted + 1]

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -499,6 +499,48 @@ proc roundFloat f {
     format "%.10g" $f
 }
 
+#IPv6 detection utilities
+#for this detaction there are 3 different attempts
+#1) running ifconfig and filter on 'inet6*::1' 
+#2) netstat -an and filter on '*::1*'
+#3) in the and if both of tham fail, the last is the socket connection on ::1 address
+proc is_ipv6_available {} {
+    if {[catch {exec ifconfig lo0} result] == 0} {
+        if {[string match "*inet6*::1*" $result]} {
+            return 1
+        }
+    }
+    
+    if {[catch {exec netstat -an} result] == 0} {
+        if {[string match "*::1*" $result]} {
+            return 1
+        }
+    }
+    
+    if {[catch {
+        set sock [socket -async ::1 22]
+        close $sock
+        return 1
+    }]} {
+        return 0
+    }
+    
+    return 0
+}
+
+#Check the presence of env variable VALKEY_REQUIRE_IPV6 to decide if run the tests or not
+proc should_skip_ipv6_tests {} {
+    if {[info exists ::env(VALKEY_REQUIRE_IPV6)] && $::env(VALKEY_REQUIRE_IPV6) == "1"} {
+        return 0
+    }
+    
+    if {![is_ipv6_available]} {
+        puts "Warning: IPv6 not available, skipping IPv6 tests"
+        return 1
+    }
+    return 0
+}
+
 set ::last_port_attempted 0
 proc find_available_port {start count} {
     set port [expr $::last_port_attempted + 1]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1010,7 +1010,7 @@ proc close_replication_stream {s} {
 proc is_ipv6_available {} {
         if {[catch {
             set server [socket -server ::1 0]
-            set port [lindex [chan configure $server -sockname] 2]
+            set port [lindex [chan configure $server -sockname] 5]
             set client [socket ::1 $port]
             close $server
             close $client

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1003,7 +1003,7 @@ proc close_replication_stream {s} {
 }
 
 # IPv6 detection utilities
-# for this detaction: the socket connection on ::1 address
+# for this detection: the socket connection on ::1 address
 proc is_ipv6_available {} {
     if {[catch {
         set server [socket -server dummy -myaddr ::1 0]

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -51,7 +51,6 @@ set ::portcount 8000; # we don't wanna use more than 10000 to avoid collision wi
 set ::traceleaks 0
 set ::valgrind 0
 set ::durable 0
-set ::require_ipv6 0
 set ::tls 0
 set ::io_threads 0
 set ::tls_module 0
@@ -698,7 +697,6 @@ proc print_help_screen {} {
         "--io-threads       Run tests with IO threads."
         "--tls              Run tests in TLS mode."
         "--tls-module       Run tests in TLS mode with Valkey module."
-        "--require-ipv6     Run tests forcing the ipv6."
         "--host <addr>      Run tests against an external host."
         "--port <port>      TCP port to use against external host."
         "--other-server-path <path>"
@@ -869,8 +867,6 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--help}} {
         print_help_screen
         exit 0
-    } elseif {$opt eq {--require-ipv6}} {
-        set ::require_ipv6 1
     } else {
         puts "Wrong argument: $opt"
         exit 1
@@ -1015,10 +1011,10 @@ proc is_ipv6_available {} {
         set client [socket ::1 $port]
         close $server
         close $client
+    }] == 0} {
         return 1
-    }]} {
-        return 0
     }
+    return 0
 }
 
 # With the parallel test running multiple server instances at the same time

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -698,6 +698,7 @@ proc print_help_screen {} {
         "--io-threads       Run tests with IO threads."
         "--tls              Run tests in TLS mode."
         "--tls-module       Run tests in TLS mode with Valkey module."
+        "--require-ipv6     Run tests forcing the ipv6."
         "--host <addr>      Run tests against an external host."
         "--port <port>      TCP port to use against external host."
         "--other-server-path <path>"
@@ -1005,28 +1006,20 @@ proc close_replication_stream {s} {
     return
 }
 
-#IPv6 detection utilities
-#for this detaction: the socket connection on ::1 address
+# IPv6 detection utilities
+# for this detaction: the socket connection on ::1 address
 proc is_ipv6_available {} {
-        if {[catch {
-            set server [socket -server ::1 0]
-            set port [lindex [chan configure $server -sockname] 5]
-            set client [socket ::1 $port]
-            close $server
-            close $client
-            return 1
+    if {[catch {
+        set server [socket -server dummy -myaddr ::1 0]
+        set port [lindex [chan configure $server -sockname] 2]
+        set client [socket ::1 $port]
+        close $server
+        close $client
+        return 1
     }]} {
-            return 0
+        return 0
     }
 }
-
-#Check if is required the flag to decide if run the tests or not
-if {!$::require_ipv6 && ![is_ipv6_available]} {
-    lappend ::denytags "ipv6"
-    puts "IPv6 not available on this system, skipping IPv6 tests"
-}
-
-
 
 # With the parallel test running multiple server instances at the same time
 # we need a fast enough computer, otherwise a lot of tests may generate

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -51,6 +51,7 @@ set ::portcount 8000; # we don't wanna use more than 10000 to avoid collision wi
 set ::traceleaks 0
 set ::valgrind 0
 set ::durable 0
+set ::require_ipv6 0
 set ::tls 0
 set ::io_threads 0
 set ::tls_module 0
@@ -867,6 +868,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--help}} {
         print_help_screen
         exit 0
+    } elseif {$opt eq {--require-ipv6}} {
+        set ::require_ipv6 1
     } else {
         puts "Wrong argument: $opt"
         exit 1
@@ -1001,6 +1004,29 @@ proc close_replication_stream {s} {
     r config set repl-ping-replica-period 10
     return
 }
+
+#IPv6 detection utilities
+#for this detaction: the socket connection on ::1 address
+proc is_ipv6_available {} {
+        if {[catch {
+            set server [socket -server ::1 0]
+            set port [lindex [chan configure $server -sockname] 2]
+            set client [socket ::1 $port]
+            close $server
+            close $client
+            return 1
+    }]} {
+            return 0
+    }
+}
+
+#Check if is required the flag to decide if run the tests or not
+if {!$::require_ipv6 && ![is_ipv6_available]} {
+    lappend ::denytags "ipv6"
+    puts "IPv6 not available on this system, skipping IPv6 tests"
+}
+
+
 
 # With the parallel test running multiple server instances at the same time
 # we need a fast enough computer, otherwise a lot of tests may generate

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -279,6 +279,7 @@ start_server {tags {"introspection"}} {
             $c close
         }
     }
+
     test {CLIENT KILL with CAPA filter} {
         set c1 [valkey_client]
         $c1 client setname "killme-capa"
@@ -508,6 +509,7 @@ start_server {tags {"introspection"}} {
         # Use the extracted IP for filtering.
         r client list not-ip $not_ip not-ip $not_ip
     } {}
+
     start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
         test {CLIENT LIST with IPv6 negative filter} {
             set c [valkey ::1 [srv 0 port] 0 $::tls]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -279,7 +279,6 @@ start_server {tags {"introspection"}} {
             $c close
         }
     }
-    
     test {CLIENT KILL with CAPA filter} {
         set c1 [valkey_client]
         $c1 client setname "killme-capa"
@@ -509,7 +508,6 @@ start_server {tags {"introspection"}} {
         # Use the extracted IP for filtering.
         r client list not-ip $not_ip not-ip $not_ip
     } {}
-   
     start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
         test {CLIENT LIST with IPv6 negative filter} {
             set c [valkey ::1 [srv 0 port] 0 $::tls]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -518,7 +518,7 @@ start_server {tags {"introspection"}} {
             set client_info [$c client info]
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-            set filtered [$c client list not-ip $ipv6only]
+            set filtered [$c client list not-ip "1.2.3.4" not-ip $ipv6only]
             assert_no_match *client-ipv6* $filtered
 
             $c close

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -225,18 +225,20 @@ start_server {tags {"introspection"}} {
         assert_match *client-ip* $filtered
     } {}
 
-    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-        test {CLIENT LIST with IPv6 filter} {
-            set c [valkey ::1 [srv 0 port] 0 $::tls]
-            $c client setname "client-ipv6"
+    if {![should_skip_ipv6_tests]} {
+        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+            test {CLIENT LIST with IPv6 filter} {
+                set c [valkey ::1 [srv 0 port] 0 $::tls]
+                $c client setname "client-ipv6"
 
-            set client_info [$c client info]
+                set client_info [$c client info]
 
-            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-            set filtered [$c client list ip $ipv6only]
-            assert_match *client-ipv6* $filtered
+                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+                set filtered [$c client list ip $ipv6only]
+                assert_match *client-ipv6* $filtered
 
-            $c close
+                $c close
+            }
         }
     }
 
@@ -264,19 +266,21 @@ start_server {tags {"introspection"}} {
         assert_error "*I/O error*" {$c1 ping}
     } {}
 
-    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-        test {CLIENT LIST with IPv6 filter} {
-            set c [valkey ::1 [srv 0 port] 0 $::tls]
-            $c client setname "client-ipv6"
+    if {![should_skip_ipv6_tests]} {
+        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+            test {CLIENT KILL with IPv6 filter} {
+                set c [valkey ::1 [srv 0 port] 0 $::tls]
+                $c client setname "client-ipv6"
 
-            set client_info [$c client info]
+                set client_info [$c client info]
 
-            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-            set filtered [r client kill ip $ipv6only]
+                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+                set filtered [r client kill ip $ipv6only]
 
-            assert_error "*I/O error*" {$c ping}
+                assert_error "*I/O error*" {$c ping}
 
-            $c close
+                $c close
+            }
         }
     }
 
@@ -509,13 +513,17 @@ start_server {tags {"introspection"}} {
         # Use the extracted IP for filtering.
         r client list not-ip $not_ip not-ip $not_ip
     } {}
+    if {![should_skip_ipv6_tests]} {
+        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+            test {CLIENT LIST with IPv6 negative filter} {
+                set c [valkey ::1 [srv 0 port] 0 $::tls]
+                $c client setname "client-ipv6"
 
-    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-        test {CLIENT LIST with IPv6 negative filter} {
-            set c [valkey ::1 [srv 0 port] 0 $::tls]
-            $c client setname "client-ipv6"
+                set client_info [$c client info]
 
-            set client_info [$c client info]
+                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+                set filtered [$c client list not-ip $ipv6only]
+                assert_no_match *client-ipv6* $filtered
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
             set filtered [$c client list not-ip "1.2.3.4" not-ip $ipv6only]

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -225,7 +225,6 @@ start_server {tags {"introspection"}} {
         assert_match *client-ip* $filtered
     } {}
 
-    
     start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
         test {CLIENT LIST with IPv6 filter} {
             set c [valkey ::1 [srv 0 port] 0 $::tls]
@@ -240,7 +239,6 @@ start_server {tags {"introspection"}} {
             $c close
         }
     }
-
 
     test {CLIENT LIST with CAPA filter} {
         set c1 [valkey_client]
@@ -266,7 +264,6 @@ start_server {tags {"introspection"}} {
         assert_error "*I/O error*" {$c1 ping}
     } {}
 
-    
     start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
         test {CLIENT KILL with IPv6 filter} {
             set c [valkey ::1 [srv 0 port] 0 $::tls]
@@ -283,7 +280,6 @@ start_server {tags {"introspection"}} {
         }
     }
     
-
     test {CLIENT KILL with CAPA filter} {
         set c1 [valkey_client]
         $c1 client setname "killme-capa"
@@ -523,10 +519,6 @@ start_server {tags {"introspection"}} {
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
             set filtered [$c client list not-ip $ipv6only]
-            assert_no_match *client-ipv6* $filtered
-
-            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-            set filtered [$c client list not-ip "1.2.3.4" not-ip $ipv6only]
             assert_no_match *client-ipv6* $filtered
 
             $c close

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -225,22 +225,22 @@ start_server {tags {"introspection"}} {
         assert_match *client-ip* $filtered
     } {}
 
-    if {![should_skip_ipv6_tests]} {
-        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-            test {CLIENT LIST with IPv6 filter} {
-                set c [valkey ::1 [srv 0 port] 0 $::tls]
-                $c client setname "client-ipv6"
+    
+    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+        test {CLIENT LIST with IPv6 filter} {
+            set c [valkey ::1 [srv 0 port] 0 $::tls]
+            $c client setname "client-ipv6"
 
-                set client_info [$c client info]
+            set client_info [$c client info]
 
-                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-                set filtered [$c client list ip $ipv6only]
-                assert_match *client-ipv6* $filtered
+            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+            set filtered [$c client list ip $ipv6only]
+            assert_match *client-ipv6* $filtered
 
-                $c close
-            }
+            $c close
         }
     }
+
 
     test {CLIENT LIST with CAPA filter} {
         set c1 [valkey_client]
@@ -266,23 +266,23 @@ start_server {tags {"introspection"}} {
         assert_error "*I/O error*" {$c1 ping}
     } {}
 
-    if {![should_skip_ipv6_tests]} {
-        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-            test {CLIENT KILL with IPv6 filter} {
-                set c [valkey ::1 [srv 0 port] 0 $::tls]
-                $c client setname "client-ipv6"
+    
+    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+        test {CLIENT KILL with IPv6 filter} {
+            set c [valkey ::1 [srv 0 port] 0 $::tls]
+            $c client setname "client-ipv6"
 
-                set client_info [$c client info]
+            set client_info [$c client info]
 
-                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-                set filtered [r client kill ip $ipv6only]
+            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+            set filtered [r client kill ip $ipv6only]
 
-                assert_error "*I/O error*" {$c ping}
+            assert_error "*I/O error*" {$c ping}
 
-                $c close
-            }
+            $c close
         }
     }
+    
 
     test {CLIENT KILL with CAPA filter} {
         set c1 [valkey_client]
@@ -513,17 +513,17 @@ start_server {tags {"introspection"}} {
         # Use the extracted IP for filtering.
         r client list not-ip $not_ip not-ip $not_ip
     } {}
-    if {![should_skip_ipv6_tests]} {
-        start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
-            test {CLIENT LIST with IPv6 negative filter} {
-                set c [valkey ::1 [srv 0 port] 0 $::tls]
-                $c client setname "client-ipv6"
+   
+    start_server {tags {"ipv6"} overrides {bind {127.0.0.1 ::1}}} {
+        test {CLIENT LIST with IPv6 negative filter} {
+            set c [valkey ::1 [srv 0 port] 0 $::tls]
+            $c client setname "client-ipv6"
 
-                set client_info [$c client info]
+            set client_info [$c client info]
 
-                regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
-                set filtered [$c client list not-ip $ipv6only]
-                assert_no_match *client-ipv6* $filtered
+            regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
+            set filtered [$c client list not-ip $ipv6only]
+            assert_no_match *client-ipv6* $filtered
 
             regexp {addr=\[([a-fA-F0-9:]+)\]:\d+} $client_info -> ipv6only
             set filtered [$c client list not-ip "1.2.3.4" not-ip $ipv6only]


### PR DESCRIPTION
Skip IPv6 tests automatically when IPv6 is not available.

This fixes the problem that tests fail when IPv6 is not available on the system, which can worry users when they run `make test`.

IPv6 availibility is detected by opening a dummy server socket and trying to connect to it using a client socket over IPv6.

Fixes #2643