### PR TITLE
Refine major decision process and update TSC composition rules

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ The Valkey project is managed by a Technical Steering Committee (TSC) composed o
 The Valkey project includes all of the current and future repositories under the Valkey-io organization.
 Committers are defined as individuals with write access to the code within a repository.
 Maintainers are defined as individuals with full access to a repository and own its governance.
-Both maintainers and committers should be clearly listed in the MAINTAINERS.md file in a given projects repository.
+Both maintainers and committers should be clearly listed in the MAINTAINERS.md file in a given project's repository.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
 ## Technical Steering Committee
@@ -13,6 +13,8 @@ The TSC is responsible for oversight of all technical, project, approval, and po
 
 The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the Valkey repository.
 Maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
+At any time, no more than one third (1/3) of the TSC members may be employees, contractors, or representatives of the same organization or affiliated organizations.
+For the purposes of this document, “organization” includes companies, corporations, universities, research institutes, non-profits, governmental institutions, and any of their subsidiaries or affiliates.
 The TSC shall appoint a Chair responsible for organizing TSC meetings.
 If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
 The TSC can amend this governance document by no less than a 2/3 affirmative vote.
@@ -29,16 +31,23 @@ The TSC shall document evidence of consensus in accordance with these requiremen
 If consensus cannot be reached, the TSC shall make the decision by a vote.
 
 A vote shall also be called when an issue or pull request is marked as a major decision, which are decisions that have a significant impact on the Valkey architecture or design.
-Examples of major decisions:
+
+Technical major decisions include:
     * Fundamental changes to the Valkey core datastructures
     * Adding a new data structure or API
     * Changes that affect backward compatibility
     * New user visible fields that need to be maintained
+    * Adding or removing a new external library such as a client or module to the project when it affects runtime behavior
+
+For technical major decisions, the TSC may approve a change based on explicit “+2” support from at least two sitting TSC members, recorded on the relevant issue or pull request.
+A +2 approval is treated as approval of the technical decision by the TSC and may be retracted by a subsequent vote.
+Retraction requires a simple majority vote of all voting members; if the vote results in a tie, the status quo is preserved and the +2 approval is retracted.
+
+Non-technical major decisions always require a formal simple majority vote.
+Non-technical major decisions include:
     * Modifications to the TSC or other governance documents
     * Adding members to other roles within the Valkey project
     * Delegation of maintainership for projects to other groups or individuals
-    * Adding or removing a new external library such as a client
-    or module to the project.
 
 Any member of the TSC can call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.
@@ -46,7 +55,8 @@ The discussion shall be open to the public, with the notable exception of discus
 In any vote, each voting TSC member will have one vote.
 The TSC shall give at least two weeks for all members to submit their vote.
 Except as specifically noted elsewhere in this document, decisions by vote require a simple majority vote of all voting members.
-It is the responsibility of the TSC chair to help facilitate the voting process as needed to make sure it completes within the voting period.
+If a vote results in a tie, the status quo is preserved.
+It is the responsibility of the TSC Chair to help facilitate the voting process as needed to make sure it completes within the voting period.
 
 ## Termination of Membership
 
@@ -59,7 +69,7 @@ A maintainer's access (and accordingly, their position on the TSC) will be remov
 ## Technical direction for other Valkey projects
 
 The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for those projects.
-Delegation of decision making for a project is considered a major decision, and shall happen with an explicit vote.
+Delegation of decision making for a project is considered a non-technical major decision and shall happen with an explicit simple majority vote.
 Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repositories.
 
 The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ The Valkey project is managed by a Technical Steering Committee (TSC) composed o
 The Valkey project includes all of the current and future repositories under the Valkey-io organization.
 Committers are defined as individuals with write access to the code within a repository.
 Maintainers are defined as individuals with full access to a repository and own its governance.
-Both maintainers and committers should be clearly listed in the MAINTAINERS.md file in a given project's repository.
+Both maintainers and committers shall be clearly listed in the MAINTAINERS.md file in a given project's repository.
 Maintainers of other repositories within the Valkey project are not members of the TSC unless explicitly added.
 
 ## Technical Steering Committee
@@ -12,14 +12,15 @@ Maintainers of other repositories within the Valkey project are not members of t
 The TSC is responsible for oversight of all technical, project, approval, and policy matters for Valkey.
 
 The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the Valkey repository.
-Maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
+
 At any time, no more than one third (1/3) of the TSC members may be employees, contractors, or representatives of the same organization or affiliated organizations.
 For the purposes of this document, “organization” includes companies, corporations, universities, research institutes, non-profits, governmental institutions, and any of their subsidiaries or affiliates.
