### PR TITLE
Fix double MOVED reply on unblock at failover

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -340,7 +340,7 @@ void disconnectOrRedirectAllBlockedClients(void) {
 
             if (server.cluster_enabled) {
                 if (clusterRedirectBlockedClientIfNeeded(c))
-                    unblockClient(c, 1);
+                    unblockClientOnError(c, NULL);
             } else {
                 /* if the client is read-only and blocked by a read command, we do not unblock it */
                 if (c->flag.readonly && !(c->lastcmd->flags & CMD_WRITE)) continue;


### PR DESCRIPTION
#2329 intoduced a bug that causes a blocked client in cluster mode to receive two MOVED redirects instead of one. This was not seen in tests, except in the reply schema validator.

The fix makes sure the client's pending command is cleared after sending the MOVED redirect, to prevent if from being reprocessed.

Fixes #2676.