### PR TITLE
Fix timing issue in dual channel replication COB test

### DIFF
--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -788,6 +788,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     $primary config set dual-channel-replication-enabled yes
     $primary config set client-output-buffer-limit "replica 1100k 0 0"
     $primary config set loglevel debug
+    $primary debug delay-rdb-client-free-seconds 60
     # generate small db
     populate 10 primary 10
     start_server {} {


### PR DESCRIPTION
After #2829, valgrind report a test failure, it seems that the time is not enough to generate a COB limit in valgrind.