### PR TITLE
[Backport 9.0] Deflake replica selection test by relaxing cluster configurations (#2672)

### DIFF
--- a/tests/unit/cluster/slave-selection.tcl
+++ b/tests/unit/cluster/slave-selection.tcl
@@ -3,7 +3,7 @@
 
 # Create a cluster with 5 master and 10 slaves, so that we have 2
 # slaves for each master.
-start_cluster 5 10 {tags {external:skip cluster}} {
+start_cluster 5 10 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
 
 test "Cluster is up" {
     wait_for_cluster_state ok


### PR DESCRIPTION
Backport of #2672 

We have relaxed the `cluster-ping-interval` and `cluster-node-timeout` so that cluster has enough time to stabilize and propagate changes.

Fixes this test occasional failure when running with valgrind:

    [err]: Node #10 should eventually replicate node #5 in tests/unit/cluster/slave-selection.tcl
    #10 didn't became slave of #5