### PR TITLE
Disable Slack Notification in Daily on PRs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1439,6 +1439,7 @@ jobs:
           fi
       - name: Notify about results
         uses: ravsamhq/notify-slack-action@v2
+        if: github.event_name != 'pull_request'
         with:
           status: ${{ env.STATUS }}
           notify_when: "failure"


### PR DESCRIPTION
PRs do not have access to secrets and daily keeps failing on the Notification step on PR.
PR failures are notified to the author so Slack Notification are not required on PRs.

This PR will disable `Notify about results` job from Daily.yml when it runs on PRs.