### PR TITLE
Build: Support `make test` when PROG_SUFFIX is used

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -590,7 +590,7 @@ distclean: clean
 .PHONY: distclean
 
 test: $(SERVER_NAME) $(ENGINE_CHECK_AOF_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME)
-	@(cd ..; ./runtest)
+	@(cd ..; VALKEY_PROG_SUFFIX="$(PROG_SUFFIX)" ./runtest)
 
 test-unit: $(ENGINE_UNIT_TESTS)
 	./$(ENGINE_UNIT_TESTS)

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -8,10 +8,16 @@ if {[info exists ::env(VALKEY_BIN_DIR)]} {
     set ::VALKEY_BIN_DIR "[pwd]/src"
 }
 
+# Optional program suffix (e.g. `make PROG_SUFFIX=-alt` will create binary valkey-server-alt).
+# Passed from `make test` as environment variable VALKEY_PROG_SUFFIX.
+set ::VALKEY_PROG_SUFFIX [expr {
+    [info exists ::env(VALKEY_PROG_SUFFIX)] ? $::env(VALKEY_PROG_SUFFIX) : ""
+}]
+
 # Helper to build absolute paths
 proc valkey_bin_absolute_path {name} {
-    set p [file join $::VALKEY_BIN_DIR $name]
-    return $p
+    set full_name "${name}${::VALKEY_PROG_SUFFIX}"
+    return [file join $::VALKEY_BIN_DIR $full_name]
 }
 
 set ::VALKEY_SERVER_BIN    [valkey_bin_absolute_path "valkey-server"]


### PR DESCRIPTION
Closes #2883

Support a new environment variable `VALKEY_PROG_SUFFIX` in the test framework, which can be used for running tests if the binaries are compiled with a program suffix. For example, if the binaries are compiled using `make PROG_SUFFIX=-alt` to produce binaries named valkey-server-alt, valkey-cli-alt, etc., run the tests against these binaries using `VALKEY_PROG_SUFFIX=-alt ./runtest` or simply using `make test`.

Now the test with the make variable `PROG_SUFFIX` works well.

```
% make PROG_SUFFIX="-alt"
		...
		...
		CC trace/trace_aof.o
    LINK valkey-server-alt
    INSTALL valkey-sentinel-alt
    CC valkey-cli.o
    CC serverassert.o
    CC cli_common.o
    CC cli_commands.o
    LINK valkey-cli-alt
    CC valkey-benchmark.o
    LINK valkey-benchmark-alt
    INSTALL valkey-check-rdb-alt
    INSTALL valkey-check-aof-alt

Hint: It's a good idea to run 'make test' ;)
% 
% make test                                                                
cd src && /Library/Developer/CommandLineTools/usr/bin/make test
    CC Makefile.dep
    CC release.o
    LINK valkey-server-alt
    INSTALL valkey-check-aof-alt
    INSTALL valkey-check-rdb-alt
    LINK valkey-cli-alt
    LINK valkey-benchmark-alt
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 39435
Testing unit/pubsub
```
