### PR TITLE
Refactor TCL reference to support running tests with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ build-debug/
 build-release/
 cmake-build-debug/
 cmake-build-release/
-ignore/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ build-debug/
 build-release/
 cmake-build-debug/
 cmake-build-release/
+ignore/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,34 @@ unset(BUILD_TEST_MODULES CACHE)
 unset(BUILD_EXAMPLE_MODULES CACHE)
 unset(USE_TLS CACHE)
 unset(DEBUG_FORCE_DEFRAG CACHE)
+
+# Helper to copy runtest scripts to allow running tests with CMake built binaries
+function(copy_runtest_script script_name)
+    set(src "${CMAKE_SOURCE_DIR}/${script_name}")
+    set(dst "${CMAKE_BINARY_DIR}/${script_name}")
+    file(READ "${src}" contents)
+
+    # Split at the first newline (after shebang #!/bin/sh)
+    string(FIND "${contents}" "\n" index_of_first_newline_char)
+    math(EXPR first_index_script_body "${index_of_first_newline_char} + 1")
+
+    string(SUBSTRING "${contents}" 0 ${first_index_script_body} shebang_line)
+    string(SUBSTRING "${contents}" ${first_index_script_body} -1 script_body)
+
+    # Insert our environment variable lines
+    set(insert_content
+"# Most tests assume running from the project root
+cd ${CMAKE_SOURCE_DIR}
+export VALKEY_BIN_DIR=\"${CMAKE_BINARY_DIR}/bin\"
+")
+    # Reconstruct the full script
+    set(new_contents "${shebang_line}${insert_content}${script_body}")
+    file(WRITE "${dst}" "${new_contents}")
+    file(CHMOD "${dst}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
+endfunction()
+
+copy_runtest_script("runtest")
+copy_runtest_script("runtest-cluster")
+copy_runtest_script("runtest-moduleapi")
+copy_runtest_script("runtest-rdma")
+copy_runtest_script("runtest-sentinel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ export VALKEY_BIN_DIR=\"${CMAKE_BINARY_DIR}/bin\"
     # Reconstruct the full script
     set(new_contents "${shebang_line}${insert_content}${script_body}")
     file(WRITE "${dst}" "${new_contents}")
-    file(CHMOD "${dst}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
+    file(CHMOD "${dst}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endfunction()
 
 copy_runtest_script("runtest")

--- a/cmake/Modules/ValkeySetup.cmake
+++ b/cmake/Modules/ValkeySetup.cmake
@@ -50,13 +50,15 @@ endif ()
 
 # Helper function for creating symbolic link so that: link -> source
 macro (valkey_create_symlink source link)
-    install(
-        CODE "execute_process(                      \
-    COMMAND /bin/bash ${CMAKE_BINARY_DIR}/CreateSymlink.sh \
-    ${source} \
-    ${link}   \
-    )"
-        COMPONENT "valkey")
+  add_custom_command(
+    TARGET ${source} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo
+            "Creating symlink: ${link} -> $<TARGET_FILE:${source}>"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            "$<TARGET_FILE_NAME:${source}>"
+            "$<TARGET_FILE_DIR:${source}>/${link}"
+    VERBATIM
+  )
 endmacro ()
 
 # Install a binary

--- a/cmake/Modules/ValkeySetup.cmake
+++ b/cmake/Modules/ValkeySetup.cmake
@@ -52,8 +52,6 @@ endif ()
 macro (valkey_create_symlink source link)
   add_custom_command(
     TARGET ${source} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo
-            "Creating symlink: ${link} -> $<TARGET_FILE:${source}>"
     COMMAND ${CMAKE_COMMAND} -E create_symlink
             "$<TARGET_FILE_NAME:${source}>"
             "$<TARGET_FILE_DIR:${source}>/${link}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ endif ()
 # Create symbolic links under src/ directory so that TCL tests can find the binaries
 add_custom_target(link_test_binaries ALL
     DEPENDS valkey-server valkey-cli valkey-benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo "Creating symlinks for test environment"
+    COMMAND ${CMAKE_COMMAND} -E echo "Creating symlinks under src/ for test environment"
 
     # Link build binaries into src/
     COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-server

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,11 +95,11 @@ if (BUILD_UNIT_TESTS)
 endif ()
 
 # Friendly hint like the Makefile one
-file(RELATIVE_PATH _VALKEY_BIN_RELATIVE_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}")
+file(RELATIVE_PATH _CMAKE_DIR_RELATIVE_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}")
 add_custom_target(hint ALL
     DEPENDS valkey-server valkey-cli valkey-benchmark
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "Hint: It is a good idea to run tests with your CMake-built binaries \\;\\)"
-    COMMAND ${CMAKE_COMMAND} -E echo "      ./${_VALKEY_BIN_RELATIVE_PATH}/runtest"
+    COMMAND ${CMAKE_COMMAND} -E echo "      ./${_CMAKE_DIR_RELATIVE_PATH}/runtest"
     COMMAND ${CMAKE_COMMAND} -E echo ""
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,3 +93,19 @@ endif ()
 if (BUILD_UNIT_TESTS)
     add_subdirectory(unit)
 endif ()
+
+# Create symbolic links under src/ directory so that TCL tests can find the binaries
+add_custom_target(link_test_binaries ALL
+    DEPENDS valkey-server valkey-cli valkey-benchmark
+    COMMAND ${CMAKE_COMMAND} -E echo "Creating symlinks for test environment"
+
+    # Link build binaries into src/
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-server
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-cli> ${CMAKE_SOURCE_DIR}/src/valkey-cli
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-benchmark> ${CMAKE_SOURCE_DIR}/src/valkey-benchmark
+
+    # These aliases all point to valkey-server
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-check-aof
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-check-rdb
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-sentinel
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,3 +93,13 @@ endif ()
 if (BUILD_UNIT_TESTS)
     add_subdirectory(unit)
 endif ()
+
+# Friendly hint like the Makefile one
+file(RELATIVE_PATH _VALKEY_BIN_RELATIVE_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/bin")
+add_custom_target(hint ALL
+    DEPENDS valkey-server valkey-cli valkey-benchmark
+    COMMAND ${CMAKE_COMMAND} -E echo ""
+    COMMAND ${CMAKE_COMMAND} -E echo "Hint: It is a good idea to run tests with your CMake-built binaries \\;\\)"
+    COMMAND ${CMAKE_COMMAND} -E echo "      VALKEY_BIN_DIR=${_VALKEY_BIN_RELATIVE_PATH} ./runtest"
+    COMMAND ${CMAKE_COMMAND} -E echo ""
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,11 +95,11 @@ if (BUILD_UNIT_TESTS)
 endif ()
 
 # Friendly hint like the Makefile one
-file(RELATIVE_PATH _VALKEY_BIN_RELATIVE_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/bin")
+file(RELATIVE_PATH _VALKEY_BIN_RELATIVE_PATH "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}")
 add_custom_target(hint ALL
     DEPENDS valkey-server valkey-cli valkey-benchmark
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "Hint: It is a good idea to run tests with your CMake-built binaries \\;\\)"
-    COMMAND ${CMAKE_COMMAND} -E echo "      VALKEY_BIN_DIR=${_VALKEY_BIN_RELATIVE_PATH} ./runtest"
+    COMMAND ${CMAKE_COMMAND} -E echo "      ./${_VALKEY_BIN_RELATIVE_PATH}/runtest"
     COMMAND ${CMAKE_COMMAND} -E echo ""
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,19 +93,3 @@ endif ()
 if (BUILD_UNIT_TESTS)
     add_subdirectory(unit)
 endif ()
-
-# Create symbolic links under src/ directory so that TCL tests can find the binaries
-add_custom_target(link_test_binaries ALL
-    DEPENDS valkey-server valkey-cli valkey-benchmark
-    COMMAND ${CMAKE_COMMAND} -E echo "Creating symlinks under src/ for test environment"
-
-    # Link build binaries into src/
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-server
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-cli> ${CMAKE_SOURCE_DIR}/src/valkey-cli
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-benchmark> ${CMAKE_SOURCE_DIR}/src/valkey-benchmark
-
-    # These aliases all point to valkey-server
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-check-aof
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-check-rdb
-    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:valkey-server> ${CMAKE_SOURCE_DIR}/src/valkey-sentinel
-)

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -2,6 +2,9 @@
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 
+# Set the executable paths at project root
+source tests/support/set_executable_path.tcl
+
 cd tests/cluster
 source cluster.tcl
 source ../instances.tcl

--- a/tests/cluster/tests/04-resharding.tcl
+++ b/tests/cluster/tests/04-resharding.tcl
@@ -84,7 +84,7 @@ test "Cluster consistency during live resharding" {
             flush stdout
             set target [dict get [get_myself [randomInt 5]] id]
             set tribpid [lindex [exec \
-                ../../../src/valkey-cli --cluster reshard \
+                ../../../$::VALKEY_CLI_BIN --cluster reshard \
                 127.0.0.1:[get_instance_attrib valkey 0 port] \
                 --cluster-from all \
                 --cluster-to $target \

--- a/tests/cluster/tests/04-resharding.tcl
+++ b/tests/cluster/tests/04-resharding.tcl
@@ -84,7 +84,7 @@ test "Cluster consistency during live resharding" {
             flush stdout
             set target [dict get [get_myself [randomInt 5]] id]
             set tribpid [lindex [exec \
-                ../../../$::VALKEY_CLI_BIN --cluster reshard \
+                $::VALKEY_CLI_BIN --cluster reshard \
                 127.0.0.1:[get_instance_attrib valkey 0 port] \
                 --cluster-from all \
                 --cluster-to $target \

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -38,7 +38,7 @@ test "Set allow-replica-migration yes" {
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
-        ../../../src/valkey-cli --cluster rebalance \
+        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]
@@ -59,7 +59,7 @@ test "Resharding back some slot to master #0" {
     # new resharding.
     after 10000
     set output [exec \
-        ../../../src/valkey-cli --cluster rebalance \
+        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=.01 \

--- a/tests/cluster/tests/12-replica-migration-2.tcl
+++ b/tests/cluster/tests/12-replica-migration-2.tcl
@@ -38,7 +38,7 @@ test "Set allow-replica-migration yes" {
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
-        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
+        $::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]
@@ -59,7 +59,7 @@ test "Resharding back some slot to master #0" {
     # new resharding.
     after 10000
     set output [exec \
-        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
+        $::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=.01 \

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -37,7 +37,7 @@ test "Set allow-replica-migration no" {
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
-        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
+        $::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]

--- a/tests/cluster/tests/12.1-replica-migration-3.tcl
+++ b/tests/cluster/tests/12.1-replica-migration-3.tcl
@@ -37,7 +37,7 @@ test "Set allow-replica-migration no" {
 set master0_id [dict get [get_myself 0] id]
 test "Resharding all the master #0 slots away from it" {
     set output [exec \
-        ../../../src/valkey-cli --cluster rebalance \
+        ../../../$::VALKEY_CLI_BIN --cluster rebalance \
         127.0.0.1:[get_instance_attrib valkey 0 port] \
         {*}[valkeycli_tls_config "../../../tests"] \
         --cluster-weight ${master0_id}=0 >@ stdout ]

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -8,7 +8,7 @@ proc config_set_all_nodes {keyword value} {
 
 proc fix_cluster {addr} {
     set code [catch {
-        exec ../../../src/valkey-cli {*}[valkeycli_tls_config "../../../tests"] --cluster fix $addr << yes
+        exec ../../../$::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster fix $addr << yes
     } result]
     if {$code != 0} {
         puts "valkey-cli --cluster fix returns non-zero exit code, output below:\n$result"
@@ -17,7 +17,7 @@ proc fix_cluster {addr} {
     # but we can ignore that and rely on the check below.
     assert_cluster_state ok
     wait_for_condition 100 100 {
-        [catch {exec ../../../src/valkey-cli {*}[valkeycli_tls_config "../../../tests"] --cluster check $addr} result] == 0
+        [catch {exec ../../../$::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster check $addr} result] == 0
     } else {
         puts "valkey-cli --cluster check returns non-zero exit code, output below:\n$result"
         fail "Cluster could not settle with configuration"
@@ -26,7 +26,7 @@ proc fix_cluster {addr} {
 
 proc wait_cluster_stable {} {
     wait_for_condition 1000 50 {
-        [catch {exec ../../../src/valkey-cli --cluster \
+        [catch {exec ../../../$::VALKEY_CLI_BIN --cluster \
             check 127.0.0.1:[get_instance_attrib valkey 0 port] \
             {*}[valkeycli_tls_config "../../../tests"] \
             }] == 0

--- a/tests/cluster/tests/includes/utils.tcl
+++ b/tests/cluster/tests/includes/utils.tcl
@@ -8,7 +8,7 @@ proc config_set_all_nodes {keyword value} {
 
 proc fix_cluster {addr} {
     set code [catch {
-        exec ../../../$::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster fix $addr << yes
+        exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster fix $addr << yes
     } result]
     if {$code != 0} {
         puts "valkey-cli --cluster fix returns non-zero exit code, output below:\n$result"
@@ -17,7 +17,7 @@ proc fix_cluster {addr} {
     # but we can ignore that and rely on the check below.
     assert_cluster_state ok
     wait_for_condition 100 100 {
-        [catch {exec ../../../$::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster check $addr} result] == 0
+        [catch {exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "../../../tests"] --cluster check $addr} result] == 0
     } else {
         puts "valkey-cli --cluster check returns non-zero exit code, output below:\n$result"
         fail "Cluster could not settle with configuration"
@@ -26,7 +26,7 @@ proc fix_cluster {addr} {
 
 proc wait_cluster_stable {} {
     wait_for_condition 1000 50 {
-        [catch {exec ../../../$::VALKEY_CLI_BIN --cluster \
+        [catch {exec $::VALKEY_CLI_BIN --cluster \
             check 127.0.0.1:[get_instance_attrib valkey 0 port] \
             {*}[valkeycli_tls_config "../../../tests"] \
             }] == 0

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -48,18 +48,18 @@ if {[catch {cd tmp}]} {
 # the provided configuration file. Returns the PID of the process.
 proc exec_instance {type dirname cfgfile} {
     if {$type eq "valkey"} {
-        set prgname valkey-server
+        set program_path $::VALKEY_SERVER_BIN
     } elseif {$type eq "sentinel"} {
-        set prgname valkey-sentinel
+        set program_path $::VALKEY_SENTINEL_BIN
     } else {
         error "Unknown instance type."
     }
 
     set errfile [file join $dirname err.txt]
     if {$::valgrind} {
-        set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ../../../src/${prgname} $cfgfile 2>> $errfile &]
+        set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ../../../${program_path} $cfgfile 2>> $errfile &]
     } else {
-        set pid [exec ../../../src/${prgname} $cfgfile 2>> $errfile &]
+        set pid [exec ../../../${program_path} $cfgfile 2>> $errfile &]
     }
     return $pid
 }

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -57,9 +57,9 @@ proc exec_instance {type dirname cfgfile} {
 
     set errfile [file join $dirname err.txt]
     if {$::valgrind} {
-        set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ../../../${program_path} $cfgfile 2>> $errfile &]
+        set pid [exec valgrind --track-origins=yes --suppressions=../../../src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full ${program_path} $cfgfile 2>> $errfile &]
     } else {
-        set pid [exec ../../../${program_path} $cfgfile 2>> $errfile &]
+        set pid [exec ${program_path} $cfgfile 2>> $errfile &]
     }
     return $pid
 }

--- a/tests/integration/aof-race.tcl
+++ b/tests/integration/aof-race.tcl
@@ -8,7 +8,7 @@ tags {"aof external:skip"} {
     # was subsequently appended to the new AOF, resulting in duplicate commands.
     start_server_aof [list dir $server_path] {
         set client [valkey [srv host] [srv port] 0 $::tls]
-        set bench [open "|src/valkey-benchmark -q -s [srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
+        set bench [open "|$::VALKEY_BENCHMARK_BIN -q -s [srv unixsocket] -c 20 -n 20000 incr foo" "r+"]
 
         wait_for_condition 100 1 {
             [$client get foo] > 0

--- a/tests/integration/aof.tcl
+++ b/tests/integration/aof.tcl
@@ -109,7 +109,7 @@ tags {"aof external:skip logreqres:skip"} {
     ## Test that valkey-check-aof indeed sees this AOF is not valid
     test "Short read: Utility should confirm the AOF is not valid" {
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*not valid*" $result
     }
@@ -121,13 +121,13 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*ok_up_to_line=8*" $result
     }
 
     test "Short read: Utility should be able to fix the AOF" {
-        set result [exec src/valkey-check-aof --fix $aof_manifest_file << "y\n"]
+        set result [exec $::VALKEY_CHECK_AOF_BIN --fix $aof_manifest_file << "y\n"]
         assert_match "*Successfully truncated AOF*" $result
     }
 
@@ -399,7 +399,7 @@ tags {"aof external:skip logreqres:skip"} {
 
     test {Truncate AOF to specific timestamp} {
         # truncate to timestamp 1628217473
-        exec src/valkey-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file
+        exec $::VALKEY_CHECK_AOF_BIN --truncate-to-timestamp 1628217473 $aof_manifest_file
         start_server_aof [list dir $server_path] {
             set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
@@ -409,7 +409,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         # truncate to timestamp 1628217471
-        exec src/valkey-check-aof --truncate-to-timestamp 1628217471 $aof_manifest_file
+        exec $::VALKEY_CHECK_AOF_BIN --truncate-to-timestamp 1628217471 $aof_manifest_file
         start_server_aof [list dir $server_path] {
             set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
@@ -419,7 +419,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         # truncate to timestamp 1628217470
-        exec src/valkey-check-aof --truncate-to-timestamp 1628217470 $aof_manifest_file
+        exec $::VALKEY_CHECK_AOF_BIN --truncate-to-timestamp 1628217470 $aof_manifest_file
         start_server_aof [list dir $server_path] {
             set c [valkey [srv host] [srv port] 0 $::tls]
             wait_done_loading $c
@@ -428,7 +428,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         # truncate to timestamp 1628217469
-        catch {exec src/valkey-check-aof --truncate-to-timestamp 1628217469 $aof_manifest_file} e
+        catch {exec $::VALKEY_CHECK_AOF_BIN --truncate-to-timestamp 1628217469 $aof_manifest_file} e
         assert_match {*aborting*} $e
     }
 
@@ -478,7 +478,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_file
         } result
         assert_match "*Start checking Old-Style AOF*is valid*" $result
     }
@@ -490,14 +490,14 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_file
         } result
         assert_match "*Start checking Old-Style AOF*is valid*" $result
     }
 
     test {Test valkey-check-aof for old style rdb-preamble AOF} {
         catch {
-            exec src/valkey-check-aof tests/assets/rdb-preamble.aof
+            exec $::VALKEY_CHECK_AOF_BIN tests/assets/rdb-preamble.aof
         } result
         assert_match "*Start checking Old-Style AOF*RDB preamble is OK, proceeding with AOF tail*is valid*" $result
     }
@@ -519,7 +519,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*Start checking Multi Part AOF*Start to check BASE AOF (RESP format)*BASE AOF*is valid*Start to check INCR files*INCR AOF*is valid*All AOF files and manifest are valid*" $result
     }
@@ -538,7 +538,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*Start checking Multi Part AOF*Start to check BASE AOF (RDB format)*DB preamble is OK, proceeding with AOF tail*BASE AOF*is valid*Start to check INCR files*INCR AOF*is valid*All AOF files and manifest are valid*" $result
     }
@@ -551,7 +551,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*Invalid AOF manifest file format*" $result
     }
@@ -574,12 +574,12 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN $aof_manifest_file
         } result
         assert_match "*not valid*" $result
 
         catch {
-            exec src/valkey-check-aof --fix $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN --fix $aof_manifest_file
         } result
         assert_match "*Failed to truncate AOF*because it is not the last file*" $result
     }
@@ -607,7 +607,7 @@ tags {"aof external:skip logreqres:skip"} {
         }
 
         catch {
-            exec src/valkey-check-aof --truncate-to-timestamp 1628217473 $aof_manifest_file
+            exec $::VALKEY_CHECK_AOF_BIN --truncate-to-timestamp 1628217473 $aof_manifest_file
         } result
         assert_match "*Failed to truncate AOF*to timestamp*because it is not the last file*" $result
     }

--- a/tests/integration/psync2-reg.tcl
+++ b/tests/integration/psync2-reg.tcl
@@ -40,7 +40,7 @@ start_server {} {
     }
 
     set cycle_start_time [clock milliseconds]
-    set bench_pid [exec src/valkey-benchmark -s $R_unixsocket(0) -n 10000000 -r 1000 incr __rand_int__ > /dev/null &]
+    set bench_pid [exec $::VALKEY_BENCHMARK_BIN -s $R_unixsocket(0) -n 10000000 -r 1000 incr __rand_int__ > /dev/null &]
     while 1 {
         set elapsed [expr {[clock milliseconds]-$cycle_start_time}]
         if {$elapsed > $duration*1000} break

--- a/tests/integration/valkey-check-rdb.tcl
+++ b/tests/integration/valkey-check-rdb.tcl
@@ -5,14 +5,14 @@ proc get_function_code {args} {
 tags {"check-rdb external:skip logreqres:skip"} {
     test {Check old valid RDB} {
         catch {
-            exec src/valkey-check-rdb tests/assets/encodings.rdb
+            exec $::VALKEY_CHECK_RDB_BIN tests/assets/encodings.rdb
         } result
         assert_match {*\[offset ???\] \\o/ RDB looks OK! \\o/*} $result
     }
 
     test {Check foreign RDB without unknown data} {
         catch {
-            exec src/valkey-check-rdb tests/assets/encodings-rdb12.rdb
+            exec $::VALKEY_CHECK_RDB_BIN tests/assets/encodings-rdb12.rdb
         } result
         assert_match {*\[offset ?\] Foreign RDB version 12 detected*} $result
         assert_match {*\[offset ???\] \\o/ RDB looks OK, but loading requires config 'rdb-version-check relaxed'*} $result
@@ -20,7 +20,7 @@ tags {"check-rdb external:skip logreqres:skip"} {
 
     test {Check foreign RDB with unknown data} {
         catch {
-            exec src/valkey-check-rdb tests/assets/encodings-rdb75-unknown-types.rdb
+            exec $::VALKEY_CHECK_RDB_BIN tests/assets/encodings-rdb75-unknown-types.rdb
         } result
         assert_match {*\[offset ?\] Foreign RDB version 75 detected*} $result
         assert_match {*--- RDB ERROR DETECTED ---*} $result
@@ -30,7 +30,7 @@ tags {"check-rdb external:skip logreqres:skip"} {
 
     test {Check future RDB without unknown data} {
         catch {
-            exec src/valkey-check-rdb tests/assets/encodings-rdb987.rdb
+            exec $::VALKEY_CHECK_RDB_BIN tests/assets/encodings-rdb987.rdb
         } result
         assert_match {*\[offset ?\] Future RDB version 987 detected*} $result
         assert_match {*\[offset ???\] \\o/ RDB looks OK, but loading requires config 'rdb-version-check relaxed'*} $result
@@ -38,7 +38,7 @@ tags {"check-rdb external:skip logreqres:skip"} {
 
     test {Check future RDB with unknown data} {
         catch {
-            exec src/valkey-check-rdb tests/assets/encodings-rdb987-unknown-types.rdb
+            exec $::VALKEY_CHECK_RDB_BIN tests/assets/encodings-rdb987-unknown-types.rdb
         } result
         assert_match {*\[offset ?\] Future RDB version 987 detected*} $result
         assert_match {*--- RDB ERROR DETECTED ---*} $result
@@ -54,7 +54,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             r save
             set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
             catch {
-                exec src/valkey-check-rdb $dump_rdb --stats --format info
+                exec $::VALKEY_CHECK_RDB_BIN $dump_rdb --stats --format info
             } result
             assert_match "*db.0.type.string.keys.total:0*" $result
             assert_match "*db.0.type.list.keys.total:0*" $result
@@ -73,7 +73,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             
             set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
             catch {
-                exec src/valkey-check-rdb $dump_rdb
+                exec $::VALKEY_CHECK_RDB_BIN $dump_rdb
             } result
             assert_match "*$function_num functions*" $result
         }
@@ -130,7 +130,7 @@ tags {"check-rdb network external:skip logreqres:skip"} {
             
             set dump_rdb [file join [lindex [r config get dir] 1] dump.rdb]
             catch {
-                exec src/valkey-check-rdb $dump_rdb --stats --format info
+                exec $::VALKEY_CHECK_RDB_BIN $dump_rdb --stats --format info
             } result
 
             assert_match "*db.0.type.string.keys.total:10*" $result

--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -2,6 +2,9 @@
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 
+# Set the executable paths at project root
+source tests/support/set_executable_path.tcl
+
 cd tests/sentinel
 source ../instances.tcl
 

--- a/tests/support/benchmark.tcl
+++ b/tests/support/benchmark.tcl
@@ -12,21 +12,21 @@ proc valkeybenchmark_tls_config {testsdir} {
 }
 
 proc valkeybenchmark {host port {opts {}}} {
-    set cmd [list src/valkey-benchmark -h $host -p $port]
+    set cmd [list $::VALKEY_BENCHMARK_BIN -h $host -p $port]
     lappend cmd {*}[valkeybenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
 }
 
 proc valkeybenchmarkuri {host port {opts {}}} {
-    set cmd [list src/valkey-benchmark -u valkey://$host:$port]
+    set cmd [list $::VALKEY_BENCHMARK_BIN -u valkey://$host:$port]
     lappend cmd {*}[valkeybenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
 }
 
 proc valkeybenchmarkuriuserpass {host port user pass {opts {}}} {
-    set cmd [list src/valkey-benchmark -u valkey://$user:$pass@$host:$port]
+    set cmd [list $::VALKEY_BENCHMARK_BIN -u valkey://$user:$pass@$host:$port]
     lappend cmd {*}[valkeybenchmark_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd

--- a/tests/support/cli.tcl
+++ b/tests/support/cli.tcl
@@ -13,14 +13,14 @@ proc valkeycli_tls_config {testsdir} {
 
 # Returns command line for executing valkey-cli
 proc valkeycli {host port {opts {}}} {
-    set cmd [list src/valkey-cli -h $host -p $port]
+    set cmd [list $::VALKEY_CLI_BIN -h $host -p $port]
     lappend cmd {*}[valkeycli_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
 }
 
 proc valkeycliuri {scheme host port {opts {}}} {
-    set cmd [list src/valkey-cli -u $scheme$host:$port]
+    set cmd [list $::VALKEY_CLI_BIN -u $scheme$host:$port]
     lappend cmd {*}[valkeycli_tls_config "tests"]
     lappend cmd {*}$opts
     return $cmd
@@ -28,7 +28,7 @@ proc valkeycliuri {scheme host port {opts {}}} {
 
 # Returns command line for executing valkey-cli with a unix socket address
 proc valkeycli_unixsocket {unixsocket {opts {}}} {
-    return [list src/valkey-cli -s $unixsocket {*}$opts]
+    return [list $::VALKEY_CLI_BIN -s $unixsocket {*}$opts]
 }
 
 # Run valkey-cli with specified args on the server of specified level.

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -70,7 +70,7 @@ proc cluster_find_available_replica {first} {
 
 proc fix_cluster {addr} {
     set code [catch {
-        exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster fix $addr << yes
+        exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "./tests"] --cluster fix $addr << yes
     } result]
     if {$code != 0} {
         puts "valkey-cli --cluster fix returns non-zero exit code, output below:\n$result"
@@ -79,7 +79,7 @@ proc fix_cluster {addr} {
     # but we can ignore that and rely on the check below.
     wait_for_cluster_state ok
     wait_for_condition 100 100 {
-        [catch {exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster check $addr} result] == 0
+        [catch {exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "./tests"] --cluster check $addr} result] == 0
     } else {
         puts "valkey-cli --cluster check returns non-zero exit code, output below:\n$result"
         fail "Cluster could not settle with configuration"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -530,7 +530,7 @@ proc start_server {options {code undefined}} {
     if {$start_other_server} {
         set executable $::other_server_path
     } else {
-        set executable "src/valkey-server"
+        set executable $::VALKEY_SERVER_BIN
     }
     if {![file executable $executable]} {
         error "Server executable file not found or not executable: $executable"

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -1,13 +1,15 @@
 # Set the directory to find Valkey binaries for tests. Historically we've been
 # using make to build binaries under the src/ directory. Since we start supporting
-# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`
-set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "src"}]
+# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`.
+# This must be an absolute path.
+set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "[pwd]/src"}]
+puts "VALKEY_BIN_DIR is set to $VALKEY_BIN_DIR"
 
 # Helper to build absolute paths
 proc __build_absolute_path {name} {
     set p [file join $::VALKEY_BIN_DIR $name]
     if {![file executable $p]} {
-        error "Binary not found or not executable: $p (VALKEY_BIN_DIR=$::VALKEY_BIN_DIR)"
+        error "Binary not found or not executable: $p \nDo you intend to run the binaries built from Make or CMake?"
     }
     return $p
 }

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -1,0 +1,21 @@
+# Set the directory to find Valkey binaries for tests. Historically we've been
+# using make to build binaries under the src/ directory. Since we start supporting
+# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`
+set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "src"}]
+puts "::VALKEY_BIN_DIR is $::VALKEY_BIN_DIR"
+
+# Helper to build absolute paths
+proc __build_absolute_path {name} {
+    set p [file join $::VALKEY_BIN_DIR $name]
+    if {![file executable $p]} {
+        error "Binary not found or not executable: $p (VALKEY_BIN_DIR=$::VALKEY_BIN_DIR)"
+    }
+    return $p
+}
+
+set ::VALKEY_SERVER_BIN    [__build_absolute_path "valkey-server"]
+set ::VALKEY_CLI_BIN       [__build_absolute_path "valkey-cli"]
+set ::VALKEY_BENCHMARK_BIN [__build_absolute_path "valkey-benchmark"]
+set ::VALKEY_CHECK_AOF_BIN [__build_absolute_path "valkey-check-aof"]
+set ::VALKEY_CHECK_RDB_BIN [__build_absolute_path "valkey-check-rdb"]
+set ::VALKEY_SENTINEL_BIN  [__build_absolute_path "valkey-sentinel"]

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -1,8 +1,12 @@
 # Set the directory to find Valkey binaries for tests. Historically we've been
 # using make to build binaries under the src/ directory. Since we start supporting
-# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`.
-# This must be an absolute path.
-set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "[pwd]/src"}]
+# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`,
+# which could be either absolute or relative path (e.g. cmake-build-debug/bin).
+if {[info exists ::env(VALKEY_BIN_DIR)]} {
+    set ::VALKEY_BIN_DIR [file normalize $::env(VALKEY_BIN_DIR)]
+} else {
+    set ::VALKEY_BIN_DIR "[pwd]/src"
+}
 
 # Helper to build absolute paths
 proc valkey_bin_absolute_path {name} {

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -2,7 +2,6 @@
 # using make to build binaries under the src/ directory. Since we start supporting
 # CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`
 set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "src"}]
-puts "::VALKEY_BIN_DIR is $::VALKEY_BIN_DIR"
 
 # Helper to build absolute paths
 proc __build_absolute_path {name} {

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -3,20 +3,20 @@
 # CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`.
 # This must be an absolute path.
 set ::VALKEY_BIN_DIR [expr {[info exists ::env(VALKEY_BIN_DIR)] ? $::env(VALKEY_BIN_DIR) : "[pwd]/src"}]
-puts "VALKEY_BIN_DIR is set to $VALKEY_BIN_DIR"
 
 # Helper to build absolute paths
-proc __build_absolute_path {name} {
+proc valkey_bin_absolute_path {name} {
     set p [file join $::VALKEY_BIN_DIR $name]
-    if {![file executable $p]} {
-        error "Binary not found or not executable: $p \nDo you intend to run the binaries built from Make or CMake?"
-    }
     return $p
 }
 
-set ::VALKEY_SERVER_BIN    [__build_absolute_path "valkey-server"]
-set ::VALKEY_CLI_BIN       [__build_absolute_path "valkey-cli"]
-set ::VALKEY_BENCHMARK_BIN [__build_absolute_path "valkey-benchmark"]
-set ::VALKEY_CHECK_AOF_BIN [__build_absolute_path "valkey-check-aof"]
-set ::VALKEY_CHECK_RDB_BIN [__build_absolute_path "valkey-check-rdb"]
-set ::VALKEY_SENTINEL_BIN  [__build_absolute_path "valkey-sentinel"]
+set ::VALKEY_SERVER_BIN    [valkey_bin_absolute_path "valkey-server"]
+set ::VALKEY_CLI_BIN       [valkey_bin_absolute_path "valkey-cli"]
+set ::VALKEY_BENCHMARK_BIN [valkey_bin_absolute_path "valkey-benchmark"]
+set ::VALKEY_CHECK_AOF_BIN [valkey_bin_absolute_path "valkey-check-aof"]
+set ::VALKEY_CHECK_RDB_BIN [valkey_bin_absolute_path "valkey-check-rdb"]
+set ::VALKEY_SENTINEL_BIN  [valkey_bin_absolute_path "valkey-sentinel"]
+
+if {![file executable $::VALKEY_SERVER_BIN]} {
+    error "Binary not found or not executable: $::VALKEY_SERVER_BIN"
+}

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -1226,7 +1226,7 @@ proc system_backtrace_supported {} {
     # libmusl does not support backtrace. Also return 0 on
     # static binaries (ldd exit code 1) where we can't detect libmusl
     catch {
-        set ldd [exec ldd src/valkey-server]
+        set ldd [exec ldd $::VALKEY_SERVER_BIN]
         if {![string match {*libc.*musl*} $ldd]} {
             return 1
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -10,6 +10,7 @@ source tests/support/cluster_util.tcl
 source tests/support/tmpfile.tcl
 source tests/support/test.tcl
 source tests/support/util.tcl
+source tests/support/set_executable_path.tcl
 
 set dir [pwd]
 set ::all_tests []

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1227,10 +1227,10 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
     }
     
     test {Test loading duplicate users in config on startup} {
-        catch {exec src/valkey-server --user foo --user foo} err
+        catch {exec $::VALKEY_SERVER_BIN --user foo --user foo} err
         assert_match {*Duplicate user*} $err
 
-        catch {exec src/valkey-server --user default --user default} err
+        catch {exec $::VALKEY_SERVER_BIN --user default --user default} err
         assert_match {*Duplicate user*} $err
     } {} {external:skip}
 }

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -8,7 +8,7 @@ tags {tls:skip external:skip cluster singledb} {
 set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
 start_multiple_servers 3 [list overrides $base_conf] {
     test {Create 1 node cluster} {
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                             127.0.0.1:[srv 0 port]
 
         wait_for_condition 1000 50 {
@@ -19,7 +19,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
     }
 
     test {Create 2 node cluster} {
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                             127.0.0.1:[srv -1 port] \
                             127.0.0.1:[srv -2 port]
 
@@ -43,7 +43,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
     set node3_rd [valkey_deferring_client -2]
 
     test {Create 3 node cluster} {
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
                            127.0.0.1:[srv -1 port] \
                            127.0.0.1:[srv -2 port]
@@ -70,7 +70,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
     }
 
     test "Perform a Resharding" {
-        exec src/valkey-cli --cluster-yes --cluster reshard 127.0.0.1:[srv -2 port] \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster reshard 127.0.0.1:[srv -2 port] \
                            --cluster-to [$node1 cluster myid] \
                            --cluster-from [$node3 cluster myid] \
                            --cluster-slots 1
@@ -91,9 +91,9 @@ start_multiple_servers 3 [list overrides $base_conf] {
         # waiting for cluster_state to be okay is an independent check that all the
         # nodes actually believe each other are healthy, prevent cluster down error.
         wait_for_condition 1000 50 {
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
             [CI 0 cluster_state] eq {ok} &&
             [CI 1 cluster_state] eq {ok} &&
             [CI 2 cluster_state] eq {ok}
@@ -115,8 +115,8 @@ start_multiple_servers 3 [list overrides $base_conf] {
         assert_error "*MOVED $slot_for_foo :*" {$node1 set foo bar}
 
         # when in cluster mode, redirect using previous hostip
-        assert_equal "[exec src/valkey-cli -h 127.0.0.1 -p [srv 0 port] -c set foo bar]" {OK}
-        assert_match "[exec src/valkey-cli -h 127.0.0.1 -p [srv 0 port] -c get foo]" {bar}
+        assert_equal "[exec $::VALKEY_CLI_BIN -h 127.0.0.1 -p [srv 0 port] -c set foo bar]" {OK}
+        assert_match "[exec $::VALKEY_CLI_BIN -h 127.0.0.1 -p [srv 0 port] -c get foo]" {bar}
 
         assert_equal [$node1 CONFIG SET cluster-preferred-endpoint-type "$endpoint_type_before_set"]  {OK}
     }
@@ -187,7 +187,7 @@ start_multiple_servers 5 [list overrides $base_conf] {
     set node5_rd [valkey_client -4]
 
     test {Functions are added to new node on valkey-cli cluster add-node} {
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
                            127.0.0.1:[srv -1 port] \
                            127.0.0.1:[srv -2 port]
@@ -202,13 +202,13 @@ start_multiple_servers 5 [list overrides $base_conf] {
         }
 
         # upload a function to all the cluster
-        exec src/valkey-cli --cluster-yes --cluster call 127.0.0.1:[srv 0 port] \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster call 127.0.0.1:[srv 0 port] \
                            FUNCTION LOAD {#!lua name=TEST
                                server.register_function('test', function() return 'hello' end)
                            }
 
         # adding node to the cluster
-        exec src/valkey-cli --cluster-yes --cluster add-node \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster add-node \
                        127.0.0.1:[srv -3 port] \
                        127.0.0.1:[srv 0 port]
 
@@ -236,7 +236,7 @@ start_multiple_servers 5 [list overrides $base_conf] {
 
         # adding node 5 to the cluster should failed because it already contains the 'test' function
         catch {
-            exec src/valkey-cli --cluster-yes --cluster add-node \
+            exec $::VALKEY_CLI_BIN --cluster-yes --cluster add-node \
                         127.0.0.1:[srv -4 port] \
                         127.0.0.1:[srv 0 port]
         } e
@@ -250,7 +250,7 @@ test {Migrate the last slot away from a node using valkey-cli} {
     start_multiple_servers 4 [list overrides $base_conf] {
 
         # Create a cluster of 3 nodes
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
                            127.0.0.1:[srv -1 port] \
                            127.0.0.1:[srv -2 port]
@@ -264,11 +264,11 @@ test {Migrate the last slot away from a node using valkey-cli} {
         }
 
         # Insert some data
-        assert_equal OK [exec src/valkey-cli -c -p [srv 0 port] SET foo bar]
-        set slot [exec src/valkey-cli -c -p [srv 0 port] CLUSTER KEYSLOT foo]
+        assert_equal OK [exec $::VALKEY_CLI_BIN -c -p [srv 0 port] SET foo bar]
+        set slot [exec $::VALKEY_CLI_BIN -c -p [srv 0 port] CLUSTER KEYSLOT foo]
 
         # Add new node to the cluster
-        exec src/valkey-cli --cluster-yes --cluster add-node \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster add-node \
                      127.0.0.1:[srv -3 port] \
                      127.0.0.1:[srv 0 port]
         
@@ -306,10 +306,10 @@ test {Migrate the last slot away from a node using valkey-cli} {
         # Using --cluster check make sure we won't get `Not all slots are covered by nodes`.
         # Wait for the cluster to become stable make sure the cluster is up during MIGRATE.
         wait_for_condition 1000 50 {
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -3 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -3 port]}] == 0 &&
             [CI 0 cluster_state] eq {ok} &&
             [CI 1 cluster_state] eq {ok} &&
             [CI 2 cluster_state] eq {ok} &&
@@ -319,7 +319,7 @@ test {Migrate the last slot away from a node using valkey-cli} {
         }
 
         # Move the only slot back to original node using valkey-cli
-        exec src/valkey-cli --cluster reshard 127.0.0.1:[srv -3 port] \
+        exec $::VALKEY_CLI_BIN --cluster reshard 127.0.0.1:[srv -3 port] \
             --cluster-from $newnode_id \
             --cluster-to $owner_id \
             --cluster-slots 1 \
@@ -361,7 +361,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
     # The last two are used to test --cluster add-node
 
     test "valkey-cli -4 --cluster create using $ip_or_localhost with cluster-port" {
-        exec src/valkey-cli -4 --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN -4 --cluster-yes --cluster create \
                            $ip_or_localhost:[srv 0 port] \
                            $ip_or_localhost:[srv -1 port] \
                            $ip_or_localhost:[srv -2 port]
@@ -382,7 +382,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 
     test "valkey-cli -4 --cluster add-node using $ip_or_localhost with cluster-port" {
         # Adding node to the cluster (without cluster-port)
-        exec src/valkey-cli -4 --cluster-yes --cluster add-node \
+        exec $::VALKEY_CLI_BIN -4 --cluster-yes --cluster add-node \
                            $ip_or_localhost:[srv -3 port] \
                            $ip_or_localhost:[srv 0 port]
 
@@ -398,7 +398,7 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
         }
 
         # Adding node to the cluster (with cluster-port)
-        exec src/valkey-cli -4 --cluster-yes --cluster add-node \
+        exec $::VALKEY_CLI_BIN -4 --cluster-yes --cluster add-node \
                            $ip_or_localhost:[srv -4 port] \
                            $ip_or_localhost:[srv 0 port]
 
@@ -440,7 +440,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
     set node3_rd [valkey_deferring_client -2]
 
     test {Create 3 node cluster} {
-        exec src/valkey-cli --cluster-yes --cluster create \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
                            127.0.0.1:[srv 0 port] \
                            127.0.0.1:[srv -1 port] \
                            127.0.0.1:[srv -2 port]
@@ -481,7 +481,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
     test "Perform a Multi-database Resharding" {
         # 4 batches to migrate 100 keys
         for {set i 0} {$i < 4} {incr i} {
-            exec src/valkey-cli --cluster-yes --cluster reshard 127.0.0.1:[srv 0 port] \
+            exec $::VALKEY_CLI_BIN --cluster-yes --cluster reshard 127.0.0.1:[srv 0 port] \
                                 --cluster-to [$node3 cluster myid] \
                                 --cluster-from [$node1 cluster myid] \
                                 --cluster-pipeline 25 \

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -40,7 +40,7 @@ proc test_migrated_replica {type} {
         set addr "[srv 0 host]:[srv 0 port]"
         set myid [R 3 CLUSTER MYID]
         set code [catch {
-            exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
+            exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
         } result]
         if {$code != 0} {
             fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"
@@ -256,7 +256,7 @@ proc test_sub_replica {type} {
         set addr "[srv 0 host]:[srv 0 port]"
         set myid [R 3 CLUSTER MYID]
         set code [catch {
-            exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
+            exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
         } result]
         if {$code != 0} {
             fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"
@@ -371,7 +371,7 @@ proc test_cluster_setslot {type} {
         set addr "[srv 0 host]:[srv 0 port]"
         set myid [R 3 CLUSTER MYID]
         set code [catch {
-            exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
+            exec $::VALKEY_CLI_BIN {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $myid=0
         } result]
         if {$code != 0} {
             fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1503,44 +1503,44 @@ start_server {tags {"introspection"}} {
 
     test {valkey-server command line arguments - error cases} {
         # Take '--invalid' as the option.
-        catch {exec src/valkey-server --invalid} err
+        catch {exec $::VALKEY_SERVER_BIN --invalid} err
         assert_match {*Bad directive or wrong number of arguments*} $err
 
-        catch {exec src/valkey-server --port} err
+        catch {exec $::VALKEY_SERVER_BIN --port} err
         assert_match {*'port'*wrong number of arguments*} $err
 
-        catch {exec src/valkey-server --port 6380 --loglevel} err
+        catch {exec $::VALKEY_SERVER_BIN --port 6380 --loglevel} err
         assert_match {*'loglevel'*wrong number of arguments*} $err
 
         # Take `6379` and `6380` as the port option value.
-        catch {exec src/valkey-server --port 6379 6380} err
+        catch {exec $::VALKEY_SERVER_BIN --port 6379 6380} err
         assert_match {*'port "6379" "6380"'*wrong number of arguments*} $err
 
         # Take `--loglevel` and `verbose` as the port option value.
-        catch {exec src/valkey-server --port --loglevel verbose} err
+        catch {exec $::VALKEY_SERVER_BIN --port --loglevel verbose} err
         assert_match {*'port "--loglevel" "verbose"'*wrong number of arguments*} $err
 
         # Take `--bla` as the port option value.
-        catch {exec src/valkey-server --port --bla --loglevel verbose} err
+        catch {exec $::VALKEY_SERVER_BIN --port --bla --loglevel verbose} err
         assert_match {*'port "--bla"'*argument couldn't be parsed into an integer*} $err
 
         # Take `--bla` as the loglevel option value.
-        catch {exec src/valkey-server --logfile --my--log--file --loglevel --bla} err
+        catch {exec $::VALKEY_SERVER_BIN --logfile --my--log--file --loglevel --bla} err
         assert_match {*'loglevel "--bla"'*argument(s) must be one of the following*} $err
 
         # Using MULTI_ARG's own check, empty option value
-        catch {exec src/valkey-server --shutdown-on-sigint} err
+        catch {exec $::VALKEY_SERVER_BIN --shutdown-on-sigint} err
         assert_match {*'shutdown-on-sigint'*argument(s) must be one of the following*} $err
-        catch {exec src/valkey-server --shutdown-on-sigint "now force" --shutdown-on-sigterm} err
+        catch {exec $::VALKEY_SERVER_BIN --shutdown-on-sigint "now force" --shutdown-on-sigterm} err
         assert_match {*'shutdown-on-sigterm'*argument(s) must be one of the following*} $err
 
         # Something like `valkey-server --some-config --config-value1 --config-value2 --loglevel debug` would break,
         # because if you want to pass a value to a config starting with `--`, it can only be a single value.
-        catch {exec src/valkey-server --replicaof 127.0.0.1 abc} err
+        catch {exec $::VALKEY_SERVER_BIN --replicaof 127.0.0.1 abc} err
         assert_match {*'replicaof "127.0.0.1" "abc"'*Invalid primary port*} $err
-        catch {exec src/valkey-server --replicaof --127.0.0.1 abc} err
+        catch {exec $::VALKEY_SERVER_BIN --replicaof --127.0.0.1 abc} err
         assert_match {*'replicaof "--127.0.0.1" "abc"'*Invalid primary port*} $err
-        catch {exec src/valkey-server --replicaof --127.0.0.1 --abc} err
+        catch {exec $::VALKEY_SERVER_BIN --replicaof --127.0.0.1 --abc} err
         assert_match {*'replicaof "--127.0.0.1"'*wrong number of arguments*} $err
     } {} {external:skip}
 

--- a/tests/unit/moduleapi/cluster.tcl
+++ b/tests/unit/moduleapi/cluster.tcl
@@ -78,7 +78,7 @@ start_cluster 3 0 [list config_lines $modules] {
 
 
     test "Perform a Resharding" {
-        exec src/valkey-cli --cluster-yes --cluster reshard 127.0.0.1:[srv -2 port] \
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster reshard 127.0.0.1:[srv -2 port] \
                            --cluster-to [$node1 cluster myid] \
                            --cluster-from [$node3 cluster myid] \
                            --cluster-slots 1
@@ -104,9 +104,9 @@ start_cluster 3 0 [list config_lines $modules] {
 
     test "Wait for cluster to be stable" {
         wait_for_condition 1000 50 {
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
             [CI 0 cluster_state] eq {ok} &&
             [CI 1 cluster_state] eq {ok} &&
             [CI 2 cluster_state] eq {ok}

--- a/tests/unit/moduleapi/moduleconfigs.tcl
+++ b/tests/unit/moduleapi/moduleconfigs.tcl
@@ -231,15 +231,15 @@ start_server {tags {"modules"}} {
     }
     test {startup moduleconfigs} {
         # No loadmodule directive
-        catch {exec src/valkey-server --moduleconfigs.string "hello"} err
+        catch {exec $::VALKEY_SERVER_BIN --moduleconfigs.string "hello"} err
         assert_match {*Module Configuration detected without loadmodule directive or no ApplyConfig call: aborting*} $err
 
         # Bad config value
-        catch {exec src/valkey-server --loadmodule "$testmodule" --moduleconfigs.string "rejectisfreed"} err
+        catch {exec $::VALKEY_SERVER_BIN --loadmodule "$testmodule" --moduleconfigs.string "rejectisfreed"} err
         assert_match {*Issue during loading of configuration moduleconfigs.string : Cannot set string to 'rejectisfreed'*} $err
 
         # missing LoadConfigs call
-        catch {exec src/valkey-server --loadmodule "$testmodule" noload --moduleconfigs.string "hello"} err
+        catch {exec $::VALKEY_SERVER_BIN --loadmodule "$testmodule" noload --moduleconfigs.string "hello"} err
         assert_match {*Module Configurations were not set, likely a missing LoadConfigs call. Unloading the module.*} $err
 
         # successful


### PR DESCRIPTION
Historically, Valkey’s TCL test suite expected all binaries (src/valkey-server, src/valkey-cli, src/valkey-benchmark, etc.) to exist under the src/ directory. This PR enables Valkey TCL tests to run seamlessly after a CMake build — no manual symlinks or make build required.

The test framework accepts a new environment variable `VALKEY_BIN_DIR` to look for the binaries.

CMake will copy all TCL test entrypoints (runtest, runtest-cluster, etc.) into the CMake build dir (e.g. `cmake-build-debug`) and insert `VALKEY_BIN_DIR` into these. Now we can either do ./cmake-build-debug/runtest at the project root or ./runtest at the Cmake dir to run all tests.

A new CMake post-build target prints a friendly reminder after successful builds, guiding developers on how to run tests with their CMake binaries:

```
Hint: It is a good idea to run tests with your CMake-built binaries ;)
      ./cmake-build-debug/runtest

Build finished
```

A helper TCL script `tests/support/set_executable_path.tcl` is added to support this change, which gets called by all test entrypoints: `runtest`, `runtest-cluster`, `runtest-sentinel`.