### PR TITLE
Add optional REPLACE argument to MOVE

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -2369,7 +2369,9 @@ struct COMMAND_ARG MIGRATE_Args[] = {
 
 #ifndef SKIP_CMD_HISTORY_TABLE
 /* MOVE history */
-#define MOVE_History NULL
+commandHistory MOVE_History[] = {
+{"10.0.0","added REPLACE option."},
+};
 #endif
 
 #ifndef SKIP_CMD_TIPS_TABLE
@@ -2388,6 +2390,7 @@ keySpec MOVE_Keyspecs[1] = {
 struct COMMAND_ARG MOVE_Args[] = {
 {MAKE_ARG("key",ARG_TYPE_KEY,0,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
 {MAKE_ARG("db",ARG_TYPE_INTEGER,-1,NULL,NULL,NULL,CMD_ARG_NONE,0,NULL)},
+{MAKE_ARG("replace",ARG_TYPE_PURE_TOKEN,-1,"REPLACE",NULL,"10.0.0",CMD_ARG_OPTIONAL,0,NULL)},
 };
 
 /********** OBJECT ENCODING ********************/
@@ -11879,7 +11882,7 @@ struct COMMAND_STRUCT serverCommandTable[] = {
 {MAKE_CMD("expiretime","Returns the expiration time of a key as a Unix timestamp.","O(1)","7.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,EXPIRETIME_History,0,EXPIRETIME_Tips,0,expiretimeCommand,2,CMD_READONLY|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_READ,NULL,EXPIRETIME_Keyspecs,1,NULL,1),.args=EXPIRETIME_Args},
 {MAKE_CMD("keys","Returns all key names that match a pattern.","O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,KEYS_History,0,KEYS_Tips,2,keysCommand,2,CMD_READONLY,ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_READ|ACL_CATEGORY_SLOW,NULL,KEYS_Keyspecs,0,NULL,1),.args=KEYS_Args},
 {MAKE_CMD("migrate","Atomically transfers a key from one instance to another.","This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.","2.6.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MIGRATE_History,4,MIGRATE_Tips,1,migrateCommand,-6,CMD_WRITE,ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_SLOW|ACL_CATEGORY_WRITE,NULL,MIGRATE_Keyspecs,2,migrateGetKeys,9),.args=MIGRATE_Args},
-{MAKE_CMD("move","Moves a key to another database.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MOVE_History,0,MOVE_Tips,0,moveCommand,3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_WRITE,moveDbIdArgs,MOVE_Keyspecs,1,NULL,2),.args=MOVE_Args},
+{MAKE_CMD("move","Moves a key to another database.","O(1)","1.0.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,MOVE_History,1,MOVE_Tips,0,moveCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_WRITE,moveDbIdArgs,MOVE_Keyspecs,1,NULL,3),.args=MOVE_Args},
 {MAKE_CMD("object","A container for object introspection commands.","Depends on subcommand.","2.2.3",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,OBJECT_History,0,OBJECT_Tips,0,NULL,-2,0,ACL_CATEGORY_SLOW,NULL,OBJECT_Keyspecs,0,NULL,0),.subcommands=OBJECT_Subcommands},
 {MAKE_CMD("persist","Removes the expiration time of a key.","O(1)","2.2.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,PERSIST_History,0,PERSIST_Tips,0,persistCommand,2,CMD_WRITE|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_WRITE,NULL,PERSIST_Keyspecs,1,NULL,1),.args=PERSIST_Args},
 {MAKE_CMD("pexpire","Sets the expiration time of a key in milliseconds.","O(1)","2.6.0",CMD_DOC_NONE,NULL,NULL,"generic",COMMAND_GROUP_GENERIC,PEXPIRE_History,1,PEXPIRE_Tips,0,pexpireCommand,-3,CMD_WRITE|CMD_FAST,ACL_CATEGORY_FAST|ACL_CATEGORY_KEYSPACE|ACL_CATEGORY_WRITE,NULL,PEXPIRE_Keyspecs,1,NULL,3),.args=PEXPIRE_Args},

--- a/src/commands/move.json
+++ b/src/commands/move.json
@@ -4,8 +4,14 @@
         "complexity": "O(1)",
         "group": "generic",
         "since": "1.0.0",
-        "arity": 3,
+        "arity": -3,
         "function": "moveCommand",
+        "history": [
+            [
+                "10.0.0",
+                "added REPLACE option."
+            ]
+        ],
         "command_flags": [
             "WRITE",
             "FAST"
@@ -46,6 +52,13 @@
             {
                 "name": "db",
                 "type": "integer"
+            },
+            {
+                "name": "replace",
+                "token": "REPLACE",
+                "type": "pure-token",
+                "since": "10.0.0",
+                "optional": true
             }
         ],
         "reply_schema": {
@@ -55,7 +68,7 @@
                     "const": 1
                 },
                 {
-                    "description": "Key wasn't moved. When key already exists in the destination database, or it does not exist in the source database",
+                    "description": "Key wasn't moved. When key already exists in the destination database without REPLACE, or it does not exist in the source database",
                     "const": 0
                 }
             ]

--- a/src/db.c
+++ b/src/db.c
@@ -1541,6 +1541,23 @@ void moveCommand(client *c) {
     int srcid, dbid;
     long long expire;
 
+    /* Parse optional REPLACE token (MOVE key db [REPLACE]).
+     * Without REPLACE, MOVE returns 0 if the key already exists in the target DB.
+     * With REPLACE, the destination key is overwritten by the moved key. */
+    int set_key_flags = SETKEY_DOESNT_EXIST;
+    if (c->argc > 4) {
+        addReplyErrorObject(c, shared.syntaxerr);
+        return;
+    } else if (c->argc == 4) {
+        if (!strcasecmp(objectGetVal(c->argv[3]), "replace")) {
+            set_key_flags = SETKEY_ADD_OR_UPDATE;
+        } else {
+            addReplyErrorObject(c, shared.syntaxerr);
+            return;
+        }
+    }
+    set_key_flags |= SETKEY_NO_SIGNAL;
+
     /* Obtain source and target DB pointers */
     src = c->db;
     srcid = c->db->id;
@@ -1569,8 +1586,8 @@ void moveCommand(client *c) {
     }
     expire = objectGetExpire(o);
 
-    /* Return zero if the key already exists in the target DB */
-    if (lookupKeyWrite(dst, c->argv[1]) != NULL) {
+    /* Without REPLACE, return zero if the key already exists in the target DB. */
+    if (lookupKeyWrite(dst, c->argv[1]) != NULL && (set_key_flags & SETKEY_DOESNT_EXIST)) {
         addReply(c, shared.czero);
         return;
     }
@@ -1578,7 +1595,7 @@ void moveCommand(client *c) {
     incrRefCount(o);           /* ref counter = 2 */
     dbDelete(src, c->argv[1]); /* ref counter = 1 */
 
-    dbAdd(dst, c->argv[1], &o);
+    setKey(c, dst, c->argv[1], &o, set_key_flags);
     if (expire != -1) o = setExpire(c, dst, c->argv[1], expire);
 
     /* OK! key moved */

--- a/tests/unit/keyspace.tcl
+++ b/tests/unit/keyspace.tcl
@@ -452,6 +452,94 @@ foreach {type large} [array get largevalue] {
         r select 9
     } {OK} {singledb:skip}
 
+    test {MOVE can replace an existing key} {
+        r select 10
+        r del move-replace-key
+        r set move-replace-key "1"
+        r select 9
+        r del move-replace-key
+        r set move-replace-key "0"
+        assert_equal 1 [r move move-replace-key 10 replace]
+        r select 10
+        assert_equal "0" [r get move-replace-key]
+        r select 9
+    } {OK} {singledb:skip}
+
+    test {MOVE REPLACE moves source TTL over existing destination TTL} {
+        r select 10
+        r del move-replace-ttl
+        r set move-replace-ttl "dst" ex 200
+        r select 9
+        r del move-replace-ttl
+        r set move-replace-ttl "src" ex 100
+        assert_equal 1 [r move move-replace-ttl 10 replace]
+        assert_equal -2 [r ttl move-replace-ttl]
+        r select 10
+        assert_equal "src" [r get move-replace-ttl]
+        assert {[r ttl move-replace-ttl] > 0 && [r ttl move-replace-ttl] <= 100}
+        r select 9
+    } {OK} {singledb:skip}
+
+    test {MOVE REPLACE removes destination TTL when source has none} {
+        r select 10
+        r del move-replace-no-ttl
+        r set move-replace-no-ttl "dst" ex 100
+        r select 9
+        r del move-replace-no-ttl
+        r set move-replace-no-ttl "src"
+        assert_equal 1 [r move move-replace-no-ttl 10 replace]
+        r select 10
+        assert_equal "src" [r get move-replace-no-ttl]
+        assert_equal -1 [r ttl move-replace-no-ttl]
+        r select 9
+    } {OK} {singledb:skip}
+
+    test {MOVE REPLACE syntax errors} {
+        assert_error "ERR syntax error*" {r move move-replace-key 10 notreplace}
+        assert_error "ERR syntax error*" {r move move-replace-key 10 replace extra}
+    } {} {singledb:skip}
+
+    test {MOVE REPLACE emits move keyspace notifications} {
+        r config set notify-keyspace-events KEg
+        r select 10
+        r del move-replace-notify
+        r set move-replace-notify "dst"
+        r select 9
+        r del move-replace-notify
+        r set move-replace-notify "src"
+
+        set rd1 [valkey_deferring_client]
+        assert_equal {1} [psubscribe $rd1 *]
+        assert_equal 1 [r move move-replace-notify 10 replace]
+        assert_equal "pmessage * __keyspace@9__:move-replace-notify move_from" [$rd1 read]
+        assert_equal "pmessage * __keyevent@9__:move_from move-replace-notify" [$rd1 read]
+        assert_equal "pmessage * __keyspace@10__:move-replace-notify move_to" [$rd1 read]
+        assert_equal "pmessage * __keyevent@10__:move_to move-replace-notify" [$rd1 read]
+        $rd1 close
+        r config set notify-keyspace-events {}
+        r select 9
+    } {OK} {singledb:skip}
+
+    test {MOVE REPLACE invalidates WATCH on destination key} {
+        r select 10
+        r del move-replace-watch
+        r set move-replace-watch "dst"
+
+        set rd1 [valkey_client]
+        $rd1 select 10
+        $rd1 watch move-replace-watch
+        $rd1 multi
+
+        r select 9
+        r del move-replace-watch
+        r set move-replace-watch "src"
+        assert_equal 1 [r move move-replace-watch 10 replace]
+        $rd1 set move-replace-watch queued
+        assert_equal {} [$rd1 exec]
+        $rd1 close
+        r select 9
+    } {OK} {singledb:skip}
+
     test {SET/GET keys in different DBs} {
         r set a hello
         r set b world
@@ -557,6 +645,7 @@ foreach {type large} [array get largevalue] {
         r SET [string repeat "a" 50000] 1
         r KEYS [string repeat "*?" 50000]
     } {}
+
 }
 
 start_cluster 1 0 {tags {"keyspace external:skip cluster"}} {


### PR DESCRIPTION
Add `REPLACE` option to `MOVE` to overwrite an existing key in the destination DB. 😄 

Issue : #2278
