### PR TITLE
Adjust test runners to the number of tests to run

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -907,6 +907,11 @@ if {[llength $filtered_tests] < [llength $::all_tests]} {
     set ::all_tests $filtered_tests
 }
 
+# Don't start more test runners than the total number of tests to run.
+if {$::numclients > [llength $filtered_tests] && $::total_loops == 1} {
+    set ::numclients [llength $filtered_tests]
+}
+
 proc attach_to_replication_stream_on_connection {conn} {
     r config set repl-ping-replica-period 3600
     if {$::tls} {


### PR DESCRIPTION
This is fixing a minor annoyance when running single tests. With this change, the runtest script doesn't start more runners than the total number of tests to run. These are seen in the printouts like `[ready]: 68359`.

Screenshot before:

```
$ ./runtest --single tests/unit/limits.tcl 
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 68359
Testing unit/limits
[ready]: 68355
[ready]: 68362
[ready]: 68356
[ready]: 68361
[ready]: 68358
[ready]: 68364
[ready]: 68366
[ready]: 68367
[ready]: 68368
[ready]: 68357
[ready]: 68360
[ready]: 68363
[ready]: 68365
[ready]: 68369
[ready]: 68370
[ok]: Check if maxclients works refusing connections (906 ms)
[1/1 done]: unit/limits (1 seconds)

                   The End

Execution time of different units:
  1 seconds - unit/limits

\o/ All tests passed without errors!

Cleanup: may take some time... OK
```

Screenshot after:

```
$ ./runtest --single tests/unit/limits.tcl 
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 68439
Testing unit/limits
[ok]: Check if maxclients works refusing connections (906 ms)
[1/1 done]: unit/limits (1 seconds)

                   The End

Execution time of different units:
  1 seconds - unit/limits

\o/ All tests passed without errors!

Cleanup: may take some time... OK
```