### PR TITLE
Add VM_AddCommandACLCategories API to assign ACL categories to existing commands (built-in and module)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1676,6 +1676,44 @@ int VM_SetCommandACLCategories(ValkeyModuleCommand *command, const char *aclflag
     return VALKEYMODULE_OK;
 }
 
+/* ValkeyModule_AddCommandACLCategories can be used to add ACL categories to an
+ * existing command by name (including non-module / built-in commands).
+ *
+ * The set of ACL categories should be passed as a space separated C string
+ * 'aclflags'. The specified categories are OR-ed into the command's existing
+ * ACL categories (i.e., this function adds categories and does not replace the
+ * previous ones).
+ *
+ * Example, the acl flags 'write slow' marks the command as part of the write and
+ * slow ACL categories, in addition to any categories it already belongs to.
+ *
+ * On success VALKEYMODULE_OK is returned. On error VALKEYMODULE_ERR is returned.
+ *
+ * This function can only be called during the ValkeyModule_OnLoad function. If called
+ * outside of this function, an error is returned.
+ *
+ * Note: Changing ACL categories may require ACL recomputation for existing users.
+ * The server will handle this when the module is loaded if at least one command had
+ * ACL categories modified by the module.
+ */
+int VM_AddCommandACLCategories(ValkeyModuleCtx *ctx, const char *cmdname, const char *aclflags) {
+    if (ctx == NULL || ctx->module == NULL || !ctx->module->onload) return VALKEYMODULE_ERR;
+    if (cmdname == NULL || cmdname[0] == '\0') return VALKEYMODULE_ERR;
+    if (aclflags == NULL || aclflags[0] == '\0') return VALKEYMODULE_ERR;
+
+    struct serverCommand *cmd = lookupCommandByCString(cmdname);
+    if (cmd == NULL) return VALKEYMODULE_ERR;
+
+    int64_t categories_flags = aclflags ? categoryFlagsFromString((char *)aclflags) : 0;
+    if (categories_flags == -1) return VALKEYMODULE_ERR;
+
+    drainIOThreadsQueue();
+    cmd->acl_categories |= categories_flags;
+    ctx->module->num_commands_with_acl_categories++;
+
+    return VALKEYMODULE_OK;
+}
+
 /* Set additional command information.
  *
  * Affects the output of `COMMAND`, `COMMAND INFO` and `COMMAND DOCS`, Cluster,
@@ -14307,6 +14345,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(CreateSubcommand);
     REGISTER_API(SetCommandInfo);
     REGISTER_API(SetCommandACLCategories);
+    REGISTER_API(AddCommandACLCategories);
     REGISTER_API(AddACLCategory);
     REGISTER_API(SetModuleAttribs);
     REGISTER_API(IsModuleNameBusy);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -1458,6 +1458,7 @@ VALKEYMODULE_API int (*ValkeyModule_SetCommandInfo)(ValkeyModuleCommand *command
                                                     const ValkeyModuleCommandInfo *info) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_SetCommandACLCategories)(ValkeyModuleCommand *command,
                                                              const char *ctgrsflags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AddCommandACLCategories)(ValkeyModuleCtx *ctx, const char *cmdname, const char *aclflags) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_AddACLCategory)(ValkeyModuleCtx *ctx, const char *name) VALKEYMODULE_ATTR;
 VALKEYMODULE_API void (*ValkeyModule_SetModuleAttribs)(ValkeyModuleCtx *ctx, const char *name, int ver, int apiver)
     VALKEYMODULE_ATTR;
@@ -2196,6 +2197,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(CreateSubcommand);
     VALKEYMODULE_GET_API(SetCommandInfo);
     VALKEYMODULE_GET_API(SetCommandACLCategories);
+    VALKEYMODULE_GET_API(AddCommandACLCategories);
     VALKEYMODULE_GET_API(AddACLCategory);
     VALKEYMODULE_GET_API(SetModuleAttribs);
     VALKEYMODULE_GET_API(IsModuleNameBusy);

--- a/tests/modules/aclcheck.c
+++ b/tests/modules/aclcheck.c
@@ -355,6 +355,30 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
 
     if (ValkeyModule_SetCommandACLCategories(test_add_new_aclcategories, "foocategory") == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
-    
+
+    if (ValkeyModule_AddACLCategory(ctx, "add_acl") == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
+    if (ValkeyModule_AddCommandACLCategories(ctx, "set", "add_acl") == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
+    if (ValkeyModule_AddCommandACLCategories(ctx, "config", "add_acl") == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
+    if (ValkeyModule_AddCommandACLCategories(ctx, "memory|usage", "add_acl") == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
+    if (ValkeyModule_AddCommandACLCategories(ctx, "aclcheck.module.command.test.add.new.aclcategories", "add_acl") == VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
+    if (ValkeyModule_AddCommandACLCategories(ctx, "fail_command", "add_acl") != VALKEYMODULE_ERR) {
+        return VALKEYMODULE_ERR;
+    }
+
     return VALKEYMODULE_OK;
 }

--- a/tests/unit/moduleapi/aclcheck.tcl
+++ b/tests/unit/moduleapi/aclcheck.tcl
@@ -104,6 +104,29 @@ start_server {tags {"modules acl"}} {
         assert_equal [r acl DRYRUN j2 aclcheck.module.command.aclcategories.read.only.category] OK
     }
 
+    test {test commands acl categories are added correctly} {
+        set add_acl [r ACL CAT add_acl]
+        puts "DEBUG add_role=$add_acl"
+
+        assert {[lsearch -exact $add_acl "set"] >= 0}
+        assert {[lsearch -exact $add_acl "config"] >= 0}
+        assert {[lsearch -exact $add_acl "memory|usage"] >= 0}
+        assert {[lsearch -exact $add_acl "aclcheck.module.command.test.add.new.aclcategories"] >= 0}
+        assert {[lsearch -exact $add_acl "fail_command"] < 0}
+
+        r acl SETUSER roleuser on >password -@all +@add_acl allkeys
+
+        assert_equal [r acl DRYRUN roleuser set x 1] OK
+        assert_equal [r acl DRYRUN roleuser aclcheck.module.command.test.add.new.aclcategories] OK
+        assert_equal [r ACL DRYRUN roleuser config get "*"] OK
+        assert_equal [r ACL DRYRUN roleuser memory usage x] OK
+
+        catch {r acl DRYRUN roleuser memory stats} e
+        assert_match {*has no permissions to run the 'memory|stats' command*} $e
+        catch {r acl DRYRUN roleuser get x} e
+        assert_match {*has no permissions to run the 'get' command*} $e
+    }
+
     test {Unload the module - aclcheck} {
         assert_equal {OK} [r module unload aclcheck]
     }


### PR DESCRIPTION
Add ValkeyModule_AddCommandACLCategories(): allow modules to assign ACL categories to existing (built-in and module) commands ! 

issue : #1833 