### PR TITLE
Restrict ttl from being negative and avoid crash in import-mode

### DIFF
--- a/src/expire.c
+++ b/src/expire.c
@@ -669,7 +669,7 @@ int checkAlreadyExpired(long long when) {
      * If the server is receiving the key from a slot migration, we will accept
      * expired keys and wait for the source to propagate deletion. */
     if (server.current_client && server.current_client->slot_migration_job) return 0;
-    return (when <= commandTimeSnapshot() && !server.loading && !server.primary_host && !server.import_mode);
+    return (when <= commandTimeSnapshot() && !server.loading && !server.primary_host && (when < 0 || !server.import_mode));
 }
 
 /* Parse additional flags of expire commands up to the specify max_index.

--- a/src/expire.c
+++ b/src/expire.c
@@ -785,6 +785,10 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         return;
     }
     when += basetime;
+    /* A negative expiration time should cause a key to expire and be deleted immediately.
+     * However, in some cases (such as import-mode), we might need to pause expiration,
+     * and we don't want keys with negative expiration times (could cause a crash during active expiration).
+     * Therefore, we simply change the expiration time to 0 to mark the key as expired. */
     if (when < 0) {
         when = 0;
     }

--- a/src/expire.c
+++ b/src/expire.c
@@ -669,7 +669,7 @@ int checkAlreadyExpired(long long when) {
      * If the server is receiving the key from a slot migration, we will accept
      * expired keys and wait for the source to propagate deletion. */
     if (server.current_client && server.current_client->slot_migration_job) return 0;
-    return (when <= commandTimeSnapshot() && !server.loading && !server.primary_host && (when < 0 || !server.import_mode));
+    return (when <= commandTimeSnapshot() && !server.loading && !server.primary_host && !server.import_mode);
 }
 
 /* Parse additional flags of expire commands up to the specify max_index.
@@ -785,6 +785,9 @@ void expireGenericCommand(client *c, long long basetime, int unit) {
         return;
     }
     when += basetime;
+    if (when < 0) {
+        when = 0;
+    }
 
     robj *obj = lookupKeyWrite(c->db, key);
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -949,6 +949,18 @@ start_server {tags {"expire"}} {
             fail "Keys did not actively expire."
         }
     }
+
+    test {Negative ttl will force key delete although import mode is on} {
+        r flushall
+        r config set import-mode yes
+        r set foo bar
+        r expireat foo -1
+        r set foo1 bar
+        r expireat foo1 -10000
+        r config set import-mode no
+        after 500
+        assert_equal [r dbsize] 0
+    }
 }
 
 start_server {tags {expire} overrides {hz 100}} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -950,16 +950,20 @@ start_server {tags {"expire"}} {
         }
     }
 
-    test {Negative ttl will force key delete although import mode is on} {
+    test {Negative ttl will not cause server to crash when import mode is on} {
         r flushall
         r config set import-mode yes
         r set foo bar
         r expireat foo -1
         r set foo1 bar
         r expireat foo1 -10000
+        assert_equal [r dbsize] 2
         r config set import-mode no
-        after 500
-        assert_equal [r dbsize] 0
+        wait_for_condition 30 100 {
+            [r dbsize] == 0
+        } else {
+            fail "key wasn't expired"
+        }
     }
 }
 


### PR DESCRIPTION
When import-mode is yes, we might be able to set an expired TTL. At the same time,
commands like EXPIREAT/EXPIRE do not restrict TTL from being negative. After we
set import-mode to no, server will crash at:
```
 int activeExpireCycleTryExpire(serverDb *db, robj *val, long long now, int didx) { 
     long long t = objectGetExpire(val); 
     serverAssert(t >= 0); 
```

In this case, we restrict ttl from being negative in expireGenericCommand, we simply
change the expiration time to 0 to mark the key as expired since in import-mode, the
import-source client can always read the expired keys anyway.

import-mode was introduced in #1185