### PR TITLE
Make the number of healthy nodes in gossip section configurable

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4764,14 +4764,27 @@ void clusterSendPing(clusterLink *link, int type) {
      *
      * Since we have non-voting replicas that lower the probability of an entry
      * to feature our node, we set the number of entries per packet as
-     * 10% of the total nodes we have. */
-    wanted = floor(dictSize(server.cluster->nodes) / 10);
+     * a configurable percentage (default 10%) of the total nodes we have,
+     * bounded by the actual number of known nodes. */
+    int total_nodes = dictSize(server.cluster->nodes);
+    wanted = (total_nodes * server.cluster_message_gossip_perc / 100);
     if (wanted < 3) wanted = 3;
-    if (wanted > freshnodes) wanted = freshnodes;
+    if (wanted > total_nodes) wanted = total_nodes;
 
-    /* Include all the nodes in PFAIL state, so that failure reports are
-     * faster to propagate to go from PFAIL to FAIL state. */
+    /* Prioritize pfail nodes over other nodes.
+     * Healthy nodes can communicate through direct ping/pong if required and failed node
+     * information would be broadcasted. */
     int pfail_wanted = server.cluster->stats_pfail_nodes;
+    if (pfail_wanted >= wanted) {
+        pfail_wanted = wanted;
+        wanted = 0;
+    } else {
+        wanted = wanted - pfail_wanted;
+    }
+
+    if (wanted > freshnodes) {
+        wanted = freshnodes;
+    }
 
     /* Compute the maximum estlen to allocate our buffer. We'll fix the estlen
      * later according to the number of gossip sections we really were able

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4770,16 +4770,9 @@ void clusterSendPing(clusterLink *link, int type) {
     if (wanted < 3) wanted = 3;
     if (wanted > freshnodes) wanted = freshnodes;
 
-    /* Prioritize pfail nodes over other nodes.
-     * Healthy nodes can communicate through direct ping/pong if required and failed node
-     * information would be broadcasted. */
+    /* Include all the nodes in PFAIL state, so that failure reports are
+     * faster to propagate to go from PFAIL to FAIL state. */
     int pfail_wanted = server.cluster->stats_pfail_nodes;
-    if (pfail_wanted >= wanted) {
-        pfail_wanted = wanted;
-        wanted = 0;
-    } else {
-        wanted = wanted - pfail_wanted;
-    }
 
     /* Compute the maximum estlen to allocate our buffer. We'll fix the estlen
      * later according to the number of gossip sections we really were able

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4766,10 +4766,9 @@ void clusterSendPing(clusterLink *link, int type) {
      * to feature our node, we set the number of entries per packet as
      * a configurable percentage (default 10%) of the total nodes we have,
      * bounded by the actual number of known nodes. */
-    int total_nodes = dictSize(server.cluster->nodes);
-    wanted = (total_nodes * server.cluster_message_gossip_perc / 100);
+    wanted = (dictSize(server.cluster->nodes) * server.cluster_message_gossip_perc / 100);
     if (wanted < 3) wanted = 3;
-    if (wanted > total_nodes) wanted = total_nodes;
+    if (wanted > freshnodes) wanted = freshnodes;
 
     /* Prioritize pfail nodes over other nodes.
      * Healthy nodes can communicate through direct ping/pong if required and failed node
@@ -4780,10 +4779,6 @@ void clusterSendPing(clusterLink *link, int type) {
         wanted = 0;
     } else {
         wanted = wanted - pfail_wanted;
-    }
-
-    if (wanted > freshnodes) {
-        wanted = freshnodes;
     }
 
     /* Compute the maximum estlen to allocate our buffer. We'll fix the estlen

--- a/src/config.c
+++ b/src/config.c
@@ -3363,7 +3363,7 @@ standardConfig static_configs[] = {
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("cluster-message-gossip-size", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, 100, server.cluster_message_gossip_perc, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("cluster-message-gossip-perc", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, 100, server.cluster_message_gossip_perc, 10, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),

--- a/src/config.c
+++ b/src/config.c
@@ -3363,6 +3363,7 @@ standardConfig static_configs[] = {
     createIntConfig("rdma-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.rdma_ctx_config.port, 0, INTEGER_CONFIG, NULL, updateRdmaPort),
     createIntConfig("rdma-rx-size", NULL, IMMUTABLE_CONFIG, 64 * 1024, 16 * 1024 * 1024, server.rdma_ctx_config.rx_size, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("rdma-completion-vector", NULL, IMMUTABLE_CONFIG, -1, 1024, server.rdma_ctx_config.completion_vector, -1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("cluster-message-gossip-size", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1, 100, server.cluster_message_gossip_perc, 10, INTEGER_CONFIG, NULL, NULL),
 
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
@@ -3370,6 +3371,7 @@ standardConfig static_configs[] = {
     createUIntConfig("socket-mark-id", NULL, IMMUTABLE_CONFIG, 0, UINT_MAX, server.socket_mark_id, 0, INTEGER_CONFIG, NULL, NULL),
     createUIntConfig("max-new-connections-per-cycle", NULL, MODIFIABLE_CONFIG, 1, 1000, server.max_new_conns_per_cycle, 10, INTEGER_CONFIG, NULL, NULL),
     createUIntConfig("max-new-tls-connections-per-cycle", NULL, MODIFIABLE_CONFIG, 1, 1000, server.max_new_tls_conns_per_cycle, 1, INTEGER_CONFIG, NULL, NULL),
+
 #ifdef LOG_REQ_RES
     createUIntConfig("client-default-resp", NULL, IMMUTABLE_CONFIG | HIDDEN_CONFIG, 2, 3, server.client_default_resp, 2, INTEGER_CONFIG, NULL, NULL),
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -2264,6 +2264,7 @@ struct valkeyServer {
     int cluster_port;                                      /* Set the cluster port for a node. */
     mstime_t cluster_node_timeout;                         /* Cluster node timeout. */
     mstime_t cluster_ping_interval;                        /* A debug configuration for setting how often cluster nodes send ping messages. */
+    int cluster_message_gossip_perc;                       /* A configuration for setting the percentage of peer nodes to be gossiped in ping/pong messages. */
     char *cluster_configfile;                              /* Cluster auto-generated config file name. */
     struct clusterState *cluster;                          /* State of the cluster */
     int cluster_migration_barrier;                         /* Cluster replicas migration barrier. */

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -116,8 +116,8 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
 }
 
 start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
