### PR TITLE
Fix discarded-qualifiers warnings reported by fedorarawhide

### DIFF
--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -331,7 +331,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
-        char *del = strstr(curr, "://");
+        const char *del = strstr(curr, "://");
         curr += (del - curr) + 3;
 #else
         char *copy = strdup(curr);
@@ -341,7 +341,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         exit(1);
 #endif
     } else if (!strncasecmp(scheme, curr, strlen(scheme)) || !strncasecmp(redisScheme, curr, strlen(redisScheme))) {
-        char *del = strstr(curr, "://");
+        const char *del = strstr(curr, "://");
         curr += (del - curr) + 3;
     } else {
         fprintf(stderr, "Invalid URI scheme\n");

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -331,7 +331,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
-        const char *del = strstr(curr, "://");
+        const char *del = strstr(curr, "://");1
         curr += (del - curr) + 3;
 #else
         char *copy = strdup(curr);

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -331,7 +331,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
-        const char *del = strstr(curr, "://");1
+        const char *del = strstr(curr, "://");
         curr += (del - curr) + 3;
 #else
         char *copy = strdup(curr);

--- a/src/module.c
+++ b/src/module.c
@@ -6833,7 +6833,7 @@ uint64_t moduleTypeEncodeId(const char *name, int encver) {
 
     uint64_t id = 0;
     for (int j = 0; j < 9; j++) {
-        char *p = strchr(cset, name[j]);
+        const char *p = strchr(cset, name[j]);
         if (!p) return 0;
         unsigned long pos = p - cset;
         id = (id << 6) | pos;

--- a/src/networking.c
+++ b/src/networking.c
@@ -818,7 +818,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         char *err_prefix = "ERR";
         size_t prefix_len = 3;
         if (s[0] == '-') {
-            char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
+            const char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
             /* If we cannot retrieve the error prefix, use the default: "ERR". */
             if (spaceloc) {
                 const size_t errEndPos = (size_t)(spaceloc - s);

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -62,7 +62,7 @@
 
 static int parseBulk(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
 
@@ -81,7 +81,7 @@ static int parseBulk(ReplyParser *parser, void *p_ctx) {
 
 static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.simple_str_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -89,7 +89,7 @@ static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
 
 static int parseError(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; // for \r\n
     parser->callbacks.error_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -97,7 +97,7 @@ static int parseError(ReplyParser *parser, void *p_ctx) {
 
 static int parseLong(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     long long val;
     string2ll(proto + 1, p - proto - 1, &val);
@@ -107,7 +107,7 @@ static int parseLong(ReplyParser *parser, void *p_ctx) {
 
 static int parseAttributes(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -118,7 +118,7 @@ static int parseAttributes(ReplyParser *parser, void *p_ctx) {
 
 static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
     string2ll(proto + 1, p - proto - 1, &bulklen);
@@ -132,7 +132,7 @@ static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
 
 static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.big_number_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -140,7 +140,7 @@ static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
 
 static int parseNull(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.null_callback(p_ctx, proto, parser->curr_location - proto);
     return C_OK;
@@ -148,7 +148,7 @@ static int parseNull(ReplyParser *parser, void *p_ctx) {
 
 static int parseDouble(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     char buf[MAX_LONG_DOUBLE_CHARS + 1];
     size_t len = p - proto - 1;
@@ -164,7 +164,7 @@ static int parseDouble(ReplyParser *parser, void *p_ctx) {
 
 static int parseBool(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.bool_callback(p_ctx, proto[1] == 't', proto, parser->curr_location - proto);
     return C_OK;
@@ -172,7 +172,7 @@ static int parseBool(ReplyParser *parser, void *p_ctx) {
 
 static int parseArray(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -187,7 +187,7 @@ static int parseArray(ReplyParser *parser, void *p_ctx) {
 
 static int parseSet(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -198,7 +198,7 @@ static int parseSet(ReplyParser *parser, void *p_ctx) {
 
 static int parseMap(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;


### PR DESCRIPTION
fedorarawhide CI reports these warnings:
```
networking.c: In function 'afterErrorReply':
networking.c:821:30: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  821 |             char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
```