### PR TITLE
Fix outdated comment around clusterLink->flags

### DIFF
--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -40,7 +40,7 @@ typedef struct clusterLink {
     size_t rcvbuf_alloc;                   /* Allocated size of rcvbuf */
     clusterNode *node;                     /* Node related to this link. Initialized to NULL when unknown */
     int inbound;                           /* 1 if this link is an inbound link accepted from the related node */
-    int flags;                             /* We share CLUSTER_NODE_* with clusterNode->flags. */
+    int flags;                             /* CLUSTER_LINK_... */
 } clusterLink;
 
 /* Cluster link flags and macros. */


### PR DESCRIPTION
This clusterLink->flags was added in #2310, during the review, we at
the end chose to add a new CLUSTER_LINK_XXX flag instead of sharing the
old CLUSTER_NODE_XXX flag.