### PR TITLE
Fix crash on module unload when ACL includes module commands; clean stale ACL rules and harden recompute

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -678,6 +678,86 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
 
 }
 
+/* Remove stale module command rules from all users' selectors command_rules strings.
+ * This cleans up rules referring to commands/subcommands that no longer exist
+ * (e.g., after unloading a module), while preserving ACL categories. */
+void ACLCleanupStaleCommandRulesAllUsers(void) {
+    raxIterator ri;
+    raxStart(&ri,Users);
+    raxSeek(&ri,"^",NULL,0);
+    while(raxNext(&ri)) {
+        user *u = ri.data;
+        listIter li;
+        listNode *ln;
+        listRewind(u->selectors,&li);
+        while((ln = listNext(&li))) {
+            aclSelector *selector = (aclSelector *) listNodeValue(ln);
+            int argc = 0;
+            sds *argv = sdssplitargs(selector->command_rules, &argc);
+            if (!argv) continue;
+            sds new_rules = sdsempty();
+            for (int i = 0; i < argc; i++) {
+                sds tok = argv[i];
+                if (sdslen(tok) == 0) continue;
+                char first = tok[0];
+                if (first != '+' && first != '-') {
+                    /* Unknown formatting, keep as-is */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Body after +/- */
+                const char *body = tok+1;
+                if (*body == '@') {
+                    /* Category: always keep */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Command or subcommand. Extract main and optional sub after '|' */
+                const char *pipe = strchr(body, '|');
+                sds main = pipe ? sdsnewlen(body, pipe - body) : sdsnew(body);
+                struct redisCommand *cmd = dictFetchValue(server.orig_commands, main);
+                int keep = 0;
+                if (cmd) {
+                    if (!pipe) {
+                        keep = 1;
+                    } else {
+                        const char *sub = pipe + 1;
+                        if (cmd->subcommands_dict) {
+                            sds sub_sds = sdsnew(sub);
+                            struct redisCommand *sc = dictFetchValue(cmd->subcommands_dict, sub_sds);
+                            sdsfree(sub_sds);
+                            if (sc) keep = 1;
+                        }
+                    }
+                }
+                sdsfree(main);
+                if (keep) {
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                } else {
+                    serverLog(LL_VERBOSE,
+                              "Removing stale ACL rule '%s' for user '%s' (command not found)",
+                              tok, u->name);
+                }
+            }
+            sdsfreesplitres(argv, argc);
+            if (sdslen(new_rules)) {
+                /* Trim trailing space if present */
+                size_t nrlen = sdslen(new_rules);
+                if (nrlen > 0 && new_rules[nrlen-1] == ' ') {
+                    sdsrange(new_rules, 0, (ssize_t)nrlen - 2);
+                }
+                sdsfree(selector->command_rules);
+                selector->command_rules = new_rules;
+            } else {
+                sdsfree(selector->command_rules);
+                selector->command_rules = sdsempty();
+                sdsfree(new_rules);
+            }
+        }
+    }
+    raxStop(&ri);
+}
+
 int ACLSetSelectorCategory(aclSelector *selector, const char *category, int allow) {
     uint64_t cflag = ACLGetCommandCategoryFlagByName(category + 1);
     if (!cflag) return C_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -12285,6 +12285,9 @@ int moduleUnload(sds name, const char **errmsg) {
 
     moduleUnregisterCleanup(module);
 
+    /* Cleanup stale ACL command rules that may reference unloaded module commands. */
+    ACLCleanupStaleCommandRulesAllUsers();
+
     /* Unload the dynamic library. */
     if (dlclose(module->handle) == -1) {
         char *error = dlerror();

--- a/src/server.h
+++ b/src/server.h
@@ -2946,6 +2946,7 @@ sds getAclErrorMessage(int acl_res, user *user, struct redisCommand *cmd, sds er
 void ACLUpdateDefaultUserPassword(sds password);
 sds genRedisInfoStringACLStats(sds info);
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void);
+void ACLCleanupStaleCommandRulesAllUsers(void);
 
 /* Sorted sets data type */
 


### PR DESCRIPTION
**Problem:** 

Unloading a module crashes if any ACL user has rules referencing that module’s commands or subcommands (e.g., +hello.simple). The crash occurs in ACLRecomputeCommandBitsFromCommandRulesAllUsers while applying stale rules; previously it asserted on failure.

**Root Cause:** 
Stale ACL command rules persist in users’ selectors after module unload. Recompute attempts to reapply them, resulting in invalid lookups or assertions.

**Fix:**
Add ACLCleanupStaleCommandRulesAllUsers to proactively remove non-existent module commands/subcommands from selector->command_rules.
Make ACLRecomputeCommandBitsFromCommandRulesAllUsers skip invalid rules with a warning instead of asserting.