### PR TITLE
New INFO section for scripting engines

### DIFF
--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -206,6 +206,10 @@ ValkeyModule *scriptingEngineGetModule(scriptingEngine *engine) {
     return engine->module;
 }
 
+uint64_t scriptingEngineGetAbiVersion(scriptingEngine *engine) {
+    return engine->impl.methods.version;
+}
+
 /*
  * Iterates the list of engines registered in the engine manager and calls the
  * callback function with each engine.

--- a/src/scripting_engine.h
+++ b/src/scripting_engine.h
@@ -48,6 +48,7 @@ void scriptingEngineManagerForEachEngine(engineIterCallback callback, void *cont
 sds scriptingEngineGetName(scriptingEngine *engine);
 client *scriptingEngineGetClient(scriptingEngine *engine);
 ValkeyModule *scriptingEngineGetModule(scriptingEngine *engine);
+uint64_t scriptingEngineGetAbiVersion(scriptingEngine *engine);
 
 /*
  * API to call engine callback functions.

--- a/src/server.c
+++ b/src/server.c
@@ -5755,13 +5755,13 @@ static void collectScriptingEngineInfo(scriptingEngine *engine, void *context) {
     engineMemoryInfo mem_info = scriptingEngineCallGetMemoryInfo(engine, VMSE_ALL);
 
     collector->info = sdscatprintf(collector->info,
-        "engine_%d:name=%s,module=%s,abi_version=%lu,used_memory=%zu,memory_overhead=%zu\r\n",
-        collector->total_engines,
-        engine_name,
-        module ? module->name : "built-in",
-        abi_version,
-        mem_info.used_memory,
-        mem_info.engine_memory_overhead);
+                                   "engine_%d:name=%s,module=%s,abi_version=%lu,used_memory=%zu,memory_overhead=%zu\r\n",
+                                   collector->total_engines,
+                                   engine_name,
+                                   module ? module->name : "built-in",
+                                   (unsigned long)abi_version,
+                                   mem_info.used_memory,
+                                   mem_info.engine_memory_overhead);
 
     collector->total_engines++;
     collector->total_used_memory += mem_info.used_memory;
@@ -5773,22 +5773,21 @@ sds genValkeyInfoStringScriptingEngines(sds info) {
         .info = sdsempty(),
         .total_engines = 0,
         .total_used_memory = 0,
-        .total_overhead = 0
-    };
+        .total_overhead = 0};
 
     /* Collect information from all registered engines */
     scriptingEngineManagerForEachEngine(collectScriptingEngineInfo, &collector);
 
     info = sdscatprintf(info,
-        "# Scripting Engines\r\n"
-        "engines_count:%d\r\n"
-        "engines_total_used_memory:%zu\r\n"
-        "engines_total_memory_overhead:%zu\r\n"
-        "%s",
-        collector.total_engines,
-        collector.total_used_memory,
-        collector.total_overhead,
-        collector.info);
+                        "# Scripting Engines\r\n"
+                        "engines_count:%d\r\n"
+                        "engines_total_used_memory:%zu\r\n"
+                        "engines_total_memory_overhead:%zu\r\n"
+                        "%s",
+                        collector.total_engines,
+                        collector.total_used_memory,
+                        collector.total_overhead,
+                        collector.info);
 
     sdsfree(collector.info);
     return info;
@@ -6928,8 +6927,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-         * so we avoid these pointless loops when they're not going to do anything. */
+    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+     * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;
@@ -7374,7 +7373,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
     }
     if (server.sentinel_mode) sentinelCheckConfigFile();
 
-        /* Do system checks */
+    /* Do system checks */
 #ifdef __linux__
     linuxMemoryWarnings();
     sds err_msg = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -5737,6 +5737,63 @@ void releaseInfoSectionDict(dict *sec) {
     if (sec != cached_default_info_sections) dictRelease(sec);
 }
 
+typedef struct scriptingEngineInfoCollector {
+    sds info;
+    int total_engines;
+    size_t total_used_memory;
+    size_t total_overhead;
+} scriptingEngineInfoCollector;
+
+static void collectScriptingEngineInfo(scriptingEngine *engine, void *context) {
+    scriptingEngineInfoCollector *collector = (scriptingEngineInfoCollector *)context;
+
+    sds engine_name = scriptingEngineGetName(engine);
+    ValkeyModule *module = scriptingEngineGetModule(engine);
+    uint64_t abi_version = scriptingEngineGetAbiVersion(engine);
+
+    /* Get memory information for the engine */
+    engineMemoryInfo mem_info = scriptingEngineCallGetMemoryInfo(engine, VMSE_ALL);
+
+    collector->info = sdscatprintf(collector->info,
+        "engine_%d:name=%s,module=%s,abi_version=%lu,used_memory=%zu,memory_overhead=%zu\r\n",
+        collector->total_engines,
+        engine_name,
+        module ? module->name : "built-in",
+        abi_version,
+        mem_info.used_memory,
+        mem_info.engine_memory_overhead);
+
+    collector->total_engines++;
+    collector->total_used_memory += mem_info.used_memory;
+    collector->total_overhead += mem_info.engine_memory_overhead;
+}
+
+sds genValkeyInfoStringScriptingEngines(sds info) {
+    scriptingEngineInfoCollector collector = {
+        .info = sdsempty(),
+        .total_engines = 0,
+        .total_used_memory = 0,
+        .total_overhead = 0
+    };
+
+    /* Collect information from all registered engines */
+    scriptingEngineManagerForEachEngine(collectScriptingEngineInfo, &collector);
+
+    info = sdscatprintf(info,
+        "# Scripting Engines\r\n"
+        "engines_count:%d\r\n"
+        "engines_total_used_memory:%zu\r\n"
+        "engines_total_memory_overhead:%zu\r\n"
+        "%s",
+        collector.total_engines,
+        collector.total_used_memory,
+        collector.total_overhead,
+        collector.info);
+
+    sdsfree(collector.info);
+    return info;
+}
+
 /* Create a dictionary with unique section names to be used by genValkeyInfoString.
  * 'argv' and 'argc' are list of arguments for INFO.
  * 'defaults' is an optional null terminated list of default sections.
@@ -6408,6 +6465,12 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                             "# Cluster\r\n"
                             "cluster_enabled:%d\r\n",
                             server.cluster_enabled);
+    }
+
+    /* Scripting engines */
+    if (all_sections || (dictFind(section_dict, "scriptingengines") != NULL)) {
+        if (sections++) info = sdscat(info, "\r\n");
+        info = genValkeyInfoStringScriptingEngines(info);
     }
 
     /* Key space */
