### PR TITLE
Fixes test-freebsd workflow in daily (package lang/tclX)

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1253,7 +1253,7 @@ jobs:
           version: 13.2
           shell: bash
           run: |
-            sudo pkg install -y bash gmake lang/tcl86 lang/tclx
+            sudo pkg install -y bash gmake lang/tcl86 lang/tclX
             gmake
             ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 


### PR DESCRIPTION
This PR fixes the freebsd daily job that has been failing consistently for the last days with the error "pkg: No packages available to install matching 'lang/tclx' have been found in the repositories".

The package name is corrected from `lang/tclx` to `lang/tclX`. The lowercase version worked previously but appears to have stopped working in an update of freebsd's pkg tool to 2.4.x.

Example of failed job:
https://github.com/valkey-io/valkey/actions/runs/19282092345/job/55135193499
