### PR TITLE
Attempt to fix flaky SCAN consistency test

### DIFF
--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -14,7 +14,7 @@ test {scan family consistency with configured hash seed} {
 
                 $primary flushall
                 $replica replicaof $primary_host $primary_port
-                wait_for_sync $replica
+                wait_replica_online $primary
 
                 set n 50
                 for {set i 0} {$i < $n} {incr i} {


### PR DESCRIPTION
Related test failures:
https://github.com/valkey-io/valkey/actions/runs/19282092345/job/55135193394
https://github.com/valkey-io/valkey/actions/runs/19200556305/job/54887767594

> *** [err]: scan family consistency with configured hash seed in tests/integration/scan-family-consistency.tcl
> Expected '5 {k:1 k:25 z k:11 k:18 k:27 k:45 k:7 k:12 k:19 k:29 k:40 k:41 k:43}' to be equal to '5 {k:1 k:25 k:11 z k:18 k:27 k:45 k:7 k:12 k:19 k:29 k:40 k:41 k:43}' (context: type eval line 26 cmd {assert_equal $primary_cursor_next $replica_cursor_next} proc ::start_server)

The reason is that the RDB part of the primary-replica synchronization affects the resize policy of the hashtable.
See https://github.com/valkey-io/valkey/blob/b835463a73d01f2d8a041dfc6b754db6952bcbb8/src/server.c#L807-L818