### PR TITLE
Run Extra Tests with only a label

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,11 +2,9 @@ name: Daily
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
     branches:
       # any PR to a release branch.
       - "[0-9].[0-9]"
-      - "unstable"
     paths-ignore:
       - '**/*.md'
       - '**/00-RELEASENOTES'
@@ -14,8 +12,6 @@ on:
   pull_request_target:
     types: [labeled]
     branches:
-      # any PR to a release branch.
-      - "[0-9].[0-9]"
       - "unstable"
   schedule:
     - cron: "0 0 * * *"
@@ -47,14 +43,14 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 jobs:
   test-ubuntu-jemalloc:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'ubuntu')
     timeout-minutes: 1440
     steps:
@@ -122,7 +118,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       (!contains(github.event.inputs.skipjobs, 'ubuntu') || !contains(github.event.inputs.skipjobs, 'arm'))
     timeout-minutes: 14400
     steps:
@@ -164,7 +161,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'fortify')
     container: ubuntu:plucky
     timeout-minutes: 1440
@@ -210,7 +208,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
     timeout-minutes: 1440
     steps:
@@ -249,7 +248,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
     timeout-minutes: 1440
     steps:
@@ -288,7 +288,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, '32bit')
     timeout-minutes: 1440
     steps:
@@ -334,7 +335,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 1440
     steps:
@@ -380,7 +382,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 1440
     steps:
@@ -426,7 +429,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 1440
     steps:
@@ -460,7 +464,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 1440
     steps:
@@ -498,7 +503,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'specific')
     timeout-minutes: 1440
     steps:
@@ -870,7 +876,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'lttng')
     timeout-minutes: 1440
     steps:
@@ -910,7 +917,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'rpm-distros')
     strategy:
       fail-fast: false
@@ -976,7 +984,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     strategy:
       fail-fast: false
@@ -1121,7 +1130,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !(contains(github.event.inputs.skiptests, 'valkey') && contains(github.event.inputs.skiptests, 'modules'))
     timeout-minutes: 1440
     steps:
@@ -1152,7 +1162,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'sentinel')
     timeout-minutes: 1440
     steps:
@@ -1180,7 +1191,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'cluster')
     timeout-minutes: 1440
     steps:
@@ -1212,7 +1224,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'macos')
     timeout-minutes: 1440
     steps:
@@ -1240,7 +1253,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
     timeout-minutes: 1440
     steps:
@@ -1270,7 +1284,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
@@ -1311,7 +1326,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
@@ -1353,7 +1369,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
       !contains(github.event.inputs.skipjobs, 'reply-schema')
     steps:
       - name: prep

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,17 @@ name: Daily
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
+    branches:
+      # any PR to a release branch.
+      - "[0-9].[0-9]"
+      - "unstable"
+    paths-ignore:
+      - '**/*.md'
+      - '**/00-RELEASENOTES'
+      - '**/COPYING'
+  pull_request_target:
+    types: [labeled]
     branches:
       # any PR to a release branch.
       - "[0-9].[0-9]"
@@ -39,7 +50,8 @@ concurrency:
 
 permissions:
   contents: read
-
+  pull-requests: write
+  issues: write
 jobs:
   test-ubuntu-jemalloc:
     runs-on: ubuntu-latest
@@ -1383,6 +1395,22 @@ jobs:
           path: "./utils/req-res-validator/requirements.txt"
       - name: validator
         run: ./utils/req-res-log-validator.py --verbose --fail-missing-reply-schemas ${{ (!contains(github.event.inputs.skiptests, 'valkey') && !contains(github.event.inputs.skiptests, 'module') && !contains(github.event.inputs.sentinel, 'valkey') && !contains(github.event.inputs.skiptests, 'cluster')) && github.event.inputs.test_args == '' && github.event.inputs.cluster_test_args == '' && '--fail-commands-not-all-hit' || '' }}
+
+  remove-run-extra-tests-label:
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'run-extra-tests'
+    steps:
+      - name: Remove run-extra-tests label
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'run-extra-tests'
+            }).catch(err => console.log('label not present', err.message));
 
   notify-about-job-results:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1398,6 +1398,30 @@ jobs:
 
   remove-run-extra-tests-label:
     runs-on: ubuntu-latest
