### PR TITLE
Authenticate slot migration client on source node to internal user

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1384,7 +1384,7 @@ void initSlotExportJobClient(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
     job->client = createClient(job->conn);
     job->conn = NULL;
-    job->client->flag.authenticated = 1;
+    clientSetUser(job->client, NULL, 1);
     job->client->slot_migration_job = job;
     initClientReplicationData(job->client);
 }


### PR DESCRIPTION
Just setting the authenticated flag actually authenticates to the default user in this case. The default user may be granted no permission to use CLUSTER SYNCSLOTS.

Instaed, we now authenticate to the NULL/internal user, which grants access to all commands. This is the same as what we do for replication:

https://github.com/valkey-io/valkey/blob/864de555ced5354976ae4f97f44977041556115f/src/replication.c#L4717

Add a test for this case as well.

Closes #2783 