### PR TITLE
Fix #2678 don't add loadmodule when from config

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -14,6 +14,7 @@ exat = "exat"
 optin = "optin"
 smove = "smove"
 Parth = "Parth" # seems like the spellchecker does not like it is similar to "Path"
+NAM = "NAM" # Name similar to Name
 nd = "nd"
 
 [default]

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -1,16 +1,166 @@
-Hello! This file is just a placeholder, since this is the "unstable" branch
-of Valkey, the place where all the development happens.
+Valkey 9.1 release notes
+========================
 
-There is no release notes for this branch, it gets forked into another branch
-every time there is a partial feature freeze in order to eventually create
-a new stable release.
+Upgrade urgency levels:
 
-Usually "unstable" is stable enough for you to use it in development environments
-however you should never use it in production environments. It is possible
-to download the latest stable release here:
+| Level    | Meaning                                                             |
+|----------|---------------------------------------------------------------------|
+| LOW      | No need to upgrade unless there are new features you want to use.   |
+| MODERATE | Program an upgrade of the server, but it's not urgent.              |
+| HIGH     | There is a critical bug that may affect a subset of users. Upgrade! |
+| CRITICAL | There is a critical bug affecting MOST USERS. Upgrade ASAP.         |
+| SECURITY | There are security fixes in the release.                            |
 
-    https://valkey.io/download/
+Valkey 9.1.0-rc1 - Released Tue Mar 17 00:00:00 2026
+-------------------------------------
 
-More information is available at https://valkey.io
+Upgrade urgency LOW: This is the first release candidate of Valkey 9.1.0, with
+new features, performance improvements, and bug fixes.
 