+    needs:
+      - test-ubuntu-jemalloc
+      - test-ubuntu-arm
+      - test-ubuntu-jemalloc-fortify
+      - test-ubuntu-libc-malloc
+      - test-ubuntu-no-malloc-usable-size
+      - test-ubuntu-32bit
+      - test-ubuntu-tls
+      - test-ubuntu-tls-no-tls
+      - test-ubuntu-io-threads
+      - test-ubuntu-tls-io-threads
+      - test-ubuntu-reclaim-cache
+      - test-ubuntu-lttng
+      - test-rpm-distros-jemalloc
+      - test-rpm-distros-tls-module
+      - test-rpm-distros-tls-module-no-tls
+      - test-macos-latest
+      - test-macos-latest-sentinel
+      - test-macos-latest-cluster
+      - build-old-macos-versions
+      - test-freebsd
+      - test-alpine-jemalloc
+      - test-alpine-libc-malloc
+      - reply-schemas-validator
     if: always() && github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'run-extra-tests'
     steps:
       - name: Remove run-extra-tests label

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,7 +2,7 @@ name: Daily
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     branches:
       # any PR to a release branch.
       - "[0-9].[0-9]"
@@ -17,10 +17,6 @@ on:
       # any PR to a release branch.
       - "[0-9].[0-9]"
       - "unstable"
-    paths-ignore:
-      - '**/*.md'
-      - '**/00-RELEASENOTES'
-      - '**/COPYING'
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -58,7 +54,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'ubuntu')
     timeout-minutes: 1440
     steps:
@@ -126,7 +122,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       (!contains(github.event.inputs.skipjobs, 'ubuntu') || !contains(github.event.inputs.skipjobs, 'arm'))
     timeout-minutes: 14400
     steps:
@@ -168,7 +164,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'fortify')
     container: ubuntu:plucky
     timeout-minutes: 1440
@@ -214,7 +210,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
     timeout-minutes: 1440
     steps:
@@ -253,7 +249,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'malloc')
     timeout-minutes: 1440
     steps:
@@ -292,7 +288,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, '32bit')
     timeout-minutes: 1440
     steps:
@@ -338,7 +334,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 1440
     steps:
@@ -384,7 +380,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     timeout-minutes: 1440
     steps:
@@ -430,7 +426,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 1440
     steps:
@@ -464,7 +460,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'tls') && !contains(github.event.inputs.skipjobs, 'iothreads')
     timeout-minutes: 1440
     steps:
@@ -502,7 +498,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'specific')
     timeout-minutes: 1440
     steps:
@@ -874,7 +870,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'lttng')
     timeout-minutes: 1440
     steps:
@@ -914,7 +910,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'rpm-distros')
     strategy:
       fail-fast: false
@@ -980,7 +976,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'tls')
     strategy:
       fail-fast: false
@@ -1125,7 +1121,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !(contains(github.event.inputs.skiptests, 'valkey') && contains(github.event.inputs.skiptests, 'modules'))
     timeout-minutes: 1440
     steps:
@@ -1156,7 +1152,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'sentinel')
     timeout-minutes: 1440
     steps:
@@ -1184,7 +1180,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'macos') && !contains(github.event.inputs.skiptests, 'cluster')
     timeout-minutes: 1440
     steps:
@@ -1216,7 +1212,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'macos')
     timeout-minutes: 1440
     steps:
@@ -1244,7 +1240,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'freebsd')
     timeout-minutes: 1440
     steps:
@@ -1274,7 +1270,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
@@ -1315,7 +1311,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'alpine')
     container: alpine:latest
     steps:
@@ -1357,7 +1353,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
-        (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
+        ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && (contains(github.event.pull_request.labels.*.name, 'run-extra-tests') || github.event.pull_request.base.ref != 'unstable'))) &&
       !contains(github.event.inputs.skipjobs, 'reply-schema')
     steps:
       - name: prep


### PR DESCRIPTION
Change the behaviour of the CI job triggered by the run-extra-tests label.

Run the tests immediately when applying the run-extra-tests label to a PR, without requiring an extra commit to be pushed to trigger the test run.

When the extra tests have run, the job removes the label.