### PR TITLE
Reduce flakiness of atomic slot migration AOF test

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2176,11 +2176,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {
 
         # Restart the replica and wait for resync
         do_node_restart 3
-        wait_for_condition 50 1000 {
-            [status [srv -3 client] master_link_status] == "up"
-        } else {
-            fail "Replica is not synced"
-        }
+        wait_for_sync [srv -3 client] 50 1000
 
         # Replica should still see the migration. Note that since AOF does not
         # persist the replication ID, this is because of a full resync.

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2174,8 +2174,13 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {
         wait_for_migration_field 3 $jobname state occurring-on-primary
         assert_match "0" [R 3 DBSIZE]
 
-        # Restart the replica
+        # Restart the replica and wait for resync
         do_node_restart 3
+        wait_for_condition 50 1000 {
+            [status [srv -3 client] master_link_status] == "up"
+        } else {
+            fail "Replica is not synced"
+        }
 
         # Replica should still see the migration. Note that since AOF does not
         # persist the replication ID, this is because of a full resync.


### PR DESCRIPTION
If we don't wait for the replica to resync, the migration may be cancelled by the time the replica resyncs, resulting in a test failure when we can't find the migration on the replica.