### PR TITLE
Sentinel: Refactor test design to allow two clusters setup to help avoid data leakage during failover

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -73,12 +73,14 @@ proc exec_instance {type dirname cfgfile} {
 
 # Spawn a server or sentinel instance, depending on 'type'.
 proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
+    set current_instances_count [llength [set ::${type}_instances]]
     for {set j 0} {$j < $count} {incr j} {
+        set instance_id [expr $current_instances_count + $j]
         set port [find_available_port $base_port $::valkey_port_count]
         # plaintext port (only used for TLS cluster)
         set pport 0
         # Create a directory for this instance.
-        set dirname "${type}_${j}"
+        set dirname "${type}_${instance_id}"
         lappend ::dirs $dirname
         catch {exec rm -rf $dirname}
         file mkdir $dirname
@@ -148,7 +150,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
 
             # Check availability
             if {[server_is_up 127.0.0.1 $port 100] == 0} {
-                puts "Starting $type #$j at port $port failed, try another"
+                puts "Starting $type #$instance_id at port $port failed, try another"
                 incr retry -1
                 set port [find_available_port $base_port $::valkey_port_count]
                 set cfg [open $cfgfile a+]
@@ -161,7 +163,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
                 }
                 close $cfg
             } else {
-                puts "Starting $type #$j at port $port"
+                puts "Starting $type #$instance_id at port $port"
                 lappend ::pids $pid
                 break
             }
@@ -171,13 +173,14 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
         if {[server_is_up $::host $port 100] == 0} {
             set logfile [file join $dirname log.txt]
             puts [exec tail $logfile]
-            abort_sentinel_test "Problems starting $type #$j: ping timeout, maybe server start failed, check $logfile"
+            abort_sentinel_test "Problems starting $type #$instance_id: ping timeout, maybe server start failed, check $logfile"
         }
 
         # Push the instance into the right list
         set link [valkey $::host $port 0 $::tls]
         $link reconnect 1
         lappend ::${type}_instances [list \
+            instance_id $instance_id \
             pid $pid \
             host $::host \
             port $port \
@@ -185,6 +188,23 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             link $link \
         ]
     }