@@ -7484,7 +7547,7 @@ int parseExtendedCommandArgumentsOrReply(client *c, int *flags, int *unit, robj 
                    (opt[1] == 'f' || opt[1] == 'F') &&
                    (opt[2] == 'e' || opt[2] == 'E') &&
                    (opt[3] == 'q' || opt[3] == 'Q') && opt[4] == '\0' &&
-                   next && 
+                   next &&
                    !(*flags & ARGS_SET_NX || *flags & ARGS_SET_XX || *flags & ARGS_SET_IFEQ) && (command_type == COMMAND_SET))
         {
             *flags |= ARGS_SET_IFEQ;

--- a/src/server.c
+++ b/src/server.c
@@ -6927,8 +6927,8 @@ void dismissMemoryInChild(void) {
     /* madvise(MADV_DONTNEED) may not work if Transparent Huge Pages is enabled. */
     if (server.thp_enabled) return;
 
-    /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
-     * so we avoid these pointless loops when they're not going to do anything. */
+        /* Currently we use zmadvise_dontneed only when we use jemalloc with Linux.
+         * so we avoid these pointless loops when they're not going to do anything. */
 #if defined(USE_JEMALLOC) && defined(__linux__)
     listIter li;
     listNode *ln;
@@ -7373,7 +7373,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
     }
     if (server.sentinel_mode) sentinelCheckConfigFile();
 
-    /* Do system checks */
+        /* Do system checks */
 #ifdef __linux__
     linuxMemoryWarnings();
     sds err_msg = NULL;

--- a/tests/unit/moduleapi/scriptingengine.tcl
+++ b/tests/unit/moduleapi/scriptingengine.tcl
@@ -176,6 +176,42 @@ start_server {tags {"modules"}} {
         assert_equal $result 0
     }
 
+    test {Test INFO scriptingengines section} {
+        # Get the scripting engines info section
+        set info [r info scriptingengines]
+
+        # Verify the section header exists
+        assert_match "*# Scripting Engines*" $info
+
+        # Verify we have exactly 2 engines (LUA + HELLO)
+        assert_match "*engines_count:*" $info
+        regexp {engines_count:([0-9]+)} $info -> engines_count
+        assert_equal $engines_count 2
+
+        # Verify memory fields exist and are non-negative numbers
+        assert_match "*engines_total_used_memory:*" $info
+        assert_match "*engines_total_memory_overhead:*" $info
+        regexp {engines_total_used_memory:([0-9]+)} $info -> total_memory
+        regexp {engines_total_memory_overhead:([0-9]+)} $info -> total_overhead
+        assert {$total_memory >= 0}
+        assert {$total_overhead >= 0}
+
+        # Verify individual engine information exists
+        assert_match "*engine_0:*" $info
+        assert_match "*engine_1:*" $info
+
+        # Check that engines have proper format including abi_version
+        assert_match "*engine_*:name=*,module=*,abi_version=*,used_memory=*,memory_overhead=*" $info
+
+        # Verify both LUA and HELLO engines are present
+        assert_match "*name=LUA*" $info
+        assert_match "*name=HELLO*" $info
+
+        # Verify LUA is built-in and HELLO is from module
+        assert_match "*name=LUA,module=built-in*" $info
+        assert_match "*name=HELLO,module=helloengine*" $info
+    }
+
     test {Unload scripting engine module} {
         set result [r module unload helloengine]
         assert_equal $result "OK"


### PR DESCRIPTION
This commit adds a new `INFO` section called "Scripting Engines" that shows the information of the current scripting engines available in the server.

Here's an output example:

```
> info scriptingengines
# Scripting Engines
engines_count:2
engines_total_used_memory:68608
engines_total_memory_overhead:56
engine_0:name=LUA,module=built-in,abi_version=4,used_memory=68608,memory_overhead=16
engine_1:name=HELLO,module=helloengine,abi_version=4,used_memory=0,memory_overhead=40
```