-Happy hacking!
+### New Features and enhanced behavior
+* Database-level access control by @dvkashapov (#2309)
+* Move Lua scripting engine into a Valkey module by @rjd15372 (#2858)
+* Support cross node consistency for `SCAN` commands through configurable DB hash seed by @sarthakaggarwal97 (#2608)
+* Support automatic TLS reload by @yang-z-o (#3020)
+* Support TLS authentication using SAN URI by @yang-z-o (#3078)
+* Prevent invalid TLS certificates from being loaded by @yang-z-o (#2999)
+* Failing to save the cluster config file will no longer exit the process by @enjoy-binbin (#1032)
+
+### Command and API updates
+* Makes `CLUSTER KEYSLOT` available in standalone mode by @stockholmux (#3040)
+* Update HSETEX so that it always issue keyspace notifications after validation by @ranshid (#3001)
+* Adds HGETDEL command by @roshkhatri (#2851)
+* Support NX/XX flag in HSETEX command by @hanxizh9910 (#2668)
+* New `CLUSTERSCAN` command for cluster-wide key scanning across nodes by @nmvk (#2934)
+* New `MSETEX` command to set multiple keys with a shared expiration by @enjoy-binbin (#3121)
+* `CLUSTER SHARDS`/`CLUSTER SLOTS` now include an `availability-zone` field by @bandalgomsu (#3156)
+
+### Performance and Efficiency improvements
+* Optimize zset memory usage by embedding element in skiplist by @chzhoo (#2508)
+* Remove internal server object pointer overhead in small strings by @rainsupreme (#2516)
+* Optimize skiplist query efficiency by embedding the skiplist header by @chzhoo (#2867)
+* Improve performance during rehashing by @chzhoo (#3073)
+* Optimize SREM/ZREM/HDEL to pause auto shrink when deleting multiple items by @enjoy-binbin (#3144)
+* Abort and swap the tables if ht1 is very full during the hashtable shrink rehashing by @enjoy-binbin (#3175)
+* Improve performance of copy avoidance when command reply tracking is disabled by @dvkashapov (#3086)
+* Enable hardware clock by default by @dvkashapov (#3103)
+* Improve `COMMAND` performance by caching responses by @ebarskiy (#2839)
+* Add support for asynchronous freeing of keys on writable replicas by @Scut-Corgis (#2849)
+* Faster `XRANGE`/`XREVRANGE` via stream range hot-path optimization by @nesty92 (#3002)
+* Replicas can reuse the RDB file as AOF preamble after disk-based full sync by @RayaCoo (#1901)
+
+### Module API changes
+* Add ValkeyModule_ClusterKeySlotC by @bandalgomsu (#2984)
+* Add more client info flags to module API by @martinrvisser (#2868)
+* Add prefix-aware ACL permission checks and new module API by @eifrah-aws (#2796)
+* Support unsigned 64-bit numeric config values in module API by @artikell (#1546)
+
+### Observability and logging
+* Cumulative metrics for active I/O threads usage by @deepakrn (#2463)
+* Cumulative metric for active main thread usage by @dvkashapov (#2931)
+* Support whole cluster info for INFO command in cluster_info section by @soloestoy, @ranshid (#2876, #2964)
+* Add remaining_repl_size field in `CLUSTER GETSLOTMIGRATIONS` output by @enjoy-binbin (#3135)
+* Add logging helper function to print node's ip:port when nodename not explicitly set by @zhijun42 (#2777)
+* Dual-channel-replication announces itself at replica-announce-ip if configured by @jdheyburn (#2846)
+* Show replica dual-channel replication buffer memory in `INFO MEMORY` and `MEMORY STATS` by @enjoy-binbin (#2924)
+* Add `rdb_transmitted` state to replica state in `INFO` by @enjoy-binbin (#2833)
+* New INFO section for scripting engines by @rjd15372 (#2738)
+* Adding json support for log-format config by @jbergstroem (#1791)
+* Add server side TLS certificate expiry tracking and INFO telemetry by @YiwenZhang12 (#2913)
+* Add option to use libbacktrace for backtraces in crash reports by @rainsupreme (#3034)
+
+### Build and Tooling
+* Show RPS histogram in valkey-benchmark by @hanxizh9910 (#2471)
+* Add --warmup and --duration parameters to valkey-benchmark by @rainsupreme (#2581)
+* Lazy loading of RDMA libs in CLI/Benchmark when building as module by @Ada-Church-Closure (#3072)
+* Add support for atomic slot migration to valkey-cli by @murphyjacob4 (#2755)
+* Replace C++ fast_float dependency with pure C implementation (ffc) by @lemire (#3329)
+
+### Bug Fixes
+* Strictly check CRLF when parsing querybuf by @enjoy-binbin (#2872)
+
+### Contributors
+* Adam Fowler @adam-fowler
+* Aditya Teltia @AdityaTeltia
+* Alina Liu @asagege
+* Allen Samuels @allenss-amazon
+* Alon Arenberg @alon-arenberg
+* aradz44 @aradz44
+* Arthur Lee @arthurkiller
+* bandalgomsu @bandalgomsu
+* Baswanth @baswanth09
+* Benson-li @li-benson
+* Binbin @enjoy-binbin
+* Björn Svensson @bjosv
+* bpint @bpint
+* chzhoo @chzhoo
+* cjx-zar @cjx-zar
+* Daniil Kashapov @dvkashapov
+* Deepak Nandihalli @deepakrn
+* Diego Ciciani @diegociciani
+* eifrah-aws @eifrah-aws
+* Evgeny Barskiy @ebarskiy
+* Gabi Ganam @gabiganam
+* Gagan H R @gaganhr94
+* Hanxi Zhang @hanxizh9910
+* Harkrishn Patro @hpatro
+* Harry Lin @harrylin98
+* hieu2102 @hieu2102
+* Jacob Murphy @murphyjacob4
+* jiegang0219 @jiegang0219
+* Jim Brunner @JimB123
+* Johan Bergström @jbergstroem
+* John @johnufida
+* Joseph Heyburn @jdheyburn
+* Katie Holly @Fusl
+* Ken @otherscase
+* korjeek @korjeek
+* Kurt McKee @kurtmckee
+* Kyle J. Davis @stockholmux
+* Kyle Kim @kyle-yh-kim
+* Leon Anavi @leon-anavi
+* Madelyn Olson @madolson
+* Mangat Singh Toor @immangat
+* Marc Jakobi @mrcjkb
+* martinrvisser @martinrvisser
+* Marvin Rösch @marvinroesch
+* Murad Shahmammadli @MuradSh
+* NAM UK KIM @namuk2004
+* Nikhil Manglore @Nikhil-Manglore
+* Ouri Half @ouriamzn
+* Patrik Hermansson @phermansson
+* Ping Xie @PingXie
+* Quanye Yang @Ada-Church-Closure
+* Rain Valentine @rainsupreme
+* Ran Shidlansik @ranshid
+* Ricardo Dias @rjd15372
+* Ritoban Dutta @ritoban23
+* Roshan Khatri @roshkhatri
+* ruihong123 @ruihong123
+* Sachin Venkatesha Murthy @sachinvmurthy
+* Sarthak Aggarwal @sarthakaggarwal97
+* Satheesha CH Gowda @satheesha
+* Seungmin Lee @sungming2
+* Shinobu Nunotaba @Ada-Church-Closure
+* Simon Baatz @gmbnomis
+* skyfirelee @artikell
+* Sourav Singh Rawat @frostzt
+* stydxm @stydxm
+* Ted Lyngmo @TedLyngmo
+* Tony Wooster @twooster
+* uriyage @uriyage
+* Vadym Khoptynets @poiuj
+* Venkat Pamulapati @ChiliPaneer
+* Viktor Söderqvist @zuiderkwast
+* Vitah Lin @vitahlin
+* Vitali @VitalyAR
+* withRiver @withRiver
+* wxmzy88 @wxmzy88
+* xbasel @xbasel
+* Yair Gottdenker @yairgott
+* Yana Molodetsky @yanamolo
+* Yang Zhao @yang-z-o
+* Yiwen Zhang @YiwenZhang12
+* yzc-yzc @yzc-yzc
+* zhaozhao.zz @soloestoy
+* Zhijun Liao @zhijun42

--- a/src/config.c
+++ b/src/config.c
@@ -450,6 +450,8 @@ static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **er
  * within conf file parsing. This is only needed to support the deprecated
  * abnormal aggregate `save T C` functionality. Remove in the future. */
 static int reading_config_file;
+/* support detecting include vs main config file */
+static int reading_include_file = 0;
 
 void loadServerConfigFromString(sds config) {
     deprecatedConfig deprecated_configs[] = {
@@ -541,7 +543,9 @@ void loadServerConfigFromString(sds config) {
 
         /* Execute config directives */
         if (!strcasecmp(argv[0], "include") && argc == 2) {
+            reading_include_file = 1;
             loadServerConfig(argv[1], 0, NULL);
+            reading_include_file = 0;
         } else if (!strcasecmp(argv[0], "rename-command") && argc == 3) {
             struct serverCommand *cmd = lookupCommandBySds(argv[1]);
 
@@ -574,7 +578,7 @@ void loadServerConfigFromString(sds config) {
                 goto loaderr;
             }
         } else if (!strcasecmp(argv[0], "loadmodule") && argc >= 2) {
-            moduleEnqueueLoadModule(argv[1], &argv[2], argc - 2);
+            moduleEnqueueLoadModule(argv[1], &argv[2], argc - 2, reading_include_file);
         } else if (strchr(argv[0], '.')) {
             if (argc < 2) {
                 err = "Module config specified without value";
@@ -1618,7 +1622,7 @@ void rewriteConfigLoadmoduleOption(struct rewriteConfigState *state) {
     while ((de = dictNext(di)) != NULL) {
         struct ValkeyModule *module = dictGetVal(de);
         line = moduleLoadQueueEntryToLoadmoduleOptionStr(module, "loadmodule");
-        rewriteConfigRewriteLine(state, "loadmodule", line, 1);
+        if (line) rewriteConfigRewriteLine(state, "loadmodule", line, 1);
     }
     dictReleaseIterator(di);
     /* Mark "loadmodule" as processed in case modules is empty. */

--- a/src/module.c
+++ b/src/module.c
@@ -84,6 +84,7 @@
 
 struct moduleLoadQueueEntry {
     sds path;
+    int from_include;
     int argc;
     robj **argv;
 };
@@ -679,7 +680,7 @@ void freeClientModuleData(client *c) {
     c->module_data = NULL;
 }
 
-void moduleEnqueueLoadModule(sds path, sds *argv, int argc) {
+void moduleEnqueueLoadModule(sds path, sds *argv, int argc, int from_include) {
     int i;
     struct moduleLoadQueueEntry *loadmod;
 
@@ -687,6 +688,7 @@ void moduleEnqueueLoadModule(sds path, sds *argv, int argc) {
     loadmod->argv = argc ? zmalloc(sizeof(robj *) * argc) : NULL;
     loadmod->path = sdsnew(path);
     loadmod->argc = argc;
+    loadmod->from_include = from_include;
     for (i = 0; i < argc; i++) {
         loadmod->argv[i] = createRawStringObject(argv[i], sdslen(argv[i]));
     }
@@ -697,6 +699,10 @@ sds moduleLoadQueueEntryToLoadmoduleOptionStr(ValkeyModule *module,
                                               const char *config_option_str) {
     sds line;
 
+    if (module->loadmod->from_include) {
+        /* no need to add as already from config */
+        return NULL;
+    }
     line = sdsnew(config_option_str);
     line = sdscatlen(line, " ", 1);
     line = sdscatsds(line, module->loadmod->path);
@@ -12629,7 +12635,7 @@ void moduleLoadFromQueue(void) {
     listRewind(server.loadmodule_queue, &li);
     while ((ln = listNext(&li))) {
         struct moduleLoadQueueEntry *loadmod = ln->value;
-        if (moduleLoad(loadmod->path, (void **)loadmod->argv, loadmod->argc, 0) == C_ERR) {
+        if (moduleLoad(loadmod->path, (void **)loadmod->argv, loadmod->argc, 0, loadmod->from_include) == C_ERR) {
             serverLog(LL_WARNING, "Can't load module from %s: server aborting", loadmod->path);
             exit(1);
         }
@@ -12818,7 +12824,7 @@ void moduleUnregisterCleanup(ValkeyModule *module) {
 
 /* Load a module and initialize it. On success C_OK is returned, otherwise
  * C_ERR is returned. */
-int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loadex) {
+int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loadex, int from_include) {
     int (*onload)(void *, void **, int);
     void *handle;
 
@@ -12893,6 +12899,7 @@ int moduleLoad(const char *path, void **module_argv, int module_argc, int is_loa
     ctx.module->loadmod->path = sdsnew(path);
     ctx.module->loadmod->argv = module_argc ? zmalloc(sizeof(robj *) * module_argc) : NULL;
     ctx.module->loadmod->argc = module_argc;
+    ctx.module->loadmod->from_include = from_include;
     for (int i = 0; i < module_argc; i++) {
         ctx.module->loadmod->argv[i] = module_argv[i];
         incrRefCount(ctx.module->loadmod->argv[i]);
@@ -13961,7 +13968,7 @@ void moduleCommand(client *c) {
             argv = &c->argv[3];
         }
 
-        if (moduleLoad(objectGetVal(c->argv[2]), (void **)argv, argc, 0) == C_OK)
+        if (moduleLoad(objectGetVal(c->argv[2]), (void **)argv, argc, 0, 0) == C_OK)
             addReply(c, shared.ok);
         else
             addReplyError(c, "Error loading the extension. Please check the server logs.");
@@ -13976,7 +13983,7 @@ void moduleCommand(client *c) {
         /* If this is a loadex command we want to populate server.module_configs_queue with
          * sds NAME VALUE pairs. We also want to increment argv to just after ARGS, if supplied. */
         if (parseLoadexArguments((ValkeyModuleString ***)&argv, &argc) == VALKEYMODULE_OK &&
-            moduleLoad(objectGetVal(c->argv[2]), (void **)argv, argc, 1) == C_OK)
+            moduleLoad(objectGetVal(c->argv[2]), (void **)argv, argc, 1, 0) == C_OK)
             addReply(c, shared.ok);
         else {
             dictEmpty(server.module_configs_queue, NULL);

--- a/src/module.h
+++ b/src/module.h
@@ -169,7 +169,7 @@ static inline void moduleInitDigestContext(ValkeyModuleDigest *mdvar) {
     memset(mdvar->x, 0, sizeof(mdvar->x));
 }
 
-void moduleEnqueueLoadModule(sds path, sds *argv, int argc);
+void moduleEnqueueLoadModule(sds path, sds *argv, int argc, int from_include);
 sds moduleLoadQueueEntryToLoadmoduleOptionStr(ValkeyModule *module,
                                               const char *config_option_str);
 ValkeyModuleCtx *moduleAllocateContext(void);
@@ -181,7 +181,7 @@ void moduleFreeContext(ValkeyModuleCtx *ctx);
 void moduleInitModulesSystem(void);
 void moduleInitModulesSystemLast(void);
 void modulesCron(void);
-int moduleLoad(const char *path, void **argv, int argc, int is_loadex);
+int moduleLoad(const char *path, void **argv, int argc, int is_loadex, int from_include);
 int moduleUnload(sds name, const char **errmsg);
 void moduleUnloadAllModules(void);
 void moduleLoadFromQueue(void);

--- a/src/server.c
+++ b/src/server.c
@@ -7630,7 +7630,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
 #ifdef LUA_ENABLED
 #define LUA_LIB_STR STRINGIFY(LUA_LIB)
     if (scriptingEngineManagerFind("lua") == NULL) {
-        if (moduleLoad(LUA_LIB_STR, NULL, 0, 0) != C_OK) {
+        if (moduleLoad(LUA_LIB_STR, NULL, 0, 0, 1) != C_OK) {
             serverPanic("Lua engine initialization failed, check the server logs.");
         }
     }

--- a/src/version.h
+++ b/src/version.h
@@ -4,13 +4,13 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "255.255.255"
-#define VALKEY_VERSION_NUM 0x00ffffff
+#define VALKEY_VERSION "9.1.0"
+#define VALKEY_VERSION_NUM 0x00090100
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
-#define VALKEY_RELEASE_STAGE "dev"
+#define VALKEY_RELEASE_STAGE "rc1"
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
See #2678 

Track in `moduleLoadQueueEntry` where the module was loaded from
* config (moduleEnqueueLoadModule)*
* command (module load or loaded)

Only add `loadmodule` line when not from config to avoid duplicate line.