### PR TITLE
Fix crash unloading module referenced by ACL rules

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -721,94 +721,6 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
     raxStop(&ri);
 }
 
-static struct serverCommand *ACLLookupCommand(const char *name) {
-    struct serverCommand *cmd;
-    sds sdsname = sdsnew(name);
-    cmd = lookupCommandBySdsLogic(server.orig_commands, sdsname);
-    sdsfree(sdsname);
-    return cmd;
-}
-
-/* Remove stale module command rules from all users' selectors command_rules strings.
- * This cleans up rules referring to commands/subcommands that no longer exist
- * (e.g., after unloading a module), while preserving ACL categories. */
-void ACLCleanupStaleCommandRulesAllUsers(void) {
-    raxIterator ri;
-    raxStart(&ri,Users);
-    raxSeek(&ri,"^",NULL,0);
-    while(raxNext(&ri)) {
-        user *u = ri.data;
-        listIter li;
-        listNode *ln;
-        listRewind(u->selectors,&li);
-        while((ln = listNext(&li))) {
-            aclSelector *selector = (aclSelector *) listNodeValue(ln);
-            int argc = 0;
-            sds *argv = sdssplitargs(selector->command_rules, &argc);
-            if (!argv) continue;
-            sds new_rules = sdsempty();
-            for (int i = 0; i < argc; i++) {
-                sds tok = argv[i];
-                if (sdslen(tok) == 0) continue;
-                char first = tok[0];
-                if (first != '+' && first != '-') {
-                    /* Unknown formatting, keep as-is */
-                    new_rules = sdscatfmt(new_rules, "%S ", tok);
-                    continue;
-                }
-                /* Body after +/- */
-                const char *body = tok+1;
-                if (*body == '@') {
-                    /* Category: always keep */
-                    new_rules = sdscatfmt(new_rules, "%S ", tok);
-                    continue;
-                }
-                /* Command or subcommand. Extract main and optional sub after '|' */
-                const char *pipe = strchr(body, '|');
-                sds main = pipe ? sdsnewlen(body, pipe - body) : sdsnew(body);
-                struct serverCommand *cmd = ACLLookupCommand(main);
-                int keep = 0;
-                if (cmd) {
-                    if (!pipe) {
-                        keep = 1;
-                    } else {
-                        const char *sub = pipe + 1;
-                        if (cmd->subcommands_ht) {
-                            sds sub_sds = sdsnew(sub);
-                            struct serverCommand *sc = (struct serverCommand *)dictFetchValue(cmd->subcommands_ht, sub_sds);
-                            sdsfree(sub_sds);
-                            if (sc) keep = 1;
-                        }
-                    }
-                }
-                sdsfree(main);
-                if (keep) {
-                    new_rules = sdscatfmt(new_rules, "%S ", tok);
-                } else {
-                    serverLog(LL_VERBOSE,
-                              "Removing stale ACL rule '%s' for user '%s' (command not found)",
-                              tok, u->name);
-                }
-            }
-            sdsfreesplitres(argv, argc);
-            if (sdslen(new_rules)) {
-                /* Trim trailing space if present */
-                size_t nrlen = sdslen(new_rules);
-                if (nrlen > 0 && new_rules[nrlen-1] == ' ') {
-                    sdsrange(new_rules, 0, (ssize_t)nrlen - 2);
-                }
-                sdsfree(selector->command_rules);
-                selector->command_rules = new_rules;
-            } else {
-                sdsfree(selector->command_rules);
-                selector->command_rules = sdsempty();
-                sdsfree(new_rules);
-            }
-        }
-    }
-    raxStop(&ri);
-}
-
 static int ACLSetSelectorCategory(aclSelector *selector, const char *category, int allow) {
     uint64_t cflag = ACLGetCommandCategoryFlagByName(category + 1);
     if (!cflag) return C_ERR;
@@ -984,6 +896,97 @@ robj *ACLDescribeUser(user *u) {
     incrRefCount(u->acl_string);
 
     return u->acl_string;
+}
+
+/* Get a command from the original command table, that is not affected
+ * by the command renaming operations: we base all the ACL work from that
+ * table, so that ACLs are valid regardless of command renaming. */
+static struct serverCommand *ACLLookupCommand(const char *name) {
+    struct serverCommand *cmd;
+    sds sdsname = sdsnew(name);
+    cmd = lookupCommandBySdsLogic(server.orig_commands, sdsname);
+    sdsfree(sdsname);
+    return cmd;
+}
+
+/* Remove stale module command rules from all users' selectors command_rules strings.
+ * This cleans up rules referring to commands/subcommands that no longer exist
+ * (e.g., after unloading a module), while preserving ACL categories. */
+void ACLCleanupStaleCommandRulesAllUsers(void) {
+    raxIterator ri;
+    raxStart(&ri,Users);
+    raxSeek(&ri,"^",NULL,0);
+    while(raxNext(&ri)) {
+        user *u = ri.data;
+        listIter li;
+        listNode *ln;
+        listRewind(u->selectors,&li);
+        while((ln = listNext(&li))) {
+            aclSelector *selector = (aclSelector *) listNodeValue(ln);
+            int argc = 0;
+            sds *argv = sdssplitargs(selector->command_rules, &argc);
+            if (!argv) continue;
+            sds new_rules = sdsempty();
+            for (int i = 0; i < argc; i++) {
+                sds tok = argv[i];
+                if (sdslen(tok) == 0) continue;
+                char first = tok[0];
+                if (first != '+' && first != '-') {
+                    /* Unknown formatting, keep as-is */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Body after +/- */
+                const char *body = tok+1;
+                if (*body == '@') {
+                    /* Category: always keep */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Command or subcommand. Extract main and optional sub after '|' */
+                const char *pipe = strchr(body, '|');
+                sds main = pipe ? sdsnewlen(body, pipe - body) : sdsnew(body);
+                struct serverCommand *cmd = ACLLookupCommand(main);
+                int keep = 0;
+                if (cmd) {
+                    if (!pipe) {
+                        keep = 1;
+                    } else {
+                        const char *sub = pipe + 1;
+                        if (cmd->subcommands_ht) {
+                            sds sub_sds = sdsnew(sub);
+                            struct serverCommand *sc = lookupCommandBySdsLogic(cmd->subcommands_ht, sub_sds);
+                            sdsfree(sub_sds);
+                            if (sc) keep = 1;
+                        }
+                    }
+                }
+                sdsfree(main);
+                if (keep) {
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                } else {
+                    serverLog(LL_VERBOSE,
+                              "Removing stale ACL rule '%s' for user '%s' (command not found)",
+                              tok, u->name);
+                }
+            }
+            sdsfreesplitres(argv, argc);
+            if (sdslen(new_rules)) {
+                /* Trim trailing space if present */
+                size_t nrlen = sdslen(new_rules);
+                if (nrlen > 0 && new_rules[nrlen-1] == ' ') {
+                    sdsrange(new_rules, 0, (ssize_t)nrlen - 2);
+                }
+                sdsfree(selector->command_rules);
+                selector->command_rules = new_rules;
+            } else {
+                sdsfree(selector->command_rules);
+                selector->command_rules = sdsempty();
+                sdsfree(new_rules);
+            }
+        }
+    }
+    raxStop(&ri);
 }
 
 /* Flush the array of allowed first-args for the specified user

--- a/src/acl.c
+++ b/src/acl.c
@@ -721,6 +721,94 @@ void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void) {
     raxStop(&ri);
 }
 
+static struct serverCommand *ACLLookupCommand(const char *name) {
+    struct serverCommand *cmd;
+    sds sdsname = sdsnew(name);
+    cmd = lookupCommandBySdsLogic(server.orig_commands, sdsname);
+    sdsfree(sdsname);
+    return cmd;
+}
+
+/* Remove stale module command rules from all users' selectors command_rules strings.
+ * This cleans up rules referring to commands/subcommands that no longer exist
+ * (e.g., after unloading a module), while preserving ACL categories. */
+void ACLCleanupStaleCommandRulesAllUsers(void) {
+    raxIterator ri;
+    raxStart(&ri,Users);
+    raxSeek(&ri,"^",NULL,0);
+    while(raxNext(&ri)) {
+        user *u = ri.data;
+        listIter li;
+        listNode *ln;
+        listRewind(u->selectors,&li);
+        while((ln = listNext(&li))) {
+            aclSelector *selector = (aclSelector *) listNodeValue(ln);
+            int argc = 0;
+            sds *argv = sdssplitargs(selector->command_rules, &argc);
+            if (!argv) continue;
+            sds new_rules = sdsempty();
+            for (int i = 0; i < argc; i++) {
+                sds tok = argv[i];
+                if (sdslen(tok) == 0) continue;
+                char first = tok[0];
+                if (first != '+' && first != '-') {
+                    /* Unknown formatting, keep as-is */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Body after +/- */
+                const char *body = tok+1;
+                if (*body == '@') {
+                    /* Category: always keep */
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                    continue;
+                }
+                /* Command or subcommand. Extract main and optional sub after '|' */
+                const char *pipe = strchr(body, '|');
+                sds main = pipe ? sdsnewlen(body, pipe - body) : sdsnew(body);
+                struct serverCommand *cmd = ACLLookupCommand(main);
+                int keep = 0;
+                if (cmd) {
+                    if (!pipe) {
+                        keep = 1;
+                    } else {
+                        const char *sub = pipe + 1;
+                        if (cmd->subcommands_ht) {
+                            sds sub_sds = sdsnew(sub);
+                            struct serverCommand *sc = (struct serverCommand *)dictFetchValue(cmd->subcommands_ht, sub_sds);
+                            sdsfree(sub_sds);
+                            if (sc) keep = 1;
+                        }
+                    }
+                }
+                sdsfree(main);
+                if (keep) {
+                    new_rules = sdscatfmt(new_rules, "%S ", tok);
+                } else {
+                    serverLog(LL_VERBOSE,
+                              "Removing stale ACL rule '%s' for user '%s' (command not found)",
+                              tok, u->name);
+                }
+            }
+            sdsfreesplitres(argv, argc);
+            if (sdslen(new_rules)) {
+                /* Trim trailing space if present */
+                size_t nrlen = sdslen(new_rules);
+                if (nrlen > 0 && new_rules[nrlen-1] == ' ') {
+                    sdsrange(new_rules, 0, (ssize_t)nrlen - 2);
+                }
+                sdsfree(selector->command_rules);
+                selector->command_rules = new_rules;
+            } else {
+                sdsfree(selector->command_rules);
+                selector->command_rules = sdsempty();
+                sdsfree(new_rules);
+            }
+        }
+    }
+    raxStop(&ri);
+}
+
 static int ACLSetSelectorCategory(aclSelector *selector, const char *category, int allow) {
     uint64_t cflag = ACLGetCommandCategoryFlagByName(category + 1);
     if (!cflag) return C_ERR;
@@ -896,17 +984,6 @@ robj *ACLDescribeUser(user *u) {
     incrRefCount(u->acl_string);
 
     return u->acl_string;
-}
-
-/* Get a command from the original command table, that is not affected
- * by the command renaming operations: we base all the ACL work from that
- * table, so that ACLs are valid regardless of command renaming. */
-static struct serverCommand *ACLLookupCommand(const char *name) {
-    struct serverCommand *cmd;
-    sds sdsname = sdsnew(name);
-    cmd = lookupCommandBySdsLogic(server.orig_commands, sdsname);
-    sdsfree(sdsname);
-    return cmd;
 }
 
 /* Flush the array of allowed first-args for the specified user

--- a/src/module.c
+++ b/src/module.c
@@ -12753,6 +12753,7 @@ void moduleUnregisterCleanup(ValkeyModule *module) {
     moduleUnsubscribeAllServerEvents(module);
     moduleRemoveConfigs(module);
     moduleUnregisterAuthCBs(module);
+    ACLCleanupStaleCommandRulesAllUsers();
 }
 
 /* Load a module and initialize it. On success C_OK is returned, otherwise

--- a/src/server.h
+++ b/src/server.h
@@ -3265,6 +3265,7 @@ sds getAclErrorMessage(int acl_res, user *user, struct serverCommand *cmd, sds e
 void ACLUpdateDefaultUserPassword(sds password);
 sds genValkeyInfoStringACLStats(sds info);
 void ACLRecomputeCommandBitsFromCommandRulesAllUsers(void);
+void ACLCleanupStaleCommandRulesAllUsers(void);
 
 /* Sorted sets data type */
 

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1364,4 +1364,26 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
             $replica AUTH joe anything
         }
     }
+
+    test {ACL cleanup stale command rules on module unload} {
+        # Load the test module that registers a command with subcommands
+        set module_path [file normalize tests/modules/subcommands.so]
+        r MODULE LOAD $module_path
+
+        # Create a user with an ACL entry referencing the module subcommand
+        r ACL SETUSER testuser on nopass +subcommands.bitarray|set
+        set user_before [r ACL GETUSER testuser]
+        # The user commands string may include the implicit -@all prefix;
+        # check that the subcommand rule we added is present instead of
+        # asserting exact equality.
+        assert {[string first "+subcommands.bitarray|set" [dict get $user_before commands]] >= 0}
+
+        # Unload the module, this triggers ACLCleanupStaleCommandRulesAllUsers()
+        r MODULE UNLOAD subcommands
+
+        # After unload the module command is removed, ACL rules should be cleaned
+        set user_after [r ACL GETUSER testuser]
+        # After cleanup the user should have only the default -@all command rule
+        assert {[dict get $user_after commands] eq "-@all"}
+    }
 }

--- a/tmp/valkey.conf
+++ b/tmp/valkey.conf
@@ -1,0 +1,4 @@
+aclfile "/Users/sacvenka/Desktop/OCI-Cache/oci-cache-modules/module-ociadmin/tmp/users_in_oci.acl"
+loadmodule /Users/sacvenka/Desktop/OCI-Cache/oci-cache-modules/module-ociadmin/target/debug/libociadmin.dylib
+enable-module-command yes
+enable-debug-command yes

--- a/tmp/valkey.conf
+++ b/tmp/valkey.conf
@@ -1,4 +1,0 @@
-aclfile "/Users/sacvenka/Desktop/OCI-Cache/oci-cache-modules/module-ociadmin/tmp/users_in_oci.acl"
-loadmodule /Users/sacvenka/Desktop/OCI-Cache/oci-cache-modules/module-ociadmin/target/debug/libociadmin.dylib
-enable-module-command yes
-enable-debug-command yes


### PR DESCRIPTION
Problem:

Unloading a module crashes if any ACL user has rules referencing that module’s commands or subcommands (e.g., +hello.simple). The crash occurs in ACLRecomputeCommandBitsFromCommandRulesAllUsers while applying stale rules; previously it asserted on failure.

Root Cause:
Stale ACL command rules persist in users’ selectors after module unload. Recompute attempts to reapply them, resulting in invalid lookups or assertions.

Fixes #2797 

Add ACLCleanupStaleCommandRulesAllUsers to proactively remove non-existent module commands/subcommands from selector->command_rules.
Make ACLRecomputeCommandBitsFromCommandRulesAllUsers skip invalid rules with a warning instead of asserting.