### PR TITLE
Optimize streams range hot path

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -5987,25 +5987,6 @@ size_t getClientMemoryUsage(client *c, size_t *output_buffer_mem_usage) {
     return mem;
 }
 
-/* Get the class of a client, used in order to enforce limits to different
- * classes of clients.
- *
- * The function will return one of the following:
- * CLIENT_TYPE_NORMAL -> Normal client, including MONITOR
- * CLIENT_TYPE_REPLICA  -> replica
- * CLIENT_TYPE_PUBSUB -> Client subscribed to Pub/Sub channels
- * CLIENT_TYPE_PRIMARY -> The client representing our replication primary.
- */
-int getClientType(client *c) {
-    if (c->flag.primary) return CLIENT_TYPE_PRIMARY;
-    /* Even though MONITOR clients are marked as replicas, we
-     * want the expose them as normal clients. */
-    if (c->flag.replica && !c->flag.monitor) return CLIENT_TYPE_REPLICA;
-    if (c->flag.pubsub) return CLIENT_TYPE_PUBSUB;
-    if (c->slot_migration_job) return isImportSlotMigrationJob(c->slot_migration_job) ? CLIENT_TYPE_SLOT_IMPORT : CLIENT_TYPE_SLOT_EXPORT;
-    return CLIENT_TYPE_NORMAL;
-}
-
 int getClientTypeByName(char *name) {
     if (!strcasecmp(name, "normal"))
         return CLIENT_TYPE_NORMAL;

--- a/src/server.h
+++ b/src/server.h
@@ -1353,12 +1353,11 @@ typedef struct client {
     time_t last_interaction;          /* Time of the last interaction, used for timeout */
     serverDb *db;                     /* Pointer to currently SELECTed DB. */
     /* Client state structs. */
-    ClientPubSubData *pubsub_data;        /* Required for: pubsub commands and tracking. lazily initialized when first needed */
-    ClientReplicationData *repl_data;     /* Required for Replication operations. lazily initialized when first needed */
-    ClientModuleData *module_data;        /* Required for Module operations. lazily initialized when first needed */
-    multiState *mstate;                   /* MULTI/EXEC state, lazily initialized when first needed */
-    blockingState *bstate;                /* Blocking state, lazily initialized when first needed */
-    slotMigrationJob *slot_migration_job; /* Pointer to the slot migration job, or NULL. */
+    ClientPubSubData *pubsub_data;    /* Required for: pubsub commands and tracking. lazily initialized when first needed */
+    ClientReplicationData *repl_data; /* Required for Replication operations. lazily initialized when first needed */
+    ClientModuleData *module_data;    /* Required for Module operations. lazily initialized when first needed */
+    multiState *mstate;               /* MULTI/EXEC state, lazily initialized when first needed */
+    blockingState *bstate;            /* Blocking state, lazily initialized when first needed */
     /* Output buffer and reply handling */
     long duration;                       /* Current command duration. Used for measuring latency of blocking/non-blocking cmds */
     char *buf;                           /* Output buffer */
@@ -1378,11 +1377,13 @@ typedef struct client {
         uint64_t raw_flag;
         struct ClientFlags flag;
     };
-    uint16_t write_flags;            /* Client Write flags - used to communicate the client write state. */
-    volatile uint8_t io_read_state;  /* Indicate the IO read state of the client */
-    volatile uint8_t io_write_state; /* Indicate the IO write state of the client */
-    uint8_t resp;                    /* RESP protocol version. Can be 2 or 3. */
-    uint8_t cur_tid;                 /* ID of IO thread currently performing IO for this client */
+    /* Cache Locality: Grouped with 'flag' for getClientType() hot path. */
+    slotMigrationJob *slot_migration_job; /* Pointer to the slot migration job, or NULL. */
+    uint16_t write_flags;                 /* Client Write flags - used to communicate the client write state. */
+    volatile uint8_t io_read_state;       /* Indicate the IO read state of the client */
+    volatile uint8_t io_write_state;      /* Indicate the IO write state of the client */
+    uint8_t resp;                         /* RESP protocol version. Can be 2 or 3. */
+    uint8_t cur_tid;                      /* ID of IO thread currently performing IO for this client */
     /* In updateClientMemoryUsage() we track the memory usage of
      * each client and add it to the sum of all the clients of a given type,
      * however we need to remember what was the old contribution of each
@@ -1431,6 +1432,28 @@ typedef struct client {
     clientReqResInfo reqres;
 #endif
 } client;
+
+/* Forward declaration */
+bool isImportSlotMigrationJob(slotMigrationJob *job);
+
+/* Get the class of a client, used in order to enforce limits to different
+ * classes of clients.
+ *
+ * The function will return one of the following:
+ * CLIENT_TYPE_NORMAL -> Normal client, including MONITOR
+ * CLIENT_TYPE_REPLICA  -> replica
+ * CLIENT_TYPE_PUBSUB -> Client subscribed to Pub/Sub channels
+ * CLIENT_TYPE_PRIMARY -> The client representing our replication primary.
+ */
+static inline int getClientType(client *c) {
+    if (unlikely(c->flag.primary)) return CLIENT_TYPE_PRIMARY;
+    /* Even though MONITOR clients are marked as replicas, we
+     * want the expose them as normal clients. */
+    if (unlikely(c->flag.replica) && !c->flag.monitor) return CLIENT_TYPE_REPLICA;
+    if (c->flag.pubsub) return CLIENT_TYPE_PUBSUB;
+    if (unlikely(c->slot_migration_job)) return isImportSlotMigrationJob(c->slot_migration_job) ? CLIENT_TYPE_SLOT_IMPORT : CLIENT_TYPE_SLOT_EXPORT;
+    return CLIENT_TYPE_NORMAL;
+}
 
 /* When a command generates a lot of discrete elements to the client output buffer, it is much faster to
  * skip certain types of initialization. This type is used to indicate a client that has been initialized

--- a/src/stream.h
+++ b/src/stream.h
@@ -38,8 +38,8 @@ typedef struct streamIterator {
     int entry_flags;                     /* Flags of entry we are emitting. */
     int rev;                             /* True if iterating end to start (reverse). */
     int skip_tombstones;                 /* True if not emitting tombstone entries. */
-    uint64_t start_key[2];               /* Start key as 128 bit big endian. */
-    uint64_t end_key[2];                 /* End key as 128 bit big endian. */
+    streamID start_id;                   /* Start id for the range */
+    streamID end_id;                     /* End id for the range */
     raxIterator ri;                      /* Rax iterator. */
     unsigned char *lp;                   /* Current listpack. */
     unsigned char *lp_ele;               /* Current listpack cursor. */

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1358,11 +1358,23 @@ void streamLastValidID(stream *s, streamID *maxid) {
  * allocator's 48 bytes bin. */
 #define STREAM_ID_STR_LEN 44
 
+/* Write a stream ID into a buffer.
+ * The buffer must be pre-allocated with at least STREAM_ID_STR_LEN bytes.
+ * It is much faster than:
+ * sdscatfmt(sds,"%U-%U", id->ms,id->seq);
+ */
+int streamID2string(char *s, streamID *id) {
+    char *p = s;
+    p += ull2string(p, LONG_STR_SIZE, id->ms);
+    *p++ = '-';
+    p += ull2string(p, LONG_STR_SIZE, id->seq);
+    return p - s;
+}
+
 sds createStreamIDString(streamID *id) {
-    /* Optimization: pre-allocate a big enough buffer to avoid reallocs. */
-    sds str = sdsnewlen(SDS_NOINIT, STREAM_ID_STR_LEN);
-    sdssetlen(str, 0);
-    return sdscatfmt(str, "%U-%U", id->ms, id->seq);
+    char buf[STREAM_ID_STR_LEN];
+    int len = streamID2string(buf, id);
+    return sdsnewlen(buf, len);
 }
 
 /* Emit a reply in the client output buffer by formatting a Stream ID
@@ -1679,6 +1691,8 @@ size_t streamReplyWithRange(client *c,
         return streamReplyWithRangeFromConsumerPEL(c, s, start, end, count, consumer);
     }
 
+    char replyid[STREAM_ID_STR_LEN];
+
     if (!(flags & STREAM_RWR_RAWENTRIES)) arraylen_ptr = addReplyDeferredLen(c);
     streamIteratorStart(&si, s, start, end, rev);
     while (streamIteratorGetID(&si, &id, &numfields)) {
@@ -1705,7 +1719,8 @@ size_t streamReplyWithRange(client *c,
         /* Emit a two elements array for each item. The first is
          * the ID, the second is an array of field-value pairs. */
         addReplyArrayLen(c, 2);
-        addReplyStreamID(c, &id);
+        int idlen = streamID2string(replyid, &id);
+        addReplyBulkCBuffer(c, replyid, idlen);
 
         addReplyArrayLen(c, numfields * 2);
 

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1040,34 +1040,41 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
  *  }
  *  streamIteratorStop(&myiterator); */
 void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamID *end, int rev) {
-    /* Initialize the iterator and translates the iteration start/stop
-     * elements into a 128 big big-endian number. */
+    /* Initialize the iterator and store the iteration range. */
     if (start) {
-        streamEncodeID(si->start_key, start);
+        si->start_id.ms = start->ms;
+        si->start_id.seq = start->seq;
     } else {
-        si->start_key[0] = 0;
-        si->start_key[1] = 0;
+        si->start_id.ms = 0;
+        si->start_id.seq = 0;
     }
 
     if (end) {
-        streamEncodeID(si->end_key, end);
+        si->end_id.ms = end->ms;
+        si->end_id.seq = end->seq;
     } else {
-        si->end_key[0] = UINT64_MAX;
-        si->end_key[1] = UINT64_MAX;
+        si->end_id.ms = UINT64_MAX;
+        si->end_id.seq = UINT64_MAX;
     }
 
     /* Seek the correct node in the radix tree. */
     raxStart(&si->ri, s->rax);
     if (!rev) {
         if (start && (start->ms || start->seq)) {
-            raxSeek(&si->ri, "<=", (unsigned char *)si->start_key, sizeof(si->start_key));
+            uint64_t start_key[2];
+            start_key[0] = htonu64(start->ms);
+            start_key[1] = htonu64(start->seq);
+            raxSeek(&si->ri, "<=", (unsigned char *)start_key, sizeof(start_key));
             if (raxEOF(&si->ri)) raxSeek(&si->ri, "^", NULL, 0);
         } else {
             raxSeek(&si->ri, "^", NULL, 0);
         }
     } else {
         if (end && (end->ms || end->seq)) {
-            raxSeek(&si->ri, "<=", (unsigned char *)si->end_key, sizeof(si->end_key));
+            uint64_t end_key[2];
+            end_key[0] = htonu64(end->ms);
+            end_key[1] = htonu64(end->seq);
+            raxSeek(&si->ri, "<=", (unsigned char *)end_key, sizeof(end_key));
             if (raxEOF(&si->ri)) raxSeek(&si->ri, "$", NULL, 0);
         } else {
             raxSeek(&si->ri, "$", NULL, 0);
@@ -1162,8 +1169,6 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
             si->lp_ele = lpNext(si->lp, si->lp_ele);
             id->seq += lpGetInteger(si->lp_ele);
             si->lp_ele = lpNext(si->lp, si->lp_ele);
-            unsigned char buf[sizeof(streamID)];
-            streamEncodeID(buf, id);
 
             /* The number of entries is here or not depending on the
              * flags. */
@@ -1178,17 +1183,17 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
             /* If current >= start, and the entry is not marked as
              * deleted or tombstones are included, emit it. */
             if (!si->rev) {
-                if (memcmp(buf, si->start_key, sizeof(streamID)) >= 0 &&
+                if (streamCompareID(id, &si->start_id) >= 0 &&
                     (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
-                    if (memcmp(buf, si->end_key, sizeof(streamID)) > 0) return 0; /* We are already out of range. */
+                    if (streamCompareID(id, &si->end_id) > 0) return 0; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
                     return 1; /* Valid item returned. */
                 }
             } else {
-                if (memcmp(buf, si->end_key, sizeof(streamID)) <= 0 &&
+                if (streamCompareID(id, &si->end_id) <= 0 &&
                     (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
-                    if (memcmp(buf, si->start_key, sizeof(streamID)) < 0) return 0; /* We are already out of range. */
+                    if (streamCompareID(id, &si->start_id) < 0) return 0; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
                     return 1; /* Valid item returned. */
@@ -1287,11 +1292,11 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     /* Re-seek the iterator to fix the now messed up state. */
     streamID start, end;
     if (si->rev) {
-        streamDecodeID(si->start_key, &start);
+        start = si->start_id;
         end = *current;
     } else {
         start = *current;
-        streamDecodeID(si->end_key, &end);
+        end = si->end_id;
     }
     streamIteratorStop(si);
     streamIteratorStart(si, si->stream, &start, &end, si->rev);

--- a/src/util.c
+++ b/src/util.c
@@ -411,8 +411,7 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
     while (value >= 100) {
         int const i = (value % 100) * 2;
         value /= 100;
-        dst[next] = digits[i + 1];
-        dst[next - 1] = digits[i];
+        memcpy(dst + next - 1, digits + i, 2);
         next -= 2;
     }
 
@@ -421,8 +420,7 @@ int ull2string(char *dst, size_t dstlen, unsigned long long value) {
         dst[next] = '0' + (uint32_t)value;
     } else {
         int i = (uint32_t)value * 2;
-        dst[next] = digits[i + 1];
-        dst[next - 1] = digits[i];
+        memcpy(dst + next - 1, digits + i, 2);
     }
     return length;
 err:


### PR DESCRIPTION
This PR improves stream performance in the range iteration and reply generation paths, benefits xadd, xrange, xrevrange, xreadgroup.

- ull2string memcpy optimization
- streamID struct + streamCompareID
- streamID2string + reply path
- getClientType inline + cache locality

Inspired by the high-level description (not the code) of https://github.com/redis/redis/pull/14480
