### PR TITLE
Fix build on 32-bit ARM by only using NEON on AArch64

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -392,7 +392,7 @@ void setcpuaffinity(const char *cpulist);
 #endif
 
 /* Check if we can compile ARM SIMD code */
-#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#if defined(__aarch64__) && (defined(__ARM_NEON) || defined(__ARM_NEON__))
 #define HAVE_ARM_NEON 1
 #else
 #define HAVE_ARM_NEON 0


### PR DESCRIPTION
Only enable `HAVE_ARM_NEON` on AArch64 because it supports vaddvq and all needed compiler intrinsics.

Fixes the following error when building for machine `qemuarm` using the Yocto Project and OpenEmbedded:

```
| bitops.c: In function 'popcountNEON':
| bitops.c:219:23: error: implicit declaration of function 'vaddvq_u16'; did you mean 'vaddq_u16'? [-Wimplicit-function-declaration]
|   219 |         uint32_t t1 = vaddvq_u16(sc);
|       |                       ^~~~~~~~~~
|       |                       vaddq_u16
| bitops.c:225:14: error: implicit declaration of function 'vaddvq_u8'; did you mean 'vaddq_u8'? [-Wimplicit-function-declaration]
|   225 |         t += vaddvq_u8(vcntq_u8(vld1q_u8(p)));
|       |              ^~~~~~~~~
|       |              vaddq_u8
```

More details are available in the following log: https://errors.yoctoproject.org/Errors/Details/889836/