### PR TITLE
[Cluster] Consolidate many sender NULL checks to simplify clusterProcessPacket

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3889,7 +3889,29 @@ int clusterProcessPacket(clusterLink *link) {
                 clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
                 return 0;
             }
+
+            /* Update our info about the node */
+            if (type == CLUSTERMSG_TYPE_PONG) {
+                link->node->pong_received = now;
+                link->node->ping_sent = 0;
+
+                /* The PFAIL condition can be reversed without external
+                 * help if it is momentary (that is, if it does not
+                 * turn into a FAIL state).
+                 *
+                 * The FAIL condition is also reversible under specific
+                 * conditions detected by clearNodeFailureIfNeeded(). */
+                if (nodeTimedOut(link->node)) {
+                    link->node->flags &= ~CLUSTER_NODE_PFAIL;
+                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
+                } else if (nodeFailed(link->node)) {
+                    clearNodeFailureIfNeeded(link->node);
+                }
+            }
         }
+
+        /* All the following operations require a known sender node */
+        if (!sender) return 1;
 
         /* Copy the CLUSTER_NODE_NOFAILOVER flag from what the sender
          * announced. This is a dynamic flag that we receive from the
@@ -3897,172 +3919,150 @@ int clusterProcessPacket(clusterLink *link) {
          * be propagated because the replica ranking used to understand the
          * delay of each replica in the voting process, needs to know
          * what are the instances really competing. */
-        if (sender) {
-            int nofailover = flags & CLUSTER_NODE_NOFAILOVER;
-            sender->flags &= ~CLUSTER_NODE_NOFAILOVER;
-            sender->flags |= nofailover;
-        }
+        int nofailover = flags & CLUSTER_NODE_NOFAILOVER;
+        sender->flags &= ~CLUSTER_NODE_NOFAILOVER;
+        sender->flags |= nofailover;
 
         /* Update the node address if it changed. */
-        if (sender && type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender) &&
+        if (type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender) &&
             nodeUpdateAddressIfNeeded(sender, link, hdr)) {
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
         }
 
