### PR TITLE
Avoid loading keys for unowned slots

### DIFF
--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -947,7 +947,6 @@ void kvstoreSetIsImporting(kvstore *kvs, int didx, int is_importing) {
 
     if (is_importing) {
         /* Importing should only be marked on empty hashtables */
-
         assert(!ht || hashtableSize(ht) == 0);
         hashtableAdd(kvs->importing, (void *)(intptr_t)didx);
         return;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -710,7 +710,10 @@ void kvstoreTryResizeHashtables(kvstore *kvs, int limit) {
     for (int i = 0; i < limit; i++) {
         int didx = kvs->resize_cursor;
         hashtable *ht = kvstoreGetHashtable(kvs, didx);
-        if (ht) hashtableRightsizeIfNeeded(ht);
+        if (ht) {
+            hashtableRightsizeIfNeeded(ht);
+            freeHashtableIfNeeded(kvs, didx);
+        }
         kvs->resize_cursor = (didx + 1) % kvs->num_hashtables;
     }
 }

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -947,6 +947,7 @@ void kvstoreSetIsImporting(kvstore *kvs, int didx, int is_importing) {
 
     if (is_importing) {
         /* Importing should only be marked on empty hashtables */
+
         assert(!ht || hashtableSize(ht) == 0);
         hashtableAdd(kvs->importing, (void *)(intptr_t)didx);
         return;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3479,7 +3479,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             sdsfree(key);
             decrRefCount(val);
             server.rdb_last_load_keys_expired++;
-        } else if (server.cluster_enabled && !(rdbflags & RDBFLAGS_AOF_PREAMBLE) && !clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot)) {
+        } else if (server.cluster_enabled && iAmPrimary() && !clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot)) {
             sdsfree(key);
             if (val) decrRefCount(val);
             server.rdb_unowned_slot_keys_skipped++;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2941,6 +2941,7 @@ void startLoading(size_t size, int rdbflags, int async) {
     server.loading_rdb_used_mem = 0;
     server.rdb_last_load_keys_expired = 0;
     server.rdb_last_load_keys_loaded = 0;
+    server.rdb_unowned_slot_keys_skipped = 0;
     blockingOperationStarts();
 
     /* Cleanup slot migrations (we need a clean state for the incoming load) */
@@ -3225,8 +3226,10 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             if ((slot_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if ((expires_slot_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if (server.cluster_enabled && slot_id < CLUSTER_SLOTS) {
-                if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
-                if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
+                if (!clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
+                    if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
+                    if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
+                }
                 should_expand_db = 0;
             }
             continue; /* Read next opcode. */
@@ -3304,12 +3307,14 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 if (server.cluster_enabled && slot_id >= 0 && slot_id < CLUSTER_SLOTS) {
                     /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that
                      * slot holds. */
-                    if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
-                    if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
-                    if (keys_with_volatile_items_slot_size) {
-                        kvstoreHashtableExpand(db->keys_with_volatile_items,
-                                               slot_id,
-                                               keys_with_volatile_items_slot_size);
+                    if (!clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
+                        if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
+                        if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
+                        if (keys_with_volatile_items_slot_size) {
+                            kvstoreHashtableExpand(db->keys_with_volatile_items,
+                                                   slot_id,
+                                                   keys_with_volatile_items_slot_size);
+                        }
                     }
                     should_expand_db = 0;
                 }
@@ -3424,6 +3429,13 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
 
         /* Read key */
         if ((key = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL)) == NULL) goto eoferr;
+
+        // get the slot of the read key. This is used in order to decide later if the key should be skipped or not.
+        unsigned int keySlot = CLUSTER_SLOTS;
+        if (server.cluster_enabled) {
+            keySlot = keyHashSlot(key, sdslen(key));
+        }
+
         /* Read value */
         val = rdbLoadObject(type, rdb, key, db->id, &error);
 
@@ -3467,6 +3479,10 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             sdsfree(key);
             decrRefCount(val);
             server.rdb_last_load_keys_expired++;
+        } else if (server.cluster_enabled && !(rdbflags & RDBFLAGS_AOF_PREAMBLE) && !clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot)) {
+            sdsfree(key);
+            if (val) decrRefCount(val);
+            server.rdb_unowned_slot_keys_skipped++;
         } else {
             robj keyobj;
             initStaticStringObject(keyobj, key);
@@ -3535,19 +3551,19 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         }
     }
 
-    if (empty_keys_skipped) {
-        serverLog(LL_NOTICE, "Done loading RDB, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
-                  server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
+    if (empty_keys_skipped || server.rdb_unowned_slot_keys_skipped) {
+        serverLog(LL_NOTICE, "Done loading RDB, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld, unowned slot keys skipped: %lld.",
+                  server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped, server.rdb_unowned_slot_keys_skipped);
     } else {
         serverLog(LL_NOTICE, "Done loading RDB, keys loaded: %lld, keys expired: %lld.",
                   server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
     }
     return RDB_OK;
 
-    /* Unexpected end of file is handled here calling rdbReportReadError():
-     * this will in turn either abort the server in most cases, or if we are loading
-     * the RDB file from a socket during initial SYNC (diskless replica mode),
-     * we'll report the error to the caller, so that we can retry. */
+/* Unexpected end of file is handled here calling rdbReportReadError():
+ * this will in turn either abort the server in most cases, or if we are loading
+ * the RDB file from a socket during initial SYNC (diskless replica mode),
+ * we'll report the error to the caller, so that we can retry. */
 eoferr:
     serverLog(LL_WARNING, "Short read or OOM loading DB. Unrecoverable error, aborting now.");
     rdbReportReadError("Unexpected EOF reading RDB file");

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2941,7 +2941,7 @@ void startLoading(size_t size, int rdbflags, int async) {
     server.loading_rdb_used_mem = 0;
     server.rdb_last_load_keys_expired = 0;
     server.rdb_last_load_keys_loaded = 0;
-    server.rdb_unowned_slot_keys_skipped = 0;
+    server.rdb_last_load_keys_skipped_unowned_slot = 0;
     blockingOperationStarts();
 
     /* Cleanup slot migrations (we need a clean state for the incoming load) */
@@ -3482,7 +3482,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         } else if (server.cluster_enabled && iAmPrimary() && !(clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot) || clusterIsSlotImporting(keySlot))) {
             sdsfree(key);
             if (val) decrRefCount(val);
-            server.rdb_unowned_slot_keys_skipped++;
+            server.rdb_last_load_keys_skipped_unowned_slot++;
         } else {
             robj keyobj;
             initStaticStringObject(keyobj, key);
@@ -3551,9 +3551,9 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
         }
     }
 
-    if (empty_keys_skipped || server.rdb_unowned_slot_keys_skipped) {
+    if (empty_keys_skipped || server.rdb_last_load_keys_skipped_unowned_slot) {
         serverLog(LL_NOTICE, "Done loading RDB, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld, unowned slot keys skipped: %lld.",
-                  server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped, server.rdb_unowned_slot_keys_skipped);
+                  server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped, server.rdb_last_load_keys_skipped_unowned_slot);
     } else {
         serverLog(LL_NOTICE, "Done loading RDB, keys loaded: %lld, keys expired: %lld.",
                   server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3226,7 +3226,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             if ((slot_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if ((expires_slot_size = rdbLoadLen(rdb, NULL)) == RDB_LENERR) goto eoferr;
             if (server.cluster_enabled && slot_id < CLUSTER_SLOTS) {
-                if (!clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
+                if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
                     if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
                     if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
                 }
@@ -3307,7 +3307,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 if (server.cluster_enabled && slot_id >= 0 && slot_id < CLUSTER_SLOTS) {
                     /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that
                      * slot holds. */
-                    if (!clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
+                    if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
                         if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
                         if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
                         if (keys_with_volatile_items_slot_size) {

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3307,7 +3307,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 if (server.cluster_enabled && slot_id >= 0 && slot_id < CLUSTER_SLOTS) {
                     /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that
                      * slot holds. */
-                    if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id)) {
+                    if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id) || clusterIsSlotImporting(keySlot)) {
                         if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
                         if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
                         if (keys_with_volatile_items_slot_size) {
@@ -3479,7 +3479,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             sdsfree(key);
             decrRefCount(val);
             server.rdb_last_load_keys_expired++;
-        } else if (server.cluster_enabled && iAmPrimary() && !clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot)) {
+        } else if (server.cluster_enabled && iAmPrimary() && !(clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), keySlot) || clusterIsSlotImporting(keySlot))) {
             sdsfree(key);
             if (val) decrRefCount(val);
             server.rdb_unowned_slot_keys_skipped++;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3307,7 +3307,7 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                 if (server.cluster_enabled && slot_id >= 0 && slot_id < CLUSTER_SLOTS) {
                     /* In cluster mode we resize individual slot specific dictionaries based on the number of keys that
                      * slot holds. */
-                    if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id) || clusterIsSlotImporting(keySlot)) {
+                    if (clusterNodeCoversSlot(clusterNodeGetPrimary(getMyClusterNode()), slot_id) || clusterIsSlotImporting(slot_id)) {
                         if (slot_size) kvstoreHashtableExpand(db->keys, slot_id, slot_size);
                         if (expires_slot_size) kvstoreHashtableExpand(db->expires, slot_id, expires_slot_size);
                         if (keys_with_volatile_items_slot_size) {

--- a/src/server.c
+++ b/src/server.c
@@ -2925,7 +2925,7 @@ void initServer(void) {
     server.rdb_save_time_start = -1;
     server.rdb_last_load_keys_expired = 0;
     server.rdb_last_load_keys_loaded = 0;
-    server.rdb_unowned_slot_keys_skipped = 0;
+    server.rdb_last_load_keys_skipped_unowned_slot = 0;
     server.dirty = 0;
     server.crashed = 0;
     resetServerStats();
@@ -6091,7 +6091,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "rdb_last_cow_size:%zu\r\n", server.stat_rdb_cow_bytes,
                 "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
                 "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
-                "rdb_unowned_slot_keys_skipped:%lld\r\n", server.rdb_unowned_slot_keys_skipped,
+                "rdb_last_load_keys_skipped_unowned_slot:%lld\r\n", server.rdb_last_load_keys_skipped_unowned_slot,
                 "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
                 "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
                 "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,

--- a/src/server.c
+++ b/src/server.c
@@ -2925,6 +2925,7 @@ void initServer(void) {
     server.rdb_save_time_start = -1;
     server.rdb_last_load_keys_expired = 0;
     server.rdb_last_load_keys_loaded = 0;
+    server.rdb_unowned_slot_keys_skipped = 0;
     server.dirty = 0;
     server.crashed = 0;
     resetServerStats();
@@ -6090,6 +6091,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "rdb_last_cow_size:%zu\r\n", server.stat_rdb_cow_bytes,
                 "rdb_last_load_keys_expired:%lld\r\n", server.rdb_last_load_keys_expired,
                 "rdb_last_load_keys_loaded:%lld\r\n", server.rdb_last_load_keys_loaded,
+                "rdb_unowned_slot_keys_skipped:%lld\r\n", server.rdb_unowned_slot_keys_skipped,
                 "aof_enabled:%d\r\n", server.aof_state != AOF_OFF,
                 "aof_rewrite_in_progress:%d\r\n", server.child_type == CHILD_TYPE_AOF,
                 "aof_rewrite_scheduled:%d\r\n", server.aof_rewrite_scheduled,

--- a/src/server.h
+++ b/src/server.h
@@ -1974,40 +1974,40 @@ struct valkeyServer {
                                            default no. (for testings). */
 
     /* RDB persistence */
-    long long dirty;                      /* Changes to DB from the last save */
-    long long dirty_before_bgsave;        /* Used to restore dirty on failed BGSAVE */
-    long long rdb_last_load_keys_expired; /* number of expired keys when loading RDB */
-    long long rdb_last_load_keys_loaded;  /* number of loaded keys when loading RDB */
-    long long rdb_unowned_slot_keys_skipped;  /* number of keys skipped in the last load since they map to a slot not owned by this node */
-    struct saveparam *saveparams;         /* Save points array for RDB */
-    int saveparamslen;                    /* Number of saving points */
-    char *rdb_filename;                   /* Name of RDB file */
-    int rdb_compression;                  /* Use compression in RDB? */
-    int rdb_checksum;                     /* Use RDB checksum? */
-    int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
-                                             the instance does not use persistence. */
-    time_t lastsave;                      /* Unix time of last successful save */
-    time_t lastbgsave_try;                /* Unix time of last attempted bgsave */
-    time_t rdb_save_time_last;            /* Time used by last RDB save run. */
-    time_t rdb_save_time_start;           /* Current RDB save start time. */
-    int rdb_bgsave_scheduled;             /* BGSAVE when possible if true. */
-    int rdb_child_type;                   /* Type of save by active child. */
-    int lastbgsave_status;                /* C_OK or C_ERR */
-    int stop_writes_on_bgsave_err;        /* Don't allow writes if can't BGSAVE */
-    int rdb_pipe_read;                    /* RDB pipe used to transfer the rdb data */
-                                          /* to the parent process in diskless repl. */
-    int rdb_child_exit_pipe;              /* Used by the diskless parent allow child exit. */
-    connection **rdb_pipe_conns;          /* Connections which are currently the */
-    int rdb_pipe_numconns;                /* target of diskless rdb fork child. */
-    int rdb_pipe_numconns_writing;        /* Number of rdb conns with pending writes. */
-    char *rdb_pipe_buff;                  /* In diskless replication, this buffer holds data */
-    int rdb_pipe_bufflen;                 /* that was read from the rdb pipe. */
-    int rdb_key_save_delay;               /* Delay in microseconds between keys while
-                                           * writing aof or rdb. (for testings). negative
-                                           * value means fractions of microseconds (on average). */
-    int key_load_delay;                   /* Delay in microseconds between keys while
-                                           * loading aof or rdb. (for testings). negative
-                                           * value means fractions of microseconds (on average). */
+    long long dirty;                         /* Changes to DB from the last save */
+    long long dirty_before_bgsave;           /* Used to restore dirty on failed BGSAVE */
+    long long rdb_last_load_keys_expired;    /* number of expired keys when loading RDB */
+    long long rdb_last_load_keys_loaded;     /* number of loaded keys when loading RDB */
+    long long rdb_unowned_slot_keys_skipped; /* number of keys skipped in the last load since they map to a slot not owned by this node */
+    struct saveparam *saveparams;            /* Save points array for RDB */
+    int saveparamslen;                       /* Number of saving points */
+    char *rdb_filename;                      /* Name of RDB file */
+    int rdb_compression;                     /* Use compression in RDB? */
+    int rdb_checksum;                        /* Use RDB checksum? */
+    int rdb_del_sync_files;                  /* Remove RDB files used only for SYNC if
+                                                the instance does not use persistence. */
+    time_t lastsave;                         /* Unix time of last successful save */
+    time_t lastbgsave_try;                   /* Unix time of last attempted bgsave */
+    time_t rdb_save_time_last;               /* Time used by last RDB save run. */
+    time_t rdb_save_time_start;              /* Current RDB save start time. */
+    int rdb_bgsave_scheduled;                /* BGSAVE when possible if true. */
+    int rdb_child_type;                      /* Type of save by active child. */
+    int lastbgsave_status;                   /* C_OK or C_ERR */
+    int stop_writes_on_bgsave_err;           /* Don't allow writes if can't BGSAVE */
+    int rdb_pipe_read;                       /* RDB pipe used to transfer the rdb data */
+                                             /* to the parent process in diskless repl. */
+    int rdb_child_exit_pipe;                 /* Used by the diskless parent allow child exit. */
+    connection **rdb_pipe_conns;             /* Connections which are currently the */
+    int rdb_pipe_numconns;                   /* target of diskless rdb fork child. */
+    int rdb_pipe_numconns_writing;           /* Number of rdb conns with pending writes. */
+    char *rdb_pipe_buff;                     /* In diskless replication, this buffer holds data */
+    int rdb_pipe_bufflen;                    /* that was read from the rdb pipe. */
+    int rdb_key_save_delay;                  /* Delay in microseconds between keys while
+                                              * writing aof or rdb. (for testings). negative
+                                              * value means fractions of microseconds (on average). */
+    int key_load_delay;                      /* Delay in microseconds between keys while
+                                              * loading aof or rdb. (for testings). negative
+                                              * value means fractions of microseconds (on average). */
     /* Pipe and data structures for child -> parent info sharing. */
     int child_info_pipe[2]; /* Pipe used to write the child_info_data. */
     int child_info_nread;   /* Num of bytes of the last read from pipe */

--- a/src/server.h
+++ b/src/server.h
@@ -1978,6 +1978,7 @@ struct valkeyServer {
     long long dirty_before_bgsave;        /* Used to restore dirty on failed BGSAVE */
     long long rdb_last_load_keys_expired; /* number of expired keys when loading RDB */
     long long rdb_last_load_keys_loaded;  /* number of loaded keys when loading RDB */
+    long long rdb_unowned_slot_keys_skipped;  /* number of keys skipped in the last load since they map to a slot not owned by this node */
     struct saveparam *saveparams;         /* Save points array for RDB */
     int saveparamslen;                    /* Number of saving points */
     char *rdb_filename;                   /* Name of RDB file */

--- a/src/server.h
+++ b/src/server.h
@@ -1978,7 +1978,6 @@ struct valkeyServer {
     long long dirty_before_bgsave;           /* Used to restore dirty on failed BGSAVE */
     long long rdb_last_load_keys_expired;    /* number of expired keys when loading RDB */
     long long rdb_last_load_keys_loaded;     /* number of loaded keys when loading RDB */
-    long long rdb_unowned_slot_keys_skipped; /* number of keys skipped in the last load since they map to a slot not owned by this node */
     struct saveparam *saveparams;            /* Save points array for RDB */
     int saveparamslen;                       /* Number of saving points */
     char *rdb_filename;                      /* Name of RDB file */
@@ -2008,6 +2007,8 @@ struct valkeyServer {
     int key_load_delay;                      /* Delay in microseconds between keys while
                                               * loading aof or rdb. (for testings). negative
                                               * value means fractions of microseconds (on average). */
+    long long rdb_last_load_keys_skipped_unowned_slot; /* number of keys skipped in the last load since they map to a slot not owned by this node */
+    
     /* Pipe and data structures for child -> parent info sharing. */
     int child_info_pipe[2]; /* Pipe used to write the child_info_data. */
     int child_info_nread;   /* Num of bytes of the last read from pipe */

--- a/src/server.h
+++ b/src/server.h
@@ -1974,41 +1974,42 @@ struct valkeyServer {
                                            default no. (for testings). */
 
     /* RDB persistence */
-    long long dirty;                         /* Changes to DB from the last save */
-    long long dirty_before_bgsave;           /* Used to restore dirty on failed BGSAVE */
-    long long rdb_last_load_keys_expired;    /* number of expired keys when loading RDB */
-    long long rdb_last_load_keys_loaded;     /* number of loaded keys when loading RDB */
-    struct saveparam *saveparams;            /* Save points array for RDB */
-    int saveparamslen;                       /* Number of saving points */
-    char *rdb_filename;                      /* Name of RDB file */
-    int rdb_compression;                     /* Use compression in RDB? */
-    int rdb_checksum;                        /* Use RDB checksum? */
-    int rdb_del_sync_files;                  /* Remove RDB files used only for SYNC if
-                                                the instance does not use persistence. */
-    time_t lastsave;                         /* Unix time of last successful save */
-    time_t lastbgsave_try;                   /* Unix time of last attempted bgsave */
-    time_t rdb_save_time_last;               /* Time used by last RDB save run. */
-    time_t rdb_save_time_start;              /* Current RDB save start time. */
-    int rdb_bgsave_scheduled;                /* BGSAVE when possible if true. */
-    int rdb_child_type;                      /* Type of save by active child. */
-    int lastbgsave_status;                   /* C_OK or C_ERR */
-    int stop_writes_on_bgsave_err;           /* Don't allow writes if can't BGSAVE */
-    int rdb_pipe_read;                       /* RDB pipe used to transfer the rdb data */
-                                             /* to the parent process in diskless repl. */
-    int rdb_child_exit_pipe;                 /* Used by the diskless parent allow child exit. */
-    connection **rdb_pipe_conns;             /* Connections which are currently the */
-    int rdb_pipe_numconns;                   /* target of diskless rdb fork child. */
-    int rdb_pipe_numconns_writing;           /* Number of rdb conns with pending writes. */
-    char *rdb_pipe_buff;                     /* In diskless replication, this buffer holds data */
-    int rdb_pipe_bufflen;                    /* that was read from the rdb pipe. */
-    int rdb_key_save_delay;                  /* Delay in microseconds between keys while
-                                              * writing aof or rdb. (for testings). negative
-                                              * value means fractions of microseconds (on average). */
-    int key_load_delay;                      /* Delay in microseconds between keys while
-                                              * loading aof or rdb. (for testings). negative
-                                              * value means fractions of microseconds (on average). */
+    long long dirty;                      /* Changes to DB from the last save */
+    long long dirty_before_bgsave;        /* Used to restore dirty on failed BGSAVE */
+    long long rdb_last_load_keys_expired; /* number of expired keys when loading RDB */
+    long long rdb_last_load_keys_loaded;  /* number of loaded keys when loading RDB */
+    struct saveparam *saveparams;         /* Save points array for RDB */
+    int saveparamslen;                    /* Number of saving points */
+    char *rdb_filename;                   /* Name of RDB file */
+    int rdb_compression;                  /* Use compression in RDB? */
+    int rdb_checksum;                     /* Use RDB checksum? */
+    int rdb_del_sync_files;               /* Remove RDB files used only for SYNC if
+                                             the instance does not use persistence. */
+    time_t lastsave;                      /* Unix time of last successful save */
+    time_t lastbgsave_try;                /* Unix time of last attempted bgsave */
+    time_t rdb_save_time_last;            /* Time used by last RDB save run. */
+    time_t rdb_save_time_start;           /* Current RDB save start time. */
+    int rdb_bgsave_scheduled;             /* BGSAVE when possible if true. */
+    int rdb_child_type;                   /* Type of save by active child. */
+    int lastbgsave_status;                /* C_OK or C_ERR */
+    int stop_writes_on_bgsave_err;        /* Don't allow writes if can't BGSAVE */
+    int rdb_pipe_read;                    /* RDB pipe used to transfer the rdb data */
+                                          /* to the parent process in diskless repl. */
+    int rdb_child_exit_pipe;              /* Used by the diskless parent allow child exit. */
+    connection **rdb_pipe_conns;          /* Connections which are currently the */
+    int rdb_pipe_numconns;                /* target of diskless rdb fork child. */
+    int rdb_pipe_numconns_writing;        /* Number of rdb conns with pending writes. */
+    char *rdb_pipe_buff;                  /* In diskless replication, this buffer holds data */
+    int rdb_pipe_bufflen;                 /* that was read from the rdb pipe. */
+    int rdb_key_save_delay;               /* Delay in microseconds between keys while
+                                           * writing aof or rdb. (for testings). negative
+                                           * value means fractions of microseconds (on average). */
+    int key_load_delay;                   /* Delay in microseconds between keys while
+                                           * loading aof or rdb. (for testings). negative
+                                           * value means fractions of microseconds (on average). */
+
     long long rdb_last_load_keys_skipped_unowned_slot; /* number of keys skipped in the last load since they map to a slot not owned by this node */
-    
+
     /* Pipe and data structures for child -> parent info sharing. */
     int child_info_pipe[2]; /* Pipe used to write the child_info_data. */
     int child_info_nread;   /* Num of bytes of the last read from pipe */

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2429,3 +2429,40 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {
         assert_match "OK" [R 2 FLUSHDB SYNC]
     }
 }
+
+start_cluster 3 0 {tags {logreqres:skip external:skip cluster}} {
+
+    set node0_id [R 0 CLUSTER MYID]
+    set node1_id [R 1 CLUSTER MYID]
+    set node2_id [R 2 CLUSTER MYID]
+
+    set 16383_slot_tag "{6ZJ}"
+
+    test "Load snapshot skip keys of migrated slots" {
+        # Load data before the snapshot
+        populate 250 "$16383_slot_tag:1:" 1000 -2
+        assert_match "250" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+        # save data of the populated primary
+        assert_match "OK" [R 2 SAVE]
+
+        # Load data while the snapshot is ongoing
+        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
+
+        wait_for_migration 0 16383
+        assert_match "250" [R 0 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+
+        # restart node 2
+        do_node_restart 2
+        
+        wait_for_cluster_state ok
+        
+        assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
+        assert_match "250" [getInfoProperty [R 2 info] rdb_unowned_slot_keys_skipped]
+
+        # Cleanup
+        assert_match "OK" [R 0 FLUSHALL SYNC]
+        assert_match "OK" [R 0 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node2_id]
+    }
+}

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2459,7 +2459,7 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster}} {
         wait_for_cluster_state ok
         
         assert_match "0" [R 2 CLUSTER COUNTKEYSINSLOT 16383]
-        assert_match "250" [getInfoProperty [R 2 info] rdb_unowned_slot_keys_skipped]
+        assert_match "250" [getInfoProperty [R 2 info] rdb_last_load_keys_skipped_unowned_slot]
 
         # Cleanup
         assert_match "OK" [R 0 FLUSHALL SYNC]


### PR DESCRIPTION
fixes https://github.com/valkey-io/valkey/issues/539

This is an attempt to resolve the issue of loading keys for unowned slots in cluster mode enabled Valkey cluster.
Some issues not addressed yet:
* [ ] AOF-preamble handling. For example, This might require us to restrict the AOF commands processing (processCommand) when keys are placed on different shards. 
* [x] create a test for the new functionality