### PR TITLE
Improve header comment and strengthen type checking for entry

### DIFF
--- a/src/entry.h
+++ b/src/entry.h
@@ -9,39 +9,11 @@
  *----------------------------------------------------------------------------*/
 
 /*
- * The entry pointer is the field `sds`. We encode the entry layout type
- * in the SDS header.
- *
- * An entry represents a key–value pair with an optional expiration timestamp.
- * The pointer of type `entry *` always points to the VALUE `sds`.
- *
- * Layout 1: Embedded Field and Value (Compact Form)
- *
- *   +-------------------+-------------------+-------------------+
- *   | Expiration (opt)  | Field (sds)       | Value (sds)       |
- *   | 8 bytes (int64_t) | "field" + header  | "value" + header  |
- *   +-------------------+-------------------+-------------------+
- *                                   ^
- *                                   |
- *                             entry pointer
- *
- * - Both field and value are small and embedded.
- * - The expiration is stored just before the first sds.
- *
- *
- * Layout 2: Pointer-Based Value (Large Values)
- *
- *   +-------------------+-------------------+------------------+
- *   | Expiration (opt)  | Value pointer     | Field (sds)      |
- *   | 8 bytes (int64_t) | 8 bytes (void *)  | "field" + header |
- *   +-------------------+-------------------+------------------+
- *                                           ^
- *                                           |
- *                                           entry pointer
- *
- * - The value is stored separately via a pointer.
- * - Used for large value sizes. */
-typedef void entry;
+ * An "entry" is a field/value sds pair, with an optional expiration time.  The
+ * entry is used as part of the HASH datatype, and supports hash field expiration.
+ */
+
+typedef struct _entry entry;
 
 /* The maximum allocation size we want to use for entries with embedded
  * values. */

--- a/src/server.h
+++ b/src/server.h
@@ -3432,8 +3432,8 @@ robj *setTypeDup(robj *o);
 #define HASH_SET_COPY 0
 
 
-void hashTypeFreeVolatileSet(robj *o);         /* needed only for freeHashObject */
-void hashTypeTrackEntry(robj *o, void *entry); /* needed only for rdbLoadObject */
+void hashTypeFreeVolatileSet(robj *o);          /* needed only for freeHashObject */
+void hashTypeTrackEntry(robj *o, entry *entry); /* needed only for rdbLoadObject */
 size_t hashTypeScanDefrag(robj *ob, size_t cursor, void *(*defragAlloc)(void *));
 size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fields, robj **out_fields);
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -52,6 +52,11 @@ typedef enum {
     EXPIRATION_MODIFICATION_EXPIRE_ASAP = 2,      /* if apply of the expiration modification was set to a time in the past (i.e field is immediately expired) */
 } expiryModificationResult;
 
+// A vsetGetExpiryFunc
+static long long entryGetExpiryVsetFunc(const void *e) {
+    return entryGetExpiry((const entry *)e);
+}
+
 /*-----------------------------------------------------------------------------
  * Hash type Expiry API
  *----------------------------------------------------------------------------*/
@@ -103,28 +108,28 @@ void hashTypeFreeVolatileSet(robj *o) {
     hashTypeIgnoreTTL(o, true);
 }
 
-void hashTypeTrackEntry(robj *o, void *entry) {
+void hashTypeTrackEntry(robj *o, entry *entry) {
     vset *set;
     if (hashTypeHasVolatileFields(o)) {
         set = hashTypeGetVolatileSet(o);
     } else {
         set = hashTypeGetOrcreateVolatileSet(o);
     }
-    bool added = vsetAddEntry(set, entryGetExpiry, entry);
+    bool added = vsetAddEntry(set, entryGetExpiryVsetFunc, entry);
     serverAssert(added);
 }
 
-static void hashTypeUntrackEntry(robj *o, void *entry) {
+static void hashTypeUntrackEntry(robj *o, entry *entry) {
     if (!entryHasExpiry(entry)) return;
     vset *set = hashTypeGetVolatileSet(o);
     debugServerAssert(set);
-    serverAssert(vsetRemoveEntry(set, entryGetExpiry, entry));
+    serverAssert(vsetRemoveEntry(set, entryGetExpiryVsetFunc, entry));
     if (vsetIsEmpty(set)) {
         hashTypeFreeVolatileSet(o);
     }
 }
 
-static void hashTypeTrackUpdateEntry(robj *o, void *old_entry, void *new_entry, long long old_expiry, long long new_expiry) {
+static void hashTypeTrackUpdateEntry(robj *o, entry *old_entry, entry *new_entry, long long old_expiry, long long new_expiry) {
     int old_tracked = (old_entry && old_expiry != EXPIRY_NONE);
     int new_tracked = (new_entry && new_expiry != EXPIRY_NONE);
     /* If entry was not tracked before and not going to be tracked now, we can simply return */
@@ -134,14 +139,14 @@ static void hashTypeTrackUpdateEntry(robj *o, void *old_entry, void *new_entry, 
     vset *set = hashTypeGetOrcreateVolatileSet(o);
     debugServerAssert(!old_tracked || !vsetIsEmpty(set));
 
-    serverAssert(vsetUpdateEntry(set, entryGetExpiry, old_entry, new_entry, old_expiry, new_expiry) == 1);
+    serverAssert(vsetUpdateEntry(set, entryGetExpiryVsetFunc, old_entry, new_entry, old_expiry, new_expiry) == 1);
 
     if (vsetIsEmpty(set)) {
         hashTypeFreeVolatileSet(o);
     }
 }
 
-bool hashHashtableTypeValidate(hashtable *ht, void *entry) {
+bool hashHashtableTypeValidate(hashtable *ht, entry *entry) {
     UNUSED(ht);
     expirationPolicy policy = getExpirationPolicyWithFlags(0);
     if (policy == POLICY_IGNORE_EXPIRE) return true;
@@ -2156,7 +2161,7 @@ size_t hashTypeDeleteExpiredFields(robj *o, mstime_t now, unsigned long max_fiel
     /* skip TTL checks temporarily (to allow hashtable pops) */
     hashTypeIgnoreTTL(o, true);
     expiryContext ctx = {.key = o, .fields = out_entries, .n_fields = 0};
-    size_t expired = vsetRemoveExpired(vset, entryGetExpiry, hashTypeExpireEntry, now, max_fields, &ctx);
+    size_t expired = vsetRemoveExpired(vset, entryGetExpiryVsetFunc, hashTypeExpireEntry, now, max_fields, &ctx);
     serverAssert(ctx.n_fields <= max_fields);
     if (vsetIsEmpty(vset)) {
         hashTypeFreeVolatileSet(o);


### PR DESCRIPTION
In `entry.c`, the `entry` is a block of memory with variable contents.  The structure can be difficult to understand.  A new header comment more clearly documents the contents/layout of the `entry`.

Also, in `entry.h`, the `entry` was defined by `typedef void entry`.  This allows blind casting to the `entry` type.  It defeats compiler type checking.

Even though the `entry` has a variable definition, we can define entry as a legitimate type which allows the compiler to perform type checking.  By performing `typedef struct _entry entry`, now the `entry` is understood to be a pointer to some type of undefined structure.  We can pass a pointer and the compiler can typecheck the pointer.  (Of course we can't dereference it, because we haven't actually defined the struct.)