### PR TITLE
Fix chained replica crash when doing dual channel replication

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1863,7 +1863,10 @@ void disconnectReplicas(void) {
     listNode *ln;
     listRewind(server.replicas, &li);
     while ((ln = listNext(&li))) {
-        freeClient((client *)ln->value);
+        client *replica = (client *)ln->value;
+        /* If we are going to disconnect all replicas, there is no need to protect the rdb channel. */
+        replica->flag.protected_rdb_channel = 0;
+        freeClient(replica);
     }
 }
 

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1397,46 +1397,44 @@ test "Chained replicas does not assert when using dual channel replication" {
 
             $replica config set dual-channel-replication-enabled yes
 
-            test "Psync established after rdb load - within grace period" {
-                # Test Sequence:
-                # 1. Replica initiates synchronization via RDB channel.
-                # 2. Primary's main process is suspended.
-                # 3. Replica completes RDB loading and pauses before establishing PSYNC connection.
-                # 4. Primary resumes operation and detects closed RDB channel.
-                # 5. Replica resumes operation.
-                # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
-                $replica replicaof $primary_host $primary_port
-                wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
-                pause_process $replica_pid
-                wait_and_resume_process -1
-                wait_for_condition 50 100 {
-                    [string match {*replicas_waiting_psync:1*} [$primary info replication]]
+            # Test Sequence:
+            # 1. Replica initiates synchronization via RDB channel.
+            # 2. Primary's main process is suspended.
+            # 3. Replica completes RDB loading and pauses before establishing PSYNC connection.
+            # 4. Primary resumes operation and detects closed RDB channel.
+            # 5. Replica resumes operation.
+            # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
+            $replica replicaof $primary_host $primary_port
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
+            pause_process $replica_pid
+            wait_and_resume_process -1
+            wait_for_condition 50 100 {
+                [string match {*replicas_waiting_psync:1*} [$primary info replication]]
+            } else {
+                fail "Primary freed RDB client before psync was established"
+            }
+
+            # Test Sequence:
+            # 1. replica -> primary
+            # 2. replica -> primary -> new_primary
+            # Make sure that the primary does not assert.
+            start_server {} {
+                set new_primary [srv 0 client]
+                set new_primary_host [srv 0 host]
+                set new_primary_port [srv 0 port]
+
+                $primary replicaof $new_primary_host $new_primary_port
+                resume_process $primary_pid
+                $primary debug pause-after-fork 0
+
+                resume_process $replica_pid
+
+                $new_primary set foo bar
+                wait_for_condition 1000 50 {
+                    [$primary get foo] eq "bar" &&
+                    [$replica get foo] eq "bar"
                 } else {
-                    fail "Primary freed RDB client before psync was established"
-                }
-
-                # Test Sequence:
-                # 1. replica -> primary
-                # 2. replica -> primary -> new_primary
-                # Make sure that the primary does not assert.
-                start_server {} {
-                    set new_primary [srv 0 client]
-                    set new_primary_host [srv 0 host]
-                    set new_primary_port [srv 0 port]
-
-                    $primary replicaof $new_primary_host $new_primary_port
-                    resume_process $primary_pid
-                    $primary debug pause-after-fork 0
-
-                    resume_process $replica_pid
-
-                    $new_primary set foo bar
-                    wait_for_condition 1000 50 {
-                        [$primary get foo] eq "bar" &&
-                        [$replica get foo] eq "bar"
-                    } else {
-                        fail "Chained replicas did not sync"
-                    }
+                    fail "Chained replicas did not sync"
                 }
             }
         }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1376,12 +1376,24 @@ start_server {tags {"dual-channel-replication external:skip"}} {
     }
 }
 
-test "Chained replicas does not assert when using dual channel replication" {
+# Test Sequence:
+# 1. replica -> primary.
+# 2. Replica initiates synchronization via RDB channel.
+# 3. Primary's main process is suspended.
+# 4. Replica completes RDB loading and pauses before establishing PSYNC connection.
+# 5. Primary resumes operation and detects closed RDB channel.
+# 6. Primary protects the RDB channel, maintains the RDB channel.
+# 7. replica -> primary -> new_primary
+# 8. Starting a new server, set up a chained replica.
+# 9. The primary completes sync from the new_primary server and disconnects all replica
+#    clients (including the RDB channel).
+# 10. Make sure that the primary does not assert.
+# 11. Replica resumes operation, check the replication is working correctly.
+test "Chained replicas can disconnect protected RDB channel client when using dual channel replication" {
     start_server {tags {"dual-channel-replication external:skip"}} {
         set primary [srv 0 client]
         set primary_host [srv 0 host]
         set primary_port [srv 0 port]
-        set primary_pid [srv 0 pid]
 
         $primary config set repl-diskless-sync yes
         $primary config set dual-channel-replication-enabled yes
@@ -1390,45 +1402,35 @@ test "Chained replicas does not assert when using dual channel replication" {
 
         start_server {} {
             set replica [srv 0 client]
-            set replica_host [srv 0 host]
-            set replica_port [srv 0 port]
-            set replica_pid  [srv 0 pid]
-            set loglines [count_log_lines 0]
+            set replica_pid [srv 0 pid]
 
             $replica config set dual-channel-replication-enabled yes
 
-            # Test Sequence:
-            # 1. Replica initiates synchronization via RDB channel.
-            # 2. Primary's main process is suspended.
-            # 3. Replica completes RDB loading and pauses before establishing PSYNC connection.
-            # 4. Primary resumes operation and detects closed RDB channel.
-            # 5. Replica resumes operation.
-            # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
+            # The primary will protect the replica's RDB channel.
+            set loglines [count_log_lines 0]
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 1000 50
             pause_process $replica_pid
             wait_and_resume_process -1
-            wait_for_condition 50 100 {
+            $primary debug pause-after-fork 0
+            wait_for_condition 1000 50 {
                 [string match {*replicas_waiting_psync:1*} [$primary info replication]]
             } else {
                 fail "Primary freed RDB client before psync was established"
             }
 
-            # Test Sequence:
-            # 1. replica -> primary
-            # 2. replica -> primary -> new_primary
-            # Make sure that the primary does not assert.
             start_server {} {
                 set new_primary [srv 0 client]
                 set new_primary_host [srv 0 host]
                 set new_primary_port [srv 0 port]
 
+                # Doing the chained replica, make sure it won't assert.
+                set loglines [count_log_lines -2]
                 $primary replicaof $new_primary_host $new_primary_port
-                resume_process $primary_pid
-                $primary debug pause-after-fork 0
+                wait_for_log_messages -2 {"*Done loading RDB*"} $loglines 1000 50
 
+                # Check the replication is working correctly.
                 resume_process $replica_pid
-
                 $new_primary set foo bar
                 wait_for_condition 1000 50 {
                     [$primary get foo] eq "bar" &&

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -1375,3 +1375,70 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         }
     }
 }
+
+test "Chained replicas does not assert when using dual channel replication" {
+    start_server {tags {"dual-channel-replication external:skip"}} {
+        set primary [srv 0 client]
+        set primary_host [srv 0 host]
+        set primary_port [srv 0 port]
+        set primary_pid [srv 0 pid]
+
+        $primary config set repl-diskless-sync yes
+        $primary config set dual-channel-replication-enabled yes
+        $primary debug pause-after-fork 1
+        $primary debug delay-rdb-client-free-seconds 60
+
+        start_server {} {
+            set replica [srv 0 client]
+            set replica_host [srv 0 host]
+            set replica_port [srv 0 port]
+            set replica_pid  [srv 0 pid]
+            set loglines [count_log_lines 0]
+
+            $replica config set dual-channel-replication-enabled yes
+
+            test "Psync established after rdb load - within grace period" {
+                # Test Sequence:
+                # 1. Replica initiates synchronization via RDB channel.
+                # 2. Primary's main process is suspended.
+                # 3. Replica completes RDB loading and pauses before establishing PSYNC connection.
+                # 4. Primary resumes operation and detects closed RDB channel.
+                # 5. Replica resumes operation.
+                # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
+                $replica replicaof $primary_host $primary_port
+                wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
+                pause_process $replica_pid
+                wait_and_resume_process -1
+                wait_for_condition 50 100 {
+                    [string match {*replicas_waiting_psync:1*} [$primary info replication]]
+                } else {
+                    fail "Primary freed RDB client before psync was established"
+                }
+
+                # Test Sequence:
+                # 1. replica -> primary
+                # 2. replica -> primary -> new_primary
+                # Make sure that the primary does not assert.
+                start_server {} {
+                    set new_primary [srv 0 client]
+                    set new_primary_host [srv 0 host]
+                    set new_primary_port [srv 0 port]
+
+                    $primary replicaof $new_primary_host $new_primary_port
+                    resume_process $primary_pid
+                    $primary debug pause-after-fork 0
+
+                    resume_process $replica_pid
+
+                    $new_primary set foo bar
+                    wait_for_condition 1000 50 {
+                        [$primary get foo] eq "bar" &&
+                        [$replica get foo] eq "bar"
+                    } else {
+                        fail "Chained replicas did not sync"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
There is a crash in freeReplicationBacklog:
```
Discarding previously cached primary state.
ASSERTION FAILED
'listLength(server.replicas) == 0' is not true
freeReplicationBacklog
```

The reason is that during dual channel operation, the RDB channel is protected.
In the chained replica case, `disconnectReplicas` is called to disconnect all
replica clients, but since the RDB channel is protected, `freeClient` does not
actually free the replica client. Later, we encounter an assertion failure in
`freeReplicationBacklog`.
```
void replicationAttachToNewPrimary(void) {
    /* Replica starts to apply data from new primary, we must discard the cached
     * primary structure. */
    serverAssert(server.primary == NULL);
    replicationDiscardCachedPrimary();

    /* Cancel any in progress imports (we will now use the primary's) */
    clusterCleanSlotImportsOnFullSync();

    disconnectReplicas();     /* Force our replicas to resync with us as well. */
    freeReplicationBacklog(); /* Don't allow our chained replicas to PSYNC. */
}
```

Dual channel replication was introduced in #60.