### PR TITLE
Fix incorrect kvstore size and BIT accounting after completed migration

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -865,9 +865,6 @@ void performSlotImportJobFailover(slotMigrationJob *job) {
     /* 4) Pong all the other nodes so that they can update the state accordingly
      *    and detect that we have taken over the slots. */
     clusterDoBeforeSleep(CLUSTER_TODO_BROADCAST_ALL);
-
-    /* 5) Mark all slots as stable in the kvstore (for SCAN/KEYS/RANDOMKEY) */
-    setSlotImportingStateInAllDbs(job->slot_ranges, 0);
 }
 
 bool clusterIsAnySlotImporting(void) {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -949,10 +949,10 @@ void kvstoreSetIsImporting(kvstore *kvs, int didx, int is_importing) {
         return;
     }
 
-    hashtableDelete(kvs->importing, (void *)(intptr_t)didx);
     /* Once we mark a hashtable as not importing, we need to begin tracking in
      * the kvstore metadata */
-    if (ht && hashtableSize(ht) != 0) {
+    if (hashtableDelete(kvs->importing, (void *)(intptr_t)didx) && ht && hashtableSize(ht) != 0) {
         cumulativeKeyCountAdd(kvs, didx, hashtableSize(ht));
+        kvs->importing_key_count -= hashtableSize(ht);
     }
 }


### PR DESCRIPTION
When working on #2635 I errorneously duplicated the setSlotImportingStateInAllDbs call for successful imports. This resulted in us doubling the key count in the kvstore. This results in DBSIZE reporting an incorrect sum, and also causes BIT corruption that can eventually result in a crash.

The solution is:

1. Only call setSlotImportingStateInAllDbs once (in our finishSlotMigrationJob function)
2. Make setSlotImportingStateInAllDbs idempotent by checking if the delete from the kvstore importing hashtable is a no-op

This also fixes a bug where the number of importing keys is not lowered after the migration, but this is less critical since it is only used when resizing the dictionary on RDB load. However, it could result in un-loadable RDBs if the importing key count gets large enough.