### PR TITLE
Fix cluster slot stats for scripts with cross-slot keys

### DIFF
--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -226,14 +226,6 @@ void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration) {
     server.cluster->slot_stats[c->slot].cpu_usec += duration;
 }
 
-/* For cross-slot scripting, its caller client's slot must be invalidated,
- * such that its slot-stats aggregation is bypassed. */
-void clusterSlotStatsInvalidateSlotIfApplicable(scriptRunCtx *ctx) {
-    if (!(ctx->flags & SCRIPT_ALLOW_CROSS_SLOT)) return;
-
-    ctx->original_client->slot = -1;
-}
-
 static int canAddNetworkBytesIn(client *c) {
     /* First, cluster mode must be enabled.
      * Second, command should target a specific slot.

--- a/src/cluster_slot_stats.h
+++ b/src/cluster_slot_stats.h
@@ -1,6 +1,5 @@
 #include "server.h"
 #include "cluster.h"
-#include "script.h"
 #include "cluster_legacy.h"
 
 /* General use-cases. */
@@ -10,7 +9,6 @@ int clusterSlotStatsEnabled(int slot);
 
 /* cpu-usec metric. */
 void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration);
-void clusterSlotStatsInvalidateSlotIfApplicable(scriptRunCtx *ctx);
 
 /* network-bytes-in metric. */
 void clusterSlotStatsAddNetworkBytesInForUserClient(client *c);

--- a/src/module.c
+++ b/src/module.c
@@ -6773,6 +6773,9 @@ cleanup:
 
     if (reply) autoMemoryAdd(ctx, VALKEYMODULE_AM_REPLY, reply);
     if (ctx->module) ctx->module->in_call--;
+    if (is_running_script) {
+        scriptClusterSlotStatsInvalidateSlotIfApplicable();
+    }
     if (c) moduleReleaseTempClient(c);
     return reply;
 }

--- a/src/script.c
+++ b/src/script.c
@@ -587,7 +587,7 @@ void scriptCall(scriptRunCtx *run_ctx, sds *err) {
     }
     call(c, call_flags);
     serverAssert(c->flag.blocked == 0);
-    clusterSlotStatsInvalidateSlotIfApplicable(run_ctx);
+    scriptClusterSlotStatsInvalidateSlotIfApplicable();
     return;
 
 error:
@@ -643,4 +643,11 @@ void scriptSetOriginalClientSlot(int slot) {
 sds scriptGetRunningEngineName(void) {
     serverAssert(scriptIsRunning());
     return scriptingEngineGetName(curr_run_ctx->engine);
+}
+
+/* For cross-slot scripting, its caller client's slot must be invalidated,
+ * such that its slot-stats aggregation is bypassed. */
+void scriptClusterSlotStatsInvalidateSlotIfApplicable(void) {
+    if (!scriptAllowsCrossSlot()) return;
+    curr_run_ctx->original_client->slot = -1;
 }

--- a/src/script.h
+++ b/src/script.h
@@ -127,6 +127,7 @@ int scriptAllowsCrossSlot(void);
 int scriptGetSlot(void);
 void scriptSetSlot(int slot);
 void scriptSetOriginalClientSlot(int slot);
+void scriptClusterSlotStatsInvalidateSlotIfApplicable(void);
 
 sds scriptGetRunningEngineName(void);
 


### PR DESCRIPTION
This commit fixes the cluster slot stats for scripts executed by scripting engines when the scripts access cross-slot keys.

This was not a bug in Lua scripting engine, but `VM_Call` was missing a call to invalidate the script caller client slot to prevent the accumulation of stats.