### PR TITLE
Reorder valkey.conf: move configs to correct sections

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -2237,38 +2237,6 @@ notify-keyspace-events ""
 
 ############################### ADVANCED CONFIG ###############################
 
-# It is possible to pin different threads and processes of the server to specific
-# CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different server threads in different
-# CPUs, but also in order to make sure that multiple server instances running
-# in the same host will be pinned to different CPUs.
-#
-# Normally you can do this using the "taskset" command, however it is also
-# possible to do this via the server configuration directly, both in Linux and FreeBSD.
-#
-# You can pin the server/IO threads, bio threads, aof rewrite child process,
-# bgsave child process and the slot migration process.
-# The syntax to specify the cpu list is the same as the taskset command:
-#
-# Set server/io threads to cpu affinity 0,2,4,6:
-# server-cpulist 0-7:2
-#
-# Set bio threads to cpu affinity 1,3:
-# bio-cpulist 1,3
-#
-# Set aof rewrite child process to cpu affinity 8,9,10,11:
-# aof-rewrite-cpulist 8-11
-#
-# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
-# bgsave-cpulist 1,10-11
-
-# In some cases the server will emit warnings and even refuse to start if it detects
-# that the system is in bad state, it is possible to suppress these warnings
-# by setting the following config which takes a space delimited list of warnings
-# to suppress
-#
-# ignore-warnings ARM64-COW-BUG
-
 # Hashes are encoded using a memory efficient data structure when they have a
 # small number of entries, and the biggest entry does not exceed a given
 # threshold. These thresholds can be configured using the following directives.
@@ -2561,6 +2529,38 @@ rdb-save-incremental-fsync yes
 # When the config is set to 0, prefetching is disabled.
 #
 # prefetch-batch-max-size 16
+
+# It is possible to pin different threads and processes of the server to specific
+# CPUs in your system, in order to maximize the performances of the server.
+# This is useful both in order to pin different server threads in different
+# CPUs, but also in order to make sure that multiple server instances running
+# in the same host will be pinned to different CPUs.
+#
+# Normally you can do this using the "taskset" command, however it is also
+# possible to do this via the server configuration directly, both in Linux and FreeBSD.
+#
+# You can pin the server/IO threads, bio threads, aof rewrite child process,
+# bgsave child process and the slot migration process.
+# The syntax to specify the cpu list is the same as the taskset command:
+#
+# Set server/io threads to cpu affinity 0,2,4,6:
+# server-cpulist 0-7:2
+#
+# Set bio threads to cpu affinity 1,3:
+# bio-cpulist 1,3
+#
+# Set aof rewrite child process to cpu affinity 8,9,10,11:
+# aof-rewrite-cpulist 8-11
+#
+# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
+# bgsave-cpulist 1,10-11
+
+# In some cases the server will emit warnings and even refuse to start if it detects
+# that the system is in bad state, it is possible to suppress these warnings
+# by setting the following config which takes a space delimited list of warnings
+# to suppress
+#
+# ignore-warnings ARM64-COW-BUG
 
 
 ########################### ACTIVE DEFRAGMENTATION #######################

--- a/valkey.conf
+++ b/valkey.conf
@@ -521,6 +521,44 @@ locale-collate ""
 #
 # extended-redis-compatibility no
 
+# It is possible to pin different threads and processes of the server to specific
+# CPUs in your system, in order to maximize the performances of the server.
+# This is useful both in order to pin different server threads in different
+# CPUs, but also in order to make sure that multiple server instances running
+# in the same host will be pinned to different CPUs.
+#
+# Normally you can do this using the "taskset" command, however it is also
+# possible to do this via the server configuration directly, both in Linux and FreeBSD.
+#
+# You can pin the server/IO threads, bio threads, aof rewrite child process,
+# bgsave child process and the slot migration process.
+# The syntax to specify the cpu list is the same as the taskset command:
+#
+# Set server/io threads to cpu affinity 0,2,4,6:
+# server-cpulist 0-7:2
+#
+# Set bio threads to cpu affinity 1,3:
+# bio-cpulist 1,3
+#
+# Set aof rewrite child process to cpu affinity 8,9,10,11:
+# aof-rewrite-cpulist 8-11
+#
+# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
+# bgsave-cpulist 1,10-11
+
+# In some cases the server will emit warnings and even refuse to start if it detects
+# that the system is in bad state, it is possible to suppress these warnings
+# by setting the following config which takes a space delimited list of warnings
+# to suppress
+#
+# ignore-warnings ARM64-COW-BUG
+
+# Inform Valkey of the availability zone if running in a cloud environment.  Currently
+# this is exposed in the INFO and HELLO commands for clients to use. Default is
+# the empty string.
+#
+# availability-zone "zone-name"
+
 ################################ SNAPSHOTTING  ################################
 
 # Save the DB to disk.
@@ -2595,41 +2633,3 @@ rdb-save-incremental-fsync yes
 
 # Jemalloc background thread for purging will be enabled by default
 jemalloc-bg-thread yes
