### PR TITLE
Make the COB soft limit also use repl-backlog-size when its value is smaller

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -5975,12 +5975,13 @@ int checkClientOutputBufferLimits(client *c) {
      * This doesn't have memory consumption implications since the replica client
      * will share the backlog buffers memory. */
     size_t hard_limit_bytes = server.client_obuf_limits[class].hard_limit_bytes;
+    size_t soft_limit_bytes = server.client_obuf_limits[class].soft_limit_bytes;
     if (class == CLIENT_TYPE_REPLICA && hard_limit_bytes && (long long)hard_limit_bytes < server.repl_backlog_size)
         hard_limit_bytes = server.repl_backlog_size;
+    if (class == CLIENT_TYPE_REPLICA && soft_limit_bytes && (long long)soft_limit_bytes < server.repl_backlog_size)
+        soft_limit_bytes = server.repl_backlog_size;
     if (server.client_obuf_limits[class].hard_limit_bytes && used_mem >= hard_limit_bytes) hard = 1;
-    if (server.client_obuf_limits[class].soft_limit_bytes &&
-        used_mem >= server.client_obuf_limits[class].soft_limit_bytes)
-        soft = 1;
+    if (server.client_obuf_limits[class].soft_limit_bytes && used_mem >= soft_limit_bytes) soft = 1;
 
     /* We need to check if the soft limit is reached continuously for the
      * specified amount of seconds. */

--- a/tests/integration/replication-buffer.tcl
+++ b/tests/integration/replication-buffer.tcl
@@ -279,6 +279,16 @@ test "Partial resynchronization is successful even client-output-buffer-limit is
             }
             assert_equal [s sync_full] {1}
             assert_equal [s sync_partial_ok] $psync_count
+            verify_no_log_message 0 "*closed for overcoming of output buffer limits*" 0
+
+            # Take this opportunity to test the soft limit, we won't encounter the COB limit.
+            set loglines [count_log_lines 0]
+            r config set client-output-buffer-limit "replica 0 512k 0"
+            pause_process [srv -1 pid]
+            r set key $big_str
+            after 1100
+            resume_process [srv -1 pid]
+            verify_no_log_message 0 "*closed for overcoming of output buffer limits*" $loglines
         }
     }
 }


### PR DESCRIPTION
We have the same settings for the hard limit, and we should apply them to the soft
limit as well. When the `repl-backlog-size` value is larger, all replication buffers
can be handled by the replication backlog, so there's no need to worry about the
client output buffer soft limit in here. Furthermore, when `soft_seconds` is 0, in
some ways, the soft limit behaves the same (mostly) as the hard limit.