+If, at any time, the 1/3 organization limit is exceeded (for example, due to changes in employment, company acquisitions, or organizational affiliations), the TSC shall be notified as soon as possible.
+The TSC must promptly take action to restore compliance, which may include removing or reassigning members in accordance with the procedures outlined in the "Termination of Membership" section.
+The TSC shall strive to resolve the situation within 30 days of notification, and document the steps taken to restore compliance.
 
-If, at any time, the 1/3 organization limit is exceeded (for example, due to changes in employment, company acquisitions, or organizational affiliations), the TSC shall be notified as soon as possible. The TSC must promptly take action to restore compliance, which may include removing or reassigning members in accordance with the procedures outlined in the "Termination of Membership" section. The TSC should strive to resolve the situation within 30 days of notification, and document the steps taken to restore compliance.
 The TSC shall appoint a Chair responsible for organizing TSC meetings.
 If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
-The TSC can amend this governance document by no less than a 2/3 affirmative vote.
 
 The TSC may, at its discretion, add or remove members who are not maintainers of the main Valkey repository.
 The TSC may, at its discretion, add or remove maintainers from other repositories within the Valkey project.
@@ -34,6 +35,8 @@ If consensus cannot be reached, the TSC shall make the decision by a vote.
 
 A vote shall also be called when an issue or pull request is marked as a major decision, which are decisions that have a significant impact on the Valkey architecture or design.
 
+### Technical Major Decisions
+
 Technical major decisions include:
     * Fundamental changes to the Valkey core datastructures
     * Adding a new data structure or API
@@ -41,15 +44,23 @@ Technical major decisions include:
     * New user visible fields that need to be maintained
     * Adding or removing a new external library such as a client or module to the project when it affects runtime behavior
 
-For technical major decisions, the TSC may approve a change based on explicit “+2” support from at least two TSC members, recorded on the relevant issue or pull request.
-A +2 approval is treated as approval of the technical decision by the TSC and may be retracted by a subsequent vote.
-Retraction requires a simple majority vote of all voting members; if the vote results in a tie, the status quo is preserved and the +2 approval is retracted.
+Technical major decisions shall be approved by a simple majority vote whenever one can be obtained.
+If a simple majority cannot be reached within a two-week voting period, and no TSC member has cast a veto vote, the decision may instead be approved through explicit “+2” support from at least two TSC members, recorded on the relevant issue or pull request.
+If the PR author or issue proposer is a TSC member, their +1 counts toward the +2.
+If any TSC member casts a veto vote, the decision must follow the simple majority voting process and cannot be approved through +2.
+Once a technical major decision has been approved through the +2 mechanism, any subsequent concerns shall be raised through a new major decision process; +2 approvals are not retracted directly.
 
-Non-technical major decisions always require a formal simple majority vote.
-Non-technical major decisions include:
-    * Modifications to the TSC or other governance documents
-    * Adding members to other roles within the Valkey project
-    * Delegation of maintainership for projects to other groups or individuals
+### Governance Major Decisions
+
+Governance major decisions include:
+    * Adding TSC members or involuntary removal of TSC members
+    * Modifying this governance document
+    * Delegation of maintainership for projects or governance authority
+    * Creating, modifying, or removing roles within the Valkey project
+    * Any change that alters voting rules, TSC responsibilities, or project oversight
+    * Structural changes to the TSC, including composition limits
+
+Governance major decisions shall require approval by a 2/3 affirmative vote of the entire TSC.
 
 Any member of the TSC can call a vote with reasonable notice to the TSC, setting out a discussion period and a separate voting period.
 Any discussion may be conducted in person or electronically by text, voice, or video.
@@ -64,17 +75,17 @@ It is the responsibility of the TSC Chair to help facilitate the voting process 
 
 A maintainer's access (and accordingly, their position on the TSC) will be removed if any of the following occur:
 
