### PR TITLE
Adds a summary for tests 

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -94,11 +94,11 @@ set ::solo_tests_count 0
 set ::debug_defrag 0
 set ::completed_tests 0
 set ::total_loops 1
-set ::ok_tests_count 0
-set ::err_tests_count 0
-set ::loop_failed_current 0
-set ::loop_passes 0
-set ::loop_failures 0
+set ::ok_count 0
+set ::err_count 0
+set ::loop_err_current 0
+set ::loop_ok_count 0
+set ::loop_err_count 0
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.
@@ -380,11 +380,11 @@ proc test_server_main {} {
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
-    set ::ok_tests_count 0
-    set ::err_tests_count 0
-    set ::loop_failed_current 0
-    set ::loop_passes 0
-    set ::loop_failures 0
+    set ::ok_count 0
+    set ::err_count 0
+    set ::loop_err_current 0
+    set ::loop_ok_count 0
+    set ::loop_err_count 0
 
     # Enter the event loop to handle clients I/O
     after 100 test_server_cron
@@ -398,7 +398,7 @@ proc test_server_cron {} {
     if {$elapsed > $::timeout} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
-        set ::loop_failed_current 1
+        set ::loop_err_current 1
         foreach fd $::active_clients {
             if {[info exist ::active_clients_task($fd)]} {
                 set task $::active_clients_task($fd)
@@ -421,6 +421,7 @@ proc test_server_cron {} {
         show_clients_state
         force_kill_all_servers
         kill_clients
+        record_loop_result
         the_end
     }
 
@@ -472,7 +473,7 @@ proc read_from_test_client fd {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
-        incr ::ok_tests_count
+        incr ::ok_count
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
         if {!$::quiet} {
@@ -486,8 +487,8 @@ proc read_from_test_client fd {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
         lappend ::failed_tests $err
-        set ::loop_failed_current 1
-        incr ::err_tests_count
+        set ::loop_err_current 1
+        incr ::err_count
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts "(Fast fail: test will exit now)"
@@ -564,6 +565,17 @@ proc lremove {listVar value} {
     set var [lreplace $var $idx $idx]
 }
 
+proc record_loop_result {} {
+    if {$::total_loops > 1} {
+        if {$::loop_err_current} {
+            incr ::loop_err_count
+        } else {
+            incr ::loop_ok_count
+        }
+    }
+    set ::loop_err_current 0
+}
+
 # A new client is idle. Remove it from the list of active clients and
 # if there are still test units to run, launch them.
 proc signal_idle_client fd {
@@ -572,21 +584,22 @@ proc signal_idle_client fd {
         [lsearch -all -inline -not -exact $::active_clients $fd]
 
     # New unit to process?
+    set total_tests [llength $::all_tests]
     set clients_to_wake {}
-    if {$::loop > 1 && $::next_test == [llength $::all_tests] && [llength $::active_clients] == 0} {
-        if {$::loop_failed_current} {
-            incr ::loop_failures
-        } else {
-            incr ::loop_passes
-        }
-        set ::loop_failed_current 0
+
+    # When running in loop mode, wait for the last active client to finish
+    # before starting the next iteration so that we can attribute the
+    # previous loop's status correctly. At that point we wake any clients
+    # that were already idle so they can immediately begin the next loop.
+    if {$::loop > 1 && $::next_test == $total_tests && [llength $::active_clients] == 0} {
+        record_loop_result
         set ::next_test 0
         incr ::loop -1
         set clients_to_wake $::idle_clients
         set ::idle_clients {}
     }
 
-    if {$::next_test != [llength $::all_tests]} {
+    if {$::next_test != $total_tests} {
         if {!$::quiet} {
             puts [colorstr bold-white "Testing [lindex $::all_tests $::next_test]"]
             set ::active_clients_task($fd) "ASSIGNED: $fd ([lindex $::all_tests $::next_test])"
@@ -609,7 +622,8 @@ proc signal_idle_client fd {
     } else {
         lappend ::idle_clients $fd
         set ::active_clients_task($fd) "SLEEPING, no more units to assign"
-        if {[llength $::active_clients] == 0 && $::loop <= 1} {
+        if {[llength $::active_clients] == 0} {
+            record_loop_result
             the_end
         }
     }
@@ -622,20 +636,13 @@ proc signal_idle_client fd {
 # The the_end function gets called when all the test units were already
 # executed, so the test finished.
 proc print_test_summary {} {
-    set out "\nTest Summary: [colorstr bold-green $::ok_tests_count] passed, [colorstr bold-red $::err_tests_count] failed"
-    if {$::loop > 0} {
-        append out "\nTest Loops Summary: [colorstr bold-green $::loop_passes] passed, [colorstr bold-red $::loop_failures] failed"
+    puts "\nTest Summary: [colorstr bold-green $::ok_count] passed, [colorstr bold-red $::err_count] failed"
+    if {$::loop_ok_count > 0 || $::loop_err_count > 0} {
+        puts "Test Loops Summary: [colorstr bold-green $::loop_ok_count] passed, [colorstr bold-red $::loop_err_count] failed"
     }
-    puts $out
 }
 
 proc the_end {} {
-    if {$::loop_failed_current} {
-        incr ::loop_failures
-    } else {
-        incr ::loop_passes
-    }
-    set ::loop_failed_current 0
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
     puts "Execution time of different units:"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -94,8 +94,6 @@ set ::solo_tests_count 0
 set ::debug_defrag 0
 set ::completed_tests 0
 set ::total_loops 1
-set ::ok_count 0
-set ::err_count 0
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -94,7 +94,6 @@ set ::solo_tests_count 0
 set ::debug_defrag 0
 set ::completed_tests 0
 set ::total_loops 1
-set ::test_run_report [dict create]
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.
@@ -465,9 +464,6 @@ proc read_from_test_client fd {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
         incr ::ok_count
-        if {$::verbose} {
-            record_test_run_pass $fd $data
-        }
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
         if {!$::quiet} {
@@ -498,9 +494,6 @@ proc read_from_test_client fd {
         force_kill_all_servers
         exit 1
     } elseif {$status eq {testing}} {
-        if {$::verbose} {
-            record_test_run_attempt $fd $data
-        }
         set ::active_clients_task($fd) "(IN PROGRESS) $data"
     } elseif {$status eq {server-spawning}} {
         set ::active_clients_task($fd) "(SPAWNING SERVER) $data"
@@ -608,132 +601,12 @@ proc print_test_summary {} {
     puts "\nTest Summary: [colorstr bold-green $::ok_count] passed, [colorstr bold-red $::err_count] failed"
 }
 
-proc record_test_run_attempt {fd test_name} {
-    set file ""
-    if {[info exist ::active_clients_file($fd)]} {
-        set file $::active_clients_file($fd)
-    }
-    ensure_test_run_entry $test_name $file
-    test_report_incr $test_name $file attempted_runs
-}
-
-proc record_test_run_pass {fd test_name} {
-    set file ""
-    if {[info exist ::active_clients_file($fd)]} {
-        set file $::active_clients_file($fd)
-    }
-    ensure_test_run_entry $test_name $file
-    test_report_incr $test_name $file passed_runs
-}
-
-# normalized memory leak tests so different tests with different pids are not an different entry
-proc normalize_test_name {name} {
-    regsub -all {\s*\(pid\s+\d+\)} $name "" name
-    return [string trim $name]
-}
-
-proc ensure_test_run_entry {test_name file} {
-    upvar 0 ::test_run_report report
-    if {![info exists report]} {
-        set report [dict create]
-    }
-    set normalised_test [normalize_test_name $test_name]
-    set key [list $normalised_test $file]
-    if {![dict exists $report $key]} {
-        dict set report $key [dict create test_name $normalised_test file $file passed_runs 0 attempted_runs 0]
-    }
-}
-
-proc test_report_incr {test_name file field {amount 1}} {
-    upvar 0 ::test_run_report report
-    set normalised_test [normalize_test_name $test_name]
-    set key [list $normalised_test $file]
-    dict with report $key {
-        incr $field $amount
-    }
-}
-
-proc print_tests_run_report {} {
-    upvar 0 ::test_run_report report
-    if {![info exists report]} { return }
-    if {[dict size $report] == 0} { return }
-
-    set rows {}
-    set keys [dict keys $report]
-    foreach key $keys {
-        set entry   [dict get $report $key]
-        set test    [dict get $entry test_name]
-        set file    [dict get $entry file]
-        if {$file eq ""} { set file "-" }
-        set passed  [dict get $entry passed_runs]
-        set runs    [dict get $entry attempted_runs]
-        set failed  [expr {$runs - $passed}]
-        lappend rows [list $file $test $passed $failed $runs]
-    }
-
-    set rows [lsort -dictionary -index 1 $rows]
-    set rows [lsort -dictionary -index 0 $rows]
-
-    set header [list "File" "Test" "Passed" "Failed" "Runs"]
-    set widths [list \
-        [string length [lindex $header 0]] \
-        [string length [lindex $header 1]] \
-        [string length [lindex $header 2]] \
-        [string length [lindex $header 3]] \
-        [string length [lindex $header 4]] \
-    ]
-
-    foreach row $rows {
-        for {set i 0} {$i < 5} {incr i} {
-            set cell [lindex $row $i]
-            set cellstr "$cell"
-            set curw [lindex $widths $i]
-            if {[string length $cellstr] > $curw} {
-                lset widths $i [string length $cellstr]
-            }
-        }
-    }
-
-    proc __print_sep {widths} {
-        set parts {}
-        foreach w $widths {
-            lappend parts "+[string repeat "-" [expr {$w+2}]]"
-        }
-        puts "[join $parts {}]+"
-    }
-
-    proc __print_row {cols widths} {
-        set out {}
-        for {set i 0} {$i < [llength $cols]} {incr i} {
-            set cell [lindex $cols $i]
-            set w    [lindex $widths $i]
-            if {$i < 2} {
-                append out "| [format "%-*s" $w $cell] "
-            } else {
-                append out "| [format "%*s"  $w $cell] "
-            }
-        }
-        append out "|"
-        puts $out
-    }
-
-    puts "\nDetailed Test Run Report:"
-    __print_sep $widths
-    __print_row $header $widths
-    __print_sep $widths
-    foreach row $rows { __print_row $row $widths }
-    __print_sep $widths
-}
-
 proc the_end {} {
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
     puts "Execution time of different units:"
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
-    }
-    if {$::verbose} {
-        print_tests_run_report
     }
     print_test_summary
     if {[llength $::failed_tests]} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -94,6 +94,7 @@ set ::solo_tests_count 0
 set ::debug_defrag 0
 set ::completed_tests 0
 set ::total_loops 1
+set ::test_run_report [dict create]
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.
@@ -464,6 +465,7 @@ proc read_from_test_client fd {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
         incr ::ok_count
+        record_test_run_pass $fd $data
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
         if {!$::quiet} {
@@ -494,6 +496,7 @@ proc read_from_test_client fd {
         force_kill_all_servers
         exit 1
     } elseif {$status eq {testing}} {
+        record_test_run_attempt $fd $data
         set ::active_clients_task($fd) "(IN PROGRESS) $data"
     } elseif {$status eq {server-spawning}} {
         set ::active_clients_task($fd) "(SPAWNING SERVER) $data"
@@ -601,6 +604,122 @@ proc print_test_summary {} {
     puts "\nTest Summary: [colorstr bold-green $::ok_count] passed, [colorstr bold-red $::err_count] failed"
 }
 
+proc record_test_run_attempt {fd test_name} {
+    set file ""
+    if {[info exist ::active_clients_file($fd)]} {
+        set file $::active_clients_file($fd)
+    }
+    ensure_test_run_entry $test_name $file
+    test_report_incr $test_name $file successful_runs
+}
+
+proc record_test_run_pass {fd test_name} {
+    set file ""
+    if {[info exist ::active_clients_file($fd)]} {
+        set file $::active_clients_file($fd)
+    }
+    ensure_test_run_entry $test_name $file
+    test_report_incr $test_name $file passed_runs
+}
+
+proc normalize_test_name {name} {
+    regsub -all {\s*\(pid\s+\d+\)} $name "" name
+    return [string trim $name]
+}
+
+proc ensure_test_run_entry {test_name file} {
+    upvar 0 ::test_run_report report
+    if {![info exists report]} {
+        set report [dict create]
+    }
+    set normalised_test [normalize_test_name $test_name]
+    set key [list $normalised_test $file]
+    if {![dict exists $report $key]} {
+        dict set report $key [dict create test_name $normalised_test file $file passed_runs 0 successful_runs 0]
+    }
+}
+
+proc test_report_incr {test_name file field {amount 1}} {
+    upvar 0 ::test_run_report report
+    set normalised_test [normalize_test_name $test_name]
+    set key [list $normalised_test $file]
+    dict with report $key {
+        incr $field $amount
+    }
+}
+
+proc print_tests_run_report {} {
+    upvar 0 ::test_run_report report
+    if {![info exists report]} { return }
+    if {[dict size $report] == 0} { return }
+
+    set rows {}
+    set keys [dict keys $report]
+    foreach key $keys {
+        set entry   [dict get $report $key]
+        set test    [dict get $entry test_name]
+        set file    [dict get $entry file]
+        if {$file eq ""} { set file "-" }
+        set passed  [dict get $entry passed_runs]
+        set runs    [dict get $entry successful_runs]
+        set failed  [expr {$runs - $passed}]
+        lappend rows [list $file $test $passed $failed $runs]
+    }
+
+    set rows [lsort -dictionary -index 1 $rows]
+    set rows [lsort -dictionary -index 0 $rows]
+
+    set header [list "File" "Test" "Passed" "Failed" "Runs"]
+    set widths [list \
+        [string length [lindex $header 0]] \
+        [string length [lindex $header 1]] \
+        [string length [lindex $header 2]] \
+        [string length [lindex $header 3]] \
+        [string length [lindex $header 4]] \
+    ]
+
+    foreach row $rows {
+        for {set i 0} {$i < 5} {incr i} {
+            set cell [lindex $row $i]
+            set cellstr "$cell"
+            set curw [lindex $widths $i]
+            if {[string length $cellstr] > $curw} {
+                lset widths $i [string length $cellstr]
+            }
+        }
+    }
+
+    proc __print_sep {widths} {
+        set parts {}
+        foreach w $widths {
+            lappend parts "+[string repeat "-" [expr {$w+2}]]"
+        }
+        puts "[join $parts {}]+"
+    }
+
+    proc __print_row {cols widths} {
+        set out {}
+        for {set i 0} {$i < [llength $cols]} {incr i} {
+            set cell [lindex $cols $i]
+            set w    [lindex $widths $i]
+            if {$i < 2} {
+                append out "| [format "%-*s" $w $cell] "
+            } else {
+                append out "| [format "%*s"  $w $cell] "
+            }
+        }
+        append out "|"
+        puts $out
+    }
+
+    puts "\nDetailed Test Run Report:"
+    __print_sep $widths
+    __print_row $header $widths
+    __print_sep $widths
+    foreach row $rows { __print_row $row $widths }
+    __print_sep $widths
+}
+
 proc the_end {} {
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
@@ -608,6 +727,7 @@ proc the_end {} {
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
     }
+    print_tests_run_report
     print_test_summary
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -614,7 +614,7 @@ proc record_test_run_attempt {fd test_name} {
         set file $::active_clients_file($fd)
     }
     ensure_test_run_entry $test_name $file
-    test_report_incr $test_name $file successful_runs
+    test_report_incr $test_name $file attempted_runs
 }
 
 proc record_test_run_pass {fd test_name} {
@@ -626,6 +626,7 @@ proc record_test_run_pass {fd test_name} {
     test_report_incr $test_name $file passed_runs
 }
 
+# normalized memory leak tests so different tests with different pids are not an different entry
 proc normalize_test_name {name} {
     regsub -all {\s*\(pid\s+\d+\)} $name "" name
     return [string trim $name]
@@ -639,7 +640,7 @@ proc ensure_test_run_entry {test_name file} {
     set normalised_test [normalize_test_name $test_name]
     set key [list $normalised_test $file]
     if {![dict exists $report $key]} {
-        dict set report $key [dict create test_name $normalised_test file $file passed_runs 0 successful_runs 0]
+        dict set report $key [dict create test_name $normalised_test file $file passed_runs 0 attempted_runs 0]
     }
 }
 
@@ -665,7 +666,7 @@ proc print_tests_run_report {} {
         set file    [dict get $entry file]
         if {$file eq ""} { set file "-" }
         set passed  [dict get $entry passed_runs]
-        set runs    [dict get $entry successful_runs]
+        set runs    [dict get $entry attempted_runs]
         set failed  [expr {$runs - $passed}]
         lappend rows [list $file $test $passed $failed $runs]
     }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -94,6 +94,11 @@ set ::solo_tests_count 0
 set ::debug_defrag 0
 set ::completed_tests 0
 set ::total_loops 1
+set ::ok_tests_count 0
+set ::err_tests_count 0
+set ::loop_failed_current 0
+set ::loop_passes 0
+set ::loop_failures 0
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.
@@ -375,6 +380,11 @@ proc test_server_main {} {
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
+    set ::ok_tests_count 0
+    set ::err_tests_count 0
+    set ::loop_failed_current 0
+    set ::loop_passes 0
+    set ::loop_failures 0
 
     # Enter the event loop to handle clients I/O
     after 100 test_server_cron
@@ -388,6 +398,7 @@ proc test_server_cron {} {
     if {$elapsed > $::timeout} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
+        set ::loop_failed_current 1
         foreach fd $::active_clients {
             if {[info exist ::active_clients_task($fd)]} {
                 set task $::active_clients_task($fd)
@@ -461,6 +472,7 @@ proc read_from_test_client fd {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
+        incr ::ok_tests_count
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
         if {!$::quiet} {
@@ -474,6 +486,8 @@ proc read_from_test_client fd {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
         lappend ::failed_tests $err
+        set ::loop_failed_current 1
+        incr ::err_tests_count
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts "(Fast fail: test will exit now)"
@@ -558,6 +572,20 @@ proc signal_idle_client fd {
         [lsearch -all -inline -not -exact $::active_clients $fd]
 
     # New unit to process?
+    set clients_to_wake {}
+    if {$::loop > 1 && $::next_test == [llength $::all_tests] && [llength $::active_clients] == 0} {
+        if {$::loop_failed_current} {
+            incr ::loop_failures
+        } else {
+            incr ::loop_passes
+        }
+        set ::loop_failed_current 0
+        set ::next_test 0
+        incr ::loop -1
+        set clients_to_wake $::idle_clients
+        set ::idle_clients {}
+    }
+
     if {$::next_test != [llength $::all_tests]} {
         if {!$::quiet} {
             puts [colorstr bold-white "Testing [lindex $::all_tests $::next_test]"]
@@ -568,10 +596,6 @@ proc signal_idle_client fd {
         send_data_packet $fd run [lindex $::all_tests $::next_test]
         lappend ::active_clients $fd
         incr ::next_test
-        if {$::loop > 1 && $::next_test == [llength $::all_tests]} {
-            set ::next_test 0
-            incr ::loop -1
-        }
     } elseif {[llength $::run_solo_tests] != 0 && [llength $::active_clients] == 0} {
         if {!$::quiet} {
             puts [colorstr bold-white "Testing solo test"]
@@ -585,21 +609,40 @@ proc signal_idle_client fd {
     } else {
         lappend ::idle_clients $fd
         set ::active_clients_task($fd) "SLEEPING, no more units to assign"
-        if {[llength $::active_clients] == 0} {
+        if {[llength $::active_clients] == 0 && $::loop <= 1} {
             the_end
         }
+    }
+
+    foreach idle_fd $clients_to_wake {
+        signal_idle_client $idle_fd
     }
 }
 
 # The the_end function gets called when all the test units were already
 # executed, so the test finished.
+proc print_test_summary {} {
+    set out "\nTest Summary: [colorstr bold-green $::ok_tests_count] passed, [colorstr bold-red $::err_tests_count] failed"
+    if {$::loop > 0} {
+        append out "\nTest Loops Summary: [colorstr bold-green $::loop_passes] passed, [colorstr bold-red $::loop_failures] failed"
+    }
+    puts $out
+}
+
 proc the_end {} {
+    if {$::loop_failed_current} {
+        incr ::loop_failures
+    } else {
+        incr ::loop_passes
+    }
+    set ::loop_failed_current 0
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
     puts "Execution time of different units:"
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
     }
+    print_test_summary
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"
         foreach failed $::failed_tests {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -96,9 +96,6 @@ set ::completed_tests 0
 set ::total_loops 1
 set ::ok_count 0
 set ::err_count 0
-set ::loop_err_current 0
-set ::loop_ok_count 0
-set ::loop_err_count 0
 
 # Expand a unit specification (test name, file, or directory) into a list
 # of canonical unit names relative to the tests directory.
@@ -382,9 +379,6 @@ proc test_server_main {} {
     set ::failed_tests {}
     set ::ok_count 0
     set ::err_count 0
-    set ::loop_err_current 0
-    set ::loop_ok_count 0
-    set ::loop_err_count 0
 
     # Enter the event loop to handle clients I/O
     after 100 test_server_cron
@@ -398,7 +392,6 @@ proc test_server_cron {} {
     if {$elapsed > $::timeout} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
-        set ::loop_err_current 1
         foreach fd $::active_clients {
             if {[info exist ::active_clients_task($fd)]} {
                 set task $::active_clients_task($fd)
@@ -421,7 +414,6 @@ proc test_server_cron {} {
         show_clients_state
         force_kill_all_servers
         kill_clients
-        record_loop_result
         the_end
     }
 
@@ -487,7 +479,6 @@ proc read_from_test_client fd {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
         lappend ::failed_tests $err
-        set ::loop_err_current 1
         incr ::err_count
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
@@ -565,17 +556,6 @@ proc lremove {listVar value} {
     set var [lreplace $var $idx $idx]
 }
 
-proc record_loop_result {} {
-    if {$::total_loops > 1} {
-        if {$::loop_err_current} {
-            incr ::loop_err_count
-        } else {
-            incr ::loop_ok_count
-        }
-    }
-    set ::loop_err_current 0
-}
-
 # A new client is idle. Remove it from the list of active clients and
 # if there are still test units to run, launch them.
 proc signal_idle_client fd {
@@ -584,22 +564,7 @@ proc signal_idle_client fd {
         [lsearch -all -inline -not -exact $::active_clients $fd]
 
     # New unit to process?
-    set total_tests [llength $::all_tests]
-    set clients_to_wake {}
-
-    # When running in loop mode, wait for the last active client to finish
-    # before starting the next iteration so that we can attribute the
-    # previous loop's status correctly. At that point we wake any clients
-    # that were already idle so they can immediately begin the next loop.
-    if {$::loop > 1 && $::next_test == $total_tests && [llength $::active_clients] == 0} {
-        record_loop_result
-        set ::next_test 0
-        incr ::loop -1
-        set clients_to_wake $::idle_clients
-        set ::idle_clients {}
-    }
-
-    if {$::next_test != $total_tests} {
+    if {$::next_test != [llength $::all_tests]} {
         if {!$::quiet} {
             puts [colorstr bold-white "Testing [lindex $::all_tests $::next_test]"]
             set ::active_clients_task($fd) "ASSIGNED: $fd ([lindex $::all_tests $::next_test])"
@@ -609,6 +574,10 @@ proc signal_idle_client fd {
         send_data_packet $fd run [lindex $::all_tests $::next_test]
         lappend ::active_clients $fd
         incr ::next_test
+        if {$::loop > 1 && $::next_test == [llength $::all_tests]} {
+            set ::next_test 0
+            incr ::loop -1
+        }
     } elseif {[llength $::run_solo_tests] != 0 && [llength $::active_clients] == 0} {
         if {!$::quiet} {
             puts [colorstr bold-white "Testing solo test"]
@@ -623,13 +592,8 @@ proc signal_idle_client fd {
         lappend ::idle_clients $fd
         set ::active_clients_task($fd) "SLEEPING, no more units to assign"
         if {[llength $::active_clients] == 0} {
-            record_loop_result
             the_end
         }
-    }
-
-    foreach idle_fd $clients_to_wake {
-        signal_idle_client $idle_fd
     }
 }
 
@@ -637,9 +601,6 @@ proc signal_idle_client fd {
 # executed, so the test finished.
 proc print_test_summary {} {
     puts "\nTest Summary: [colorstr bold-green $::ok_count] passed, [colorstr bold-red $::err_count] failed"
-    if {$::loop_ok_count > 0 || $::loop_err_count > 0} {
-        puts "Test Loops Summary: [colorstr bold-green $::loop_ok_count] passed, [colorstr bold-red $::loop_err_count] failed"
-    }
 }
 
 proc the_end {} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -406,6 +406,7 @@ proc test_server_cron {} {
                         set file $::active_clients_file($fd)
                     }
                     lappend ::failed_tests "\[[colorstr red TIMEOUT]\]: $test_name in $file"
+                    incr ::err_count
                 }
             }
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -465,7 +465,9 @@ proc read_from_test_client fd {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
         }
         incr ::ok_count
-        record_test_run_pass $fd $data
+        if {$::verbose} {
+            record_test_run_pass $fd $data
+        }
         set ::active_clients_task($fd) "(OK) $data"
     } elseif {$status eq {skip}} {
         if {!$::quiet} {
@@ -496,7 +498,9 @@ proc read_from_test_client fd {
         force_kill_all_servers
         exit 1
     } elseif {$status eq {testing}} {
-        record_test_run_attempt $fd $data
+        if {$::verbose} {
+            record_test_run_attempt $fd $data
+        }
         set ::active_clients_task($fd) "(IN PROGRESS) $data"
     } elseif {$status eq {server-spawning}} {
         set ::active_clients_task($fd) "(SPAWNING SERVER) $data"
@@ -727,7 +731,9 @@ proc the_end {} {
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
     }
-    print_tests_run_report
+    if {$::verbose} {
+        print_tests_run_report
+    }
     print_test_summary
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"


### PR DESCRIPTION
This is inspired after my discussion with @roshkhatri and @hpatro. This changes allows us to see the results clearly after the suite is run.

```
Test Summary: 100 passed, 2 failed

!!! WARNING The following tests failed:

*** [err]: BITCOUNT with illegal arguments in tests/unit/bitops.tcl
Expected 'ERR syntax error' to match 'ERR *syntax1*' (context: type source line 93 file /Users/sarthagg/workspace/valkey/tests/support/test.tcl cmd {assert_match $pattern $error $detail} proc ::assert_error level 1) 
*** [err]: BITCOUNT with illegal arguments in tests/unit/bitops.tcl
Expected 'ERR syntax error' to match 'ERR *syntax1*' (context: type source line 93 file /Users/sarthagg/workspace/valkey/tests/support/test.tcl cmd {assert_match $pattern $error $detail} proc ::assert_error level 1) 
Cleanup: may take some time... OK
````

