### PR TITLE
Adds links to performance dashboards in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ More about running the integration tests can be found in
 [tests/README.md](tests/README.md) and for unit tests, see
 [src/unit/README.md](src/unit/README.md).
 
+## Performance monitoring
+
+Valkey Performance Dashboards provide a consolidated view of throughput trends across versions, helping contributors validate improvements and identify regressions quickly.
+
+- [Performance Overview](https://valkey.io/performance/) - Compare throughput across Valkey versions
+- [Unstable Branch Dashboard](https://perf-dashboard.valkey.io/public-dashboards/3e45bf8ded3043edaa941331cd1a94e2) - Track performance of all commits in the unstable branch
+
 ## Fixing build problems with dependencies or cached build options
 
 Valkey has some dependencies which are included in the `deps` directory.


### PR DESCRIPTION
Adds links to performance dashboards in README:
1. [Performance Overview](https://valkey.io/performance/)
2. [Unstable Branch Dashboard](https://perf-dashboard.valkey.io/public-dashboards/3e45bf8ded3043edaa941331cd1a94e2)

Unstable dashboard is helpful in to identify potential regressions like these: https://github.com/valkey-io/valkey/issues/2926