### PR TITLE
HSETEX with FXX should not create an object if it does not exist

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1971,7 +1971,7 @@ void propagateDeletion(serverDb *db, robj *key, int lazy, int slot) {
     server.replication_allowed = prev_replication_allowed;
 }
 
-static const size_t EXPIRE_BULK_LIMIT = 1024; /* Maximum number of fields to active-expire (per replicated HDEL command */
+#define EXPIRE_BULK_LIMIT ((size_t)1024) /* Maximum number of fields to active-expire (per replicated HDEL command */
 
 /* Propagate HDEL commands for deleted hash fields to AOF and replicas.
  *

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -684,6 +684,12 @@ start_server {tags {"hashexpire"}} {
         set e
     } {ERR *}
 
+     test {HSETEX EX - FXX does not create object in case key does not exist} {
+        r FLUSHALL
+        assert_equal 0 [r HSETEX myhash EX 10 FXX FIELDS 1 x y]
+        assert_equal 0 [r EXISTS myhash]
+    }
+
     ###### Test EXPIRE #############
 
 


### PR DESCRIPTION
When the hash object does not exist FXX should simply fail the check without creating the object while FNX should be trivial and succeed. 

Note - also fix a potential compilation warning on some COMPILERS doing constant folding of variable length array when size is const expression. 