### PR TITLE
Reverts hashHashtableTypeValidate signature

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -147,6 +147,7 @@ static void hashTypeTrackUpdateEntry(robj *o, entry *old_entry, entry *new_entry
 }
 
 // This is a hashtableType validateEntry callback
+// This is a hashtableType valicateEntry callback
 bool hashHashtableTypeValidate(hashtable *ht, void *entryptr) {
     UNUSED(ht);
     entry *entry = entryptr;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -146,6 +146,7 @@ static void hashTypeTrackUpdateEntry(robj *o, entry *old_entry, entry *new_entry
     }
 }
 
+// This is a hashtableType validateEntry callback
 bool hashHashtableTypeValidate(hashtable *ht, void *entryptr) {
     UNUSED(ht);
     entry *entry = entryptr;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -147,7 +147,6 @@ static void hashTypeTrackUpdateEntry(robj *o, entry *old_entry, entry *new_entry
 }
 
 // This is a hashtableType validateEntry callback
-// This is a hashtableType valicateEntry callback
 bool hashHashtableTypeValidate(hashtable *ht, void *entryptr) {
     UNUSED(ht);
     entry *entry = entryptr;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -146,8 +146,9 @@ static void hashTypeTrackUpdateEntry(robj *o, entry *old_entry, entry *new_entry
     }
 }
 
-bool hashHashtableTypeValidate(hashtable *ht, entry *entry) {
+bool hashHashtableTypeValidate(hashtable *ht, void *entryptr) {
     UNUSED(ht);
+    entry *entry = entryptr;
     expirationPolicy policy = getExpirationPolicyWithFlags(0);
     if (policy == POLICY_IGNORE_EXPIRE) return true;
 


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/actions/runs/19053371057/job/54418411647#step:6:202

Matched hashHashtableTypeValidate to the [generic hashtable callback signature ](https://github.com/valkey-io/valkey/blob/unstable/src/hashtable.h#L62)and performed the entry cast internally to preserve expiry checks.