### PR TITLE
Add TLS client presented certificate expiry warnings and KPI

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3428,6 +3428,7 @@ standardConfig static_configs[] = {
     createEnumConfig("tls-auth-clients-user", NULL, MODIFIABLE_CONFIG, tls_client_auth_user_enum, server.tls_ctx_config.client_auth_user, TLS_CLIENT_FIELD_OFF, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-session-caching", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.session_caching, 1, NULL, applyTlsCfg),
+    createLongLongConfig("tls-client-cert-expiry-warn-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.tls_client_cert_expiry_warn_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createStringConfig("tls-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file_pass, NULL, NULL, applyTlsCfg),

--- a/src/config.c
+++ b/src/config.c
@@ -2748,6 +2748,12 @@ static int applyTlsCfg(const char **err) {
     return 1;
 }
 
+static int applyTlsClientCertExpiryWarnThreshold(const char **err) {
+    UNUSED(err);
+    if (server.client_cert_expiry_warned) dictEmpty(server.client_cert_expiry_warned, NULL);
+    return 1;
+}
+
 static int applyTLSPort(const char **err) {
     /* Configure TLS in case it wasn't enabled */
     if (connTypeConfigure(connectionTypeTls(), &server.tls_ctx_config, 0) == C_ERR) {
@@ -3428,7 +3434,7 @@ standardConfig static_configs[] = {
     createEnumConfig("tls-auth-clients-user", NULL, MODIFIABLE_CONFIG, tls_client_auth_user_enum, server.tls_ctx_config.client_auth_user, TLS_CLIENT_FIELD_OFF, NULL, NULL),
     createBoolConfig("tls-prefer-server-ciphers", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.prefer_server_ciphers, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-session-caching", NULL, MODIFIABLE_CONFIG, server.tls_ctx_config.session_caching, 1, NULL, applyTlsCfg),
-    createLongLongConfig("tls-client-cert-expiry-warn-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.tls_client_cert_expiry_warn_threshold, 0, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("tls-client-cert-expiry-warn-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.tls_client_cert_expiry_warn_threshold, 0, INTEGER_CONFIG, NULL, applyTlsClientCertExpiryWarnThreshold),
     createStringConfig("tls-cert-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.cert_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file", NULL, VOLATILE_CONFIG | MODIFIABLE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file, NULL, NULL, applyTlsCfg),
     createStringConfig("tls-key-file-pass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.tls_ctx_config.key_file_pass, NULL, NULL, applyTlsCfg),

--- a/src/connection.c
+++ b/src/connection.c
@@ -168,3 +168,13 @@ sds getListensInfoString(sds info) {
 
     return info;
 }
+
+sds connGetPeerCertFingerprint(connection *conn) {
+    if (!conn || !conn->type->get_peer_cert_fingerprint) return NULL;
+    return conn->type->get_peer_cert_fingerprint(conn);
+}
+
+int connGetPeerCertValidity(connection *conn, long long *remaining_seconds) {
+    if (!conn || !remaining_seconds || !conn->type->get_peer_cert_validity) return C_ERR;
+    return conn->type->get_peer_cert_validity(conn, remaining_seconds);
+}

--- a/src/connection.c
+++ b/src/connection.c
@@ -169,11 +169,13 @@ sds getListensInfoString(sds info) {
     return info;
 }
 
+/* Return a printable fingerprint for the peer certificate, when available. */
 sds connGetPeerCertFingerprint(connection *conn) {
     if (!conn || !conn->type->get_peer_cert_fingerprint) return NULL;
     return conn->type->get_peer_cert_fingerprint(conn);
 }
 
+/* Return seconds until the peer certificate expires, or C_ERR on failure. */
 int connGetPeerCertValidity(connection *conn, long long *remaining_seconds) {
     if (!conn || !remaining_seconds || !conn->type->get_peer_cert_validity) return C_ERR;
     return conn->type->get_peer_cert_validity(conn, remaining_seconds);

--- a/src/connection.h
+++ b/src/connection.h
@@ -426,7 +426,9 @@ static inline sds connGetPeerCert(connection *conn) {
     return NULL;
 }
 
+/* Return a readable fingerprint (hash) for the peer certificate when supported. */
 sds connGetPeerCertFingerprint(connection *conn);
+/* Report how many seconds remain before the peer certificate expires. */
 int connGetPeerCertValidity(connection *conn, long long *remaining_seconds);
 
 /* Get Peer username based on connection type */

--- a/src/connection.h
+++ b/src/connection.h
@@ -146,6 +146,8 @@ typedef struct ConnectionType {
 
     /* TLS specified methods */
     sds (*get_peer_cert)(struct connection *conn);
+    sds (*get_peer_cert_fingerprint)(struct connection *conn);
+    int (*get_peer_cert_validity)(struct connection *conn, long long *remaining_seconds);
 
     /* Get peer username based on connection type */
     sds (*get_peer_username)(connection *conn);
@@ -423,6 +425,9 @@ static inline sds connGetPeerCert(connection *conn) {
 
     return NULL;
 }
+
+sds connGetPeerCertFingerprint(connection *conn);
+int connGetPeerCertValidity(connection *conn, long long *remaining_seconds);
 
 /* Get Peer username based on connection type */
 static inline sds connGetPeerUsername(connection *conn) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -1688,7 +1688,7 @@ int clientHasPendingReplies(client *c) {
 
 #define TLS_CERT_WARN_DEDUP_WINDOW_MS (24LL * 60 * 60 * 1000)
 
-/* Convert raw seconds to whole days (rounding toward negative infinity). */
+/* Convert raw seconds to whole days. */
 static long long secondsToDaysFloor(long long seconds) {
     long long days = seconds / 86400LL;
     if (seconds < 0 && (seconds % 86400LL)) days -= 1;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1724,9 +1724,9 @@ static void monitorTlsClientCertExpiry(client *c) {
     long long remaining_seconds;
     if (connGetPeerCertValidity(c->conn, &remaining_seconds) != C_OK) return;
 
-    long long remaining_days = secondsToDaysFloor(remaining_seconds);
-    if (server.client_cert_min_days_until_expiry == -1 || remaining_days < server.client_cert_min_days_until_expiry) {
-        server.client_cert_min_days_until_expiry = remaining_days;
+    if (server.client_cert_min_seconds_until_expiry == -1 ||
+        remaining_seconds < server.client_cert_min_seconds_until_expiry) {
+        server.client_cert_min_seconds_until_expiry = remaining_seconds;
     }
 
     long long threshold_days = server.tls_client_cert_expiry_warn_threshold;
@@ -1743,7 +1743,7 @@ static void monitorTlsClientCertExpiry(client *c) {
     if (remaining_seconds <= threshold_seconds) {
         long long log_days = secondsToDaysFloor(remaining_seconds);
         sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
-        serverLog(LL_WARNING,
+        serverLog(LL_NOTICE,
                   "TLS client certificate for %s expires in %lld days (threshold %lld days).",
                   client,
                   log_days,

--- a/src/networking.c
+++ b/src/networking.c
@@ -1688,12 +1688,14 @@ int clientHasPendingReplies(client *c) {
 
 #define TLS_CERT_WARN_DEDUP_WINDOW_MS (24LL * 60 * 60 * 1000)
 
+/* Convert raw seconds to whole days (rounding toward negative infinity). */
 static long long secondsToDaysFloor(long long seconds) {
     long long days = seconds / 86400LL;
     if (seconds < 0 && (seconds % 86400LL)) days -= 1;
     return days;
 }
 
+/* Tell us if we already warned about this fingerprint and the suppression window hasn't elapsed. */
 static int certWarningRecentlyLogged(sds fingerprint, mstime_t now) {
     if (!fingerprint || !server.client_cert_expiry_warned) return 0;
     dictEntry *de = dictFind(server.client_cert_expiry_warned, fingerprint);
@@ -1704,6 +1706,7 @@ static int certWarningRecentlyLogged(sds fingerprint, mstime_t now) {
     return 0;
 }
 
+/* Remember that we warned about this fingerprint so we can suppress repeats. */
 static void rememberCertWarning(sds fingerprint, mstime_t now) {
     if (!fingerprint || !server.client_cert_expiry_warned) return;
     long long *expiry = zmalloc(sizeof(long long));
@@ -1714,6 +1717,7 @@ static void rememberCertWarning(sds fingerprint, mstime_t now) {
     }
 }
 
+/* Inspect each TLS client certificate as it connects and warn when close to expiry. */
 static void monitorTlsClientCertExpiry(client *c) {
     if (!connIsTLS(c->conn)) return;
 
@@ -1737,12 +1741,12 @@ static void monitorTlsClientCertExpiry(client *c) {
 
     long long threshold_seconds = threshold_days * 86400LL;
     if (remaining_seconds <= threshold_seconds) {
-        double days_double = (double)remaining_seconds / 86400.0;
+        long long log_days = secondsToDaysFloor(remaining_seconds);
         sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
         serverLog(LL_WARNING,
-                  "TLS client certificate for %s expires in %.2f days (threshold %lld days).",
+                  "TLS client certificate for %s expires in %lld days (threshold %lld days).",
                   client,
-                  days_double,
+                  log_days,
                   threshold_days);
         sdsfree(client);
         rememberCertWarning(fingerprint, now);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1686,6 +1686,72 @@ int clientHasPendingReplies(client *c) {
     }
 }
 
+#define TLS_CERT_WARN_DEDUP_WINDOW_MS (24LL * 60 * 60 * 1000)
+
+static long long secondsToDaysFloor(long long seconds) {
+    long long days = seconds / 86400LL;
+    if (seconds < 0 && (seconds % 86400LL)) days -= 1;
+    return days;
+}
+
+static int certWarningRecentlyLogged(sds fingerprint, mstime_t now) {
+    if (!fingerprint || !server.client_cert_expiry_warned) return 0;
+    dictEntry *de = dictFind(server.client_cert_expiry_warned, fingerprint);
+    if (!de) return 0;
+    long long expiry = *(long long *)dictGetVal(de);
+    if (expiry > now) return 1;
+    dictDelete(server.client_cert_expiry_warned, fingerprint);
+    return 0;
+}
+
+static void rememberCertWarning(sds fingerprint, mstime_t now) {
+    if (!fingerprint || !server.client_cert_expiry_warned) return;
+    long long *expiry = zmalloc(sizeof(long long));
+    *expiry = now + TLS_CERT_WARN_DEDUP_WINDOW_MS;
+    if (dictAdd(server.client_cert_expiry_warned, fingerprint, expiry) != DICT_OK) {
+        zfree(expiry);
+        sdsfree(fingerprint);
+    }
+}
+
+static void monitorTlsClientCertExpiry(client *c) {
+    if (!connIsTLS(c->conn)) return;
+
+    long long remaining_seconds;
+    if (connGetPeerCertValidity(c->conn, &remaining_seconds) != C_OK) return;
+
+    long long remaining_days = secondsToDaysFloor(remaining_seconds);
+    if (server.client_cert_min_days_until_expiry == -1 || remaining_days < server.client_cert_min_days_until_expiry) {
+        server.client_cert_min_days_until_expiry = remaining_days;
+    }
+
+    long long threshold_days = server.tls_client_cert_expiry_warn_threshold;
+    if (threshold_days <= 0) return;
+
+    sds fingerprint = connGetPeerCertFingerprint(c->conn);
+    mstime_t now = mstime();
+    if (certWarningRecentlyLogged(fingerprint, now)) {
+        if (fingerprint) sdsfree(fingerprint);
+        return;
+    }
+
+    long long threshold_seconds = threshold_days * 86400LL;
+    if (remaining_seconds <= threshold_seconds) {
+        double days_double = (double)remaining_seconds / 86400.0;
+        sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
+        serverLog(LL_WARNING,
+                  "TLS client certificate for %s expires in %.2f days (threshold %lld days).",
+                  client,
+                  days_double,
+                  threshold_days);
+        sdsfree(client);
+        rememberCertWarning(fingerprint, now);
+        fingerprint = NULL;
+    }
+
+    if (fingerprint) sdsfree(fingerprint);
+}
+
 void clientAcceptHandler(connection *conn) {
     client *c = connGetPrivateData(conn);
 
@@ -1695,6 +1761,8 @@ void clientAcceptHandler(connection *conn) {
         freeClientAsync(c);
         return;
     }
+
+    monitorTlsClientCertExpiry(c);
 
     /* If the server is running in protected mode (the default) and there
      * is no password set, nor a specific interface is bound, we don't accept

--- a/src/networking.c
+++ b/src/networking.c
@@ -37,6 +37,7 @@
 #include "fpconv_dtoa.h"
 #include "fmtargs.h"
 #include "io_threads.h"
+#include "monotonic.h"
 #include "module.h"
 #include "connection.h"
 #include "zmalloc.h"
@@ -1696,7 +1697,7 @@ static long long secondsToDaysFloor(long long seconds) {
 }
 
 /* Tell us if we already warned about this fingerprint and the suppression window hasn't elapsed. */
-static int certWarningRecentlyLogged(sds fingerprint, mstime_t now) {
+static int certWarningRecentlyLogged(sds fingerprint, long long now) {
     if (!fingerprint || !server.client_cert_expiry_warned) return 0;
     dictEntry *de = dictFind(server.client_cert_expiry_warned, fingerprint);
     if (!de) return 0;
@@ -1707,7 +1708,7 @@ static int certWarningRecentlyLogged(sds fingerprint, mstime_t now) {
 }
 
 /* Remember that we warned about this fingerprint so we can suppress repeats. */
-static void rememberCertWarning(sds fingerprint, mstime_t now) {
+static void rememberCertWarning(sds fingerprint, long long now) {
     if (!fingerprint || !server.client_cert_expiry_warned) return;
     long long *expiry = zmalloc(sizeof(long long));
     *expiry = now + TLS_CERT_WARN_DEDUP_WINDOW_MS;
@@ -1724,36 +1725,33 @@ static void monitorTlsClientCertExpiry(client *c) {
     long long remaining_seconds;
     if (connGetPeerCertValidity(c->conn, &remaining_seconds) != C_OK) return;
 
-    if (server.client_cert_min_seconds_until_expiry == -1 ||
-        remaining_seconds < server.client_cert_min_seconds_until_expiry) {
-        server.client_cert_min_seconds_until_expiry = remaining_seconds;
+    if (server.tls_client_presented_cert_expires_in_seconds == -1 ||
+        remaining_seconds < server.tls_client_presented_cert_expires_in_seconds) {
+        server.tls_client_presented_cert_expires_in_seconds = remaining_seconds;
     }
 
     long long threshold_days = server.tls_client_cert_expiry_warn_threshold;
     if (threshold_days <= 0) return;
 
+    long long threshold_seconds = threshold_days * 86400LL;
+    if (remaining_seconds > threshold_seconds) return;
+
     sds fingerprint = connGetPeerCertFingerprint(c->conn);
-    mstime_t now = mstime();
+    long long now = (long long)(getMonotonicUs() / 1000);
     if (certWarningRecentlyLogged(fingerprint, now)) {
         if (fingerprint) sdsfree(fingerprint);
         return;
     }
 
-    long long threshold_seconds = threshold_days * 86400LL;
-    if (remaining_seconds <= threshold_seconds) {
-        long long log_days = secondsToDaysFloor(remaining_seconds);
-        sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
-        serverLog(LL_NOTICE,
-                  "TLS client certificate for %s expires in %lld days (threshold %lld days).",
-                  client,
-                  log_days,
-                  threshold_days);
-        sdsfree(client);
-        rememberCertWarning(fingerprint, now);
-        fingerprint = NULL;
-    }
-
-    if (fingerprint) sdsfree(fingerprint);
+    long long log_days = secondsToDaysFloor(remaining_seconds);
+    sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
+    serverLog(LL_NOTICE,
+              "TLS client-presented certificate for %s expires in %lld days (threshold %lld days).",
+              client,
+              log_days,
+              threshold_days);
+    sdsfree(client);
+    rememberCertWarning(fingerprint, now);
 }
 
 void clientAcceptHandler(connection *conn) {

--- a/src/server.c
+++ b/src/server.c
@@ -2278,7 +2278,7 @@ void initServerConfig(void) {
     server.dict_resizing = 1;
     server.import_mode = 0;
     server.tls_client_cert_expiry_warn_threshold = 0;
-    server.client_cert_min_days_until_expiry = -1;
+    server.client_cert_min_seconds_until_expiry = -1;
     server.client_cert_expiry_warned = dictCreate(&stringLongLongDictType);
 
     server.latency_tracking_info_percentiles_len = 3;
@@ -2771,7 +2771,7 @@ void resetServerStats(void) {
     server.el_cmd_cnt_max = 0;
     lazyfreeResetStats();
     if (server.client_cert_expiry_warned) dictEmpty(server.client_cert_expiry_warned, NULL);
-    server.client_cert_min_days_until_expiry = -1;
+    server.client_cert_min_seconds_until_expiry = -1;
 }
 
 /* Make the thread killable at any time, so that kill threads functions
@@ -5974,7 +5974,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "paused_reason:%s\r\n", paused_reason,
                 "paused_actions:%s\r\n", paused_actions,
                 "paused_timeout_milliseconds:%lld\r\n", paused_timeout,
-                "client_cert_min_days_until_expiry:%lld\r\n", server.client_cert_min_days_until_expiry));
+                "client_cert_min_seconds_until_expiry:%lld\r\n", server.client_cert_min_seconds_until_expiry));
     }
 
     /* Memory */

--- a/src/server.c
+++ b/src/server.c
@@ -2278,7 +2278,7 @@ void initServerConfig(void) {
     server.dict_resizing = 1;
     server.import_mode = 0;
     server.tls_client_cert_expiry_warn_threshold = 0;
-    server.client_cert_min_seconds_until_expiry = -1;
+    server.tls_client_presented_cert_expires_in_seconds = -1;
     server.client_cert_expiry_warned = dictCreate(&stringLongLongDictType);
 
     server.latency_tracking_info_percentiles_len = 3;
@@ -2771,7 +2771,7 @@ void resetServerStats(void) {
     server.el_cmd_cnt_max = 0;
     lazyfreeResetStats();
     if (server.client_cert_expiry_warned) dictEmpty(server.client_cert_expiry_warned, NULL);
-    server.client_cert_min_seconds_until_expiry = -1;
+    server.tls_client_presented_cert_expires_in_seconds = -1;
 }
 
 /* Make the thread killable at any time, so that kill threads functions
@@ -5974,7 +5974,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "paused_reason:%s\r\n", paused_reason,
                 "paused_actions:%s\r\n", paused_actions,
                 "paused_timeout_milliseconds:%lld\r\n", paused_timeout,
-                "client_cert_min_seconds_until_expiry:%lld\r\n", server.client_cert_min_seconds_until_expiry));
+                "tls_client_presented_cert_expires_in_seconds:%lld\r\n",
+                server.tls_client_presented_cert_expires_in_seconds));
     }
 
     /* Memory */

--- a/src/server.c
+++ b/src/server.c
@@ -765,6 +765,15 @@ dictType stringSetDictType = {
     NULL                    /* allow to expand */
 };
 
+dictType stringLongLongDictType = {
+    dictSdsHash,       /* hash function */
+    NULL,              /* key dup */
+    dictSdsKeyCompare, /* key compare */
+    dictSdsDestructor, /* key destructor */
+    dictVanillaFree,   /* val destructor */
+    NULL               /* allow to expand */
+};
+
 /* Dict for for case-insensitive search using null terminated C strings.
  * The key and value do not have a destructor. */
 dictType externalStringType = {
@@ -2268,6 +2277,9 @@ void initServerConfig(void) {
     server.pause_cron = 0;
     server.dict_resizing = 1;
     server.import_mode = 0;
+    server.tls_client_cert_expiry_warn_threshold = 0;
+    server.client_cert_min_days_until_expiry = -1;
+    server.client_cert_expiry_warned = dictCreate(&stringLongLongDictType);
 
     server.latency_tracking_info_percentiles_len = 3;
     server.latency_tracking_info_percentiles = zmalloc(sizeof(double) * (server.latency_tracking_info_percentiles_len));
@@ -2758,6 +2770,8 @@ void resetServerStats(void) {
     memset(server.duration_stats, 0, sizeof(durationStats) * EL_DURATION_TYPE_NUM);
     server.el_cmd_cnt_max = 0;
     lazyfreeResetStats();
+    if (server.client_cert_expiry_warned) dictEmpty(server.client_cert_expiry_warned, NULL);
+    server.client_cert_min_days_until_expiry = -1;
 }
 
 /* Make the thread killable at any time, so that kill threads functions
@@ -5959,7 +5973,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "total_blocking_keys_on_nokey:%lu\r\n", blocking_keys_on_nokey,
                 "paused_reason:%s\r\n", paused_reason,
                 "paused_actions:%s\r\n", paused_actions,
-                "paused_timeout_milliseconds:%lld\r\n", paused_timeout));
+                "paused_timeout_milliseconds:%lld\r\n", paused_timeout,
+                "client_cert_min_days_until_expiry:%lld\r\n", server.client_cert_min_days_until_expiry));
     }
 
     /* Memory */

--- a/src/server.h
+++ b/src/server.h
@@ -2265,7 +2265,7 @@ struct valkeyServer {
     int tls_auth_clients;
     serverTLSContextConfig tls_ctx_config;
     long long tls_client_cert_expiry_warn_threshold; /* Days remaining before logging warnings */
-    long long client_cert_min_days_until_expiry;     /* Minimum days observed across client certificates */
+    long long client_cert_min_seconds_until_expiry;  /* Minimum seconds observed across client certificates */
     dict *client_cert_expiry_warned;                  /* Fingerprints logged for expiry warnings */
     serverUnixContextConfig unix_ctx_config;
     serverRdmaContextConfig rdma_ctx_config;

--- a/src/server.h
+++ b/src/server.h
@@ -2264,6 +2264,9 @@ struct valkeyServer {
     int tls_replication;
     int tls_auth_clients;
     serverTLSContextConfig tls_ctx_config;
+    long long tls_client_cert_expiry_warn_threshold; /* Days remaining before logging warnings */
+    long long client_cert_min_days_until_expiry;     /* Minimum days observed across client certificates */
+    dict *client_cert_expiry_warned;                  /* Fingerprints logged for expiry warnings */
     serverUnixContextConfig unix_ctx_config;
     serverRdmaContextConfig rdma_ctx_config;
     /* cpu affinity */
@@ -2710,6 +2713,7 @@ extern double R_Zero, R_PosInf, R_NegInf, R_Nan;
 extern hashtableType hashHashtableType;
 extern hashtableType hashWithVolatileItemsHashtableType;
 extern dictType stringSetDictType;
+extern dictType stringLongLongDictType;
 extern dictType externalStringType;
 extern dictType sdsHashDictType;
 extern hashtableType clientHashtableType;

--- a/src/server.h
+++ b/src/server.h
@@ -2265,7 +2265,7 @@ struct valkeyServer {
     int tls_auth_clients;
     serverTLSContextConfig tls_ctx_config;
     long long tls_client_cert_expiry_warn_threshold; /* Days remaining before logging warnings */
-    long long client_cert_min_seconds_until_expiry;  /* Minimum seconds observed across client certificates */
+    long long tls_client_presented_cert_expires_in_seconds; /* Minimum seconds observed across client certificates */
     dict *client_cert_expiry_warned;                  /* Fingerprints logged for expiry warnings */
     serverUnixContextConfig unix_ctx_config;
     serverRdmaContextConfig rdma_ctx_config;

--- a/src/tls.c
+++ b/src/tls.c
@@ -45,6 +45,7 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/pem.h>
+#include <openssl/evp.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/decoder.h>
 #endif
@@ -1216,6 +1217,65 @@ static sds connTLSGetPeerCert(connection *conn_) {
     return cert_pem;
 }
 
+static sds connTLSGetPeerCertFingerprint(connection *conn_) {
+    tls_connection *conn = (tls_connection *)conn_;
+    if ((conn_->type != connectionTypeTls()) || !conn->ssl) return NULL;
+
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+    if (!cert) return NULL;
+
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int md_len = 0;
+    sds fingerprint = NULL;
+
+    if (X509_digest(cert, EVP_sha256(), md, &md_len)) {
+        fingerprint = sdsnewlen(NULL, md_len * 2);
+        static const char hex[] = "0123456789abcdef";
+        for (unsigned int i = 0; i < md_len; i++) {
+            fingerprint[2 * i] = hex[(md[i] >> 4) & 0xF];
+            fingerprint[2 * i + 1] = hex[md[i] & 0xF];
+        }
+    }
+
+    X509_free(cert);
+    return fingerprint;
+}
+
+static int connTLSGetPeerCertValidity(connection *conn_, long long *remaining_seconds) {
+    tls_connection *conn = (tls_connection *)conn_;
+    if (!remaining_seconds || (conn_->type != connectionTypeTls()) || !conn->ssl || !SSL_is_init_finished(conn->ssl))
+        return C_ERR;
+
+    if (SSL_get_verify_result(conn->ssl) != X509_V_OK) return C_ERR;
+
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+    if (!cert) return C_ERR;
+
+    ASN1_TIME *notAfter = X509_get_notAfter(cert);
+    if (!notAfter) {
+        X509_free(cert);
+        return C_ERR;
+    }
+
+    time_t now = server.unixtime ? server.unixtime : time(NULL);
+    ASN1_TIME *current = ASN1_TIME_set(NULL, now);
+    if (!current) {
+        X509_free(cert);
+        return C_ERR;
+    }
+
+    int days = 0, seconds = 0;
+    int diff_ok = ASN1_TIME_diff(&days, &seconds, current, notAfter);
+    ASN1_TIME_free(current);
+    X509_free(cert);
+
+    if (diff_ok != 1) return C_ERR;
+
+    long long total_seconds = (long long)days * 86400LL + seconds;
+    *remaining_seconds = total_seconds;
+    return C_OK;
+}
+
 static ConnectionType CT_TLS = {
     /* connection type */
     .get_type = connTLSGetType,
@@ -1263,6 +1323,8 @@ static ConnectionType CT_TLS = {
 
     /* TLS specified methods */
     .get_peer_cert = connTLSGetPeerCert,
+    .get_peer_cert_fingerprint = connTLSGetPeerCertFingerprint,
+    .get_peer_cert_validity = connTLSGetPeerCertValidity,
     .get_peer_username = tlsGetPeerUsername,
 
     /* Miscellaneous */

--- a/src/tls.c
+++ b/src/tls.c
@@ -1217,6 +1217,7 @@ static sds connTLSGetPeerCert(connection *conn_) {
     return cert_pem;
 }
 
+/* Create a SHA-256 fingerprint string for the peer certificate. */
 static sds connTLSGetPeerCertFingerprint(connection *conn_) {
     tls_connection *conn = (tls_connection *)conn_;
     if ((conn_->type != connectionTypeTls()) || !conn->ssl) return NULL;

--- a/valkey.conf
+++ b/valkey.conf
@@ -324,6 +324,12 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
+# Emit a warning log when a client-presented TLS certificate gets close to its
+# expiration date. The value is expressed in days. Set to 0 to disable the
+# warning; no connections are rejected when the threshold is crossed.
+#
+# tls-client-cert-expiry-warn-threshold 10
+
 ################################### RDMA ######################################
 
 # Valkey Over RDMA is experimental, it may be changed or be removed in any minor or major version.


### PR DESCRIPTION
- Handshake monitoring: Every TLS client connection has its certificate inspected immediately after the handshake. We track the smallest “days until expiry” we’ve seen since startup/reset and surface it via INFO clients as `client_cert_min_seconds_until_expiry` (initially -1). 
```
# Clients
...
client_cert_min_seconds_until_expiry:345600
```

- Configurable warnings: Introduce `tls-client-cert-expiry-warn-threshold` <days> so operators can enable proactive alerts. Example configuration:
`tls-client-cert-expiry-warn-threshold 10`
Example warning:
`TLS client certificate for id=147 addr=10.1.2.3:54128 fd=15 name=*redacted* expires in 4 days (threshold 10 days).`

- 24‑hour deduplication: To avoid flooding logs, each certificate is fingerprinted (SHA‑256) and stored in client_cert_expiry_warned with a 24‑hour suppression window. The same certificate will trigger at most one warning per day. 