+}
+
+proc remove_valkey_instance { ids } {
+    set ids [lsort -unique $ids]
+    set new {}
+    foreach instance $::valkey_instances {
+        # Treats the flat list entry {pid 93770 host 127.0.0.1 port 30000 ...}
+        # as alternating key/value pairs.
+        array set inst $instance
+        # Found the target instance
+        if { [lsearch -exact $ids $inst(instance_id)] >= 0} {
+            kill_instance "valkey" $inst(instance_id)
+        } else {
+            lappend new $instance
+        }
+    }
+    set ::valkey_instances $new
 }
 
 proc log_crashes {} {
@@ -265,9 +285,9 @@ proc cleanup {} {
     if {$::dont_clean} {
         return
     }
-    foreach dir $::dirs {
-        catch {exec rm -rf $dir}
-    }
+    # Don't clean up the log files. We often need to examine the
+    # logs regardless of whether the test fail or not.
+    # The logs will be cleaned up in run.tcl prior to running tests
 }
 
 proc abort_sentinel_test msg {
@@ -460,7 +480,8 @@ proc test {descr code} {
 # Check memory leaks when running on macOS using the "leaks" utility.
 proc check_leaks instance_types {
     if {$::leaks && [string match {*Darwin*} [exec uname -a]]} {
-        puts -nonewline "Testing for memory leaks..."; flush stdout
+        set ts [clock format [clock seconds] -format %H:%M:%S]
+        puts -nonewline "$ts> Testing for memory leaks..."; flush stdout
         foreach type $instance_types {
             foreach_instance_id [set ::${type}_instances] id {
                 if {[instance_is_killed $type $id]} continue
@@ -675,29 +696,26 @@ proc set_instance_attrib {type id attrib newval} {
     lset ::${type}_instances $id $d
 }
 
-# Create a master-slave cluster of the given number of total instances.
-# The first instance "0" is the master, all others are configured as
-# slaves.
-proc create_valkey_master_slave_cluster n {
-    foreach_valkey_id id {
-        if {$id == 0} {
-            # Our master.
+# Create a primary-replica cluster of the given number of total instances.
+# The first instance (ID 0) is the primary, all others are configured as
+# replicas.
+proc create_valkey_primary_replica_cluster { n primary_id } {
+    for {set id $primary_id} {$id < [expr $primary_id + $n]} {incr id} {
+        if {$id == $primary_id} {
             R $id slaveof no one
             R $id flushall
-        } elseif {$id < $n} {
-            R $id slaveof [get_instance_attrib valkey 0 host] \
-                          [get_instance_attrib valkey 0 port]
         } else {
-            # Instances not part of the cluster.
-            R $id slaveof no one
+            R $id slaveof [get_instance_attrib valkey $primary_id host] [get_instance_attrib valkey $primary_id port]
         }
     }
-    # Wait for all the slaves to sync.
+    # Wait for all the replicas to sync.
     wait_for_condition 1000 50 {
-        [RI 0 connected_slaves] == ($n-1)
+        [RI $primary_id connected_slaves] == ($n-1)
     } else {
-        fail "Unable to create a master-slaves cluster."
+        fail "Unable to create a primary-replica cluster. Connected [RI $primary_id connected_slaves] \
+              replicas but expected [expr $n-1]"
     }
+    puts "Successfully created a primary-replica cluster of $n instances with primary ID $primary_id"
 }
 
 proc get_instance_id_by_port {type port} {

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -12,6 +12,13 @@ set ::instances_count 5 ; # How many instances we use at max.
 set ::tlsdir "../../tls"
 
 proc main {} {
+    set start [clock milliseconds]
+    # Clean up log files from previous test run
+    foreach name [glob -tails -directory [pwd] * .*] {
+        if {$name in { . .. .gitignore }} continue
+        file delete -force -- $name
+    }
+
     parse_options
     if {$::leaked_fds_file != ""} {
         set ::env(LEAKED_FDS_FILE) $::leaked_fds_file
@@ -29,6 +36,9 @@ proc main {} {
     }
     run_tests
     cleanup
+    set end [clock milliseconds]
+    set duration [expr {($end - $start) / 1000}]
+    puts "Total test duration: ${duration} seconds"
     end_tests
 }
 

--- a/tests/sentinel/tests/00-base.tcl
+++ b/tests/sentinel/tests/00-base.tcl
@@ -127,6 +127,7 @@ test "The old primary eventually gets reconfigured as a slave" {
 }
 
 test "ODOWN is not possible without N (quorum) Sentinels reports" {
+    set sentinels [llength $::sentinel_instances]
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster quorum [expr $sentinels+1]
     }
@@ -135,13 +136,14 @@ test "ODOWN is not possible without N (quorum) Sentinels reports" {
     assert {[lindex $addr 1] == $old_port}
     kill_instance valkey $master_id
 
-    # Make sure failover did not happened.
+    # Make sure failover did not happen.
     set addr [S 0 SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     restart_instance valkey $master_id
 }
 
 test "Failover is not possible without majority agreement" {
+    set quorum [expr {$sentinels/2 + 1}]
     foreach_sentinel_id id {
         S $id SENTINEL SET mymaster quorum $quorum
     }
@@ -154,7 +156,7 @@ test "Failover is not possible without majority agreement" {
     # Kill the current master
     kill_instance valkey $master_id
 
-    # Make sure failover did not happened.
+    # Make sure failover did not happen.
     set addr [S $quorum SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster]
     assert {[lindex $addr 1] == $old_port}
     restart_instance valkey $master_id
@@ -202,7 +204,7 @@ test "New primary [join $addr {:}] role matches" {
     assert {[RI $master_id role] eq {master}}
 }
 
-test "SENTINEL RESET can resets the primary" {
+test "SENTINEL RESET can reset the primary" {
     # After SENTINEL RESET, sometimes the sentinel can sense the primary again,
     # causing the test to fail. Here we give it a few more chances.
     for {set j 0} {$j < 10} {incr j} {

--- a/tests/sentinel/tests/04-replica-selection.tcl
+++ b/tests/sentinel/tests/04-replica-selection.tcl
@@ -1,0 +1,53 @@
+# Test replica selection algorithm.
+#
+# This unit should test:
+# 1) That when there are no suitable replicas, no failover is performed.
+# 2) That among the available replicas, the one with better offset is picked.
+source "../tests/includes/init-tests.tcl"
+
+foreach_sentinel_id id {
+    S $id SENTINEL DEBUG ping-period 500
+    S $id SENTINEL DEBUG ask-period 500
+    S $id SENTINEL DEBUG info-period 500
+    S $id SENTINEL DEBUG default-down-after 1000
+}
+
+# This unit is the only one in the whole sentinel test suite that
+# requires two clusters. Here we will mainly operate on the second cluster.
+
+# Spawn 1 primary with only 1 replica
+set num_instances 2
+spawn_instance valkey $::valkey_base_port $num_instances {
+    "enable-protected-configs yes"
+    "enable-debug-command yes"
+    "save ''"
+}
+
+set primary_a_id 0
+set primary_a_name "mymaster"
+# The first 5 IDs belong to the default primary-replica cluster
+set primary_b_id $::instances_count
+set primary_b_name "another_primary"
+set replica_id [expr $primary_b_id + 1]
+
+# Create the second cluster
+init_cluster $primary_b_name $primary_b_id $num_instances
+
+# Start tests
+test "The second cluster works" {
+    # Put a simple string into the database
+    R $primary_b_id SET "mykey" "myvalue"
+
+    wait_for_condition 200 50 {
+        [R $replica_id GET "mykey"] == "myvalue"
+    } else {
+        fail "The replica and primary in the second cluster cannot sync"
+    }
+}
+
+# Now that we have two clusters, we need to do proper cleanup
+# to avoid messing up other test suites.
+foreach_sentinel_id id {
+    S $id SENTINEL REMOVE $primary_b_name
+}
+remove_valkey_instance [list $primary_b_id $replica_id]

--- a/tests/sentinel/tests/04-slave-selection.tcl
+++ b/tests/sentinel/tests/04-slave-selection.tcl
@@ -1,5 +1,0 @@
-# Test slave selection algorithm.
-#
-# This unit should test:
-# 1) That when there are no suitable slaves no failover is performed.
-# 2) That among the available slaves, the one with better offset is picked.

--- a/tests/sentinel/tests/includes/init-tests.tcl
+++ b/tests/sentinel/tests/includes/init-tests.tcl
@@ -1,63 +1,79 @@
 # Initialization tests -- most units will start including this.
 source "../tests/includes/utils.tcl"
 
-test "(init) Restart killed instances" {
-    restart_killed_instances
-}
-
-test "(init) Remove old primary entry from sentinels" {
-    foreach_sentinel_id id {
-        catch {S $id SENTINEL REMOVE mymaster}
-    }
-}
-
-set redis_slaves [expr $::instances_count - 1]
-test "(init) Create a primary-replicas cluster of [expr $redis_slaves+1] instances" {
-    create_valkey_master_slave_cluster [expr {$redis_slaves+1}]
-}
-set master_id 0
-
-test "(init) Sentinels can start monitoring a primary" {
+proc sentinel_monitor_primary { primary_name primary_id } {
     set sentinels [llength $::sentinel_instances]
     set quorum [expr {$sentinels/2+1}]
     foreach_sentinel_id id {
-        S $id SENTINEL MONITOR mymaster \
-              [get_instance_attrib valkey $master_id host] \
-              [get_instance_attrib valkey $master_id port] $quorum
+        S $id SENTINEL MONITOR $primary_name \
+          [get_instance_attrib valkey $primary_id host] [get_instance_attrib valkey $primary_id port] $quorum
     }
     foreach_sentinel_id id {
-        assert {[S $id sentinel primary mymaster] ne {}}
-        S $id SENTINEL SET mymaster down-after-milliseconds 2000
-        S $id SENTINEL SET mymaster failover-timeout 10000
-        S $id SENTINEL debug tilt-period 5000
-        S $id SENTINEL SET mymaster parallel-syncs 10
+        assert {[S $id sentinel primary $primary_name] ne {}}
+        S $id SENTINEL SET $primary_name down-after-milliseconds 2000
+        S $id SENTINEL SET $primary_name failover-timeout 10000
+        S $id SENTINEL DEBUG tilt-period 5000
+        S $id SENTINEL SET $primary_name parallel-syncs 10
         if {$::leaked_fds_file != "" && [exec uname] == "Linux"} {
-            S $id SENTINEL SET mymaster notification-script ../../tests/helpers/check_leaked_fds.tcl
-            S $id SENTINEL SET mymaster client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
+            S $id SENTINEL SET $primary_name notification-script ../../tests/helpers/check_leaked_fds.tcl
+            S $id SENTINEL SET $primary_name client-reconfig-script ../../tests/helpers/check_leaked_fds.tcl
         }
     }
 }
 
-test "(init) Sentinels can talk with the primary" {
+proc verify_sentinel_connect_to_primary { primary_name } {
     foreach_sentinel_id id {
         wait_for_condition 1000 50 {
-            [catch {S $id SENTINEL GET-PRIMARY-ADDR-BY-NAME mymaster}] == 0
+            [catch {S $id SENTINEL GET-PRIMARY-ADDR-BY-NAME $primary_name}] == 0
         } else {
-            fail "Sentinel $id can't talk with the primary."
+            fail "Sentinel $id can't talk with the primary $primary_name"
         }
     }
 }
 
-test "(init) Sentinels are able to auto-discover other sentinels" {
-    verify_sentinel_auto_discovery
-}
-
-test "(init) Sentinels are able to auto-discover replicas" {
+proc verify_sentinel_discover_replicas { primary_name expected_replicas } {
     foreach_sentinel_id id {
         wait_for_condition 1000 50 {
-            [dict get [S $id SENTINEL PRIMARY mymaster] num-slaves] == $redis_slaves
+            [dict get [S $id SENTINEL primary $primary_name] num-slaves] == $expected_replicas
         } else {
-            fail "At least some sentinels can't detect some replicas"
+            fail "For primary $primary_name, at least some sentinel can't detect some replicas"
         }
     }
 }
+
+proc init_cluster { primary_name primary_id num_instances } {
+    puts "Initializing test setup for cluster: primary $primary_name with $num_instances instances"
+
+    test "(init) Restart killed instances" {
+        restart_killed_instances
+    }
+
+    test "(init) Remove old primary entry from sentinels" {
+        foreach_sentinel_id id {
+            catch {S $id SENTINEL REMOVE $primary_name}
+        }
+    }
+
+    test "(init) Create a primary-replicas cluster of $num_instances instances" {
+        create_valkey_primary_replica_cluster $num_instances $primary_id
+    }
+
+    test "(init) Sentinels can start monitoring a primary" {
+        sentinel_monitor_primary $primary_name $primary_id
+    }
+
+    test "(init) Sentinels can talk with the primary" {
+        verify_sentinel_connect_to_primary $primary_name
+    }
+
+    test "(init) Sentinels are able to auto-discover other sentinels" {
+        verify_sentinel_auto_discovery $primary_name
+    }
+
+    test "(init) Sentinels are able to auto-discover replicas" {
+        verify_sentinel_discover_replicas $primary_name [expr $num_instances - 1]
+    }
+}
+
+set master_id 0
+init_cluster "mymaster" $master_id $::instances_count

--- a/tests/sentinel/tests/includes/utils.tcl
+++ b/tests/sentinel/tests/includes/utils.tcl
@@ -19,18 +19,22 @@ proc verify_sentinel_connect_sentinels {id} {
     return 1
 }
 
-proc verify_sentinel_auto_discovery {} {
+proc verify_sentinel_auto_discovery { {primary_name {}} } {
+    if {$primary_name eq {}} {
+        set primary_name "mymaster"
+    }
+
     set sentinels [llength $::sentinel_instances]
     foreach_sentinel_id id {
         wait_for_condition 1000 50 {
             [dict get [S $id SENTINEL PRIMARY mymaster] num-other-sentinels] == ($sentinels-1)
         } else {
-            fail "At least some sentinel can't detect some other sentinel"
+            fail "For primary $primary_name, at least some sentinel can't detect some other sentinel"
         }
         wait_for_condition 1000 50 {
             [verify_sentinel_connect_sentinels $id] == 1
         } else {
-            fail "At least some sentinel can't connect to other sentinel"
+            fail "For primary $primary_name, at least some sentinel can't connect to other sentinel"
         }
     }
 }


### PR DESCRIPTION
I found this issue in Redis repo https://github.com/redis/redis/issues/14313 and confirmed that it also exists in Valkey. The description is pretty lengthy and detailed, and the TL;DR is that **during failover sentinels will pick whatever slave instance it discovers to promote, which can cause serious data leakage if that particular slave server actually contains data of another customer/tenant**.

I spent a couple weeks on this issue and got it working as expected. To make it easier for code reading, I broke up the code changes into smaller patches for review. This is the first part.

(Note that I'm using term master/slave and I'm aware that it's the same as primary/replica)


##  How to reproduce the issue

We need to run two clusters and have two sentinel instances monitoring each one.

Duplicate the file `sentinel.conf` as `sentinel-a.conf` and `sentinel-b.conf`.  Add `sentinel monitor cluster-a 127.0.0.1 6379 1` to `sentinel-a.conf`, and `sentinel monitor cluster-b 127.0.0.1 6380 1` to `sentinel-a.conf`. Then replace all occurrence of "mymaster" to "cluster-a"/"cluster-b" correspondingly.

At the root directory of the repo:

```bash
# Set up the valkey server clusters
./src/valkey-server --port 6379  # this is cluster A
./src/valkey-server --port 6380  # this is cluster B
./src/valkey-server --port 6381 --replicaof 127.0.0.1 6379  # slave in cluster A

# Set up the sentinel instances
./src/valkey-server sentinel-a.conf --sentinel --port 26379
./src/valkey-server sentinel-b.conf --sentinel --port 26380

# Insert data
./src/valkey-cli -p 6379 set "key-cluster-a" "value-a"
./src/valkey-cli -p 6380 set "key-cluster-b" "value-b"

# Verify that the slave has replicated the data
./src/valkey-cli -p 6381 get "key-cluster-a"

# Manually ask the slave to follow a diffrent master
./src/valkey-cli -p 6381 replicaof 127.0.0.1 6380
```

Now shut down the master server (port 6379) in cluster A and we will see sentinel A starting failover trying to promote a candidate slave. Since the only slave 6381now belongs to a diffrent cluster (cluster B), the failover should fail with an event `-failover-abort-no-good-slave`, but the sentinel A still thinks slave 6381 is following master A 6379 and thus promotes 6381 to become the new master in cluster A.



## Changes I made

The challenging part of solving this issue is to set up tests. The entire sentinel test suite is designed to have only one master-slave cluster with the master named "mymaster", but my code changes would require spinning up two clusters so I had to refactor the `tests/sentinel/tests/includes/init-tests.tcl` file to support so.

I also added a simple test in file `04-replica-selection.tcl` to verify that the second cluster is now working. This file will be where I implement the tests on sentinels verifying replication ID during failover once this PR is merged. Interestingly, this file was intended to test the slave selection procedure but the test was never implemented since 2014.