### PR TITLE
Add keys_with_volatile_items_count to info stats

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -636,6 +636,19 @@ size_t getReplicaKeyWithExpireCount(void) {
     return dictSize(replicaKeysWithExpire);
 }
 
+/* Return the number of keys with fields expiring */
+unsigned long long getKeysWithVolatileItemsCount(void) {
+    unsigned long long keys_with_volatile_items_count = 0;
+    /* check each db for keys with expiring fields */
+    for (int j = 0; j < server.dbnum; j++) {
+        serverDb *db = server.db[j];
+        if (!db) continue;
+        kvstore *kvs = db->keys_with_volatile_items;
+        if (kvs) keys_with_volatile_items_count += kvstoreSize(kvs);
+    }
+    return keys_with_volatile_items_count;
+}
+
 /* Remove the keys in the hash table. We need to do that when data is
  * flushed from the server. We may receive new keys from the primary with
  * the same name/db and it is no longer a good idea to expire them.

--- a/src/expire.h
+++ b/src/expire.h
@@ -69,5 +69,6 @@ void flushReplicaKeysWithExpireList(int async);
 size_t getReplicaKeyWithExpireCount(void);
 bool timestampIsExpired(mstime_t when);
 void freeReplicaKeysWithExpireAsync(dict *replica_keys_with_expire);
+unsigned long long getKeysWithVolatileItemsCount(void);
 
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -6202,6 +6202,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "expired_keys_with_volatile_items_stale_perc:%.2f\r\n", server.stat_expired_keys_with_vola_stale_perc * 100,
                 "expired_time_cap_reached_count:%lld\r\n", server.stat_expired_time_cap_reached_count,
                 "expire_cycle_cpu_milliseconds:%lld\r\n", server.stat_expire_cycle_time_used / 1000,
+                "keys_with_volatile_items_count:%llu\r\n", getKeysWithVolatileItemsCount(),
                 "evicted_keys:%lld\r\n", server.stat_evictedkeys,
                 "evicted_clients:%lld\r\n", server.stat_evictedclients,
                 "evicted_scripts:%lld\r\n", server.stat_evictedscripts,


### PR DESCRIPTION
Allows for tracking how many keys are currently tracked that contain volatile items.

Provides a quick method for determining if hash field expiry is in use to determine if rollback to valkey 8.1 has possibility to succeed if rdb-version-check is set to relaxed.