### PR TITLE
Deflake "Dual channel replication - psync established within grace period"

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -695,7 +695,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 5. Replica resumes operation.
             # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 1
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {


### PR DESCRIPTION
increased the wait time to a total of 10 seconds where we check the log for `Done loading RDB` message

Fixes https://github.com/valkey-io/valkey/issues/2694

CI run (100 times): https://github.com/roshkhatri/valkey/actions/runs/18576201712/job/52961907806