-
-# It is possible to pin different threads and processes of the server to specific
-# CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different server threads in different
-# CPUs, but also in order to make sure that multiple server instances running
-# in the same host will be pinned to different CPUs.
-#
-# Normally you can do this using the "taskset" command, however it is also
-# possible to do this via the server configuration directly, both in Linux and FreeBSD.
-#
-# You can pin the server/IO threads, bio threads, aof rewrite child process,
-# bgsave child process and the slot migration process.
-# The syntax to specify the cpu list is the same as the taskset command:
-#
-# Set server/io threads to cpu affinity 0,2,4,6:
-# server-cpulist 0-7:2
-#
-# Set bio threads to cpu affinity 1,3:
-# bio-cpulist 1,3
-#
-# Set aof rewrite child process to cpu affinity 8,9,10,11:
-# aof-rewrite-cpulist 8-11
-#
-# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
-# bgsave-cpulist 1,10-11
-
-# In some cases the server will emit warnings and even refuse to start if it detects
-# that the system is in bad state, it is possible to suppress these warnings
-# by setting the following config which takes a space delimited list of warnings
-# to suppress
-#
-# ignore-warnings ARM64-COW-BUG
-
-# Inform Valkey of the availability zone if running in a cloud environment.  Currently
-# this is exposed in the INFO and HELLO commands for clients to use. Default is
-# the empty string.
-#
-# availability-zone "zone-name"

--- a/valkey.conf
+++ b/valkey.conf
@@ -521,38 +521,6 @@ locale-collate ""
 #
 # extended-redis-compatibility no
 
-# It is possible to pin different threads and processes of the server to specific
-# CPUs in your system, in order to maximize the performances of the server.
-# This is useful both in order to pin different server threads in different
-# CPUs, but also in order to make sure that multiple server instances running
-# in the same host will be pinned to different CPUs.
-#
-# Normally you can do this using the "taskset" command, however it is also
-# possible to do this via the server configuration directly, both in Linux and FreeBSD.
-#
-# You can pin the server/IO threads, bio threads, aof rewrite child process,
-# bgsave child process and the slot migration process.
-# The syntax to specify the cpu list is the same as the taskset command:
-#
-# Set server/io threads to cpu affinity 0,2,4,6:
-# server-cpulist 0-7:2
-#
-# Set bio threads to cpu affinity 1,3:
-# bio-cpulist 1,3
-#
-# Set aof rewrite child process to cpu affinity 8,9,10,11:
-# aof-rewrite-cpulist 8-11
-#
-# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
-# bgsave-cpulist 1,10-11
-
-# In some cases the server will emit warnings and even refuse to start if it detects
-# that the system is in bad state, it is possible to suppress these warnings
-# by setting the following config which takes a space delimited list of warnings
-# to suppress
-#
-# ignore-warnings ARM64-COW-BUG
-
 # Inform Valkey of the availability zone if running in a cloud environment.  Currently
 # this is exposed in the INFO and HELLO commands for clients to use. Default is
 # the empty string.
@@ -2268,6 +2236,38 @@ latency-monitor-threshold 0
 notify-keyspace-events ""
 
 ############################### ADVANCED CONFIG ###############################
+
+# It is possible to pin different threads and processes of the server to specific
+# CPUs in your system, in order to maximize the performances of the server.
+# This is useful both in order to pin different server threads in different
+# CPUs, but also in order to make sure that multiple server instances running
+# in the same host will be pinned to different CPUs.
+#
+# Normally you can do this using the "taskset" command, however it is also
+# possible to do this via the server configuration directly, both in Linux and FreeBSD.
+#
+# You can pin the server/IO threads, bio threads, aof rewrite child process,
+# bgsave child process and the slot migration process.
+# The syntax to specify the cpu list is the same as the taskset command:
+#
+# Set server/io threads to cpu affinity 0,2,4,6:
+# server-cpulist 0-7:2
+#
+# Set bio threads to cpu affinity 1,3:
+# bio-cpulist 1,3
+#
+# Set aof rewrite child process to cpu affinity 8,9,10,11:
+# aof-rewrite-cpulist 8-11
+#
+# Set bgsave (or slot migration) child process to cpu affinity 1,10,11:
+# bgsave-cpulist 1,10-11
+
+# In some cases the server will emit warnings and even refuse to start if it detects
+# that the system is in bad state, it is possible to suppress these warnings
+# by setting the following config which takes a space delimited list of warnings
+# to suppress
+#
+# ignore-warnings ARM64-COW-BUG
 
 # Hashes are encoded using a memory efficient data structure when they have a
 # small number of entries, and the biggest entry does not exceed a given


### PR DESCRIPTION
- Moved `server-cpulist`, `bio-cpulist`, `aof-rewrite-cpulist`, `bgsave-cpulist` configurations to ADVANCED CONFIG.
- Moved `ignore-warnings` configuration to ADVANCED CONFIG.
- Moved `availability-zone` configuration to GENERAL.

These configs were incorrectly placed at the end of the file in the ACTIVE DEFRAGMENTATION section.

Fixes #2736