### PR TITLE
Fix deadlock in IO thread shutdown during panic

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -285,6 +285,10 @@ static void shutdownIOThread(int id) {
     if (tid == pthread_self()) return;
     if (tid == 0) return;
 
+    /* Only unlock mutex for inactive threads. Active threads are already unlocked. */
+    if (id >= server.active_io_threads_num) {
+        pthread_mutex_unlock(&io_threads_mutex[id]);
+    }
     pthread_cancel(tid);
 
     if ((err = pthread_join(tid, NULL)) != 0) {


### PR DESCRIPTION
## Problem
IO thread shutdown can deadlock during server panic when the main thread calls `pthread_cancel()` while the IO thread holds its mutex, preventing the thread from observing the cancellation.

## Solution  
Release the IO thread mutex before cancelling to ensure clean thread termination.

## Testing
Reproducer:
```
bash
./src/valkey-server --io-threads 2 --enable-debug-command yes
./src/valkey-cli debug panic
```

Before: Server hangs indefinitely
After: Server terminates cleanly