### PR TITLE
Adding KPIs for commandlog large request/reply events

### DIFF
--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -102,8 +102,14 @@ void commandlogInit(void) {
  * configured max length. */
 static void commandlogPushEntryIfNeeded(client *c, robj **argv, int argc, long long value, int type) {
     if (server.commandlog[type].threshold < 0 || server.commandlog[type].max_len == 0) return; /* The corresponding commandlog disabled */
-    if (value >= server.commandlog[type].threshold)
+    if (value >= server.commandlog[type].threshold) {
         listAddNodeHead(server.commandlog[type].entries, commandlogCreateEntry(c, argv, argc, value, type));
+        if (type == COMMANDLOG_TYPE_LARGE_REQUEST) {
+            server.stat_commandlog_large_request_ops++;
+        } else if (type == COMMANDLOG_TYPE_LARGE_REPLY) {
+            server.stat_commandlog_large_reply_ops++;
+        }
+    }
 
     /* Remove old entries if needed. */
     while (listLength(server.commandlog[type].entries) > server.commandlog[type].max_len) listDelNode(server.commandlog[type].entries, listLast(server.commandlog[type].entries));

--- a/src/server.c
+++ b/src/server.c
@@ -2751,6 +2751,8 @@ void resetServerStats(void) {
     server.stat_net_cluster_slot_import_bytes = 0;
     server.stat_unexpected_error_replies = 0;
     server.stat_total_error_replies = 0;
+    server.stat_commandlog_large_request_ops = 0;
+    server.stat_commandlog_large_reply_ops = 0;
     server.stat_dump_payload_sanitizations = 0;
     server.aof_delayed_fsync = 0;
     server.stat_reply_buffer_shrinks = 0;
@@ -6213,6 +6215,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "tracking_total_prefixes:%lld\r\n", (unsigned long long)trackingGetTotalPrefixes(),
                 "unexpected_error_replies:%lld\r\n", server.stat_unexpected_error_replies,
                 "total_error_replies:%lld\r\n", server.stat_total_error_replies,
+                "commandlog_large_request_ops:%llu\r\n", server.stat_commandlog_large_request_ops,
+                "commandlog_large_reply_ops:%llu\r\n", server.stat_commandlog_large_reply_ops,
                 "dump_payload_sanitizations:%lld\r\n", server.stat_dump_payload_sanitizations,
                 "total_reads_processed:%lld\r\n", server.stat_total_reads_processed,
                 "total_writes_processed:%lld\r\n", server.stat_total_writes_processed,

--- a/src/server.h
+++ b/src/server.h
@@ -1815,6 +1815,8 @@ struct valkeyServer {
     long long stat_sync_partial_ok;                /* Number of accepted PSYNC requests. */
     long long stat_sync_partial_err;               /* Number of unaccepted PSYNC requests. */
     commandlog commandlog[COMMANDLOG_TYPE_NUM];    /* Logs of commands. */
+    unsigned long long stat_commandlog_large_request_ops; /* # of logged large requests */
+    unsigned long long stat_commandlog_large_reply_ops;   /* # of logged large replies */
     struct malloc_stats cron_malloc_stats;         /* sampled in serverCron(). */
     long long stat_net_input_bytes;                /* Bytes read from network. */
     long long stat_net_output_bytes;               /* Bytes written to network. */

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -136,6 +136,33 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         r config set min-io-threads-avoid-copy-reply $copy_avoid
     } {OK} {needs:debug}
 
+    test {COMMANDLOG - INFO stats track large request/reply ops} {
+        r config resetstat
+        r commandlog reset large-request
+        r commandlog reset large-reply
+        r config set commandlog-request-larger-than 10
+        r config set commandlog-large-request-max-len 10
+        r config set commandlog-reply-larger-than 10
+        r config set commandlog-large-reply-max-len 10
+
+        set value [string repeat B 64]
+        r set info_stats_key $value
+
+        set copy_avoid [lindex [r config get min-io-threads-avoid-copy-reply] 1]
+        r config set min-io-threads-avoid-copy-reply 0
+        r get info_stats_key
+        r config set min-io-threads-avoid-copy-reply $copy_avoid
+
+        set stats [r info stats]
+        assert_equal 1 [info_field $stats commandlog_large_request_ops]
+        assert_equal 1 [info_field $stats commandlog_large_reply_ops]
+
+        r config resetstat
+        set stats [r info stats]
+        assert_equal 0 [info_field $stats commandlog_large_request_ops]
+        assert_equal 0 [info_field $stats commandlog_large_reply_ops]
+    }
+
     test {COMMANDLOG slow - Certain commands are omitted that contain sensitive information} {
         r config set commandlog-slow-execution-max-len 100
         r config set commandlog-execution-slower-than 0


### PR DESCRIPTION
- Count how many commands are logged in commandlog as large requests/replies
- Expose the counters via INFO stats as commandlog_large_request_ops / commandlog_large_reply_ops.

```
# Stats
…
commandlog_large_request_ops:12
commandlog_large_reply_ops:7
…
```

link to open issue: https://github.com/valkey-io/valkey/issues/2911