### PR TITLE
Add psync offset range information to the failed psync log

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -863,13 +863,15 @@ int primaryTryPartialResynchronization(client *c, long long psync_offset) {
     if (!server.repl_backlog || psync_offset < server.repl_backlog->offset ||
         psync_offset > (server.repl_backlog->offset + server.repl_backlog->histlen)) {
         serverLog(LL_NOTICE,
-                  "Unable to partial resync with replica %s for lack of backlog (Replica request was: %lld).",
-                  replicationGetReplicaName(c), psync_offset);
+                  "Unable to partial resync with replica %s for lack of backlog (Replica request was %s:%lld, "
+                  "and I can only reply with the range [%lld, %lld]).",
+                  replicationGetReplicaName(c), primary_replid, psync_offset, server.repl_backlog->offset,
+                  server.repl_backlog->offset + server.repl_backlog->histlen);
         if (psync_offset > server.primary_repl_offset) {
             serverLog(LL_WARNING,
-                      "Warning: replica %s tried to PSYNC with an offset that is greater than the primary replication "
-                      "offset.",
-                      replicationGetReplicaName(c));
+                      "Warning: replica %s tried to PSYNC with an offset (%lld) that is greater than "
+                      "the primary replication offset (%lld)",
+                      replicationGetReplicaName(c), psync_offset, server.primary_repl_offset);
         }
         goto need_full_resync;
     }


### PR DESCRIPTION
Although we can infer this infomartion from the replica logs,
i think this still would be useful to see this information directly
in the primary logs.

So now we can see the psync offset range when psync fails and then
we can analyze and adjust the value of repl-backlog-size.