### PR TITLE
Use the scripting engine fake client in VM_Call

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6635,7 +6635,7 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
          * CLIENT PAUSE WRITE. */
         if (is_running_script && scriptIsReadOnly() && (cmd_flags & (CMD_WRITE | CMD_MAY_REPLICATE))) {
             errno = ENOSPC;
-            reply_error_msg = sdsnew("Write commands are not allowed from read-only scripts");
+            reply_error_msg = sdsnew("Write commands are not allowed from read-only scripts.");
             goto cleanup;
         }
 

--- a/src/module.c
+++ b/src/module.c
@@ -899,6 +899,8 @@ void moduleFreeContext(ValkeyModuleCtx *ctx) {
         moduleReleaseTempClient(ctx->client);
     else if (ctx->flags & VALKEYMODULE_CTX_NEW_CLIENT)
         freeClient(ctx->client);
+    else if (ctx->flags & VALKEYMODULE_CTX_SCRIPT_EXECUTION)
+        ctx->client = NULL; /* Do not free the client, it was assigned manually. */
 }
 
 static CallReply *moduleParseReply(client *c, ValkeyModuleCtx *ctx) {
@@ -6438,7 +6440,14 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
      * execution runtime must exist.. */
     serverAssert(!is_running_script || scriptIsRunning());
 
-    c = moduleAllocTempClient();
+    if (is_running_script) {
+        /* When running a script the context client is already a fake client
+         * prepared for running a command on behalf of the real client.
+         * This preparation is done by the scriptPrepareForRun() in script.c */
+        c = scriptGetClient();
+    } else {
+        c = moduleAllocTempClient();
+    }
 
     if (!(flags & VALKEYMODULE_ARGV_ALLOW_BLOCK)) {
         /* We do not want to allow block, the module do not expect it */
@@ -6773,7 +6782,12 @@ cleanup:
 
     if (reply) autoMemoryAdd(ctx, VALKEYMODULE_AM_REPLY, reply);
     if (ctx->module) ctx->module->in_call--;
-    if (c) moduleReleaseTempClient(c);
+    if (is_running_script) {
+        freeClientArgv(c);
+    }
+    else if (c) {
+        moduleReleaseTempClient(c);
+    }
     return reply;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -6510,11 +6510,6 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
     cmd_flags = getCommandFlags(c);
 
     if (flags & VALKEYMODULE_ARGV_SCRIPT_MODE) {
-        if (is_running_script) {
-            c->flag.module = 0;
-            c->flag.script = 1;
-        }
-
         /* In script mode, commands with CMD_NOSCRIPT flag are normally forbidden.
          * However, we allow them if both conditions are met:
          * 1. We're running in the context of a scripting engine running a script

--- a/src/module.c
+++ b/src/module.c
@@ -6784,8 +6784,7 @@ cleanup:
     if (ctx->module) ctx->module->in_call--;
     if (is_running_script) {
         freeClientArgv(c);
-    }
-    else if (c) {
+    } else if (c) {
         moduleReleaseTempClient(c);
     }
     return reply;


### PR DESCRIPTION
The scripting engine runtime has a fake client that can be used to call commands inside the scripts, and is re-used throughout the scripting engine life cycle.

The `VM_Call` implementation uses a temporary client from a client cache to run a command, but when running `VM_Call` in the context of a script, we don't need to get a temporary client from the cache, and can use the scripting engine client that was already prepared to run the command by the `scriptPrepareForRun()` function in `script.c`.

This commit makes this small change in `VM_Call` to use the scripting engine client instead of a temporary client from the client cache.