-    test "Gossip count scales with higher percentage of `cluster-message-gossip-size`" {
-        R 0 config set cluster-message-gossip-size 80
+    test "Gossip count scales with higher percentage of `cluster-message-gossip-perc`" {
+        R 0 config set cluster-message-gossip-perc 80
 
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -1,138 +1,89 @@
-# Test that cluster bus messages with certain invalid packets are rejected
-# and don't crash the system.
-
-# Build a MEET packet for the cluster bus.
-#   sender_name  - 40-char hex node ID
-#   sender_port  - TCP port
-#   sender_cport - cluster bus port
-#   opts         - dict of overrides: count, extensions, mflags0, pad_to
-#
-# By default builds a valid packet (count=0, extensions=0, mflags=0,
-# padded to CLUSTERMSG_MIN_LEN = 2256).  The original "malformed" test
-# overrides count, extensions and mflags0 to craft an intentionally broken
-# packet.
-proc build_meet_packet {sender_name sender_port sender_cport {opts {}}} {
+# Create a clusterbus message packet
+proc create_cluster_meet_packet {sender_name sender_port sender_cport {count 0} {extensions 0} {mflags 0}} {
+    # Constants
     set CLUSTER_NAMELEN 40
-    set CLUSTER_SLOTS   16384
-    set NET_IP_STR_LEN  46
+    set CLUSTER_SLOTS 16384
+    set NET_IP_STR_LEN 46
     set CLUSTERMSG_TYPE_MEET 2
-    set CLUSTERMSG_MIN_LEN   2256
+    set CLUSTERMSG_MIN_LEN 2256
 
-    set count      [dict_get_or $opts count 0]
-    set extensions [dict_get_or $opts extensions 0]
-    set mflags0    [dict_get_or $opts mflags0 0]
-    set pad_to     [dict_get_or $opts pad_to $CLUSTERMSG_MIN_LEN]
-
+    # Build the packet
     set packet ""
 
-    append packet "RCmb"                                ;# sig[4]
-    append packet [binary format I 0]                   ;# totlen (patched below)
-    append packet [binary format S 1]                   ;# ver
-    append packet [binary format S $sender_port]        ;# port
-    append packet [binary format S $CLUSTERMSG_TYPE_MEET] ;# type
-    append packet [binary format S $count]              ;# count
-    append packet [binary format W 1]                   ;# currentEpoch
-    append packet [binary format W 1]                   ;# configEpoch
-    append packet [binary format W 0]                   ;# offset
+    # Signature "RCmb" (4 bytes)
+    append packet "RCmb"
 
-    # sender[40]
-    set padded [string range "${sender_name}[string repeat "\x00" $CLUSTER_NAMELEN]" \
-                0 [expr {$CLUSTER_NAMELEN - 1}]]
-    append packet $padded
+    # totlen (uint32_t) - will be updated at the end
+    append packet [binary format I 0]
 
-    append packet [string repeat "\x00" [expr {$CLUSTER_SLOTS / 8}]] ;# myslots
-    append packet [string repeat "\x00" $CLUSTER_NAMELEN]            ;# replicaof
-    append packet [string repeat "\x00" $NET_IP_STR_LEN]            ;# myip
-    append packet [binary format S $extensions]                        ;# extensions
-    append packet [string repeat "\x00" 30]                            ;# notused1
-    append packet [binary format S 0]                                  ;# pport
-    append packet [binary format S $sender_cport]                      ;# cport
-    append packet [binary format S 1]                                  ;# flags (PRIMARY)
-    append packet [binary format c 0]                                  ;# state
-    append packet [binary format ccc $mflags0 0 0]                     ;# mflags[3]
+    # ver (uint16_t) - protocol version 1
+    append packet [binary format S 1]
 
-    # Pad to the required length (server rejects totlen != explen).
-    set cur_len [string length $packet]
-    if {$cur_len < $pad_to} {
-        append packet [string repeat "\x00" [expr {$pad_to - $cur_len}]]
+    # port (uint16_t)
+    append packet [binary format S $sender_port]
+
+    # type (uint16_t) - MEET
+    append packet [binary format S $CLUSTERMSG_TYPE_MEET]
+
+    # count (uint16_t)
+    append packet [binary format S $count]
+
+    # currentEpoch (uint64_t)
+    append packet [binary format W 1]
+
+    # configEpoch (uint64_t)
+    append packet [binary format W 1]
+
+    # offset (uint64_t)
+    append packet [binary format W 0]
+
+    # sender[40] - node name
+    set sender_padded [string range "${sender_name}[string repeat "\x00" $CLUSTER_NAMELEN]" 0 [expr {$CLUSTER_NAMELEN - 1}]]
+    append packet $sender_padded
+
+    # myslots[2048] - all zeros
+    append packet [string repeat "\x00" [expr {$CLUSTER_SLOTS / 8}]]
+
+    # replicaof[40] - all zeros
+    append packet [string repeat "\x00" $CLUSTER_NAMELEN]
+
+    # myip[46] - all zeros
+    append packet [string repeat "\x00" $NET_IP_STR_LEN]
+
+    # extensions (uint16_t)
+    append packet [binary format S $extensions]
+
+    # notused1[30] - reserved
+    append packet [string repeat "\x00" 30]
+
+    # pport (uint16_t)
+    append packet [binary format S 0]
+
+    # cport (uint16_t) - cluster bus port
+    append packet [binary format S $sender_cport]
+
+    # flags (uint16_t) - CLUSTER_NODE_PRIMARY
+    append packet [binary format S 1]
+
+    # state (unsigned char) - CLUSTER_OK
+    append packet [binary format c 0]
+
+    # mflags[3] - message flags (WITH CLUSTERMSG_FLAG0_EXT_DATA flag set)
+    # CLUSTERMSG_FLAG0_EXT_DATA = (1 << 2) = 4
+    append packet [binary format ccc $mflags 0 0]
+
+    # Pad to minimum cluster message length.
+    set packet_len [string length $packet]
+    if {$packet_len < $CLUSTERMSG_MIN_LEN} {
+        append packet [string repeat "\x00" [expr {$CLUSTERMSG_MIN_LEN - $packet_len}]]
     }
 
-    # Patch totlen
+    # Update totlen
     set totlen [string length $packet]
     set packet [string replace $packet 4 7 [binary format I $totlen]]
+
     return $packet
 }
-
-# dict get with a default value.
-proc dict_get_or {d key default} {
-    if {[dict exists $d $key]} { return [dict get $d $key] }
-    return $default
-}
-
-# ---- Non-blocking cluster-bus reader helpers --------------------------------
-
-# Accumulate up to $needed bytes into the upvar buffer from a non-blocking
-# socket.  Returns 1 when the buffer has enough data.
-proc read_into_buf {sock bufvar needed} {
-    upvar $bufvar buf
-    set have [string length $buf]
-    if {$have < $needed} {
-        append buf [read $sock [expr {$needed - $have}]]
-    }
-    return [expr {[string length $buf] >= $needed}]
-}
-
-# Read one full clusterMsg from a (possibly blocking) socket with a timeout.
-# Returns a dict: type (uint16) and count (uint16).
-proc read_cluster_msg {sock {timeout_ms 5000}} {
-    fconfigure $sock -translation binary -blocking 0 -buffering full
-
-    set buf ""
-    set totlen 0
-    set done 0
-
-    fileevent $sock readable [list set ::_sock_readable 1]
-    set after_id [after $timeout_ms [list set ::_sock_readable timeout]]
-
-    while {!$done} {
-        vwait ::_sock_readable
-        if {$::_sock_readable eq "timeout"} {
-            fileevent $sock readable {}
-            error "Timed out waiting for cluster bus response"
-        }
-        if {$totlen == 0 && [read_into_buf $sock buf 16]} {
-            binary scan $buf @4I totlen
-            set totlen [expr {$totlen & 0xFFFFFFFF}]
-        }
-        if {$totlen > 0 && [read_into_buf $sock buf $totlen]} {
-            set done 1
-        }
-    }
-
-    after cancel $after_id
-    fileevent $sock readable {}
-
-    binary scan $buf @12Su type
-    binary scan $buf @14Su count
-    return [list type $type count $count]
-}
-
-# Send a MEET packet to a cluster bus port and return the parsed response.
-# Caller gets back the dict from read_cluster_msg (type + count).
-proc send_meet_and_read_reply {cluster_port sender_name sender_port sender_cport {packet_opts {}}} {
-    set packet [build_meet_packet $sender_name $sender_port $sender_cport $packet_opts]
-
-    set sock [socket 127.0.0.1 $cluster_port]
-    fconfigure $sock -translation binary -buffering full -blocking 1
-    puts -nonewline $sock $packet
-    flush $sock
-
-    set result [read_cluster_msg $sock]
-    close $sock
-    return $result
-}
-
-# ---- Tests ------------------------------------------------------------------
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
     test "Packet with missing gossip messages don't cause invalid read" {
@@ -140,11 +91,16 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
         set cluster_port [expr {$base_port + 10000}]
         set fake_node_id "abcdef1234567890abcdef1234567890abcdef12"
 
-        # Build an intentionally malformed packet: count=100 with no gossip
-        # data, bogus extensions value, and EXT_DATA flag set.
-        set packet [build_meet_packet $fake_node_id $base_port $cluster_port \
-            {count 100 extensions 2000000000 mflags0 4}]
+        # Get initial total messages received
+        set info_before [R 0 cluster info]
+        regexp {cluster_stats_messages_received:(\d+)} $info_before -> initial_received
 
+        # Intentionally malformed packet: count=100 with no gossip data,
+        # Create a packet with extensions=0 but CLUSTERMSG_FLAG0_EXT_DATA flag set
+        # bogus extensions value, and EXT_DATA flag set.
+        set packet [create_cluster_meet_packet $fake_node_id $base_port $cluster_port 100 2000000000 4]
+
+        # Send the packet after configuring the socket to accept binary data
         set sock [socket 127.0.0.1 $cluster_port]
         fconfigure $sock -translation binary -buffering none -blocking 1
         puts -nonewline $sock $packet
@@ -155,40 +111,36 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
             [CI 0 cluster_stats_messages_received] == 1
         } else {
             fail "Packet was never received"
-        }
+        }    
     }
 }
 
-# Gossip-count bounding tests.
 start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
-    test "Gossip count in PONG respects cluster-message-gossip-size" {
-        R 0 config set cluster-message-gossip-size 20
-
-        set base_port [srv 0 port]
-        set cluster_port [expr {$base_port + 10000}]
-
-        set result [send_meet_and_read_reply $cluster_port \
-            "fakenode1234567890fakenode1234567890fake12" $base_port $cluster_port]
-
-        assert_equal 1 [dict get $result type] ;# CLUSTERMSG_TYPE_PONG
-
-        # 11 known nodes, 20% → floor(2.2)=2, clamped to min 3.
-        assert_equal [dict get $result count] 3
-    }
-
-    test "Gossip count scales with higher percentage" {
+    test "Gossip count scales with higher percentage of `cluster-message-gossip-size`" {
         R 0 config set cluster-message-gossip-size 80
 
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]
+        set packet [create_cluster_meet_packet \
+            "fakenode2234567890fakenode2234567890fake12" \
+            $base_port $cluster_port 0 0 0]
 
-        set result [send_meet_and_read_reply $cluster_port \
-            "fakenode2234567890fakenode2234567890fake12" $base_port $cluster_port]
+        set sock [socket 127.0.0.1 $cluster_port]
+        fconfigure $sock -translation binary -buffering full -blocking 1
+        puts -nonewline $sock $packet
+        flush $sock
 
-        assert_equal 1 [dict get $result type] ;# CLUSTERMSG_TYPE_PONG
+        set hdr [read $sock 16]
+        binary scan $hdr @4I totlen
+        set rest [read $sock [expr {$totlen - 16}]]
+        set reply "${hdr}${rest}"
+        close $sock
 
-        # ~12 known nodes, 80% → overall=9, freshnodes=~10 → count ~9.
-        assert_morethan [dict get $result count] 3
-        assert_lessthan_equal [dict get $result count] 9
+        binary scan $reply @12Su type
+        binary scan $reply @14Su count
+
+        assert_equal 1 $type
+        assert_morethan $count 3
+        assert_lessthan_equal $count 9
     }
 }

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -1,103 +1,150 @@
 # Test that cluster bus messages with certain invalid packets are rejected
 # and don't crash the system.
