### PR TITLE
Remove the EXAT and PXAT from some HFE notifications tests

### DIFF
--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -2993,7 +2993,7 @@ start_server {tags {"hashexpire external:skip"}} {
     }
 
     ##### HGETEX Active Expiry Keyspace Notifications #####
-    foreach command {EX PX EXAT PXAT} {
+    foreach command {EX PX} {
         test "HGETEX $command keyspace notifications for active expiry" {
             r FLUSHALL
             set initial_expired [info_field [r info stats] expired_fields]
@@ -3014,7 +3014,7 @@ start_server {tags {"hashexpire external:skip"}} {
             $rd close
         }
     }
-    
+
     test "HGETEX keyspace notification when key deleted with active expiry" {
         r FLUSHALL
         set initial_expired [info_field [r info stats] expired_fields]
@@ -3115,7 +3115,7 @@ start_server {tags {"hashexpire external:skip"}} {
     }
 
     ##### HSETEX Active Expiry Keyspace Notifications #####
-    foreach command {EX PX EXAT PXAT} {
+    foreach command {EX PX} {
         test "HSETEX $command - keyspace notifications fired on field expiry" {
             r FLUSHALL
             set initial_expired [info_field [r info stats] expired_fields]


### PR DESCRIPTION
As we can see, we expected to get hexpired, but we got hexpire instead,
this means tht the expiration time has expired during execution.
```
*** [err]: HGETEX EXAT keyspace notifications for active expiry in tests/unit/hashexpire.tcl
Expected 'pmessage __keyevent@* __keyevent@9__:hexpired myhash' to match 'pmessage __keyevent@* __keyevent@*:hexpire myhash'
```

We should remove the EXAT and PXAT from these fixtures. And we indeed have
the dedicated tests that verify that we get 'expired' when EX,PX are set to 0
or EXAT,PXAT are in the past.
