### PR TITLE
Add instruction to build Valkey with fast_float

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ as libsystemd-dev on Debian/Ubuntu or systemd-devel on CentOS) and run:
 
     % make USE_SYSTEMD=yes
 
+Since Valkey version 8.1, `fast_float` has been introduced as an optional 
+dependency, which can speed up sorted sets and other commands that use 
+the double datatype. To build with `fast_float` support, you'll need a 
+C++ compiler and run:
+
+    % make USE_FAST_FLOAT=yes
+
 To append a suffix to Valkey program names, use:
 
     % make PROG_SUFFIX="-alt"


### PR DESCRIPTION
The `README.md` file is currently missing a section to build Valkey with `fast_float`, which was introduced in Valkey 8.1 as an optional dependency (#1260)