### PR TITLE
Add monotonic clock calibration handling if clock speed is not found

### DIFF
--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -64,6 +64,25 @@ static void monotonicInit_x86linux(void) {
                 break;
             }
         }
+        /* Some CPUs may not contain clock speed in the model name */
+        if (mono_ticksPerMicrosecond == 0) {
+            /* Calibrate TSC against CLOCK_MONOTONIC */
+            struct timespec start, end;
+            uint64_t tsc_start, tsc_end;
+
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            tsc_start = __rdtsc();
+            usleep(10000); /* Sleep for 10ms */
+            tsc_end = __rdtsc();
+            clock_gettime(CLOCK_MONOTONIC, &end);
+
+            uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL +
+                                (end.tv_nsec - start.tv_nsec) / 1000;
+            uint64_t tsc_elapsed = tsc_end - tsc_start;
+            mono_ticksPerMicrosecond = tsc_elapsed / elapsed_us;
+        }
+        /* Rewind file to search for constant_tsc flag */
+        rewind(cpuinfo);
         while (fgets(buf, bufflen, cpuinfo) != NULL) {
             if (regexec(&constTscRegex, buf, nmatch, pmatch, 0) == 0) {
                 constantTsc = 1;

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -66,20 +66,26 @@ static void monotonicInit_x86linux(void) {
         }
         /* Some CPUs may not contain clock speed in the model name */
         if (mono_ticksPerMicrosecond == 0) {
-            /* Calibrate TSC against CLOCK_MONOTONIC */
-            struct timespec start, end;
-            uint64_t tsc_start, tsc_end;
+            for (int i = 0; i < 3; ++i) {
+                /* Calibrate TSC against CLOCK_MONOTONIC */
+                struct timespec start, end;
+                uint64_t tsc_start, tsc_end;
 
-            clock_gettime(CLOCK_MONOTONIC, &start);
-            tsc_start = __rdtsc();
-            usleep(10000); /* Sleep for 10ms */
-            tsc_end = __rdtsc();
-            clock_gettime(CLOCK_MONOTONIC, &end);
+                clock_gettime(CLOCK_MONOTONIC, &start);
+                tsc_start = __rdtsc();
+                usleep(10000); /* Sleep for 10ms */
+                tsc_end = __rdtsc();
+                clock_gettime(CLOCK_MONOTONIC, &end);
 
-            uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL +
-                                (end.tv_nsec - start.tv_nsec) / 1000;
-            uint64_t tsc_elapsed = tsc_end - tsc_start;
-            mono_ticksPerMicrosecond = tsc_elapsed / elapsed_us;
+                uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL + (end.tv_nsec - start.tv_nsec) / 1000;
+                uint64_t tsc_elapsed = tsc_end - tsc_start;
+                long sample_ticksPerMicrosecond = tsc_elapsed / elapsed_us;
+
+                /* Use the maximum out of 3 iterations for accuracy */
+                if (sample_ticksPerMicrosecond > mono_ticksPerMicrosecond) {
+                    mono_ticksPerMicrosecond = sample_ticksPerMicrosecond;
+                }
+            }
         }
         /* Rewind file to search for constant_tsc flag */
         rewind(cpuinfo);

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -5,6 +5,8 @@
 #include <time.h>
 #include "serverassert.h"
 
+#define TSC_CALIBRATION_ITERATIONS 3
+
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
 
@@ -66,7 +68,7 @@ static void monotonicInit_x86linux(void) {
         }
         /* Some CPUs may not contain clock speed in the model name */
         if (mono_ticksPerMicrosecond == 0) {
-            for (int i = 0; i < 3; ++i) {
+            for (int i = 0; i < TSC_CALIBRATION_ITERATIONS; ++i) {
                 /* Calibrate TSC against CLOCK_MONOTONIC */
                 struct timespec start, end;
                 uint64_t tsc_start, tsc_end;
@@ -81,7 +83,7 @@ static void monotonicInit_x86linux(void) {
                 uint64_t tsc_elapsed = tsc_end - tsc_start;
                 long sample_ticksPerMicrosecond = tsc_elapsed / elapsed_us;
 
-                /* Use the maximum out of 3 iterations for accuracy */
+                /* Use the maximum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy */
                 if (sample_ticksPerMicrosecond > mono_ticksPerMicrosecond) {
                     mono_ticksPerMicrosecond = sample_ticksPerMicrosecond;
                 }

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -5,8 +5,6 @@
 #include <time.h>
 #include "serverassert.h"
 
-#define TSC_CALIBRATION_ITERATIONS 3
-
 /* The function pointer for clock retrieval.  */
 monotime (*getMonotonicUs)(void) = NULL;
 
@@ -28,6 +26,8 @@ static char monotonic_info_string[32];
 #if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
 #include <regex.h>
 #include <x86intrin.h>
+
+#define TSC_CALIBRATION_ITERATIONS 3
 
 static long mono_ticksPerMicrosecond = 0;
 


### PR DESCRIPTION
Currently, monotonic clock initialization relies on the model name field from /proc/cpuinfo to retrieve the clock speed. However, this is not always present. In case it is not present, measure the clock tick and use it instead.

Before fix:
```
monotonic: x86 linux, unable to determine clock rate
```

After fix:
```
21695:M 25 Oct 2025 20:16:23.168 * monotonic clock: X86 TSC @ 2649 ticks/us
```

Fixes #2774 