### PR TITLE
Backport fixes to prepare for 8.1.5

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1182,7 +1182,7 @@ jobs:
           version: 13.2
           shell: bash
           run: |
-            sudo pkg install -y bash gmake lang/tcl86 lang/tclx
+            sudo pkg install -y bash gmake lang/tcl86 lang/tclX
             gmake
             ./runtest --single unit/keyspace --single unit/auth --single unit/networking --single unit/protocol
 

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -10,6 +10,20 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
+Valkey 8.1.5  -  Released Thu 04 December 2025
+================================================================================
+
+Upgrade urgency MODERATE: Program an upgrade of the server, but it's not urgent.
+
+Bug fixes
+=========
+* Fix Lua VM crash after FUNCTION FLUSH ASYNC + FUNCTION LOAD (#1826)
+* Fix invalid memory address caused by hashtable shrinking during safe iteration (#2753)
+* Cluster: Avoid usage of light weight messages to nodes with not ready bidirectional links (#2817)
+* Send duplicate multi meet packet only for node which supports it (#2840)
+* Fix loading AOF files from future Valkey versions (#2899)
+
+================================================================================
 Valkey 8.1.4  -  Released Fri 03 October 2025
 ================================================================================
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -461,10 +461,12 @@ persist-settings: distclean
 	echo STD=$(STD) >> .make-settings
 	echo WARN=$(WARN) >> .make-settings
 	echo OPT=$(OPT) >> .make-settings
+	echo PROG_SUFFIX=$(PROG_SUFFIX) >> .make-settings
 	echo MALLOC=$(MALLOC) >> .make-settings
 	echo BUILD_TLS=$(BUILD_TLS) >> .make-settings
 	echo BUILD_RDMA=$(BUILD_RDMA) >> .make-settings
 	echo USE_SYSTEMD=$(USE_SYSTEMD) >> .make-settings
+	echo USE_FAST_FLOAT=$(USE_FAST_FLOAT) >> .make-settings
 	echo CFLAGS=$(CFLAGS) >> .make-settings
 	echo LDFLAGS=$(LDFLAGS) >> .make-settings
 	echo SERVER_CFLAGS=$(SERVER_CFLAGS) >> .make-settings

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -329,7 +329,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
-        char *del = strstr(curr, "://");
+        const char *del = strstr(curr, "://");
         curr += (del - curr) + 3;
 #else
         char *copy = strdup(curr);
@@ -339,7 +339,7 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
         exit(1);
 #endif
     } else if (!strncasecmp(scheme, curr, strlen(scheme)) || !strncasecmp(redisScheme, curr, strlen(redisScheme))) {
-        char *del = strstr(curr, "://");
+        const char *del = strstr(curr, "://");
         curr += (del - curr) + 3;
     } else {
         fprintf(stderr, "Invalid URI scheme\n");

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1020,7 +1020,9 @@ void clusterUpdateMyselfFlags(void) {
     int nofailover = server.cluster_replica_no_failover ? CLUSTER_NODE_NOFAILOVER : 0;
     myself->flags &= ~CLUSTER_NODE_NOFAILOVER;
     myself->flags |= nofailover;
-    myself->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED | CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
+    myself->flags |= CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED |
+                     CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED |
+                     CLUSTER_NODE_MULTI_MEET_SUPPORTED;
     if (myself->flags != oldflags) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
     }
@@ -3282,6 +3284,13 @@ int clusterProcessPacket(clusterLink *link) {
         } else {
             sender->flags &= ~CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED;
         }
+
+        /* Check if the node can handle multi meet packet. */
+        if (flags & CLUSTER_NODE_MULTI_MEET_SUPPORTED) {
+            sender->flags |= CLUSTER_NODE_MULTI_MEET_SUPPORTED;
+        } else {
+            sender->flags &= ~CLUSTER_NODE_MULTI_MEET_SUPPORTED;
+        }
     }
 
     /* Update the last time we saw any data from this node. We
@@ -5279,7 +5288,8 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now) {
     }
     if (nodeInNormalState(node) && node->link != NULL && node->inbound_link == NULL &&
         now - node->inbound_link_freed_time > getHandshakeTimeout() &&
-        now - node->meet_sent > getHandshakeTimeout()) {
+        now - node->meet_sent > getHandshakeTimeout() &&
+        nodeSupportsMultiMeet(node)) {
         /* Node has an outbound link, but no inbound link for more than the handshake timeout.
          * This probably means this node does not know us yet, whereas we know it.
          * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -44,6 +44,7 @@
 #include "connection.h"
 #include "module.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -4398,6 +4399,18 @@ void clusterSendUpdate(clusterLink *link, clusterNode *node) {
 
     clusterSendMessage(link, msgblock);
     clusterMsgSendBlockDecrRefCount(msgblock);
+}
+
+/* Inline functions that check support of light weight messages by node
+ * and avoid using light weight messages until the bidirectional
+ * link(s) have been established. */
+static inline bool nodeSupportsLightMsgHdrForPubSub(clusterNode *n) {
+    return n->link && n->pong_received >= n->link->ctime &&
+           (n->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED);
+}
+static inline bool nodeSupportsLightMsgHdrForModule(clusterNode *n) {
+    return n->link && n->pong_received >= n->link->ctime &&
+           (n->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED);
 }
 
 /* Create a MODULE message block.

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -67,8 +67,6 @@ typedef struct clusterLink {
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
-#define nodeSupportsLightMsgHdrForPubSub(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED)
-#define nodeSupportsLightMsgHdrForModule(n) ((n)->flags & CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
 
 /* This structure represent elements of node->fail_reports. */

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -41,19 +41,22 @@ typedef struct clusterLink {
 } clusterLink;
 
 /* Cluster node flags and macros. */
-#define CLUSTER_NODE_PRIMARY (1 << 0)                      /* The node is a primary */
-#define CLUSTER_NODE_REPLICA (1 << 1)                      /* The node is a replica */
-#define CLUSTER_NODE_PFAIL (1 << 2)                        /* Failure? Need acknowledge */
-#define CLUSTER_NODE_FAIL (1 << 3)                         /* The node is believed to be malfunctioning */
-#define CLUSTER_NODE_MYSELF (1 << 4)                       /* This node is myself */
-#define CLUSTER_NODE_HANDSHAKE (1 << 5)                    /* We have still to exchange the first ping */
-#define CLUSTER_NODE_NOADDR (1 << 6)                       /* We don't know the address of this node */
-#define CLUSTER_NODE_MEET (1 << 7)                         /* Send a MEET message to this node */
-#define CLUSTER_NODE_MIGRATE_TO (1 << 8)                   /* Primary eligible for replica migration. */
-#define CLUSTER_NODE_NOFAILOVER (1 << 9)                   /* Replica will not try to failover. */
-#define CLUSTER_NODE_EXTENSIONS_SUPPORTED (1 << 10)        /* This node supports extensions. */
-#define CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED (1 << 11) /* This node supports light message header for publish type. */
-#define CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED (1 << 12)  /* This node supports light message header for module type. */
+#define CLUSTER_NODE_PRIMARY (1 << 0)                                             /* The node is a primary */
+#define CLUSTER_NODE_REPLICA (1 << 1)                                             /* The node is a replica */
+#define CLUSTER_NODE_PFAIL (1 << 2)                                               /* Failure? Need acknowledge */
+#define CLUSTER_NODE_FAIL (1 << 3)                                                /* The node is believed to be malfunctioning */
+#define CLUSTER_NODE_MYSELF (1 << 4)                                              /* This node is myself */
+#define CLUSTER_NODE_HANDSHAKE (1 << 5)                                           /* We have still to exchange the first ping */
+#define CLUSTER_NODE_NOADDR (1 << 6)                                              /* We don't know the address of this node */
+#define CLUSTER_NODE_MEET (1 << 7)                                                /* Send a MEET message to this node */
+#define CLUSTER_NODE_MIGRATE_TO (1 << 8)                                          /* Primary eligible for replica migration. */
+#define CLUSTER_NODE_NOFAILOVER (1 << 9)                                          /* Replica will not try to failover. */
+#define CLUSTER_NODE_EXTENSIONS_SUPPORTED (1 << 10)                               /* This node supports extensions. */
+#define CLUSTER_NODE_LIGHT_HDR_PUBLISH_SUPPORTED (1 << 11)                        /* This node supports light message header for publish type. */
+#define CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED (1 << 12)                         /* This node supports light message header for module type. */
+#define CLUSTER_NODE_MULTI_MEET_SUPPORTED CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED /* This node handles multi meet packet.                             \
+                                                                                     Light hdr for module and multi meet were both introduced in 8.1, \
+                                                                                     so we could reduce the same flag value. */
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \
     "\000\000\000\000\000\000\000\000\000\000\000\000"
@@ -67,6 +70,7 @@ typedef struct clusterLink {
 #define nodeFailed(n) ((n)->flags & CLUSTER_NODE_FAIL)
 #define nodeCantFailover(n) ((n)->flags & CLUSTER_NODE_NOFAILOVER)
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
+#define nodeSupportsMultiMeet(n) ((n)->flags & CLUSTER_NODE_MULTI_MEET_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
 
 /* This structure represent elements of node->fail_reports. */

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1138,14 +1138,18 @@ void hashtableResumeAutoShrink(hashtable *ht) {
 
 /* Pauses incremental rehashing. When rehashing is paused, bucket chains are not
  * automatically compacted when entries are deleted. Doing so may leave empty
- * spaces, "holes", in the bucket chains, which wastes memory. */
+ * spaces, "holes", in the bucket chains, which wastes memory. Additionally, we
+ * pause auto shrink when rehashing is paused, meaning the hashtable will not
+ * shrink the bucket count. */
 static void hashtablePauseRehashing(hashtable *ht) {
     ht->pause_rehash++;
+    hashtablePauseAutoShrink(ht);
 }
 
 /* Resumes incremental rehashing, after pausing it. */
 static void hashtableResumeRehashing(hashtable *ht) {
     ht->pause_rehash--;
+    hashtableResumeAutoShrink(ht);
 }
 
 /* Returns 1 if incremental rehashing is paused, 0 if it isn't. */
@@ -1524,6 +1528,9 @@ void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *pos) {
     assert(isPositionFilled(b, pos_in_bucket));
     b->presence &= ~(1 << pos_in_bucket);
     ht->used[table_index]--;
+    /* When we resume rehashing, it may cause the bucket to be deleted due to
+     * auto shrink. */
+    hashtablePauseAutoShrink(ht);
     hashtableResumeRehashing(ht);
     if (b->chained && !hashtableIsRehashingPaused(ht)) {
         /* Rehashing paused also means bucket chain compaction paused. It is
@@ -1532,7 +1539,7 @@ void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *pos) {
          * we do the compaction in the scan and iterator code instead. */
         fillBucketHole(ht, b, pos_in_bucket, table_index);
     }
-    hashtableShrinkIfNeeded(ht);
+    hashtableResumeAutoShrink(ht);
 }
 
 /* Initializes the state for an incremental find operation.
@@ -1710,7 +1717,6 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
     /* Prevent entries from being moved around during the scan call, as a
      * side-effect of the scan callback. */
     hashtablePauseRehashing(ht);
-    hashtablePauseAutoShrink(ht);
 
     /* Flags. */
     int emit_ref = (flags & HASHTABLE_SCAN_EMIT_REF);
@@ -1822,7 +1828,6 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
         } while (cursor & (mask_small ^ mask_large));
     }
     hashtableResumeRehashing(ht);
-    hashtableResumeAutoShrink(ht);
     return cursor;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -6684,7 +6684,7 @@ uint64_t moduleTypeEncodeId(const char *name, int encver) {
 
     uint64_t id = 0;
     for (int j = 0; j < 9; j++) {
-        char *p = strchr(cset, name[j]);
+        const char *p = strchr(cset, name[j]);
         if (!p) return 0;
         unsigned long pos = p - cset;
         id = (id << 6) | pos;

--- a/src/networking.c
+++ b/src/networking.c
@@ -597,7 +597,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         char *err_prefix = "ERR";
         size_t prefix_len = 3;
         if (s[0] == '-') {
-            char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
+            const char *spaceloc = memchr(s, ' ', len < 32 ? len : 32);
             /* If we cannot retrieve the error prefix, use the default: "ERR". */
             if (spaceloc) {
                 const size_t errEndPos = (size_t)(spaceloc - s);

--- a/src/resp_parser.c
+++ b/src/resp_parser.c
@@ -62,7 +62,7 @@
 
 static int parseBulk(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
 
@@ -81,7 +81,7 @@ static int parseBulk(ReplyParser *parser, void *p_ctx) {
 
 static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.simple_str_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -89,7 +89,7 @@ static int parseSimpleString(ReplyParser *parser, void *p_ctx) {
 
 static int parseError(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; // for \r\n
     parser->callbacks.error_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -97,7 +97,7 @@ static int parseError(ReplyParser *parser, void *p_ctx) {
 
 static int parseLong(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     long long val;
     string2ll(proto + 1, p - proto - 1, &val);
@@ -107,7 +107,7 @@ static int parseLong(ReplyParser *parser, void *p_ctx) {
 
 static int parseAttributes(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -118,7 +118,7 @@ static int parseAttributes(ReplyParser *parser, void *p_ctx) {
 
 static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long bulklen;
     parser->curr_location = p + 2; /* for \r\n */
     string2ll(proto + 1, p - proto - 1, &bulklen);
@@ -132,7 +132,7 @@ static int parseVerbatimString(ReplyParser *parser, void *p_ctx) {
 
 static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.big_number_callback(p_ctx, proto + 1, p - proto - 1, proto, parser->curr_location - proto);
     return C_OK;
@@ -140,7 +140,7 @@ static int parseBigNumber(ReplyParser *parser, void *p_ctx) {
 
 static int parseNull(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.null_callback(p_ctx, proto, parser->curr_location - proto);
     return C_OK;
@@ -148,7 +148,7 @@ static int parseNull(ReplyParser *parser, void *p_ctx) {
 
 static int parseDouble(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     char buf[MAX_LONG_DOUBLE_CHARS + 1];
     size_t len = p - proto - 1;
@@ -164,7 +164,7 @@ static int parseDouble(ReplyParser *parser, void *p_ctx) {
 
 static int parseBool(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     parser->curr_location = p + 2; /* for \r\n */
     parser->callbacks.bool_callback(p_ctx, proto[1] == 't', proto, parser->curr_location - proto);
     return C_OK;
@@ -172,7 +172,7 @@ static int parseBool(ReplyParser *parser, void *p_ctx) {
 
 static int parseArray(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -187,7 +187,7 @@ static int parseArray(ReplyParser *parser, void *p_ctx) {
 
 static int parseSet(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;
@@ -198,7 +198,7 @@ static int parseSet(ReplyParser *parser, void *p_ctx) {
 
 static int parseMap(ReplyParser *parser, void *p_ctx) {
     const char *proto = parser->curr_location;
-    char *p = strchr(proto + 1, '\r');
+    const char *p = strchr(proto + 1, '\r');
     long long len;
     string2ll(proto + 1, p - proto - 1, &len);
     p += 2;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -909,8 +909,9 @@ void ltrimCommand(client *c) {
     } else {
         listTypeTryConversion(o, LIST_CONV_SHRINKING, NULL, NULL);
     }
-    signalModifiedKey(c, c->db, c->argv[1]);
-    server.dirty += (ltrim + rtrim);
+    long long total_trim = ltrim + rtrim;
+    if (total_trim) signalModifiedKey(c, c->db, c->argv[1]);
+    server.dirty += total_trim;
     addReply(c, shared.ok);
 }
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,8 +4,8 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "8.1.4"
-#define VALKEY_VERSION_NUM 0x00080104
+#define VALKEY_VERSION "8.1.5"
+#define VALKEY_VERSION_NUM 0x00080105
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -710,7 +710,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 5. Replica resumes operation.
             # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 1
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -340,6 +340,7 @@ proc test_server_main {} {
     set ::idle_clients {}
     set ::active_clients {}
     array set ::active_clients_task {}
+    array set ::active_clients_file {}
     array set ::clients_start_time {}
     set ::clients_time_history {}
     set ::failed_tests {}
@@ -356,7 +357,25 @@ proc test_server_cron {} {
     if {$elapsed > $::timeout} {
         set err "\[[colorstr red TIMEOUT]\]: clients state report follows."
         puts $err
-        lappend ::failed_tests $err
+        foreach fd $::active_clients {
+            if {[info exist ::active_clients_task($fd)]} {
+                set task $::active_clients_task($fd)
+                set test_name [regsub {^\([^)]*\)\s*} $task {}]
+                set test_name [regsub {\s*\(pid\s+\d+\)\s*$} $test_name {}]
+                if {![string length [string trim $test_name]] && \
+                    [regexp {\(([^()]*)\)$} $task -> tn]} {
+                    set test_name $tn
+                }
+                set test_name [string trim $test_name]
+                if {[string length $test_name]} {
+                    set file {}
+                    if {[info exist ::active_clients_file($fd)]} {
+                        set file $::active_clients_file($fd)
+                    }
+                    lappend ::failed_tests "\[TIMEOUT]: $test_name in $file"
+                }
+            }
+        }
         show_clients_state
         kill_clients
         force_kill_all_servers
@@ -407,6 +426,7 @@ proc read_from_test_client fd {
         lappend ::clients_time_history $elapsed $data
         signal_idle_client $fd
         set ::active_clients_task($fd) "(DONE) $data"
+        unset ::active_clients_file($fd)
     } elseif {$status eq {ok}} {
         if {!$::quiet} {
             puts "\[[colorstr green $status]\]: $data ($elapsed ms)"
@@ -423,7 +443,8 @@ proc read_from_test_client fd {
     } elseif {$status eq {err}} {
         set err "\[[colorstr red $status]\]: $data"
         puts $err
-        lappend ::failed_tests $err
+        set test_name [lindex [split $data "\n"] 0]
+        lappend ::failed_tests $test_name
         set ::active_clients_task($fd) "(ERR) $data"
         if {$::exit_on_failure} {
             puts -nonewline "(Fast fail: test will exit now)"
@@ -514,6 +535,7 @@ proc signal_idle_client fd {
             puts [colorstr bold-white "Testing [lindex $::all_tests $::next_test]"]
             set ::active_clients_task($fd) "ASSIGNED: $fd ([lindex $::all_tests $::next_test])"
         }
+        set ::active_clients_file($fd) "tests/[lindex $::all_tests $::next_test].tcl"
         set ::clients_start_time($fd) [clock seconds]
         send_data_packet $fd run [lindex $::all_tests $::next_test]
         lappend ::active_clients $fd
@@ -528,7 +550,9 @@ proc signal_idle_client fd {
             set ::active_clients_task($fd) "ASSIGNED: $fd solo test"
         }
         set ::clients_start_time($fd) [clock seconds]
-        send_data_packet $fd run_code [lpop ::run_solo_tests]
+        set solo_data [lpop ::run_solo_tests]
+        set ::active_clients_file($fd) [lindex $solo_data 1]
+        send_data_packet $fd run_code $solo_data
         lappend ::active_clients $fd
     } else {
         lappend ::idle_clients $fd

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -64,7 +64,7 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
     }
 } ;# start_cluster
 
-start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
     test "Primaries will not time out then they are elected in the same epoch" {
         # Since we have the delay time, so these node may not initiate the
         # election at the same time (same epoch). But if they do, we make

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -953,6 +953,7 @@ start_server {tags {"expire"}} {
 
 start_server {tags {expire} overrides {hz 100}} {
     test {Active expiration triggers hashtable shrink} {
+        r debug SET-ACTIVE-EXPIRE 0
         set persistent_keys 5
         set volatile_keys 100
         set total_keys [expr $persistent_keys + $volatile_keys]
@@ -969,6 +970,7 @@ start_server {tags {expire} overrides {hz 100}} {
         assert_equal $total_keys [r dbsize]
 
         # Wait for active expiration
+        r debug SET-ACTIVE-EXPIRE 1
         wait_for_condition 100 50 {
             [r dbsize] eq $persistent_keys
         } else {


### PR DESCRIPTION
Cherry-picked and included in release notes:

* Fix Lua VM crash after FUNCTION FLUSH ASYNC + FUNCTION LOAD (#1826)
* Fix invalid memory address caused by hashtable shrinking during safe iteration (#2753)
* Cluster: Avoid usage of light weight messages to nodes with not ready bidirectional links (#2817)
* Send duplicate multi meet packet only for node which supports it (#2840)
* Fix loading AOF files from future Valkey versions (#2899)

Cherry-picked, but no need to mention in release notes:

* Deflake "Dual channel replication - psync established within grace period" (#2743)
* Fix: ltrim should not call signalModifiedKey when no elements are removed (#2787)
* [flaky-failure-fix] Increase the cluster-node-timeout to have longer delay between failover of each shard (#2793)
* Log test details at the end when the test times out (#2276)
* Disable active expiry until it's needed (#2313)
* Fixes test-freebsd workflow in daily (package lang/tclX) (#2832)
* Fix discarded-qualifiers warnings reported by fedorarawhide (#2874)
* Fix persisting missing make variables (#2881)