### PR TITLE
decouple lru/lfu from server.h

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -36,6 +36,7 @@
 #include "module.h"
 #include "cluster_migrateslots.h"
 #include "eval.h"
+#include "lrulfu.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -3329,8 +3330,8 @@ standardConfig static_configs[] = {
     createIntConfig("active-defrag-threshold-lower", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_lower, 10, INTEGER_CONFIG, NULL, NULL),                       /* Default: don't defrag when fragmentation is below 10% */
     createIntConfig("active-defrag-threshold-upper", NULL, MODIFIABLE_CONFIG, 0, 1000, server.active_defrag_threshold_upper, 100, INTEGER_CONFIG, NULL, updateDefragConfiguration), /* Default: maximum defrag force at 100% fragmentation */
     createIntConfig("active-defrag-cycle-us", NULL, MODIFIABLE_CONFIG, 0, 100000, server.active_defrag_cycle_us, 500, INTEGER_CONFIG, NULL, updateDefragConfiguration),
-    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
-    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.lfu_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("lfu-log-factor", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, lfu_config_log_factor, 10, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("lfu-decay-time", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, lfu_config_decay_time, 1, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("replica-priority", "slave-priority", MODIFIABLE_CONFIG, 0, INT_MAX, server.replica_priority, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("repl-diskless-sync-delay", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.repl_diskless_sync_delay, 5, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("maxmemory-samples", NULL, MODIFIABLE_CONFIG, 1, 64, server.maxmemory_samples, 5, INTEGER_CONFIG, NULL, NULL),

--- a/src/lrulfu.c
+++ b/src/lrulfu.c
@@ -1,7 +1,7 @@
 #include "lrulfu.h"
-#include "server.h"
+#include <stdlib.h>
 
-#define LRULFU_MASK ((1 << LRULFU_BITS) - 1) /* Mask for LRU/LFU value */
+static const uint32_t LRULFU_MASK = (1 << LRULFU_BITS) - 1;
 
 /**************** LRU ****************/
 /* LRU uses a 24 bit timestamp of the last access time (in seconds)
@@ -12,24 +12,27 @@
 /* The LRU_CLOCK_RESOLUTION is used to support an older ruby program which tests
  * the LRU behavior.  This should be set to 1 if building Valkey to support this
  * ruby test.  Otherwise, the default of 1000 is expected. */
-#define LRU_CLOCK_RESOLUTION 1000 /* LRU clock resolution in ms */
+static const uint32_t LRU_CLOCK_RESOLUTION = 1000; /* LRU clock resolution in ms */
+
+int lfu_config_log_factor;
+int lfu_config_decay_time;
+
+static uint32_t lru_clock; // Normally seconds (unless LRU_CLOCK_RESOLUTION altered)
+static uint16_t lfu_clock_minutes;
+static bool is_using_lfu_policy;
 
 
 // Current time in seconds (24 least significant bits).  Designed to roll over.
 static uint32_t LRUGetClockTime(void) {
-#if LRU_CLOCK_RESOLUTION == 1000
-    return (uint32_t)(server.unixtime & LRULFU_MASK);
-#else
-    return (uint32_t)((server.mstime / LRU_CLOCK_RESOLUTION) & LRULFU_MASK);
-#endif
+    return lru_clock;
 }
 
 
 uint32_t lru_import(uint32_t idle_secs) {
     uint32_t now = LRUGetClockTime();
-#if LRU_CLOCK_RESOLUTION != 1000
-    idle_secs = (uint32_t)((long)idle_secs * 1000 / LRU_CLOCK_RESOLUTION);
-#endif
+    if (LRU_CLOCK_RESOLUTION != 1000) {
+        idle_secs = (uint32_t)((long)idle_secs * 1000 / LRU_CLOCK_RESOLUTION);
+    }
     idle_secs = idle_secs & LRULFU_MASK;
     // Underflow is ok/expected
     return (now - idle_secs) & LRULFU_MASK;
@@ -39,9 +42,9 @@ uint32_t lru_import(uint32_t idle_secs) {
 uint32_t lru_getIdleSecs(uint32_t lru) {
     // Underflow is ok/expected
     uint32_t seconds = (LRUGetClockTime() - lru) & LRULFU_MASK;
-#if LRU_CLOCK_RESOLUTION != 1000
-    seconds = (uint32_t)((long)seconds * LRU_CLOCK_RESOLUTION / 1000);
-#endif
+    if (LRU_CLOCK_RESOLUTION != 1000) {
+        seconds = (uint32_t)((long)seconds * LRU_CLOCK_RESOLUTION / 1000);
+    }
     return seconds;
 }
 
@@ -83,7 +86,7 @@ uint32_t lru_getIdleSecs(uint32_t lru) {
 
 // Current time in minutes (16 least significant bits).  Designed to roll over.
 static uint16_t LFUGetTimeInMinutes(void) {
-    return (uint16_t)(server.unixtime / 60);
+    return lfu_clock_minutes;
 }
 
 
@@ -98,7 +101,7 @@ static uint32_t LFUDecay(uint32_t lfu) {
     uint16_t prev_time = (uint16_t)(lfu >> 8);
     uint8_t freq = (uint8_t)lfu;
     uint16_t elapsed = now - prev_time; // Wrap-around expected/valid
-    uint16_t num_periods = server.lfu_decay_time ? elapsed / server.lfu_decay_time : 0;
+    uint16_t num_periods = lfu_config_decay_time ? elapsed / lfu_config_decay_time : 0;
     freq = (num_periods > freq) ? 0 : freq - num_periods;
     return ((uint32_t)now << 8) | freq;
 }
@@ -112,7 +115,7 @@ static uint8_t LFULogIncr(uint8_t freq) {
     double r = (double)rand() / RAND_MAX;
     double baseval = (int)freq - LFU_INIT_VAL;
     if (baseval < 0) baseval = 0;
-    double p = 1.0 / (baseval * server.lfu_log_factor + 1);
+    double p = 1.0 / (baseval * lfu_config_log_factor + 1);
     if (r < p) freq++;
     return freq;
 }
@@ -135,8 +138,15 @@ uint32_t lfu_getFrequency(uint32_t lfu, uint8_t *freq) {
 
 /**************** Generic API ****************/
 
+void lrulfu_updateClockAndPolicy(long long mstime, bool is_policy_lfu) {
+    lru_clock = (uint32_t)((mstime / LRU_CLOCK_RESOLUTION) & LRULFU_MASK);
+    lfu_clock_minutes = (uint16_t)(mstime / 60000);
+    is_using_lfu_policy = is_policy_lfu;
+}
+
+
 bool lrulfu_isUsingLFU(void) {
-    return (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) != 0;
+    return is_using_lfu_policy;
 }
 
 

--- a/src/lrulfu.h
+++ b/src/lrulfu.h
@@ -26,6 +26,9 @@
 
 #define LRULFU_BITS 24
 
+extern int lfu_config_log_factor; /* LFU logarithmic counter factor. */
+extern int lfu_config_decay_time; /* LFU counter decay factor. */
+
 /**************** LRU ****************/
 
 /* Import a given LRU idleness to the current time.  */
@@ -49,11 +52,14 @@ uint32_t lfu_getFrequency(uint32_t lfu, uint8_t *freq);
 
 /**************** Generic API ****************/
 /* These API functions can be used interchangeably between LRU and LFU, depending on the setting of
- * server.maxmemory_policy.  It is preferred to use these functions rather than directly accessing
- * the LRU/LFU API functions if the use case permits.  Note that if the server's policy is changed,
+ * LRU/LFU policy.  It is preferred to use these functions rather than directly accessing
+ * the LRU/LFU API functions if the use case permits.  Note that if the LRU/LFU policy is changed,
  * LRU <-> LFU, evaluations will be incorrect until values have had time to be touched/updated.*/
 
-/* Is the server using LFU policy? */
+/* Update the LRU/LFU clock and policy.  This should be called periodically.  */
+void lrulfu_updateClockAndPolicy(long long mstime, bool isPolicyLfu);
+
+/* Are we currently using LFU policy? */
 bool lrulfu_isUsingLFU(void);
 
 /* Provide an initial value for LRU or LFU */

--- a/src/server.c
+++ b/src/server.c
@@ -1319,6 +1319,7 @@ static inline void updateCachedTimeWithUs(int update_daylight_info, const long l
     server.ustime = ustime;
     server.mstime = server.ustime / 1000;
     server.unixtime = server.mstime / 1000;
+    lrulfu_updateClockAndPolicy(server.mstime, (server.maxmemory_policy & MAXMEMORY_FLAG_LFU) != 0);
 
     /* To get information about daylight saving time, we need to call
      * localtime_r and cache the result. However calling localtime_r in this

--- a/src/server.h
+++ b/src/server.h
@@ -2119,8 +2119,6 @@ struct valkeyServer {
     int maxmemory_policy;                       /* Policy for key eviction */
     int maxmemory_samples;                      /* Precision of random sampling */
     int maxmemory_eviction_tenacity;            /* Aggressiveness of eviction processing */
-    int lfu_log_factor;                         /* LFU logarithmic counter factor. */
-    int lfu_decay_time;                         /* LFU counter decay factor. */
     long long proto_max_bulk_len;               /* Protocol bulk length maximum size. */
     int oom_score_adj_values[CONFIG_OOM_COUNT]; /* Linux oom_score_adj configuration */
     int oom_score_adj;                          /* If true, oom_score_adj is managed */


### PR DESCRIPTION
Addresses: https://github.com/valkey-io/valkey/issues/2908

This decouples the low-level LRU/LFU code from the high-level `server.h` file.
* LRU/LFU specific config values were removed from `server.h` and relocated to `lrulfu.h`
* A new LRULFU API was created to update the time (and policy) rather than accessing globals from `server.`

This doesn't address the root of the original test failure in that `server.h` may compile with different offsets (due to `off_t`) based on the include order.  See: https://github.com/valkey-io/valkey/issues/2908#issuecomment-3647452825