### PR TITLE
Fix Test dual-channel: primary tracking replica backlog refcount

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -620,7 +620,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica2 debug pause-after-fork 1
             test "Test dual-channel: primary tracking replica backlog refcount - start with empty backlog" {
                 $replica1 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 40 100]
                 set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
@@ -637,7 +637,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test dual-channel: primary tracking replica backlog refcount - start with backlog" {
                 $replica2 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 40 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1


### PR DESCRIPTION
This increases the times we check for the logs from 20 to 40.

I found that every `wait-for` check takes about 1.5 to 1.57 milliseconds so when we were checking 2000 times after 1ms we were actually spending (2000 * 1) + (2000 *1.75) = 5500ms time waiting.
this can be founds under: for 10 checks we took 35 ms more so thats around 1.75 ms per check
```
Execution time: 2034 ms (failed)
[err]: 20 100 - Test dual-channel: primary tracking replica backlog refcount - start with empty backlog in tests/integration/dual-channel-replication-flaky.tcl
```

That is why increasing it to 40 100 will check for approx 4,070 ms which is still less than the original 5500ms but should passes every single time here: https://github.com/roshkhatri/valkey/actions/runs/19279424967/job/55126976882

