### PR TITLE
Fix: ltrim should not call signalModifiedKey when no elements are removed

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -909,8 +909,9 @@ void ltrimCommand(client *c) {
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
     }
-    signalModifiedKey(c, c->db, c->argv[1]);
-    server.dirty += (ltrim + rtrim);
+    long long total_trim = ltrim + rtrim;
+    if (total_trim) signalModifiedKey(c, c->db, c->argv[1]);
+    server.dirty += total_trim;
     addReply(c, shared.ok);
 }
 


### PR DESCRIPTION
There’s an issue with the LTRIM command. When LTRIM does not actually modify the key — for example, with `LTRIM key 0 -1` — the server.dirty counter is not updated because both ltrim and rtrim values are 0. As a result, the command is not propagated. However, `signalModifiedKey` is still called regardless of whether server.dirty changes. This behavior is unexpected and can cause a mismatch between the source and target during propagation, since the LTRIM command is not sent.