-        /* Update our info about the node */
-        if (!link->inbound && type == CLUSTERMSG_TYPE_PONG) {
-            link->node->pong_received = now;
-            link->node->ping_sent = 0;
-
-            /* The PFAIL condition can be reversed without external
-             * help if it is momentary (that is, if it does not
-             * turn into a FAIL state).
-             *
-             * The FAIL condition is also reversible under specific
-             * conditions detected by clearNodeFailureIfNeeded(). */
-            if (nodeTimedOut(link->node)) {
-                link->node->flags &= ~CLUSTER_NODE_PFAIL;
-                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
-            } else if (nodeFailed(link->node)) {
-                clearNodeFailureIfNeeded(link->node);
+        /* Check for role switch: replica -> primary or primary -> replica. */
+        /* Node is a primary. */
+        if (sender_claims_to_be_primary) {
+            if (sender_last_reported_as_replica) {
+                serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
+                          sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
+                clusterSetNodeAsPrimary(sender);
             }
         }
+        /* Node is a replica. */
+        else {
+            clusterNode *sender_claimed_primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
 
-        /* Check for role switch: replica -> primary or primary -> replica. */
-        if (sender) {
-            if (sender_claims_to_be_primary) {
-                /* Node is a primary. */
-                if (sender_last_reported_as_replica) {
-                    serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                              sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
-                    clusterSetNodeAsPrimary(sender);
-                }
-            } else {
-                /* Node is a replica. */
-                clusterNode *sender_claimed_primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
+            if (sender_last_reported_as_primary) {
+                serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
+                          sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
 
-                if (sender_last_reported_as_primary) {
-                    serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                              sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
-
-                    /* Primary turned into a replica! Reconfigure the node. */
-                    if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
-                        /* `sender` was a primary and was in the same shard as its new primary */
-                        if (nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch) {
-                            serverLog(LL_NOTICE,
-                                      "Ignore stale message from %.40s (%s) in shard %.40s;"
-                                      " gossip config epoch: %llu, current config epoch: %llu",
-                                      sender->name, sender->human_nodename, sender->shard_id,
-                                      (unsigned long long)sender_claimed_config_epoch,
-                                      (unsigned long long)nodeEpoch(sender_claimed_primary));
-                            /* This packet is stale so we avoid processing it anymore. Otherwise
-                             * this may cause a primary-replica chain issue. */
-                            return 1;
-                        } else if (nodeIsReplica(sender_claimed_primary)) {
-                            /* A failover occurred in the shard where `sender` belongs to and `sender` is
-                             * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
-                             * which is the new primary in the shard. */
-                            int slots = 0, importing_slots = 0, migrating_slots = 0;
-                            clusterMoveNodeSlots(sender, sender_claimed_primary,
-                                                 &slots, &importing_slots, &migrating_slots);
-                            /* `primary` is still a `replica` in this observer node's view;
-                             * update its role and configEpoch */
-                            clusterSetNodeAsPrimary(sender_claimed_primary);
-                            sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
-                            if (slots) {
-                                serverLog(LL_NOTICE,
-                                          "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
-                                          " failed over to node %.40s (%s) with a config epoch of %llu",
-                                          sender->shard_id, sender->name, sender->human_nodename, slots,
-                                          sender_claimed_primary->name, sender_claimed_primary->human_nodename,
-                                          (unsigned long long)sender_claimed_primary->configEpoch);
-                            }
-                            if (importing_slots) {
-                                serverLog(LL_NOTICE,
-                                          "A failover occurred in migration source. Update importing "
-                                          "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
-                                          importing_slots, sender_claimed_primary->name,
-                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
-                            }
-                            if (migrating_slots) {
-                                serverLog(LL_NOTICE,
-                                          "A failover occurred in migration target. Update migrating "
-                                          "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
-                                          migrating_slots, sender_claimed_primary->name,
-                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
-                            }
-                            serverAssert(sender->numslots == 0);
-                        }
-                    } else {
-                        /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-                        int slots = clusterDelNodeSlots(sender);
+                /* Primary turned into a replica! Reconfigure the node. */
+                if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
+                    /* `sender` was a primary and was in the same shard as its new primary */
+                    if (nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch) {
                         serverLog(LL_NOTICE,
-                                  "Node %.40s (%s) is no longer primary of shard %.40s;"
-                                  " removed all %d slot(s) it used to own",
-                                  sender->name, sender->human_nodename, sender->shard_id, slots);
-                        if (sender_claimed_primary != NULL) {
-                            serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
-                                      sender->human_nodename, sender_claimed_primary->shard_id);
+                                  "Ignore stale message from %.40s (%s) in shard %.40s;"
+                                  " gossip config epoch: %llu, current config epoch: %llu",
+                                  sender->name, sender->human_nodename, sender->shard_id,
+                                  (unsigned long long)sender_claimed_config_epoch,
+                                  (unsigned long long)nodeEpoch(sender_claimed_primary));
+                        /* This packet is stale so we avoid processing it anymore. Otherwise
+                         * this may cause a primary-replica chain issue. */
+                        return 1;
+                    } else if (nodeIsReplica(sender_claimed_primary)) {
+                        /* A failover occurred in the shard where `sender` belongs to and `sender` is
+                         * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
+                         * which is the new primary in the shard. */
+                        int slots = 0, importing_slots = 0, migrating_slots = 0;
+                        clusterMoveNodeSlots(sender, sender_claimed_primary,
+                                             &slots, &importing_slots, &migrating_slots);
+                        /* `primary` is still a `replica` in this observer node's view;
+                         * update its role and configEpoch */
+                        clusterSetNodeAsPrimary(sender_claimed_primary);
+                        sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
+                        if (slots) {
+                            serverLog(LL_NOTICE,
+                                      "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
+                                      " failed over to node %.40s (%s) with a config epoch of %llu",
+                                      sender->shard_id, sender->name, sender->human_nodename, slots,
+                                      sender_claimed_primary->name, sender_claimed_primary->human_nodename,
+                                      (unsigned long long)sender_claimed_primary->configEpoch);
+                        }
+                        if (importing_slots) {
+                            serverLog(LL_NOTICE,
+                                      "A failover occurred in migration source. Update importing "
+                                      "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                      importing_slots, sender_claimed_primary->name,
+                                      sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                        }
+                        if (migrating_slots) {
+                            serverLog(LL_NOTICE,
+                                      "A failover occurred in migration target. Update migrating "
+                                      "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                      migrating_slots, sender_claimed_primary->name,
+                                      sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
                         }
                         serverAssert(sender->numslots == 0);
                     }
-
-                    sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
-                    sender->flags |= CLUSTER_NODE_REPLICA;
-
-                    /* Update config and state. */
-                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
-                }
-
-                /* Primary node changed for this replica? */
-                if (sender_claimed_primary && sender->replicaof != sender_claimed_primary) {
-                    if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
-                    serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
-                              sender->name, sender->human_nodename, sender_claimed_primary->name,
-                              sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
-                    clusterNodeAddReplica(sender_claimed_primary, sender);
-                    sender->replicaof = sender_claimed_primary;
-
-                    /* The chain reduction logic requires correctly establishing the replication relationship.
-                     * A key decision when designating a new primary for 'myself' is determining whether
-                     * 'myself' and the new primary belong to the same shard, which would imply shared
-                     * replication history and allow a safe partial synchronization (psync).
-                     *
-                     * This decision hinges on the shard_id, a per-node property that helps verify if the
-                     * two nodes share the same replication history. It's critical not to update myself's
-                     * shard_id prematurely during this process. Doing so could incorrectly associate
-                     * 'myself' with the sender's shard_id, leading the subsequent clusterSetPrimary call
-                     * to falsely assume that 'myself' and the new primary have been in the same shard.
-                     * This mistake could result in data loss by incorrectly permitting a psync.
-                     *
-                     * Therefore, it's essential to delay any shard_id updates until after the replication
-                     * relationship has been properly established and verified. */
-                    if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
-                        /* Safeguard against sub-replicas.
-                         *
-                         * A replica's primary can turn itself into a replica if its last slot
-                         * is removed. If no other node takes over the slot, there is nothing
-                         * else to trigger replica migration. In this case, they are not in the
-                         * same shard, so a full sync is required.
-                         *
-                         * Or a replica's primary can turn itself into a replica of its other
-                         * replica during a failover. In this case, they are in the same shard,
-                         * so we can try a psync. */
-                        serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
-                                  myself->replicaof->replicaof->name, myself->replicaof->name);
-                        clusterSetPrimary(myself->replicaof->replicaof, 1,
-                                          !areInSameShard(myself->replicaof->replicaof, myself));
-                        clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
-                                             CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
+                } else {
+                    /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
+                    int slots = clusterDelNodeSlots(sender);
+                    serverLog(LL_NOTICE,
+                              "Node %.40s (%s) is no longer primary of shard %.40s;"
+                              " removed all %d slot(s) it used to own",
+                              sender->name, sender->human_nodename, sender->shard_id, slots);
+                    if (sender_claimed_primary != NULL) {
+                        serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
+                                  sender->human_nodename, sender_claimed_primary->shard_id);
                     }
-
-                    /* Update the shard_id when a replica is connected to its
-                     * primary in the very first time. */
-                    updateShardId(sender, sender_claimed_primary->shard_id);
-
-                    /* Update config. */
-                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
+                    serverAssert(sender->numslots == 0);
                 }
+
+                sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
+                sender->flags |= CLUSTER_NODE_REPLICA;
+
+                /* Update config and state. */
+                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
+            }
+
+            /* Primary node changed for this replica? */
+            if (sender_claimed_primary && sender->replicaof != sender_claimed_primary) {
+                if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
+                serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
+                          sender->name, sender->human_nodename, sender_claimed_primary->name,
+                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                clusterNodeAddReplica(sender_claimed_primary, sender);
+                sender->replicaof = sender_claimed_primary;
+
+                /* The chain reduction logic requires correctly establishing the replication relationship.
+                 * A key decision when designating a new primary for 'myself' is determining whether
+                 * 'myself' and the new primary belong to the same shard, which would imply shared
+                 * replication history and allow a safe partial synchronization (psync).
+                 *
+                 * This decision hinges on the shard_id, a per-node property that helps verify if the
+                 * two nodes share the same replication history. It's critical not to update myself's
+                 * shard_id prematurely during this process. Doing so could incorrectly associate
+                 * 'myself' with the sender's shard_id, leading the subsequent clusterSetPrimary call
+                 * to falsely assume that 'myself' and the new primary have been in the same shard.
+                 * This mistake could result in data loss by incorrectly permitting a psync.
+                 *
+                 * Therefore, it's essential to delay any shard_id updates until after the replication
+                 * relationship has been properly established and verified. */
+                if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
+                    /* Safeguard against sub-replicas.
+                     *
+                     * A replica's primary can turn itself into a replica if its last slot
+                     * is removed. If no other node takes over the slot, there is nothing
+                     * else to trigger replica migration. In this case, they are not in the
+                     * same shard, so a full sync is required.
+                     *
+                     * Or a replica's primary can turn itself into a replica of its other
+                     * replica during a failover. In this case, they are in the same shard,
+                     * so we can try a psync. */
+                    serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
+                              myself->replicaof->replicaof->name, myself->replicaof->name);
+                    clusterSetPrimary(myself->replicaof->replicaof, 1,
+                                      !areInSameShard(myself->replicaof->replicaof, myself));
+                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
+                                         CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
+                }
+
+                /* Update the shard_id when a replica is connected to its
+                 * primary in the very first time. */
+                updateShardId(sender, sender_claimed_primary->shard_id);
+
+                /* Update config. */
+                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
             }
         }
 
@@ -4076,7 +4076,7 @@ int clusterProcessPacket(clusterLink *link) {
          * for it or if there was a failover in the sender's shard. Check
          * this ASAP to avoid other computational expensive checks later.*/
 
-        if (sender && sender_claims_to_be_primary &&
+        if (sender_claims_to_be_primary &&
             (sender_last_reported_as_replica || memcmp(sender->slots, hdr->myslots, sizeof(hdr->myslots)))) {
             /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
             serverAssert(nodeIsPrimary(sender));
@@ -4129,16 +4129,14 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* If our config epoch collides with the sender's try to fix
          * the problem. */
-        if (sender && nodeIsPrimary(myself) && nodeIsPrimary(sender) &&
+        if (nodeIsPrimary(myself) && nodeIsPrimary(sender) &&
             sender_claimed_config_epoch == myself->configEpoch) {
             clusterHandleConfigEpochCollision(sender);
         }
 
         /* Get info from the gossip section */
-        if (sender) {
-            clusterProcessGossipSection(hdr, link);
-            clusterProcessPingExtensions(hdr, link);
-        }
+        clusterProcessGossipSection(hdr, link);
+        clusterProcessPingExtensions(hdr, link);
     } else if (type == CLUSTERMSG_TYPE_FAIL) {
         clusterNode *failing;
 
@@ -4153,14 +4151,15 @@ int clusterProcessPacket(clusterLink *link) {
             serverLog(LL_NOTICE, "Ignoring FAIL message from unknown node %.40s about %.40s", hdr->sender,
                       hdr->data.fail.about.nodename);
         }
+    }
+    /* All following cluster message types require a known sender node */
+    else if (!sender) {
+        return 1;
     } else if (type == CLUSTERMSG_TYPE_PUBLISH || type == CLUSTERMSG_TYPE_PUBLISHSHARD) {
-        if (!sender) return 1; /* We don't know that node. */
         clusterProcessPublishPacket(&hdr->data.publish.msg, type);
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST) {
-        if (!sender) return 1; /* We don't know that node. */
         clusterSendFailoverAuthIfNeeded(sender, hdr);
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_ACK) {
-        if (!sender) return 1; /* We don't know that node. */
         /* We consider this vote only if the sender is a primary serving
          * a non zero number of slots, and its currentEpoch is greater or
          * equal to epoch where this node started the election. */
@@ -4173,7 +4172,7 @@ int clusterProcessPacket(clusterLink *link) {
     } else if (type == CLUSTERMSG_TYPE_MFSTART) {
         /* This message is acceptable only if I'm a primary and the sender
          * is one of my replicas. */
-        if (!sender || sender->replicaof != myself) return 1;
+        if (sender->replicaof != myself) return 1;
         /* Manual failover requested from replicas. Initialize the state
          * accordingly. */
         resetManualFailover();
@@ -4192,7 +4191,6 @@ int clusterProcessPacket(clusterLink *link) {
         clusterNode *n; /* The node the update is about. */
         uint64_t reportedConfigEpoch = ntohu64(hdr->data.update.nodecfg.configEpoch);
 
-        if (!sender) return 1; /* We don't know the sender. */
         n = clusterLookupNode(hdr->data.update.nodecfg.nodename, CLUSTER_NAMELEN);
         if (!n) return 1;                                    /* We don't know the reported node. */
         if (n->configEpoch >= reportedConfigEpoch) return 1; /* Nothing new. */

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3930,139 +3930,141 @@ int clusterProcessPacket(clusterLink *link) {
         }
 
         /* Check for role switch: replica -> primary or primary -> replica. */
-        /* Node is a primary. */
-        if (sender_claims_to_be_primary) {
-            if (sender_last_reported_as_replica) {
-                serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                          sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
-                clusterSetNodeAsPrimary(sender);
+        if (sender) {
+            /* Node is a primary. */
+            if (sender_claims_to_be_primary) {
+                if (sender_last_reported_as_replica) {
+                    serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
+                              sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
+                    clusterSetNodeAsPrimary(sender);
+                }
             }
-        }
-        /* Node is a replica. */
-        else {
-            clusterNode *sender_claimed_primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
+            /* Node is a replica. */
+            else {
+                clusterNode *sender_claimed_primary = clusterLookupNode(hdr->replicaof, CLUSTER_NAMELEN);
 
-            if (sender_last_reported_as_primary) {
-                serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
-                          sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
+                if (sender_last_reported_as_primary) {
+                    serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
+                              sender->human_nodename, sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
 
-                /* Primary turned into a replica! Reconfigure the node. */
-                if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
-                    /* `sender` was a primary and was in the same shard as its new primary */
-                    if (nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch) {
+                    /* Primary turned into a replica! Reconfigure the node. */
+                    if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
+                        /* `sender` was a primary and was in the same shard as its new primary */
+                        if (nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch) {
+                            serverLog(LL_NOTICE,
+                                      "Ignore stale message from %.40s (%s) in shard %.40s;"
+                                      " gossip config epoch: %llu, current config epoch: %llu",
+                                      sender->name, sender->human_nodename, sender->shard_id,
+                                      (unsigned long long)sender_claimed_config_epoch,
+                                      (unsigned long long)nodeEpoch(sender_claimed_primary));
+                            /* This packet is stale so we avoid processing it anymore. Otherwise
+                             * this may cause a primary-replica chain issue. */
+                            return 1;
+                        } else if (nodeIsReplica(sender_claimed_primary)) {
+                            /* A failover occurred in the shard where `sender` belongs to and `sender` is
+                             * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
+                             * which is the new primary in the shard. */
+                            int slots = 0, importing_slots = 0, migrating_slots = 0;
+                            clusterMoveNodeSlots(sender, sender_claimed_primary,
+                                                 &slots, &importing_slots, &migrating_slots);
+                            /* `primary` is still a `replica` in this observer node's view;
+                             * update its role and configEpoch */
+                            clusterSetNodeAsPrimary(sender_claimed_primary);
+                            sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
+                            if (slots) {
+                                serverLog(LL_NOTICE,
+                                          "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
+                                          " failed over to node %.40s (%s) with a config epoch of %llu",
+                                          sender->shard_id, sender->name, sender->human_nodename, slots,
+                                          sender_claimed_primary->name, sender_claimed_primary->human_nodename,
+                                          (unsigned long long)sender_claimed_primary->configEpoch);
+                            }
+                            if (importing_slots) {
+                                serverLog(LL_NOTICE,
+                                          "A failover occurred in migration source. Update importing "
+                                          "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                          importing_slots, sender_claimed_primary->name,
+                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                            }
+                            if (migrating_slots) {
+                                serverLog(LL_NOTICE,
+                                          "A failover occurred in migration target. Update migrating "
+                                          "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
+                                          migrating_slots, sender_claimed_primary->name,
+                                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                            }
+                            serverAssert(sender->numslots == 0);
+                        }
+                    } else {
+                        /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
+                        int slots = clusterDelNodeSlots(sender);
                         serverLog(LL_NOTICE,
-                                  "Ignore stale message from %.40s (%s) in shard %.40s;"
-                                  " gossip config epoch: %llu, current config epoch: %llu",
-                                  sender->name, sender->human_nodename, sender->shard_id,
-                                  (unsigned long long)sender_claimed_config_epoch,
-                                  (unsigned long long)nodeEpoch(sender_claimed_primary));
-                        /* This packet is stale so we avoid processing it anymore. Otherwise
-                         * this may cause a primary-replica chain issue. */
-                        return 1;
-                    } else if (nodeIsReplica(sender_claimed_primary)) {
-                        /* A failover occurred in the shard where `sender` belongs to and `sender` is
-                         * no longer a primary. Update slot assignment to `sender_claimed_config_epoch`,
-                         * which is the new primary in the shard. */
-                        int slots = 0, importing_slots = 0, migrating_slots = 0;
-                        clusterMoveNodeSlots(sender, sender_claimed_primary,
-                                             &slots, &importing_slots, &migrating_slots);
-                        /* `primary` is still a `replica` in this observer node's view;
-                         * update its role and configEpoch */
-                        clusterSetNodeAsPrimary(sender_claimed_primary);
-                        sender_claimed_primary->configEpoch = sender_claimed_config_epoch;
-                        if (slots) {
-                            serverLog(LL_NOTICE,
-                                      "A failover occurred in shard %.40s; node %.40s (%s) lost %d slot(s) and"
-                                      " failed over to node %.40s (%s) with a config epoch of %llu",
-                                      sender->shard_id, sender->name, sender->human_nodename, slots,
-                                      sender_claimed_primary->name, sender_claimed_primary->human_nodename,
-                                      (unsigned long long)sender_claimed_primary->configEpoch);
-                        }
-                        if (importing_slots) {
-                            serverLog(LL_NOTICE,
-                                      "A failover occurred in migration source. Update importing "
-                                      "source of %d slot(s) to node %.40s (%s) in shard %.40s.",
-                                      importing_slots, sender_claimed_primary->name,
-                                      sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
-                        }
-                        if (migrating_slots) {
-                            serverLog(LL_NOTICE,
-                                      "A failover occurred in migration target. Update migrating "
-                                      "target of %d slot(s) to node %.40s (%s) in shard %.40s.",
-                                      migrating_slots, sender_claimed_primary->name,
-                                      sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                                  "Node %.40s (%s) is no longer primary of shard %.40s;"
+                                  " removed all %d slot(s) it used to own",
+                                  sender->name, sender->human_nodename, sender->shard_id, slots);
+                        if (sender_claimed_primary != NULL) {
+                            serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
+                                      sender->human_nodename, sender_claimed_primary->shard_id);
                         }
                         serverAssert(sender->numslots == 0);
                     }
-                } else {
-                    /* `sender` was moved to another shard and has become a replica, remove its slot assignment */
-                    int slots = clusterDelNodeSlots(sender);
-                    serverLog(LL_NOTICE,
-                              "Node %.40s (%s) is no longer primary of shard %.40s;"
-                              " removed all %d slot(s) it used to own",
-                              sender->name, sender->human_nodename, sender->shard_id, slots);
-                    if (sender_claimed_primary != NULL) {
-                        serverLog(LL_NOTICE, "Node %.40s (%s) is now part of shard %.40s", sender->name,
-                                  sender->human_nodename, sender_claimed_primary->shard_id);
+
+                    sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
+                    sender->flags |= CLUSTER_NODE_REPLICA;
+
+                    /* Update config and state. */
+                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
+                }
+
+                /* Primary node changed for this replica? */
+                if (sender_claimed_primary && sender->replicaof != sender_claimed_primary) {
+                    if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
+                    serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
+                              sender->name, sender->human_nodename, sender_claimed_primary->name,
+                              sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
+                    clusterNodeAddReplica(sender_claimed_primary, sender);
+                    sender->replicaof = sender_claimed_primary;
+
+                    /* The chain reduction logic requires correctly establishing the replication relationship.
+                     * A key decision when designating a new primary for 'myself' is determining whether
+                     * 'myself' and the new primary belong to the same shard, which would imply shared
+                     * replication history and allow a safe partial synchronization (psync).
+                     *
+                     * This decision hinges on the shard_id, a per-node property that helps verify if the
+                     * two nodes share the same replication history. It's critical not to update myself's
+                     * shard_id prematurely during this process. Doing so could incorrectly associate
+                     * 'myself' with the sender's shard_id, leading the subsequent clusterSetPrimary call
+                     * to falsely assume that 'myself' and the new primary have been in the same shard.
+                     * This mistake could result in data loss by incorrectly permitting a psync.
+                     *
+                     * Therefore, it's essential to delay any shard_id updates until after the replication
+                     * relationship has been properly established and verified. */
+                    if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
+                        /* Safeguard against sub-replicas.
+                         *
+                         * A replica's primary can turn itself into a replica if its last slot
+                         * is removed. If no other node takes over the slot, there is nothing
+                         * else to trigger replica migration. In this case, they are not in the
+                         * same shard, so a full sync is required.
+                         *
+                         * Or a replica's primary can turn itself into a replica of its other
+                         * replica during a failover. In this case, they are in the same shard,
+                         * so we can try a psync. */
+                        serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
+                                  myself->replicaof->replicaof->name, myself->replicaof->name);
+                        clusterSetPrimary(myself->replicaof->replicaof, 1,
+                                          !areInSameShard(myself->replicaof->replicaof, myself));
+                        clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
+                                             CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
                     }
-                    serverAssert(sender->numslots == 0);
+
+                    /* Update the shard_id when a replica is connected to its
+                     * primary in the very first time. */
+                    updateShardId(sender, sender_claimed_primary->shard_id);
+
+                    /* Update config. */
+                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
                 }
-
-                sender->flags &= ~(CLUSTER_NODE_PRIMARY | CLUSTER_NODE_MIGRATE_TO);
-                sender->flags |= CLUSTER_NODE_REPLICA;
-
-                /* Update config and state. */
-                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
-            }
-
-            /* Primary node changed for this replica? */
-            if (sender_claimed_primary && sender->replicaof != sender_claimed_primary) {
-                if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
-                serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
-                          sender->name, sender->human_nodename, sender_claimed_primary->name,
-                          sender_claimed_primary->human_nodename, sender_claimed_primary->shard_id);
-                clusterNodeAddReplica(sender_claimed_primary, sender);
-                sender->replicaof = sender_claimed_primary;
-
-                /* The chain reduction logic requires correctly establishing the replication relationship.
-                 * A key decision when designating a new primary for 'myself' is determining whether
-                 * 'myself' and the new primary belong to the same shard, which would imply shared
-                 * replication history and allow a safe partial synchronization (psync).
-                 *
-                 * This decision hinges on the shard_id, a per-node property that helps verify if the
-                 * two nodes share the same replication history. It's critical not to update myself's
-                 * shard_id prematurely during this process. Doing so could incorrectly associate
-                 * 'myself' with the sender's shard_id, leading the subsequent clusterSetPrimary call
-                 * to falsely assume that 'myself' and the new primary have been in the same shard.
-                 * This mistake could result in data loss by incorrectly permitting a psync.
-                 *
-                 * Therefore, it's essential to delay any shard_id updates until after the replication
-                 * relationship has been properly established and verified. */
-                if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
-                    /* Safeguard against sub-replicas.
-                     *
-                     * A replica's primary can turn itself into a replica if its last slot
-                     * is removed. If no other node takes over the slot, there is nothing
-                     * else to trigger replica migration. In this case, they are not in the
-                     * same shard, so a full sync is required.
-                     *
-                     * Or a replica's primary can turn itself into a replica of its other
-                     * replica during a failover. In this case, they are in the same shard,
-                     * so we can try a psync. */
-                    serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
-                              myself->replicaof->replicaof->name, myself->replicaof->name);
-                    clusterSetPrimary(myself->replicaof->replicaof, 1,
-                                      !areInSameShard(myself->replicaof->replicaof, myself));
-                    clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
-                                         CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
-                }
-
-                /* Update the shard_id when a replica is connected to its
-                 * primary in the very first time. */
-                updateShardId(sender, sender_claimed_primary->shard_id);
-
-                /* Update config. */
-                clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG);
             }
         }
 


### PR DESCRIPTION
In function `clusterProcessPacket` a lot of the operations require the `sender` object being non-NULL (meaning it is a known cluster node to the receiver) and thus have many NULL checks.

In the branch of handling PING/PONG/MEET messages, I add a new NULL check to allow early return once we find out this node is unknown. This helps a lot with code reading, because many lines of code were stuffed inside an `if (sender)` branch, causing an extra indentation.

For the other message types, I consolidate the same one-line checks (they were just copy-pasted ) into a standalone `else if` check.