### PR TITLE
Skip slot cache optimization for AOF client to prevent key duplication and data corruption

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -246,10 +246,10 @@ int getKeySlot(sds key) {
      * the key slot would fallback to keyHashSlot.
      *
      * Modules and scripts executed on the primary may get replicated as multi-execs that operate on multiple slots,
-     * so we must always recompute the slot for commands coming from the primary.
+     * so we must always recompute the slot for commands coming from the primary or AOF.
      */
     if (server.current_client && server.current_client->slot >= 0 && server.current_client->flag.executing_command &&
-        !isReplicatedClient(server.current_client)) {
+        !mustObeyClient(server.current_client)) {
         debugServerAssertWithInfo(server.current_client, NULL,
                                   (int)keyHashSlot(key, (int)sdslen(key)) == server.current_client->slot);
         return server.current_client->slot;


### PR DESCRIPTION
When loading AOF in cluster mode, keys inside a MULTI/EXEC block could be
inserted into wrong hash slots, causing key duplication and data corruption.

The root cause was the slot caching optimization in getKeySlot(). This
optimization reuses a cached slot value to avoid recalculating the hash
for every key operation. However, when replaying AOF, a transaction may
contain commands affecting keys in different slots. The cached slot from
a previous command (e.g., SET k1) would incorrectly be used for subsequent
commands in the transaction (e.g., SET k0), causing k0 to be stored in k1's
slot.

The existing code already skipped this optimization for replicated clients
(commands from primary) using isReplicatedClient(). This change extends
that to also skip for AOF clients by using mustObeyClient() instead, which
covers both replicated clients and the AOF client.

Fixes #2995, introduced in #1949.