-proc create_cluster_meet_packet {sender_name sender_port sender_cport} {
-    # Constants
-    set CLUSTER_NAMELEN 40
-    set CLUSTER_SLOTS 16384
-    set NET_IP_STR_LEN 46
-    set CLUSTERMSG_TYPE_MEET 2
-    
-    # Build the packet
-    set packet ""
-    
-    # Signature "RCmb" (4 bytes)
-    append packet "RCmb"
-    
-    # totlen (uint32_t) - will be updated at the end
-    append packet [binary format I 0]
-    
-    # ver (uint16_t) - protocol version 1
-    append packet [binary format S 1]
-    
-    # port (uint16_t)
-    append packet [binary format S $sender_port]
-    
-    # type (uint16_t) - MEET
-    append packet [binary format S $CLUSTERMSG_TYPE_MEET]
-    
-    # count (uint16_t) - 100 gossip messages
-    # Value intentionally set to a high value, even though no gossip
-    # messages are included. 
-    append packet [binary format S 100]
-    
-    # currentEpoch (uint64_t)
-    append packet [binary format W 1]
-    
-    # configEpoch (uint64_t)
-    append packet [binary format W 1]
-    
-    # offset (uint64_t)
-    append packet [binary format W 0]
-    
-    # sender[40] - node name
-    set sender_padded [string range "${sender_name}[string repeat "\x00" $CLUSTER_NAMELEN]" 0 [expr {$CLUSTER_NAMELEN - 1}]]
-    append packet $sender_padded
-    
-    # myslots[2048] - all zeros
-    append packet [string repeat "\x00" [expr {$CLUSTER_SLOTS / 8}]]
-    
-    # replicaof[40] - all zeros
-    append packet [string repeat "\x00" $CLUSTER_NAMELEN]
-    
-    # myip[46] - all zeros
-    append packet [string repeat "\x00" $NET_IP_STR_LEN]
-    
-    # extensions (uint16_t) - Set to 2
-    append packet [binary format S 2000000000]
-    
-    # notused1[30] - reserved
-    append packet [string repeat "\x00" 30]
-    
-    # pport (uint16_t)
-    append packet [binary format S 0]
-    
-    # cport (uint16_t) - cluster bus port
-    append packet [binary format S $sender_cport]
-    
-    # flags (uint16_t) - CLUSTER_NODE_PRIMARY
-    append packet [binary format S 1]
-    
-    # state (unsigned char) - CLUSTER_OK
-    append packet [binary format c 0]
-    
-    # mflags[3] - message flags (WITH CLUSTERMSG_FLAG0_EXT_DATA flag set)
-    # CLUSTERMSG_FLAG0_EXT_DATA = (1 << 2) = 4
-    append packet [binary format ccc 4 0 0]
 
-    # Update totlen
+# Build a MEET packet for the cluster bus.
+#   sender_name  - 40-char hex node ID
+#   sender_port  - TCP port
+#   sender_cport - cluster bus port
+#   opts         - dict of overrides: count, extensions, mflags0, pad_to
+#
+# By default builds a valid packet (count=0, extensions=0, mflags=0,
+# padded to CLUSTERMSG_MIN_LEN = 2256).  The original "malformed" test
+# overrides count, extensions and mflags0 to craft an intentionally broken
+# packet.
+proc build_meet_packet {sender_name sender_port sender_cport {opts {}}} {
+    set CLUSTER_NAMELEN 40
+    set CLUSTER_SLOTS   16384
+    set NET_IP_STR_LEN  46
+    set CLUSTERMSG_TYPE_MEET 2
+    set CLUSTERMSG_MIN_LEN   2256
+
+    set count      [dict_get_or $opts count 0]
+    set extensions [dict_get_or $opts extensions 0]
+    set mflags0    [dict_get_or $opts mflags0 0]
+    set pad_to     [dict_get_or $opts pad_to $CLUSTERMSG_MIN_LEN]
+
+    set packet ""
+
+    append packet "RCmb"                                ;# sig[4]
+    append packet [binary format I 0]                   ;# totlen (patched below)
+    append packet [binary format S 1]                   ;# ver
+    append packet [binary format S $sender_port]        ;# port
+    append packet [binary format S $CLUSTERMSG_TYPE_MEET] ;# type
+    append packet [binary format S $count]              ;# count
+    append packet [binary format W 1]                   ;# currentEpoch
+    append packet [binary format W 1]                   ;# configEpoch
+    append packet [binary format W 0]                   ;# offset
+
+    # sender[40]
+    set padded [string range "${sender_name}[string repeat "\x00" $CLUSTER_NAMELEN]" \
+                0 [expr {$CLUSTER_NAMELEN - 1}]]
+    append packet $padded
+
+    append packet [string repeat "\x00" [expr {$CLUSTER_SLOTS / 8}]] ;# myslots
+    append packet [string repeat "\x00" $CLUSTER_NAMELEN]            ;# replicaof
+    append packet [string repeat "\x00" $NET_IP_STR_LEN]            ;# myip
+    append packet [binary format S $extensions]                        ;# extensions
+    append packet [string repeat "\x00" 30]                            ;# notused1
+    append packet [binary format S 0]                                  ;# pport
+    append packet [binary format S $sender_cport]                      ;# cport
+    append packet [binary format S 1]                                  ;# flags (PRIMARY)
+    append packet [binary format c 0]                                  ;# state
+    append packet [binary format ccc $mflags0 0 0]                     ;# mflags[3]
+
+    # Pad to the required length (server rejects totlen != explen).
+    set cur_len [string length $packet]
+    if {$cur_len < $pad_to} {
+        append packet [string repeat "\x00" [expr {$pad_to - $cur_len}]]
+    }
+
+    # Patch totlen
     set totlen [string length $packet]
     set packet [string replace $packet 4 7 [binary format I $totlen]]
-    
     return $packet
 }
+
+# dict get with a default value.
+proc dict_get_or {d key default} {
+    if {[dict exists $d $key]} { return [dict get $d $key] }
+    return $default
+}
+
+# ---- Non-blocking cluster-bus reader helpers --------------------------------
+
+# Accumulate up to $needed bytes into the upvar buffer from a non-blocking
+# socket.  Returns 1 when the buffer has enough data.
+proc read_into_buf {sock bufvar needed} {
+    upvar $bufvar buf
+    set have [string length $buf]
+    if {$have < $needed} {
+        append buf [read $sock [expr {$needed - $have}]]
+    }
+    return [expr {[string length $buf] >= $needed}]
+}
+
+# Read one full clusterMsg from a (possibly blocking) socket with a timeout.
+# Returns a dict: type (uint16) and count (uint16).
+proc read_cluster_msg {sock {timeout_ms 5000}} {
+    fconfigure $sock -translation binary -blocking 0 -buffering full
+
+    set buf ""
+    set totlen 0
+    set done 0
+
+    fileevent $sock readable [list set ::_sock_readable 1]
+    set after_id [after $timeout_ms [list set ::_sock_readable timeout]]
+
+    while {!$done} {
+        vwait ::_sock_readable
+        if {$::_sock_readable eq "timeout"} {
+            fileevent $sock readable {}
+            error "Timed out waiting for cluster bus response"
+        }
+        if {$totlen == 0 && [read_into_buf $sock buf 16]} {
+            binary scan $buf @4I totlen
+            set totlen [expr {$totlen & 0xFFFFFFFF}]
+        }
+        if {$totlen > 0 && [read_into_buf $sock buf $totlen]} {
+            set done 1
+        }
+    }
+
+    after cancel $after_id
+    fileevent $sock readable {}
+
+    binary scan $buf @12Su type
+    binary scan $buf @14Su count
+    return [list type $type count $count]
+}
+
+# Send a MEET packet to a cluster bus port and return the parsed response.
+# Caller gets back the dict from read_cluster_msg (type + count).
+proc send_meet_and_read_reply {cluster_port sender_name sender_port sender_cport {packet_opts {}}} {
+    set packet [build_meet_packet $sender_name $sender_port $sender_cport $packet_opts]
+
+    set sock [socket 127.0.0.1 $cluster_port]
+    fconfigure $sock -translation binary -buffering full -blocking 1
+    puts -nonewline $sock $packet
+    flush $sock
+
+    set result [read_cluster_msg $sock]
+    close $sock
+    return $result
+}
+
+# ---- Tests ------------------------------------------------------------------
 
 start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
     test "Packet with missing gossip messages don't cause invalid read" {
         set base_port [srv 0 port]
         set cluster_port [expr {$base_port + 10000}]
         set fake_node_id "abcdef1234567890abcdef1234567890abcdef12"
-        
-        # Get initial total messages received
-        set info_before [R 0 cluster info]
-        regexp {cluster_stats_messages_received:(\d+)} $info_before -> initial_received
-        
-        # Create a packet with extensions=0 but CLUSTERMSG_FLAG0_EXT_DATA flag set
-        set packet [create_cluster_meet_packet $fake_node_id $base_port $cluster_port]
-        
-        # Verify packet length
-        set packet_len [string length $packet]
-        
-        # Send the packet after configuring the socket to accept binary data
+
+        # Build an intentionally malformed packet: count=100 with no gossip
+        # data, bogus extensions value, and EXT_DATA flag set.
+        set packet [build_meet_packet $fake_node_id $base_port $cluster_port \
+            {count 100 extensions 2000000000 mflags0 4}]
+
         set sock [socket 127.0.0.1 $cluster_port]
         fconfigure $sock -translation binary -buffering none -blocking 1
         puts -nonewline $sock $packet
@@ -109,5 +156,39 @@ start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
         } else {
             fail "Packet was never received"
         }
+    }
+}
+
+# Gossip-count bounding tests.
+start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
+    test "Gossip count in PONG respects cluster-message-gossip-size" {
+        R 0 config set cluster-message-gossip-size 20
+
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+
+        set result [send_meet_and_read_reply $cluster_port \
+            "fakenode1234567890fakenode1234567890fake12" $base_port $cluster_port]
+
+        assert_equal 1 [dict get $result type] ;# CLUSTERMSG_TYPE_PONG
+
+        # 11 known nodes, 20% → floor(2.2)=2, clamped to min 3.
+        assert_equal [dict get $result count] 3
+    }
+
+    test "Gossip count scales with higher percentage" {
+        R 0 config set cluster-message-gossip-size 80
+
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+
+        set result [send_meet_and_read_reply $cluster_port \
+            "fakenode2234567890fakenode2234567890fake12" $base_port $cluster_port]
+
+        assert_equal 1 [dict get $result type] ;# CLUSTERMSG_TYPE_PONG
+
+        # ~12 known nodes, 80% → overall=9, freshnodes=~10 → count ~9.
+        assert_morethan [dict get $result count] 3
+        assert_lessthan_equal [dict get $result count] 9
     }
 }

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -72,12 +72,6 @@ proc create_cluster_meet_packet {sender_name sender_port sender_cport {count 0} 
     # CLUSTERMSG_FLAG0_EXT_DATA = (1 << 2) = 4
     append packet [binary format ccc $mflags 0 0]
 
-    # Pad to minimum cluster message length.
-    set packet_len [string length $packet]
-    if {$packet_len < $CLUSTERMSG_MIN_LEN} {
-        append packet [string repeat "\x00" [expr {$CLUSTERMSG_MIN_LEN - $packet_len}]]
-    }
-
     # Update totlen
     set totlen [string length $packet]
     set packet [string replace $packet 4 7 [binary format I $totlen]]

--- a/valkey.conf
+++ b/valkey.conf
@@ -2052,13 +2052,6 @@ aof-timestamp-enabled no
 # In order to setup your cluster make sure to read the documentation
 # available at https://valkey.io web site.
 
-# Cluster nodes communicate with each other via PING/PONG message type. Each message carries a gossip section i.e.
-# information about peer nodes. This configuration controls the percentage of known cluster nodes to include
-# in the gossip section of each message. The actual count is bounded by the total number of known nodes.
-#
-# Default value is 10, meaning 10% of all known nodes are gossiped per message.
-# cluster-message-gossip-size 10
-
 ########################## CLUSTER DOCKER/NAT support  ########################
 
 # In certain deployments, cluster node's address discovery fails, because

--- a/valkey.conf
+++ b/valkey.conf
@@ -2052,6 +2052,13 @@ aof-timestamp-enabled no
 # In order to setup your cluster make sure to read the documentation
 # available at https://valkey.io web site.
 
+# Cluster nodes communicate with each other via PING/PONG message type. Each message carries a gossip section i.e.
+# information about peer nodes. This configuration controls the percentage of known cluster nodes to include
+# in the gossip section of each message. The actual count is bounded by the total number of known nodes.
+#
+# Default value is 10, meaning 10% of all known nodes are gossiped per message.
+# cluster-message-gossip-size 10
+
 ########################## CLUSTER DOCKER/NAT support  ########################
 
 # In certain deployments, cluster node's address discovery fails, because


### PR DESCRIPTION
This PR introduces a new config `cluster-message-gossip-perc` which allows an operator to modify the amount of gossip node information to be sent per ping/pong/meet message. It can be modified dynamically (Related to https://github.com/valkey-io/valkey/issues/2291). The default value is 10% i.e. 10% of peer node information would be gossiped along with each ping/pong/meet packet. Users can tune this configuration, setting the value higher allows faster information dissemination whereas setting it lower would lead to direct PING messages if no information was received about a node with the `server.cluster_node_timeout/2` period.

Note: the behavior for partially failed gossip nodes still remains intact where all the `pfail` nodes are part of the message for faster propagation of information and faster transition of `PFAIL` to `FAIL`.



