### PR TITLE
Fix compile overflow warnings

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -233,7 +233,7 @@ int evalExtractShebangFlags(sds body,
         sds shebang = sdsnewlen(body, shebang_len);
         sds *parts = sdssplitargs(shebang, &numparts);
         sdsfree(shebang);
-        if (!parts || numparts == 0) {
+        if (!parts || numparts == 0 || sdslen(parts[0]) < 2) {
             if (err) *err = sdsnew("Invalid engine in script shebang");
             sdsfreesplitres(parts, numparts);
             return C_ERR;


### PR DESCRIPTION
Compilation warning in eval.c:244 when extracting shebang flags - 
attempting to allocate 18446744073709551615 bytes (SIZE_MAX) due to 
unsigned integer underflow.
```
eval.c: In function ‘evalExtractShebangFlags’:
eval.c:244:27: warning: argument 1 value ‘18446744073709551615’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
  244 |             *out_engine = zcalloc(engine_name_len + 1);
      |                           ^
zmalloc.c:256:7: note: in a call to allocation function ‘valkey_calloc’ declared here
  256 | void *zcalloc(size_t size) {
      |       ^
cd modules/lua && make OPTIMIZATION="-O3 -flto=auto -ffat-lto-objects -fno-omit-frame-pointer"
```