### PR TITLE
00-RELEASENOTES: correct 8.1.4 release date to 2025-10-03

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -10,7 +10,7 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
-Valkey 8.1.4  -  Released Fri 09 October 2025
+Valkey 8.1.4  -  Released Fri 03 October 2025
 ================================================================================
 
 Upgrade urgency SECURITY: This release includes security fixes we recommend you


### PR DESCRIPTION
The current line in `00-RELEASENOTES` says "Released Fri 09 October 2025", which is 6 days after the correct release date - and not a Friday.
The actual 8.1.4 release was Fri 03 October 2025 (see GitHub release page).
This PR updates the date accordingly.
Source: Valkey release 8.1.4 (shows Oct 3, 2025).