### PR TITLE
Add prefix‑aware ACL permission checks and new module API

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1543,11 +1543,26 @@ user *ACLGetUserByName(const char *name, size_t namelen) {
  * ACL permission checks
  * ==========================================================================*/
 
-/* Check if the key can be accessed by the selector.
+/**
+ * Checks whether a given key is allowed for the specified ACL selector.
  *
- * If the selector can access the key, ACL_OK is returned, otherwise
- * ACL_DENIED_KEY is returned. */
-static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keylen, int keyspec_flags) {
+ * The function evaluates the key against the selector's patterns, taking into account
+ * the requested key access flags (read/write) and whether the key should be
+ * treated as a prefix. If the selector has the SELECTOR_FLAG_ALLKEYS flag set,
+ * the check always succeeds.
+ *
+ * - selector The ACL selector containing the allowed key patterns.
+ * - key           Pointer to the key string to check.
+ * - keylen        Length of the key in bytes.
+ * - keyspec_flags Bitmask of requested key operations (e.g., CMD_KEY_ACCESS,
+ *                 CMD_KEY_INSERT, CMD_KEY_DELETE, CMD_KEY_UPDATE).
+ * - is_prefix     If true, the key is compared as a prefix against the selector's
+ *                 patterns using prefixmatchlen rather than a full string match.
+ *
+ * This function returns ACL_OK if the key matches at least one pattern that allows the requested
+ * operations; otherwise ACL_DENIED_KEY.
+ */
+static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keylen, int keyspec_flags, bool is_prefix) {
     /* The selector can access any key */
     if (selector->flags & SELECTOR_FLAG_ALLKEYS) return ACL_OK;
 
@@ -1566,6 +1581,12 @@ static int ACLSelectorCheckKey(aclSelector *selector, const char *key, int keyle
         keyPattern *pattern = listNodeValue(ln);
         if ((pattern->flags & key_flags) != key_flags) continue;
         size_t plen = sdslen(pattern->pattern);
+        if (is_prefix) {
+            if (prefixmatchlen(pattern->pattern, plen, key, keylen, 0))
+                return ACL_OK;
+            else
+                continue;
+        }
         if (stringmatchlen(pattern->pattern, plen, key, keylen, 0)) return ACL_OK;
     }
     return ACL_DENIED_KEY;
@@ -1690,7 +1711,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
         keyReference *resultidx = result->keys;
         for (int j = 0; j < result->numkeys; j++) {
             int idx = resultidx[j].pos;
-            ret = ACLSelectorCheckKey(selector, argv[idx]->ptr, sdslen(argv[idx]->ptr), resultidx[j].flags);
+            ret = ACLSelectorCheckKey(selector, argv[idx]->ptr, sdslen(argv[idx]->ptr), resultidx[j].flags, 0);
             if (ret != ACL_OK) {
                 if (keyidxptr) *keyidxptr = resultidx[j].pos;
                 return ret;
@@ -1723,13 +1744,31 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
     return ACL_OK;
 }
 
-/* Check if the key can be accessed by the client according to
- * the ACLs associated with the specified user according to the
- * keyspec access flags.
+/**
+ * Checks whether the given user has permission to access a specified key.
  *
- * If the user can access the key, ACL_OK is returned, otherwise
- * ACL_DENIED_KEY is returned. */
-int ACLUserCheckKeyPerm(user *u, const char *key, int keylen, int flags) {
+ * This function verifies the access control list (ACL) permissions for a user on a key.
+ * If the user pointer is  NULL, the connection is considered authorized to run any
+ * command and the function returns  ACL_OK.  Otherwise, the function iterates
+ * through the user's ACL selectors and returns  ACL_OK as soon as any selector
+ * grants permission.  If no selector grants permission,  ACL_DENIED_KEY is returned.
+ *
+ * Input parameters:
+ *
+ * - u Pointer to a user structure. If  NULL, the user is treated as
+ *    having unrestricted access.
+ * - key Pointer to the key string to check.
+ * - keylen Length of the key string in bytes.
+ * - flags Flags that may influence selector checks (implementation-specific).
+ * - is_prefix true if key should be treated as a prefix in selector
+ *    evaluation; false otherwise.
+ *
+ * Returns ACL_OK if access is granted, ACL_DENIED_KEY if access is denied.
+ *
+ * NOTE: The function performs no modification of the  user structure or the key;
+ *       it only evaluates read-only selectors.
+ */
+int ACLUserCheckKeyPerm(user *u, const char *key, int keylen, int flags, bool is_prefix) {
     listIter li;
     listNode *ln;
 
@@ -1740,7 +1779,7 @@ int ACLUserCheckKeyPerm(user *u, const char *key, int keylen, int flags) {
     listRewind(u->selectors, &li);
     while ((ln = listNext(&li))) {
         aclSelector *s = (aclSelector *)listNodeValue(ln);
-        if (ACLSelectorCheckKey(s, key, keylen, flags) == ACL_OK) {
+        if (ACLSelectorCheckKey(s, key, keylen, flags, is_prefix) == ACL_OK) {
             return ACL_OK;
         }
     }

--- a/src/acl.c
+++ b/src/acl.c
@@ -1543,8 +1543,7 @@ user *ACLGetUserByName(const char *name, size_t namelen) {
  * ACL permission checks
  * ==========================================================================*/
 
-/**
- * Checks whether a given key is allowed for the specified ACL selector.
+/* Checks whether a given key is allowed for the specified ACL selector.
  *
  * The function evaluates the key against the selector's patterns, taking into account
  * the requested key access flags (read/write) and whether the key should be
@@ -1711,7 +1710,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
         keyReference *resultidx = result->keys;
         for (int j = 0; j < result->numkeys; j++) {
             int idx = resultidx[j].pos;
-            ret = ACLSelectorCheckKey(selector, argv[idx]->ptr, sdslen(argv[idx]->ptr), resultidx[j].flags, 0);
+            ret = ACLSelectorCheckKey(selector, argv[idx]->ptr, sdslen(argv[idx]->ptr), resultidx[j].flags, false);
             if (ret != ACL_OK) {
                 if (keyidxptr) *keyidxptr = resultidx[j].pos;
                 return ret;
@@ -1744,8 +1743,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
     return ACL_OK;
 }
 
-/**
- * Checks whether the given user has permission to access a specified key.
+/* Checks whether the given user has permission to access a specified key.
  *
  * This function verifies the access control list (ACL) permissions for a user on a key.
  * If the user pointer is  NULL, the connection is considered authorized to run any

--- a/src/module.c
+++ b/src/module.c
@@ -10114,7 +10114,7 @@ int VM_ACLCheckKeyPermissions(ValkeyModuleUser *user, ValkeyModuleString *key, i
     }
 
     int keyspec_flags = moduleConvertKeySpecsFlags(flags, 0);
-    if (ACLUserCheckKeyPerm(user->user, key->ptr, sdslen(key->ptr), keyspec_flags) != ACL_OK) {
+    if (ACLUserCheckKeyPerm(user->user, key->ptr, sdslen(key->ptr), keyspec_flags, false) != ACL_OK) {
         errno = EACCES;
         return VALKEYMODULE_ERR;
     }
@@ -14159,6 +14159,39 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+/**
+ * This function verifies that the user represented by `ctx` is authorized to carry out the operations indicated in the
+ * `flags` parameter on keys that begin with the specified prefix.
+ *
+ * This function validates that the supplied ACL flags are a subset of the allowed key‑access flags
+ * (`VALKEYMODULE_CMD_KEY_ACCESS`,`VALKEYMODULE_CMD_KEY_INSERT`, `VALKEYMODULE_CMD_KEY_DELETE`,
+ * `VALKEYMODULE_CMD_KEY_UPDATE`). It then converts the flags into key‑specification flags (`CMD_KEY_*`) and calls
+ * `ACLUserCheckKeyPerm` to ensure the client has permission for the specified key prefix.
+ *
+ * If any check fails, returns `VALKEYMODULE_ERR` and sets `errno` to the appropriate error code:
+ *
+ * - `EINVAL` for invalid flags
+ * - `EACCES` for insufficient permissions
+ *
+ *  Otherwise it returns `VALKEYMODULE_OK`.
+ */
+int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleCtx *ctx, const char *key, size_t len, unsigned int flags) {
+    const int allow_mask = (VALKEYMODULE_CMD_KEY_ACCESS | VALKEYMODULE_CMD_KEY_INSERT | VALKEYMODULE_CMD_KEY_DELETE | VALKEYMODULE_CMD_KEY_UPDATE);
+
+    if ((flags & allow_mask) != flags) {
+        errno = EINVAL;
+        return VALKEYMODULE_ERR;
+    }
+
+    int keyspec_flags = moduleConvertKeySpecsFlags(flags, 0);
+    if (ACLUserCheckKeyPerm(ctx->client->user, key, len, keyspec_flags, true) != ACL_OK) {
+        errno = EACCES;
+        return VALKEYMODULE_ERR;
+    }
+
+    return VALKEYMODULE_OK;
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -14533,4 +14566,5 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ScriptingEngineDebuggerLogRespReply);
     REGISTER_API(ScriptingEngineDebuggerFlushLogs);
     REGISTER_API(ScriptingEngineDebuggerProcessCommands);
+    REGISTER_API(ACLCheckKeyPrefixPermissions);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -14177,6 +14177,11 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
 int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleUser *user, const char *key, size_t len, unsigned int flags) {
     const int allow_mask = (VALKEYMODULE_CMD_KEY_ACCESS | VALKEYMODULE_CMD_KEY_INSERT | VALKEYMODULE_CMD_KEY_DELETE | VALKEYMODULE_CMD_KEY_UPDATE);
 
+    if (user == NULL) {
+        errno = EINVAL;
+        return VALKEYMODULE_ERR;
+    }
+
     if ((flags & allow_mask) != flags) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -14159,23 +14159,28 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
-/* This function verifies that the user represented by `ctx` is authorized to carry out the operations indicated in the
+/* This function verifies that the user is authorized to carry out the operations indicated in the
  * `flags` parameter on keys that begin with the specified prefix.
  *
  * This function validates that the supplied ACL flags are a subset of the allowed key‑access flags
  * (`VALKEYMODULE_CMD_KEY_ACCESS`,`VALKEYMODULE_CMD_KEY_INSERT`, `VALKEYMODULE_CMD_KEY_DELETE`,
  * `VALKEYMODULE_CMD_KEY_UPDATE`). It then converts the flags into key‑specification flags (`CMD_KEY_*`) and calls
- * `ACLUserCheckKeyPerm` to ensure the client has permission for the specified key prefix.
+ * `ACLUserCheckKeyPerm` to ensure the user has permission for the specified key prefix.
  *
  * If any check fails, returns `VALKEYMODULE_ERR` and sets `errno` to the appropriate error code:
  *
- * - `EINVAL` for invalid flags
+ * - `EINVAL` for invalid flags or NULL user
  * - `EACCES` for insufficient permissions
  *
  *  Otherwise it returns `VALKEYMODULE_OK`.
  */
-int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleCtx *ctx, const char *key, size_t len, unsigned int flags) {
+int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleUser *user, const char *key, size_t len, unsigned int flags) {
     const int allow_mask = (VALKEYMODULE_CMD_KEY_ACCESS | VALKEYMODULE_CMD_KEY_INSERT | VALKEYMODULE_CMD_KEY_DELETE | VALKEYMODULE_CMD_KEY_UPDATE);
+
+    if (user == NULL || user->user == NULL) {
+        errno = EINVAL;
+        return VALKEYMODULE_ERR;
+    }
 
     if ((flags & allow_mask) != flags) {
         errno = EINVAL;
@@ -14183,7 +14188,7 @@ int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleCtx *ctx, const char *key, size_
     }
 
     int keyspec_flags = moduleConvertKeySpecsFlags(flags, 0);
-    if (ACLUserCheckKeyPerm(ctx->client->user, key, len, keyspec_flags, true) != ACL_OK) {
+    if (ACLUserCheckKeyPerm(user->user, key, len, keyspec_flags, true) != ACL_OK) {
         errno = EACCES;
         return VALKEYMODULE_ERR;
     }

--- a/src/module.c
+++ b/src/module.c
@@ -14159,8 +14159,7 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
-/**
- * This function verifies that the user represented by `ctx` is authorized to carry out the operations indicated in the
+/* This function verifies that the user represented by `ctx` is authorized to carry out the operations indicated in the
  * `flags` parameter on keys that begin with the specified prefix.
  *
  * This function validates that the supplied ACL flags are a subset of the allowed key‑access flags

--- a/src/module.c
+++ b/src/module.c
@@ -14177,11 +14177,6 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
 int VM_ACLCheckKeyPrefixPermissions(ValkeyModuleUser *user, const char *key, size_t len, unsigned int flags) {
     const int allow_mask = (VALKEYMODULE_CMD_KEY_ACCESS | VALKEYMODULE_CMD_KEY_INSERT | VALKEYMODULE_CMD_KEY_DELETE | VALKEYMODULE_CMD_KEY_UPDATE);
 
-    if (user == NULL || user->user == NULL) {
-        errno = EINVAL;
-        return VALKEYMODULE_ERR;
-    }
-
     if ((flags & allow_mask) != flags) {
         errno = EINVAL;
         return VALKEYMODULE_ERR;

--- a/src/server.h
+++ b/src/server.h
@@ -3218,7 +3218,7 @@ int ACLAuthenticateUser(client *c, robj *username, robj *password, robj **err);
 void addAuthErrReply(client *c, robj *err);
 unsigned long ACLGetCommandID(sds cmdname);
 user *ACLGetUserByName(const char *name, size_t namelen);
-int ACLUserCheckKeyPerm(user *u, const char *key, int keylen, int flags);
+int ACLUserCheckKeyPerm(user *u, const char *key, int keylen, int flags, bool is_prefix);
 int ACLUserCheckChannelPerm(user *u, sds channel, int literal);
 int ACLCheckAllUserCommandPerm(user *u, struct serverCommand *cmd, robj **argv, int argc, int *idxptr);
 int ACLUserCheckCmdWithUnrestrictedKeyAccess(user *u, struct serverCommand *cmd, robj **argv, int argc, int flags);

--- a/src/util.c
+++ b/src/util.c
@@ -198,8 +198,8 @@ int stringmatch(const char *pattern, const char *string, int nocase) {
 
 int prefixmatchlen(const char *pattern, int patternLen, const char *string, int stringLen, int nocase) {
     if (patternLen == 1 && pattern[0] == '*') {
-        // Minor optimization: fast path: avoid calling "stringmatchlen" if the input pattern is exactly "*":
-        // We always return 1 in this case.
+        /* Minor optimization: fast path: avoid calling "stringmatchlen" if the input pattern is exactly "*":
+         * We always return 1 in this case. */
         return 1;
     } else if (patternLen > 0 && pattern[patternLen - 1] != '*') {
         // Reject the pattern if it doesn't end with '*'

--- a/src/util.c
+++ b/src/util.c
@@ -196,6 +196,20 @@ int stringmatch(const char *pattern, const char *string, int nocase) {
     return stringmatchlen(pattern, strlen(pattern), string, strlen(string), nocase);
 }
 
+int prefixmatchlen(const char *pattern, int patternLen, const char *string, int stringLen, int nocase) {
+    if (patternLen == 1 && pattern[0] == '*') {
+        // Minor optimization: fast path: avoid calling "stringmatchlen" if the input pattern is exactly "*":
+        // We always return 1 in this case.
+        return 1;
+    } else if (patternLen > 0 && pattern[patternLen - 1] != '*') {
+        // Reject the pattern if it doesn't end with '*'
+        return 0;
+    } else {
+        // Call existing string match algorithm
+        return stringmatchlen(pattern, patternLen, string, stringLen, nocase);
+    }
+}
+
 /* Fuzz stringmatchlen() trying to crash it with bad input. */
 int stringmatchlen_fuzz_test(void) {
     char str[32];

--- a/src/util.c
+++ b/src/util.c
@@ -202,10 +202,10 @@ int prefixmatchlen(const char *pattern, int patternLen, const char *string, int 
          * We always return 1 in this case. */
         return 1;
     } else if (patternLen > 0 && pattern[patternLen - 1] != '*') {
-        // Reject the pattern if it doesn't end with '*'
+        /* Reject the pattern if it doesn't end with '*' */
         return 0;
     } else {
-        // Call existing string match algorithm
+        /* Call existing string match algorithm */
         return stringmatchlen(pattern, patternLen, string, stringLen, nocase);
     }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -72,6 +72,7 @@ typedef long long mstime_t; /* millisecond time type. */
 typedef long long ustime_t; /* microsecond time type. */
 
 int stringmatchlen(const char *p, int plen, const char *s, int slen, int nocase);
+int prefixmatchlen(const char *pattern, int patternLen, const char *string, int stringLen, int nocase);
 int stringmatch(const char *p, const char *s, int nocase);
 int stringmatchlen_fuzz_test(void);
 unsigned long long memtoull(const char *p, int *err);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -2161,7 +2161,7 @@ VALKEYMODULE_API void (*ValkeyModule_ScriptingEngineDebuggerFlushLogs)(void) VAL
 VALKEYMODULE_API void (*ValkeyModule_ScriptingEngineDebuggerProcessCommands)(int *client_disconnected,
                                                                              ValkeyModuleString **err) VALKEYMODULE_ATTR;
 
-VALKEYMODULE_API int (*ValkeyModule_ACLCheckKeyPrefixPermissions)(ValkeyModuleCtx *ctx,
+VALKEYMODULE_API int (*ValkeyModule_ACLCheckKeyPrefixPermissions)(ValkeyModuleUser *user,
                                                                   const char *key,
                                                                   size_t len,
                                                                   unsigned int flags) VALKEYMODULE_ATTR;

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -2161,9 +2161,12 @@ VALKEYMODULE_API void (*ValkeyModule_ScriptingEngineDebuggerFlushLogs)(void) VAL
 VALKEYMODULE_API void (*ValkeyModule_ScriptingEngineDebuggerProcessCommands)(int *client_disconnected,
                                                                              ValkeyModuleString **err) VALKEYMODULE_ATTR;
 
+VALKEYMODULE_API int (*ValkeyModule_ACLCheckKeyPrefixPermissions)(ValkeyModuleCtx *ctx,
+                                                                  const char *key,
+                                                                  size_t len,
+                                                                  unsigned int flags) VALKEYMODULE_ATTR;
 
 #define ValkeyModule_IsAOFClient(id) ((id) == UINT64_MAX)
-
 /* This is included inline inside each Valkey module. */
 static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) VALKEYMODULE_ATTR_UNUSED;
 static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver) {
@@ -2539,6 +2542,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(ScriptingEngineDebuggerLogRespReply);
     VALKEYMODULE_GET_API(ScriptingEngineDebuggerFlushLogs);
     VALKEYMODULE_GET_API(ScriptingEngineDebuggerProcessCommands);
+    VALKEYMODULE_GET_API(ACLCheckKeyPrefixPermissions);
 
     if (ValkeyModule_IsModuleNameBusy && ValkeyModule_IsModuleNameBusy(name)) return VALKEYMODULE_ERR;
     ValkeyModule_SetModuleAttribs(ctx, name, ver, apiver);

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -190,7 +190,7 @@ int module_check_key_permission(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
     if(argc != 3){
         return ValkeyModule_WrongArity(ctx);
     }
-    
+
     size_t key_len = 0;
     unsigned int flags = 0;
     const char* key_prefix = ValkeyModule_StringPtrLen(argv[1], &key_len);
@@ -203,7 +203,10 @@ int module_check_key_permission(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
         ValkeyModule_ReplyWithSimpleString(ctx, "EINVALID");
         return VALKEYMODULE_OK;
     }
-    int rc = ValkeyModule_ACLCheckKeyPrefixPermissions(ctx, key_prefix, key_len, flags);
+
+    ValkeyModuleString* user_name = ValkeyModule_GetCurrentUserName(ctx);
+    ValkeyModuleUser *user = ValkeyModule_GetModuleUserFromUserName(user_name);
+    int rc = ValkeyModule_ACLCheckKeyPrefixPermissions(user, key_prefix, key_len, flags);
     if (rc == VALKEYMODULE_OK) {
         // Access granted.
         ValkeyModule_ReplyWithSimpleString(ctx, "OK");
@@ -211,6 +214,8 @@ int module_check_key_permission(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
         // Access denied.
         ValkeyModule_ReplyWithSimpleString(ctx, "EACCESS");
     }
+    ValkeyModule_FreeModuleUser(user);
+    ValkeyModule_FreeString(ctx, user_name);
     return VALKEYMODULE_OK;
 }
 

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -183,6 +183,37 @@ int rm_call_aclcheck(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc){
     return VALKEYMODULE_OK;
 }
 
+int module_check_key_permission(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    if(argc != 3){
+        return ValkeyModule_WrongArity(ctx);
+    }
+    
+    size_t key_len = 0;
+    unsigned int flags = 0;
+    const char* key_prefix = ValkeyModule_StringPtrLen(argv[1], &key_len);
+    const char* check_what = ValkeyModule_StringPtrLen(argv[2], NULL);
+    if (strcasecmp(check_what, "R") == 0) {
+        flags = VALKEYMODULE_CMD_KEY_ACCESS;
+    } else if(strcasecmp(check_what, "W") == 0) {
+        flags = VALKEYMODULE_CMD_KEY_INSERT | VALKEYMODULE_CMD_KEY_DELETE | VALKEYMODULE_CMD_KEY_UPDATE;
+    } else {
+        ValkeyModule_ReplyWithSimpleString(ctx, "EINVALID");
+        return VALKEYMODULE_OK;
+    }
+    int rc = ValkeyModule_ACLCheckKeyPrefixPermissions(ctx, key_prefix, key_len, flags);
+    if (rc == VALKEYMODULE_OK) {
+        // Access granted.
+        ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    } else {
+        // Access denied.
+        ValkeyModule_ReplyWithSimpleString(ctx, "EACCESS");
+    }
+    return VALKEYMODULE_OK;
+}
+
 int module_test_acl_category(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     VALKEYMODULE_NOT_USED(argv);
     VALKEYMODULE_NOT_USED(argc);
@@ -288,6 +319,14 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
                                       "write",0,0,0) == VALKEYMODULE_ERR)
             return VALKEYMODULE_ERR;
 
+    if (ValkeyModule_CreateCommand(ctx,"acl.check_key_prefix", 
+                                   module_check_key_permission, 
+                                   "", 
+                                   0, 
+                                   0, 
+                                   0) == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    } 
     /* This validates that, when module tries to add a category with invalid characters,
      * the server returns VALKEYMODULE_ERR and set errno to `EINVAL` */
     if (ValkeyModule_AddACLCategory(ctx,"!nval!dch@r@cter$") == VALKEYMODULE_ERR)


### PR DESCRIPTION
## Description

This change introduces the ability for modules to check ACL permissions against key prefix. The update adds a dedicated `prefixmatchlen` helper and extends the core ACL selector logic to support a prefix‑matching mode.

The new API `ValkeyModule_ACLCheckPrefixPermissions` is registered and exposed to modules, and a corresponding implementation is added in `module.c`. Existing internal callers that already perform prefix checks (e.g., `VM_ACLCheckKeyPermissions`) are updated to use the new flag, while all legacy paths remain unchanged.

The change also modifies the `aclcheck§ test module that exercises the new prefix‑checking API, ensuring that read/write operations are correctly allowed or denied based on the ACL configuration.

Key areas touched:

* ACL logic
* Module API
* Testing

# Motivation

The search module presently makes costly calls to verify index permissions (see https://github.com/valkey-io/valkey-search/blob/main/src/acl.cc#L295). This PR introduces a more efficient approach for that.

