### PR TITLE
replace info cluster info in a dedicated new section

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -6429,6 +6429,12 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                             "# Cluster\r\n"
                             "cluster_enabled:%d\r\n",
                             server.cluster_enabled);
+    }
+
+    /* Cluster Status */
+    if (all_sections || (dictFind(section_dict, "cluster_status") != NULL)) {
+        if (sections++) info = sdscat(info, "\r\n");
+        info = sdscatprintf(info, "# Cluster Status\r\n");
         if (server.cluster_enabled) info = genClusterInfoString(info);
     }
 

--- a/src/server.c
+++ b/src/server.c
@@ -6431,10 +6431,10 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                             server.cluster_enabled);
     }
 
-    /* Cluster Status */
-    if (all_sections || (dictFind(section_dict, "cluster_status") != NULL)) {
+    /* Cluster Info */
+    if (all_sections || (dictFind(section_dict, "cluster_info") != NULL)) {
         if (sections++) info = sdscat(info, "\r\n");
-        info = sdscatprintf(info, "# Cluster Status\r\n");
+        info = sdscatprintf(info, "# Cluster Info\r\n");
         if (server.cluster_enabled) info = genClusterInfoString(info);
     }
 


### PR DESCRIPTION
In https://github.com/valkey-io/valkey/pull/2876 we added cluster info stats to the info command. However these statistics where added to the "cluster" section which is part of the default info sections. Since the calculation of the cluster info is done "by-demand" it can lead to high server side CPU consumption when many clients are using the "info" command on a large cluster. 

In this PR we separated the cluster info to a dedicated "cluster_stats" section, which is not enabled by default.

Alternatives considered:

1. Revert  https://github.com/valkey-io/valkey/pull/2876 - this is possible as the information is available via `CLUSTER INFO` command. The only downside is that some "control plane" adaptations need to be placed in order to gather this information in addition to the "already collected" server wide `INFO` data.
2. Optimize cluster info status collection - We could dynamically update and maintain these statistics during cluster topology state changes. The main "expensive" statistics which are needed to be collected are:
slots_assigned, slots_ok, slots_pfail, slots_fail, nodes_pfail, nodes_fail, voting_nodes_pfail, voting_nodes_fail
We could track and constantly update these during cluster pings. The main downside is potential bugs and bad accounting which might be caused by additional complexity and unhandled edge cases.  
