### PR TITLE
Backport: Fix potential infinite loop in clusterNodeGetMaster

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -7746,8 +7746,12 @@ unsigned int countKeysInSlot(unsigned int hashslot) {
 }
 
 clusterNode *clusterNodeGetMaster(clusterNode *node) {
-    while (node->slaveof != NULL) node = node->slaveof;
-    return node;
+    clusterNode *master = node; 
+    while (master->slaveof != NULL) {
+        master = master->slaveof;
+        if (master == node) break; 
+    } 
+    return master;
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
Issue #609 is marked as completed (fixed by #651); however, the fix is only present in versions 8.0 and above. 

This PR backports the fix into the 7.2 branch