+* Involuntary Removal: Removal via the [Governance Major Decision](#governance-major-decisions) voting process.
 * Resignation: Written notice of resignation to the TSC.
-* TSC Vote: 2/3 affirmative vote of the TSC to remove a member
 * Unreachable Member: If a member is unresponsive for more than six months, the remaining active members of the TSC may vote to remove the unreachable member by a simple majority.
 
 ## Technical direction for other Valkey projects
 
 The TSC may delegate decision making for other projects within the Valkey organization to the maintainers responsible for those projects.
-Delegation of decision making for a project is considered a non-technical major decision and shall happen with an explicit simple majority vote.
+Delegation of decision making for a project is considered a [Governance Major Decision](#governance-major-decisions).
 Projects within the Valkey organization must indicate the individuals with commit permissions by updating the MAINTAINERS.md within their repositories.
 
-The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they should show restraint in doing so.
+The TSC may, at its discretion, overrule the decisions made by other projects within the Valkey organization, although they shall show restraint in doing so.
 
 ## License of this document
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,8 @@ The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the V
 Maintainers (and accordingly, TSC members) may be added or removed by no less than 2/3 affirmative vote of the current TSC.
 At any time, no more than one third (1/3) of the TSC members may be employees, contractors, or representatives of the same organization or affiliated organizations.
 For the purposes of this document, “organization” includes companies, corporations, universities, research institutes, non-profits, governmental institutions, and any of their subsidiaries or affiliates.
+
+If, at any time, the 1/3 organization limit is exceeded (for example, due to changes in employment, company acquisitions, or organizational affiliations), the TSC shall be notified as soon as possible. The TSC must promptly take action to restore compliance, which may include removing or reassigning members in accordance with the procedures outlined in the "Termination of Membership" section. The TSC should strive to resolve the situation within 30 days of notification, and document the steps taken to restore compliance.
 The TSC shall appoint a Chair responsible for organizing TSC meetings.
 If the TSC Chair is removed from the TSC (or the Chair steps down from that role), it is the responsibility of the TSC to appoint a new Chair.
 The TSC can amend this governance document by no less than a 2/3 affirmative vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,9 +45,9 @@ Technical major decisions include:
     * Adding or removing a new external library such as a client or module to the project when it affects runtime behavior
 
 Technical major decisions shall be approved by a simple majority vote whenever one can be obtained.
-If a simple majority cannot be reached within a two-week voting period, and no TSC member has cast a veto vote, the decision may instead be approved through explicit “+2” support from at least two TSC members, recorded on the relevant issue or pull request.
+If a simple majority cannot be reached within a two-week voting period, and no TSC member has voted against, the decision may instead be approved through explicit “+2” support from at least two TSC members, recorded on the relevant issue or pull request.
 If the PR author or issue proposer is a TSC member, their +1 counts toward the +2.
-If any TSC member casts a veto vote, the decision must follow the simple majority voting process and cannot be approved through +2.
+If any TSC member casts a negative vote, the decision must follow the simple majority voting process and cannot be approved through +2.
 Once a technical major decision has been approved through the +2 mechanism, any subsequent concerns shall be raised through a new major decision process; +2 approvals are not retracted directly.
 
 ### Governance Major Decisions

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,7 +39,7 @@ Technical major decisions include:
     * New user visible fields that need to be maintained
     * Adding or removing a new external library such as a client or module to the project when it affects runtime behavior
 
-For technical major decisions, the TSC may approve a change based on explicit “+2” support from at least two sitting TSC members, recorded on the relevant issue or pull request.
+For technical major decisions, the TSC may approve a change based on explicit “+2” support from at least two TSC members, recorded on the relevant issue or pull request.
 A +2 approval is treated as approval of the technical decision by the TSC and may be retracted by a subsequent vote.
 Retraction requires a simple majority vote of all voting members; if the vote results in a tie, the status quo is preserved and the +2 approval is retracted.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ The TSC members are listed in the [MAINTAINERS.md](MAINTAINERS.md) file in the V
 At any time, no more than one third (1/3) of the TSC members may be employees, contractors, or representatives of the same organization or affiliated organizations.
 For the purposes of this document, “organization” includes companies, corporations, universities, research institutes, non-profits, governmental institutions, and any of their subsidiaries or affiliates.
 If, at any time, the 1/3 organization limit is exceeded (for example, due to changes in employment, company acquisitions, or organizational affiliations), the TSC shall be notified as soon as possible.
-The TSC must promptly take action to restore compliance, which may include removing or reassigning members in accordance with the procedures outlined in the "Termination of Membership" section.
+The TSC must promptly take action to restore compliance, which may include removing or reassigning members in accordance with the procedures outlined in the [Termination of Membership](#termination-of-membership) section.
 The TSC shall strive to resolve the situation within 30 days of notification, and document the steps taken to restore compliance.
 
 The TSC shall appoint a Chair responsible for organizing TSC meetings.


### PR DESCRIPTION
- Add +2 mechanism for technical major decisions
- Define simple-majority voting for non-technical decisions
- Add 1/3 organization limit for TSC membership
- Clarify delegation and governance updates as non-technical decisions