### PR TITLE
avoid memory leak of new argv when hexpire commands target only non-exiting fields

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1767,19 +1767,18 @@ void hexpireGenericCommand(client *c, long long basetime, int unit) {
     /* From this point we would return array reply */
     addReplyArrayLen(c, num_fields);
 
-    /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
-    if (set_expired) {
-        new_argv = zmalloc(sizeof(robj *) * (num_fields + 3));
-        new_argv[new_argc++] = shared.hdel;
-        incrRefCount(shared.hdel);
-        new_argv[new_argc++] = c->argv[1];
-        incrRefCount(c->argv[1]);
-    }
-
     for (i = 0; i < num_fields; i++) {
         expiryModificationResult result = EXPIRATION_MODIFICATION_NOT_EXIST;
         if (set_expired) {
             if (obj && hashTypeDelete(obj, c->argv[fields_index + i]->ptr)) {
+                /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
+                if (new_argv == NULL) {
+                    new_argv = zmalloc(sizeof(robj *) * (num_fields + 3));
+                    new_argv[new_argc++] = shared.hdel;
+                    incrRefCount(shared.hdel);
+                    new_argv[new_argc++] = c->argv[1];
+                    incrRefCount(c->argv[1]);
+                }
                 /* In case we deleted the field, add it to the new hdel command vector. */
                 new_argv[new_argc++] = c->argv[fields_index + i];
                 incrRefCount(c->argv[fields_index + i]);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -927,11 +927,7 @@ void hincrbyCommand(client *c) {
     }
     value += incr;
     new = sdsfromlonglong(value);
-    bool has_volatile_fields = hashTypeHasVolatileFields(o);
     hashTypeSet(o, c->argv[2]->ptr, new, expiry, HASH_SET_TAKE_VALUE);
-    if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
-        dbUpdateObjectWithVolatileItemsTracking(c->db, o);
-    }
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrby", c->argv[1], c->db->id);
     server.dirty++;
@@ -976,11 +972,7 @@ void hincrbyfloatCommand(client *c) {
     char buf[MAX_LONG_DOUBLE_CHARS];
     int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
     new = sdsnewlen(buf, len);
-    bool has_volatile_fields = hashTypeHasVolatileFields(o);
     hashTypeSet(o, c->argv[2]->ptr, new, expiry, HASH_SET_TAKE_VALUE);
-    if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
-        dbUpdateObjectWithVolatileItemsTracking(c->db, o);
-    }
     signalModifiedKey(c, c->db, c->argv[1]);
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrbyfloat", c->argv[1], c->db->id);
     server.dirty++;

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -887,6 +887,21 @@ start_server {tags {"hashexpire"}} {
         assert_equal -2 [r HTTL myhash FIELDS 1 f2]
     }
 
+    # HEXPIRE on a non-existent field
+    test {HEXPIRE on a non-existent field (should not issue notifications)} {
+        r FLUSHALL
+        r HSET myhash f1 v1
+        set rd [setup_single_keyspace_notification r]
+        
+        r HEXPIRE myhash 1000 FIELDS 1 f2
+        r HEXPIRE myhash 0 FIELDS 1 f2
+        # Verify no notification (getting hset and not hexpire)
+        r HSET dummy dummy dummy
+        assert_keyevent_patterns $rd dummy hset
+        assert_equal 0 [get_keys_with_volatile_items r]
+        $rd close
+    }
+
     # Error Cases
     test {HEXPIRE - conflicting conditions error} {
         r FLUSHALL

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1742,11 +1742,12 @@ start_server {tags {"hashexpire"}} {
         # Sanity check: check we only have one field in the hash
         assert_equal 1 [r HLEN myhash]
 
-        # TTL should now be gone; field becomes persistent
+        # TTL should now be gone; field becomes persistent; key should not be tracked
         set ttl [r HPTTL myhash FIELDS 1 field1]
         assert_equal -1 $ttl
         assert_equal 1 [r HGET myhash field1]
         assert_equal 1 [r HLEN myhash]
+        assert_equal 0 [get_keys_with_volatile_items r]
 
         # set expiration on the field
         assert_equal 1 [r HEXPIRE myhash 100000000 FIELDS 1 field1]
@@ -1784,11 +1785,12 @@ start_server {tags {"hashexpire"}} {
         # Sanity check: check we only have one field in the hash
         assert_equal 1 [r HLEN myhash]
 
-        # TTL should now be gone; field becomes persistent
+        # TTL should now be gone; field becomes persistent; key should not be tracked
         set ttl [r HPTTL myhash FIELDS 1 field1]
         assert_equal -1 $ttl
         assert_equal 1 [r HGET myhash field1]
         assert_equal 1 [r HLEN myhash]
+        assert_equal 0 [get_keys_with_volatile_items r]
 
         # set expiration on the field
         assert_equal 1 [r HEXPIRE myhash 100000000 FIELDS 1 field1]

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1742,12 +1742,11 @@ start_server {tags {"hashexpire"}} {
         # Sanity check: check we only have one field in the hash
         assert_equal 1 [r HLEN myhash]
 
-        # TTL should now be gone; field becomes persistent; key should not be tracked
+        # TTL should now be gone; field becomes persistent
         set ttl [r HPTTL myhash FIELDS 1 field1]
         assert_equal -1 $ttl
         assert_equal 1 [r HGET myhash field1]
         assert_equal 1 [r HLEN myhash]
-        assert_equal 0 [get_keys_with_volatile_items r]
 
         # set expiration on the field
         assert_equal 1 [r HEXPIRE myhash 100000000 FIELDS 1 field1]
@@ -1785,12 +1784,11 @@ start_server {tags {"hashexpire"}} {
         # Sanity check: check we only have one field in the hash
         assert_equal 1 [r HLEN myhash]
 
-        # TTL should now be gone; field becomes persistent; key should not be tracked
+        # TTL should now be gone; field becomes persistent
         set ttl [r HPTTL myhash FIELDS 1 field1]
         assert_equal -1 $ttl
         assert_equal 1 [r HGET myhash field1]
         assert_equal 1 [r HLEN myhash]
-        assert_equal 0 [get_keys_with_volatile_items r]
 
         # set expiration on the field
         assert_equal 1 [r HEXPIRE myhash 100000000 FIELDS 1 field1]


### PR DESCRIPTION
When HEXPIRE commands are set with a time-in-the-past they are all deleting the specified fields.
In such cases we allocate a temporal new argv in order to replicate `HDEL`.
However in case no mutation was done (ie all fields do not exist) we do not deallocate the temporal new_argv and there is a memory leak.

example:

```
HSET myhash field1 value1
1
HEXPIRE myhash 0 FIELDS 1 field2
-2
```