### PR TITLE
Avoid useless seek in xtrim

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -715,6 +715,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
     int trim_strategy = args->trim_strategy;
 
     if (trim_strategy == TRIM_STRATEGY_NONE) return 0;
+    if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen) return 0;
 
     raxIterator ri;
     raxStart(&ri, s->rax);


### PR DESCRIPTION
`xtrim` on a stream with a length less than `maxlen` and exits directly to avoid useless seek operations