### PR TITLE
Fix memory allocation size in getClusterNodesList

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7210,7 +7210,7 @@ int getMyShardSlotCount(void) {
 
 char **getClusterNodesList(size_t *numnodes) {
     size_t count = dictSize(server.cluster->nodes);
-    char **ids = zmalloc((count + 1) * CLUSTER_NAMELEN);
+    char **ids = zmalloc((count + 1) * sizeof(char *));
     dictIterator *di = dictGetIterator(server.cluster->nodes);
     dictEntry *de;
     int j = 0;


### PR DESCRIPTION
Fixed incorrect memory allocation in getClusterNodesList in src/cluster_legacy.c. Changed zmalloc((count + 1) * CLUSTER_NAMELEN) to zmalloc((count + 1) * sizeof(char *)) to correctly allocate memory for an array of pointers.