### PR TITLE
Fix UB in Daily run: Do not use pqsort for empty lists or inverted/empty range

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -508,7 +508,7 @@ void sortCommandGeneric(client *c, int readonly) {
         server.sort_alpha = alpha;
         server.sort_bypattern = sortby ? 1 : 0;
         server.sort_store = storekey ? 1 : 0;
-        if (sortby && (start != 0 || end != vectorlen - 1))
+        if (sortby && (start != 0 || end != vectorlen - 1) && vectorlen > 0 && end >= start)
             pqsort(vector, vectorlen, sizeof(serverSortObject), sortCompare, start, end);
         else
             qsort(vector, vectorlen, sizeof(serverSortObject), sortCompare);


### PR DESCRIPTION
**Summary**

Sanitizer detected pointer arithmetic overflow in `pqsort.c` when SORT command is executed on an empty list. The failure occurs because sorting an empty list (vectorlen=0) causes negative range values (-1, -2) to be passed to `pqsort()`, which interprets them as huge unsigned values, leading to pointer arithmetic that overflows and points outside of array. Suggested solution is to not call pqsort() when `vectorlen > 0 && end >= start`.

**Failing test**

- Test name: Test SORT with BY/GET patterns in MULTI after SELECT
- CI link(s): https://github.com/valkey-io/valkey/actions/runs/20561556924/job/59052837195

1. Test creates mylist in DB 0, then MULTI, SELECT 1, SORT mylist BY ...
2. In DB 1, mylist doesn't exist, so `lookupKeyRead()` returns `NULL`
3. Create an empty quicklist (`sortval = createQuicklistObject(...)`)
4. 
```
    if (start >= vectorlen) { (0 >= 0 is true):
        start = vectorlen - 1 = -1 (as signed int)
        end = vectorlen - 2  = -2 (as signed int)
    }
```
5. These are passed to `pqsort()` which takes unsigned long parameters, implicit signed to unsigned conversion and as a result pointer arithmetic produces address outside of array -> undefined behavior