### PR TITLE
Make ValkeyModule_Call compatible with calling commands from scripting engines

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -597,3 +597,43 @@ long long scriptRunDuration(void) {
     serverAssert(scriptIsRunning());
     return elapsedMs(curr_run_ctx->start_time);
 }
+
+int scriptAllowsOOM(void) {
+    serverAssert(scriptIsRunning());
+    return curr_run_ctx->flags & SCRIPT_ALLOW_OOM;
+}
+
+int scriptIsReadOnly(void) {
+    serverAssert(scriptIsRunning());
+    return curr_run_ctx->flags & SCRIPT_READ_ONLY;
+}
+
+int scriptIsWriteDirty(void) {
+    serverAssert(scriptIsRunning());
+    return curr_run_ctx->flags & SCRIPT_WRITE_DIRTY;
+}
+
+void scriptSetWriteDirtyFlag(void) {
+    serverAssert(scriptIsRunning());
+    curr_run_ctx->flags |= SCRIPT_WRITE_DIRTY;
+}
+
+int scriptAllowsCrossSlot(void) {
+    serverAssert(scriptIsRunning());
+    return curr_run_ctx->flags & SCRIPT_ALLOW_CROSS_SLOT;
+}
+
+int scriptGetSlot(void) {
+    serverAssert(scriptIsRunning());
+    return curr_run_ctx->slot;
+}
+
+void scriptSetSlot(int slot) {
+    serverAssert(scriptIsRunning());
+    curr_run_ctx->slot = slot;
+}
+
+void scriptSetOriginalClientSlot(int slot) {
+    serverAssert(scriptIsRunning());
+    curr_run_ctx->original_client->slot = slot;
+}

--- a/src/script.h
+++ b/src/script.h
@@ -116,4 +116,13 @@ client *scriptGetClient(void);
 client *scriptGetCaller(void);
 long long scriptRunDuration(void);
 
+int scriptAllowsOOM(void);
+int scriptIsReadOnly(void);
+int scriptIsWriteDirty(void);
+void scriptSetWriteDirtyFlag(void);
+int scriptAllowsCrossSlot(void);
+int scriptGetSlot(void);
+void scriptSetSlot(int slot);
+void scriptSetOriginalClientSlot(int slot);
+
 #endif /* __SCRIPT_H_ */


### PR DESCRIPTION
Note: these changes are another step towards being able to run Lua engine as an external scripting engine module.

In this commit we improve the `ValkeyModule_Call` API function code to match the validations and behavior of the `scriptCall` function, currently used by the Lua engine to run commands using `server.call` Lua Valkey API.

The changes made are backward compatible. The new behavior/validations are only enabled when calling `ValkeyModule_Call` while running a script using `EVAL` or `FCALL`.

To test these changes, we improved the `HELLO` dummy scripting engine module to support calling commands, and compare the behavior with calling the same command from a Lua script.