### PR TITLE
fix(HSETEX): replace strcmp with strcasecmp

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -38,7 +38,6 @@
 #include "vset.h"
 #include "server.h"
 #include "zmalloc.h"
-#include <_strings.h>
 #include <math.h>
 #include <string.h>
 #include "entry.h"

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -38,6 +38,7 @@
 #include "vset.h"
 #include "server.h"
 #include "zmalloc.h"
+#include <_strings.h>
 #include <math.h>
 #include <string.h>
 #include "entry.h"
@@ -1358,10 +1359,10 @@ void hsetexCommand(client *c) {
         new_argv = zmalloc(sizeof(robj *) * c->argc);
         // Copy optional args (skip NX/XX/FNX/FXX)
         for (int i = 0; i < fields_index; i++) {
-            if (strcmp(c->argv[i]->ptr, "NX") &&
-                strcmp(c->argv[i]->ptr, "XX") &&
-                strcmp(c->argv[i]->ptr, "FNX") &&
-                strcmp(c->argv[i]->ptr, "FXX")) {
+            if (strcasecmp(c->argv[i]->ptr, "NX") &&
+                strcasecmp(c->argv[i]->ptr, "XX") &&
+                strcasecmp(c->argv[i]->ptr, "FNX") &&
+                strcasecmp(c->argv[i]->ptr, "FXX")) {
                 /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
                  * EX/PX/EXAT flag. */
                 if (expire && !(flags & ARGS_PXAT) && c->argv[i + 1] == expire) {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -800,11 +800,11 @@ start_server {tags {"hashexpire"}} {
         r HSETEX myhash fxx PXAT $exp FIELDS 1 f4 v4
 
         assert_replication_stream $repl [subst {
+            {select 9}
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
             {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
             {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
-            {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
             {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
             {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
             {hsetex myhash PXAT $exp FIELDS 1 f4 v4}

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -2323,7 +2323,7 @@ start_server {tags {"hashexpire external:skip"}} {
         }
 
         test {HSETEX is not replicating validation arguments} {
-          $primary flushall            
+          $primary flushall
           set repl [attach_to_replication_stream]
           set exp [get_longer_then_long_expire_value PXAT]
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -2347,7 +2347,7 @@ start_server {tags {"hashexpire external:skip"}} {
             } else {
                 fail "hash object was not deleted on replica after timeout"
             }
-        } 
+        }
     }
 }
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -794,10 +794,10 @@ start_server {tags {"hashexpire"}} {
         r HSETEX myhash XX PXAT $exp FIELDS 1 f1 v1
         r HSETEX myhash FNX PXAT $exp FIELDS 1 f2 v2
         r HSETEX myhash FXX PXAT $exp FIELDS 1 f2 v2
-        r HSETEX myhash nx PXAT $exp FIELDS 1 f3 v3
-        r HSETEX myhash xx PXAT $exp FIELDS 1 f3 v3
-        r HSETEX myhash fnx PXAT $exp FIELDS 1 f4 v4
-        r HSETEX myhash fxx PXAT $exp FIELDS 1 f4 v4
+        r HSETEX myhash2 nx PXAT $exp FIELDS 1 f1 v1
+        r HSETEX myhash2 xx PXAT $exp FIELDS 1 f1 v1
+        r HSETEX myhash2 fnx PXAT $exp FIELDS 1 f2 v2
+        r HSETEX myhash2 fxx PXAT $exp FIELDS 1 f2 v2
 
         assert_replication_stream $repl [subst {
             {select 9}
@@ -805,9 +805,10 @@ start_server {tags {"hashexpire"}} {
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
             {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
             {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
-            {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
-            {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
-            {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
+            {hsetex myhash2 PXAT $exp FIELDS 1 f1 v1}
+            {hsetex myhash2 PXAT $exp FIELDS 1 f1 v1}
+            {hsetex myhash2 PXAT $exp FIELDS 1 f2 v2}
+            {hsetex myhash2 PXAT $exp FIELDS 1 f2 v2}
         }]
         close_replication_stream $repl
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -785,6 +785,33 @@ start_server {tags {"hashexpire"}} {
         assert_equal 0 [r HEXISTS myhash f3]
     }
 
+    test {HSETEX is not replicating validation arguments} {
+        r flushall
+        set repl [attach_to_replication_stream]
+        set exp [get_longer_then_long_expire_value PXAT]
+
+        r HSETEX myhash NX PXAT $exp FIELDS 1 f1 v1
+        r HSETEX myhash XX PXAT $exp FIELDS 1 f1 v1
+        r HSETEX myhash FNX PXAT $exp FIELDS 1 f2 v2
+        r HSETEX myhash FXX PXAT $exp FIELDS 1 f2 v2
+        r HSETEX myhash nx PXAT $exp FIELDS 1 f3 v3
+        r HSETEX myhash xx PXAT $exp FIELDS 1 f3 v3
+        r HSETEX myhash fnx PXAT $exp FIELDS 1 f4 v4
+        r HSETEX myhash fxx PXAT $exp FIELDS 1 f5 v5
+
+        assert_replication_stream $repl [subst {
+            {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
+            {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
+            {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
+            {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
+            {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
+            {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
+            {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
+            {hsetex myhash PXAT $exp FIELDS 1 f5 v5}
+        }]
+        close_replication_stream $repl
+    }
+
     ###### Test EXPIRE #############
 
 
@@ -2320,34 +2347,7 @@ start_server {tags {"hashexpire external:skip"}} {
             } else {
                 fail "hash object was not deleted on replica after timeout"
             }
-        }
-
-        test {HSETEX is not replicating validation arguments} {
-          $primary flushall
-          set repl [attach_to_replication_stream]
-          set exp [get_longer_then_long_expire_value PXAT]
-
-          $primary HSETEX myhash NX PXAT $exp FIELDS 1 f1 v1
-          $primary HSETEX myhash XX PXAT $exp FIELDS 1 f1 v1
-          $primary HSETEX myhash FNX PXAT $exp FIELDS 1 f2 v2
-          $primary HSETEX myhash FXX PXAT $exp FIELDS 1 f2 v2
-          $primary HSETEX myhash nx PXAT $exp FIELDS 1 f3 v3
-          $primary HSETEX myhash xx PXAT $exp FIELDS 1 f3 v3
-          $primary HSETEX myhash fnx PXAT $exp FIELDS 1 f4 v4
-          $primary HSETEX myhash fxx PXAT $exp FIELDS 1 f5 v5
-
-          assert_replication_stream $repl [subst {
-              {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
-              {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
-              {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
-              {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
-              {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
-              {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
-              {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
-              {hsetex myhash PXAT $exp FIELDS 1 f5 v5}
-          }]
-          close_replication_stream $repl
-        }
+        } 
     }
 }
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -2294,6 +2294,7 @@ start_server {tags {"hashexpire external:skip"}} {
                 fail "hash object was not deleted on replica after timeout"
             }
         }
+
         test {HEXPIREAT with expired time is propagated to the replica} {
             $primary flushall            
 
@@ -2319,6 +2320,33 @@ start_server {tags {"hashexpire external:skip"}} {
             } else {
                 fail "hash object was not deleted on replica after timeout"
             }
+        }
+
+        test {HSETEX is not replicating validation arguments} {
+          $primary flushall            
+          set repl [attach_to_replication_stream]
+          set exp [get_longer_then_long_expire_value PXAT]
+
+          $primary HSETEX myhash NX PXAT $exp FIELDS 1 f1 v1
+          $primary HSETEX myhash XX PXAT $exp FIELDS 1 f1 v1
+          $primary HSETEX myhash FNX PXAT $exp FIELDS 1 f2 v2
+          $primary HSETEX myhash FXX PXAT $exp FIELDS 1 f2 v2
+          $primary HSETEX myhash nx PXAT $exp FIELDS 1 f3 v3
+          $primary HSETEX myhash xx PXAT $exp FIELDS 1 f3 v3
+          $primary HSETEX myhash fnx PXAT $exp FIELDS 1 f4 v4
+          $primary HSETEX myhash fxx PXAT $exp FIELDS 1 f5 v5
+
+          assert_replication_stream $repl [subst {
+              {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
+              {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
+              {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
+              {hsetex myhash PXAT $exp FIELDS 1 f2 v2}
+              {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
+              {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
+              {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
+              {hsetex myhash PXAT $exp FIELDS 1 f5 v5}
+          }]
+          close_replication_stream $repl
         }
     }
 }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -797,7 +797,7 @@ start_server {tags {"hashexpire"}} {
         r HSETEX myhash nx PXAT $exp FIELDS 1 f3 v3
         r HSETEX myhash xx PXAT $exp FIELDS 1 f3 v3
         r HSETEX myhash fnx PXAT $exp FIELDS 1 f4 v4
-        r HSETEX myhash fxx PXAT $exp FIELDS 1 f5 v5
+        r HSETEX myhash fxx PXAT $exp FIELDS 1 f4 v4
 
         assert_replication_stream $repl [subst {
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
@@ -807,7 +807,7 @@ start_server {tags {"hashexpire"}} {
             {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
             {hsetex myhash PXAT $exp FIELDS 1 f3 v3}
             {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
-            {hsetex myhash PXAT $exp FIELDS 1 f5 v5}
+            {hsetex myhash PXAT $exp FIELDS 1 f4 v4}
         }]
         close_replication_stream $repl
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -800,7 +800,7 @@ start_server {tags {"hashexpire"}} {
         r HSETEX myhash2 fxx PXAT $exp FIELDS 1 f2 v2
 
         assert_replication_stream $repl [subst {
-            {select 9}
+            {select *}
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
             {hsetex myhash PXAT $exp FIELDS 1 f1 v1}
             {hsetex myhash PXAT $exp FIELDS 1 f2 v2}


### PR DESCRIPTION
HSETEX right now uses `strcmp` which does not account for case-insensitivity replaced it with `strcasecmp`.
Fixes #2996 