### PR TITLE
Fix flaky DBSIZE test for atomic slot migration

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -803,10 +803,12 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
                 wait_for_countkeysinslot $node_idx $slot_to_test 0
             }
-            wait_for_condition 50 100 {
-                [R $target_idx debug digest] eq [R $target_repl_idx debug digest]
-            } else {
-                fail "Target and its replica have different digests: [R $target_idx debug digest] VS [R $target_repl_idx debug digest]"
+            test "Let nodes converge after importing key containment tests" {
+                wait_for_condition 50 100 {
+                    [R $target_idx debug digest] eq [R $target_repl_idx debug digest]
+                } else {
+                    fail "Target and its replica have different digests: [R $target_idx debug digest] VS [R $target_repl_idx debug digest]"
+                }
             }
         }
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -803,6 +803,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 assert_match "1" [R $target_idx DEL $slot_to_test_tag:my_key]
                 wait_for_countkeysinslot $node_idx $slot_to_test 0
             }
+            wait_for_condition 50 100 {
+                [R $target_idx debug digest] eq [R $target_repl_idx debug digest]
+            } else {
+                fail "Target and its replica have different digests: [R $target_idx debug digest] VS [R $target_repl_idx debug digest]"
+            }
         }
 
         foreach eviction_policy {


### PR DESCRIPTION
Related test failures: 
https://github.com/valkey-io/valkey/actions/runs/19086881915/job/54528997473
https://github.com/valkey-io/valkey/actions/runs/18892904243/job/53924295239

> *** [err]: Replica importing key containment (slot 0 from node 0 to 2) - DBSIZE command excludes importing keys in tests/unit/cluster/cluster-migrateslots.tcl
> Expected '1' to match '0' (context: type eval line 2 cmd {assert_match "0" [R $node_idx DBSIZE]} proc ::test) 

The reason is that we don't wait for the primary-replica synchronization to complete before starting the next testcase.