### PR TITLE
[flaky-failure-fix] Increase the cluster-node-timeout to have longer delay between failover of each shard

### DIFF
--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -1,6 +1,6 @@
 # Check the basic monitoring and failover capabilities.
 
-start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
 
     test "Cluster is up" {
         wait_for_cluster_state ok

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -64,7 +64,7 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
     }
 } ;# start_cluster
 
-start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 9000}} {
     test "Primaries will not time out then they are elected in the same epoch" {
         # Since we have the delay time, so these node may not initiate the
         # election at the same time (same epoch). But if they do, we make

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -1,6 +1,6 @@
 # Check the basic monitoring and failover capabilities.
 
-start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
+start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
 
     test "Cluster is up" {
         wait_for_cluster_state ok
@@ -64,7 +64,7 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
     }
 } ;# start_cluster
 
-start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 9000}} {
+start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
     test "Primaries will not time out then they are elected in the same epoch" {
         # Since we have the delay time, so these node may not initiate the
         # election at the same time (same epoch). But if they do, we make


### PR DESCRIPTION
Fixes: #2699

Removing the cluster-node-timeout override to allow more delay between a shard failover operation and avoid collision.

More explanation: https://github.com/valkey-io/valkey/issues/2699#issuecomment-3464177936