### PR TITLE
Fix SCAN consistency test to only test what we guarantee

### DIFF
--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -3,10 +3,17 @@ proc scan_interleaved {primary replica cmd args} {
     set keys {}
     set toggle [randomInt 2]
     while {1} {
-        if {$toggle == 0} {
-            set scan_result [$primary $cmd {*}$args $cursor]
+        if {[llength $args] > 0} {
+            # insert cursor at position 1 (after key name and before extra args)
+            set cmd_args [linsert $args 1 $cursor]
         } else {
-            set scan_result [$replica $cmd {*}$args $cursor]
+            set cmd_args [list $cursor]
+        }
+
+        if {$toggle == 0} {
+            set scan_result [$primary $cmd {*}$cmd_args]
+        } else {
+            set scan_result [$replica $cmd {*}$cmd_args]
         }
         lappend keys {*}[lindex $scan_result 1]
         if {[lindex $scan_result 0] eq 0} {
@@ -19,55 +26,42 @@ proc scan_interleaved {primary replica cmd args} {
 }
 
 test {scan family consistency with configured hash seed} {
-    start_server {tags {"external:skip"}} {
+    set fixed_seed [randstring 16 16 alpha]
+    set shared_overrides [list appendonly no save "" hash-seed $fixed_seed]
 
-        set fixed_seed [randstring 16 16 alpha]
-        set shared_overrides [list appendonly no save "" hash-seed $fixed_seed activedefrag no hz 20]
+    start_multiple_servers 2 [list overrides $shared_overrides] {
+        set primary [srv -1 client]
+        set replica [srv 0 client]
 
-        start_server [list overrides $shared_overrides] {
-            set primary_host [srv 0 host]
-            set primary_port [srv 0 port]
+        set primary_host [srv -1 host]
+        set primary_port [srv -1 port]
 
-            start_server [list overrides $shared_overrides] {
-                set primary [srv -1 client]
-                set replica [srv 0 client]
+        $primary flushall
+        $replica replicaof $primary_host $primary_port
+        wait_for_sync $replica
 
-                $primary flushall
-                $replica replicaof $primary_host $primary_port
-                wait_for_sync $replica
+        set n 50
+        for {set i 0} {$i < $n} {incr i} {
+            $primary set "k:$i" x
+            $primary hset h "f:$i" $i
+            $primary sadd s "m:$i"
+            $primary zadd z $i "m:$i"
+        }
 
-                set n 50
-                for {set i 0} {$i < $n} {incr i} {
-                    $primary set "k:$i" x
-                    $primary hset h "f:$i" $i
-                    $primary sadd s "m:$i"
-                    $primary zadd z $i "m:$i"
-                }
+        wait_for_condition 200 50 {
+            [$replica dbsize] == [$primary dbsize]
+        } else {
+            fail "replica did not catch up dbsize (primary=[$primary dbsize], replica=[$replica dbsize])"
+        }
 
-                wait_for_condition 200 50 {
-                    [$replica dbsize] == [$primary dbsize]
-                } else {
-                    fail "replica did not catch up dbsize (primary=[$primary dbsize], replica=[$replica dbsize])"
-                }
+        set keys [scan_interleaved $primary $replica scan]
+        set keys [lsort -unique $keys]
+        assert_equal [expr {$n+3}] [llength $keys]
 
-                set keys [scan_interleaved $primary $replica scan]
-                set keys [lsort -unique $keys]
-                assert_equal [expr {$n+3}] [llength $keys]
-
-                foreach {cmd key} {hscan h sscan s zscan z} {
-                    set keys [scan_interleaved $primary $replica $cmd $key]
-
-                    if {$cmd eq "hscan" || $cmd eq "zscan"} {
-                        set extracted_keys {}
-                        foreach {k v} $keys {
-                            lappend extracted_keys $k
-                        }
-                        set keys $extracted_keys
-                    }
-                    set keys [lsort -unique $keys]
-                    assert_equal $n [llength $keys]
-                }
-            }
+        foreach {cmd key extra} {hscan h {novalues} sscan s {} zscan z {noscores}} {
+            set items [scan_interleaved $primary $replica $cmd $key {*}$extra]
+            set items [lsort -unique $items]
+            assert_equal $n [llength $items]
         }
     }
-}
+} {} {external:skip}

--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -1,8 +1,28 @@
+proc scan_interleaved {primary replica cmd args} {
+    set cursor 0
+    set keys {}
+    set toggle [randomInt 2]
+    while {1} {
+        if {$toggle == 0} {
+            set scan_result [$primary $cmd {*}$args $cursor]
+        } else {
+            set scan_result [$replica $cmd {*}$args $cursor]
+        }
+        lappend keys {*}[lindex $scan_result 1]
+        if {[lindex $scan_result 0] eq 0} {
+            break
+        }
+        set cursor [lindex $scan_result 0]
+        set toggle [expr {1 - $toggle}]
+    }
+    return $keys
+}
+
 test {scan family consistency with configured hash seed} {
     start_server {tags {"external:skip"}} {
 
-        set fixed_seed "aabbccddeeffgghh"
-        set shared_overrides [list appendonly no save "" hash-seed $fixed_seed activedefrag no hz 1]
+        set fixed_seed [randstring 16 16 alpha]
+        set shared_overrides [list appendonly no save "" hash-seed $fixed_seed activedefrag no hz 20]
 
         start_server [list overrides $shared_overrides] {
             set primary_host [srv 0 host]
@@ -14,7 +34,7 @@ test {scan family consistency with configured hash seed} {
 
                 $primary flushall
                 $replica replicaof $primary_host $primary_port
-                wait_replica_online $primary
+                wait_for_sync $replica
 
                 set n 50
                 for {set i 0} {$i < $n} {incr i} {
@@ -29,30 +49,23 @@ test {scan family consistency with configured hash seed} {
                 } else {
                     fail "replica did not catch up dbsize (primary=[$primary dbsize], replica=[$replica dbsize])"
                 }
-                set cursor {{0} {}}
-                while {1} {
-                    set primary_cursor_next [$primary scan [lindex $cursor 0]]
-                    set replica_cursor_next [$replica scan [lindex $cursor 0]]
-                    assert_equal $primary_cursor_next $replica_cursor_next
-                    if {[lindex $primary_cursor_next 0] eq "0"} {
-                        assert_equal "0" [lindex $replica_cursor_next 0]
-                        break
-                    }
-                    set cursor $primary_cursor_next
-                }
+
+                set keys [scan_interleaved $primary $replica scan]
+                set keys [lsort -unique $keys]
+                assert_equal [expr {$n+3}] [llength $keys]
 
                 foreach {cmd key} {hscan h sscan s zscan z} {
-                    set cursor {{0} {}}
-                    while {1} {
-                        set primary_cursor_next [$primary $cmd $key [lindex $cursor 0]]
-                        set replica_cursor_next [$replica $cmd $key [lindex $cursor 0]]
-                        assert_equal $primary_cursor_next $replica_cursor_next
-                        if {[lindex $primary_cursor_next 0] eq "0"} {
-                            assert_equal "0" [lindex $replica_cursor_next 0]
-                            break
+                    set keys [scan_interleaved $primary $replica $cmd $key]
+
+                    if {$cmd eq "hscan" || $cmd eq "zscan"} {
+                        set extracted_keys {}
+                        foreach {k v} $keys {
+                            lappend extracted_keys $k
                         }
-                        set cursor $primary_cursor_next
+                        set keys $extracted_keys
                     }
+                    set keys [lsort -unique $keys]
+                    assert_equal $n [llength $keys]
                 }
             }
         }

--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -1,13 +1,12 @@
-proc scan_interleaved {primary replica cmd args} {
+proc scan_interleaved {primary replica cmd {key ""} args} {
     set cursor 0
     set keys {}
     set toggle [randomInt 2]
     while {1} {
-        if {[llength $args] > 0} {
-            # insert cursor at position 1 (after key name and before extra args)
-            set cmd_args [linsert $args 1 $cursor]
+        if {$key != ""} {
+            set cmd_args [list $key $cursor {*}$args]
         } else {
-            set cmd_args [list $cursor]
+            set cmd_args [list $cursor {*}$args]
         }
 
         if {$toggle == 0} {


### PR DESCRIPTION
https://github.com/valkey-io/valkey/pull/2834#issuecomment-3531941659

As @zuiderkwast said, we test the SCAN consistency by alternating SCAN calls to primary and replica.
We cannot rely on the exact order of the elements and the returned cursor number.