### PR TITLE
Fix loading AOF files from future Valkey versions

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1431,8 +1431,8 @@ int loadSingleAppendOnlyFile(char *filename) {
     /* Check if the AOF file is in RDB format (it may be RDB encoded base AOF
      * or old style RDB-preamble AOF). In that case we need to load the RDB file
      * and later continue loading the AOF tail if it is an old style RDB-preamble AOF. */
-    char sig[5]; /* "REDIS" */
-    if (fread(sig, 1, 5, fp) != 5 || memcmp(sig, "REDIS", 5) != 0) {
+    char sig[6]; /* "REDIS" or "VALKEY" */
+    if (fread(sig, 1, 6, fp) != 6 || (memcmp(sig, "REDIS0", 6) != 0 && memcmp(sig, "VALKEY", 6) != 0)) {
         /* Not in RDB format, seek back at 0 offset. */
         if (fseek(fp, 0, SEEK_SET) == -1) goto readerr;
     } else {


### PR DESCRIPTION
This allows loading an AOF file in Valkey 8.1 with the config 'rdb-version-check' set to 'relaxed', when the AOF file is created by a future Valkey version.

Fixes #2888.