### PR TITLE
Module API docs formatting and improve script

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1069,7 +1069,7 @@ int moduleGetCommandChannelsViaAPI(struct serverCommand *cmd, robj **argv, int a
     ctx.keys_result = result;
 
     cp->func(&ctx, (void **)argv, argc);
-    /* We currently always use the array allocated by VM_RM_ChannelAtPosWithFlags() and don't try
+    /* We currently always use the array allocated by VM_ChannelAtPosWithFlags() and don't try
      * to optimize for the pre-allocated buffer. */
     moduleFreeContext(&ctx);
     return result->numkeys;

--- a/src/module.c
+++ b/src/module.c
@@ -1103,8 +1103,7 @@ int VM_IsKeysPositionRequest(ValkeyModuleCtx *ctx) {
  *
  *     if (ValkeyModule_IsKeysPositionRequest(ctx)) {
  *         ValkeyModule_KeyAtPosWithFlags(ctx, 2, VALKEYMODULE_CMD_KEY_RO | VALKEYMODULE_CMD_KEY_ACCESS);
- *         ValkeyModule_KeyAtPosWithFlags(ctx, 1, VALKEYMODULE_CMD_KEY_RW | VALKEYMODULE_CMD_KEY_UPDATE |
- * VALKEYMODULE_CMD_KEY_ACCESS);
+ *         ValkeyModule_KeyAtPosWithFlags(ctx, 1, VALKEYMODULE_CMD_KEY_RW | VALKEYMODULE_CMD_KEY_UPDATE | VALKEYMODULE_CMD_KEY_ACCESS);
  *     }
  *
  *  Note: in the example above the get keys API could have been handled by key-specs (preferred).

--- a/utils/generate-module-api-doc.rb
+++ b/utils/generate-module-api-doc.rb
@@ -242,10 +242,12 @@ end
 require "./" ++ File.dirname(__FILE__) ++ '/module-api-since.rb'
 git_dir = File.dirname(__FILE__) ++ "/../.git"
 if File.directory?(git_dir) && `which git` != ""
-    `git --git-dir="#{git_dir}" tag --sort=v:refname`.each_line do |version|
-        next if version !~ /^(\d+)\.\d+\.\d+?$/ || $1.to_i < 4
-        version.chomp!
-        `git --git-dir="#{git_dir}" cat-file blob "#{version}:src/module.c"`.each_line do |line|
+    `git --git-dir="#{git_dir}" tag --sort=v:refname`.each_line do |git_tag|
+        next if git_tag !~ /^(\d+)\.(\d+)\.(\d+)(?:-rc\d+)?$/ || $1.to_i < 7
+        # Version number, ignoring suffixes like -rc1.
+        version = "#{$1}.#{$2}.#{$3}"
+        git_tag.chomp!
+        `git --git-dir="#{git_dir}" cat-file blob "#{git_tag}:src/module.c"`.each_line do |line|
             if line =~ /^\w.*[ \*]VM_([A-z0-9]+)/
                 name = $1
                 if ! $since[name]


### PR DESCRIPTION
* A formatting error where there was a line break in the wrong place in a code example in a doc comment (used in the generated API docs). The error was introduced in an automatic code formatting commit.
* Improve API doc generation script by considering release candidates when detecting "since" for each API function. This makes it possible to run the script on a release candidate to have the docs ready before a GA release.