### PR TITLE
Propagate database changes from temp client

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -6765,6 +6765,12 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
     }
     call(c, call_flags);
 
+    /* Propagate database changes from the temporary client back to the context client
+     * when running in script mode to make next commands execute in the correct db */
+    if (c && (flags & VALKEYMODULE_ARGV_SCRIPT_MODE) && is_running_script && c->db != ctx->client->db) {
+        ctx->client->db = c->db;
+    }
+
     /* We reset errno here because on macOS some system calls set errno even when
      * they succeed. For instance, certain time-related syscalls may set errno
      * to ETIMEDOUT on successful completion.

--- a/src/script.c
+++ b/src/script.c
@@ -211,6 +211,7 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx,
     run_ctx->original_client = caller;
     run_ctx->funcname = funcname;
     run_ctx->slot = caller->slot;
+    run_ctx->original_db = caller->db;
 
     run_ctx->start_time = getMonotonicUs();
 
@@ -249,6 +250,8 @@ void scriptResetRun(scriptRunCtx *run_ctx) {
          * was detected. */
         unprotectClient(run_ctx->original_client);
     }
+
+    run_ctx->original_client->db = run_ctx->original_db;
 
     run_ctx->slot = -1;
 

--- a/src/script.h
+++ b/src/script.h
@@ -77,6 +77,7 @@ struct scriptRunCtx {
     scriptingEngine *engine;
     const char *funcname;
     client *original_client;
+    serverDb *original_db;
     int flags;
     int repl_flags;
     monotime start_time;


### PR DESCRIPTION
**Problem:** temp client does not preserve db between VM_Call() calls. SELECT changes the database context of a temporary client created for that specific call. However, this database change is not propagated back to the context client, so subsequent commands in the same script will execute in the wrong database. Intruduced in #2858
Behaviour on unstable:
```
127.0.0.1:6379> eval "server.call('SELECT', '1'); return server.call('SET', 'lua_test', 'incorrect')" 0
OK
127.0.0.1:6379> select 0
OK
127.0.0.1:6379> get lua_test
"incorrect"
127.0.0.1:6379> select 1
OK
127.0.0.1:6379[1]> get lua_test
(nil)
```

Behaviour with fixes:
```
127.0.0.1:6379> eval "server.call('SELECT', '1'); return server.call('SET', 'lua_test', 'correct')" 0
OK
127.0.0.1:6379> select 0
OK
127.0.0.1:6379> get lua_test
(nil)
127.0.0.1:6379> select 1
OK
127.0.0.1:6379[1]> get lua_test
"correct"
```