### PR TITLE
Ensure the server executable exists before running tests

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -524,11 +524,11 @@ proc start_server {options {code undefined}} {
 
     if {$start_other_server} {
         set executable $::other_server_path
-        if {![file executable $executable]} {
-            error "File not found or not executable: $executable"
-        }
     } else {
         set executable "src/valkey-server"
+    }
+    if {![file executable $executable]} {
+        error "Server executable file not found or not executable: $executable"
     }
 
     set data [split [exec cat "tests/assets/$baseconfig"] "\n"]


### PR DESCRIPTION
When running the test as usual via ` ./runtest --single unit/cluster/cluster-reliable-meet`, I find the process just hangs forever for no obvious reason:

```
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 23131
Testing unit/cluster/cluster-reliable-meet
[ready]: 23130
[ready]: 23129
[ready]: 23132
[ready]: 23133
[ready]: 23134
[ready]: 23137
[ready]: 23136
[ready]: 23135
[ready]: 23139
[ready]: 23138
[ready]: 23140
[ready]: 23141
[ready]: 23144
[ready]: 23143
[ready]: 23142
```

Then I realize it's because I forgot to rebuild the executables after  `make clean`. So I think having an explicit failure in the test script would be very helpful:

```
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 23449
Testing unit/cluster/cluster-reliable-meet
[ready]: 23450
[ready]: 23451
[ready]: 23452
[ready]: 23453
[ready]: 23455
[ready]: 23454
[ready]: 23456
[exception]: Executing test client: Server executable file not found or not executable: src/valkey-server.
Server executable file not found or not executable: src/valkey-server
    while executing
"error "Server executable file not found or not executable: $executable""
    (procedure "start_server" line 85)
    invoked from within
"start_server {overrides {cluster-enabled yes}} {start_server {overrides {cluster-enabled yes}}
......
```

