### PR TITLE
Fix lua module build failure when using CLANG

### DIFF
--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -1,13 +1,19 @@
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 
 DEPS_DIR=../../../deps
 
 ifeq ($(uname_S),Darwin)
-	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -dynamic -fno-common $(OPTIMIZATION) -std=c99 -D_GNU_SOURCE $(CFLAGS)
+	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -dynamic -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
 	SHOBJ_LDFLAGS= -bundle -undefined dynamic_lookup $(LDFLAGS)
 else
-	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -fno-common $(OPTIMIZATION) -std=c99 -D_GNU_SOURCE $(CFLAGS)
+	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
 	SHOBJ_LDFLAGS= -shared $(LDFLAGS)
+
+ifeq (clang,$(CLANG))
+	SHOBJ_LDFLAGS+= -fuse-ld=lld
+endif
+
 endif
 
 # BSD variants support


### PR DESCRIPTION
This commit fixes the build of the lua module when using CLANG to compile the code. When building with clang and with LTO enabled, the lua module build was failing in the linking phase of the shared library.

The problem was solved by using the LLVM linker, instead of the GNU linker, to link the lua module shared library.

We also fix, in this commit,  some compiler warnings that were being generated when building with clang.