### PR TITLE
[DEFLAKE] Psync established after rdb load - beyond grace period

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -500,7 +500,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         test "Test dual-channel-replication sync- psync established after rdb load" {
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages -1 {"*Done loading RDB*"} 0 2000 1
+            wait_for_log_messages -1 {"*Done loading RDB*"} 0 20 100
             wait_and_resume_process 0
 
             verify_replica_online $primary 0 500
@@ -511,7 +511,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
             wait_for_value_to_propagate_to_replica $primary $replica "key1"
             # Confirm the occurrence of a race condition.
-            wait_for_log_messages -1 {"*Dual channel replication: Psync established after rdb load*"} 0 2000 1
+            wait_for_log_messages -1 {"*Dual channel replication: Psync established after rdb load*"} 0 20 100
         }
     }
 }
@@ -620,8 +620,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica2 debug pause-after-fork 1
             test "Test dual-channel: primary tracking replica backlog refcount - start with empty backlog" {
                 $replica1 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 2000 1]
-                set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 2000 1]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -2
@@ -637,7 +637,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test dual-channel: primary tracking replica backlog refcount - start with backlog" {
                 $replica2 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 2000 1]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1
@@ -695,7 +695,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 5. Replica resumes operation.
             # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -756,7 +756,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 4. Primary resumes operation and detects closed RDB channel.
             # Expected outcome: Primary drops the RDB channel after grace period is done.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -766,7 +766,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             # Sync should fail once the replica ask for PSYNC using main channel
-            set res [wait_for_log_messages -1 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 4000 1]
+            set res [wait_for_log_messages -1 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 40 100]
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
@@ -811,7 +811,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Pause primary main process after fork
             $primary debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 100 100
 
             # At this point rdb is loaded but psync hasn't been established yet. 
             # Pause the replica so the primary main process will wake up while the
@@ -819,7 +819,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             pause_process $replica_pid
             wait_and_resume_process -1
             $primary debug pause-after-fork 0
-            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 100 100
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
@@ -831,12 +831,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary debug pause-after-fork 1
             set replica_loglines [count_log_lines 0]
             resume_process $replica_pid
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 200 100]
             set loglines [lindex $res 1]
         }
         # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
         wait_process_paused -1
-        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 1000 10
+        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 100 100
         $replica replicaof no one
         # Resume the primary and make sure the sync is dropped.
         resume_process [srv -1 pid]
@@ -904,7 +904,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set repl-diskless-sync-delay 100
             wait_and_resume_process 0
             $replica debug pause-after-fork 0
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1]
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 200 100]
             set loglines [lindex $res 0]
         }
         stop_write_load $load_handle0
@@ -1051,7 +1051,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after main conn kill" {
@@ -1082,7 +1082,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry
             $primary client kill id $replica_rdb_channel_id
             # Wait for primary to abort the sync
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after rdb conn kill" {
@@ -1229,7 +1229,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Primary did not free repl buf block after sync failure"
             }
             $primary config set repl-diskless-sync-delay 0
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
@@ -1292,7 +1292,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 fail "Primary did not free repl buf block after sync failure"
             }
             $primary config set repl-diskless-sync-delay 0
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
@@ -1352,7 +1352,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "replica didn't start sync session in time"
             }
-            wait_for_log_messages 0 {"*Loading RDB produced by Valkey version*"} $loglines 1000 10
+            wait_for_log_messages 0 {"*Loading RDB produced by Valkey version*"} $loglines 100 100
             $primary set key val
             set replica_main_conn_id [get_client_id_by_last_cmd $primary "psync"]
             $primary config set repl-diskless-sync-delay 5; # allow catch failed sync before retry

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -756,7 +756,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 4. Primary resumes operation and detects closed RDB channel.
             # Expected outcome: Primary drops the RDB channel after grace period is done.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 1
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 3
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -756,7 +756,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 4. Primary resumes operation and detects closed RDB channel.
             # Expected outcome: Primary drops the RDB channel after grace period is done.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 3
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {


### PR DESCRIPTION
Resolves: https://github.com/valkey-io/valkey/issues/2695

Increase the wait time for periodic log check for rdb load time. Also, increases the delay of log check frequency.