### PR TITLE
Bug fix: reset io_last_written on c->buf resize to prevent stale pointers

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -987,6 +987,9 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
         size_t oldbuf_size = c->buf_usable_size;
         c->buf = zmalloc_usable(new_buffer_size, &c->buf_usable_size);
         memcpy(c->buf, oldbuf, c->bufpos);
+        if (c->io_last_written.buf == oldbuf) {
+            c->io_last_written.buf = c->buf;
+        }
         zfree_with_size(oldbuf, oldbuf_size);
     }
     return 0;


### PR DESCRIPTION

Fixes an assert crash in _writeToClient():

    serverAssert(c->io_last_written.data_len == 0 ||
                 c->io_last_written.buf == c->buf);

The issue occurs when clientsCronResizeOutputBuffer() grows or reallocates c->buf while io_last_written still points to the old buffer and data_len is non-zero. On the next write, both conditions in the assertion become false.

Reset io_last_written when resizing the output buffer to prevent stale pointers and keep state consistent.

fixes https://github.com/valkey-io/valkey/issues/2769