### PR TITLE
Replace strcmp with byte-by-byte comparison in valkey-check-aof

### DIFF
--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -63,7 +63,7 @@ static long long line = 1;
 static time_t to_timestamp = 0;
 
 int consumeNewline(char *buf) {
-    if (strncmp(buf, "\r\n", 2) != 0) {
+    if (buf[0] != '\r' || buf[1] != '\n') {
         ERROR("Expected \\r\\n, got: %02x%02x", buf[0], buf[1]);
         return 0;
     }


### PR DESCRIPTION
Fixes #2792

Replace strcmp with byte-by-byte comparison to avoid accidental heap-buffer-overflow errors.