### PR TITLE
Update dual channel replication conf to mention the local buffer is imited by COB

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -3203,7 +3203,10 @@ void bufferReplData(connection *conn) {
         if (readlen && remaining_bytes == 0) {
             if (server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes &&
                 server.pending_repl_data.len > server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes) {
-                dualChannelServerLog(LL_NOTICE, "Replication buffer limit reached, stopping buffering.");
+                dualChannelServerLog(LL_NOTICE,
+                                     "Replication buffer limit reached (%llu bytes), stopping buffering. "
+                                     "Further accumulation will occur on primary side.",
+                                     server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes);
                 /* Stop accumulating primary commands. */
                 connSetReadHandler(conn, NULL);
                 break;

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -431,7 +431,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
                 populate 10000 primary 10; # set ~ 100kb
                 # Wait for replica's buffer limit reached
                 wait_for_condition 50 1000 {
-                    [log_file_matches $replica1_log "*Replication buffer limit reached, stopping buffering*"]
+                    [log_file_matches $replica1_log "*Replication buffer limit reached (*), stopping buffering*"]
                 } else {
                     fail "Replica buffer should fill"
                 }

--- a/valkey.conf
+++ b/valkey.conf
@@ -818,6 +818,12 @@ repl-diskless-load disabled
 # generally beneficial as it prevents potential performance degradation on the primary
 # server, which is typically handling more critical operations.
 #
+# During the dual channel full sync, the maximum size of the local replication buffer
+# on the replica is limited by the hard limit of the replica client output buffer on
+# the replica side. When the replica reaches the limit, it will stop accumulating the
+# further data. At this point, any additional data accumulation will occur on primary
+# side, which is depending on the replica client output buffer on the primary side.
+#
 # When toggling this configuration on or off during an ongoing synchronization process,
 # it does not change the already running sync method. The new configuration will take
 # effect only for subsequent synchronization processes.


### PR DESCRIPTION
After introducing the dual channel replication in #60, we decided in #915
not to add a new configuration item to limit the replica's local replication
buffer, just use "client-output-buffer-limit replica hard" to limit it.

We need to document this behavior and mention that once the limit is reached,
all future data will accumulate in the primary side.