### PR TITLE
Fix used_memory_dataset underflow due to miscalculated used_memory_overhead

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1374,7 +1374,6 @@ struct serverMemOverhead *getMemoryOverheadData(void) {
     for (j = 0; j < server.dbnum; j++) {
         serverDb *db = server.db[j];
         if (db == NULL) continue;
-        /* Even if kvstoreNumAllocatedHashtables() is zero, kvstoreCreate() still allocated significant memory. */
 
         unsigned long long keyscount = kvstoreSize(db->keys);
 

--- a/src/object.c
+++ b/src/object.c
@@ -1373,7 +1373,8 @@ struct serverMemOverhead *getMemoryOverheadData(void) {
 
     for (j = 0; j < server.dbnum; j++) {
         serverDb *db = server.db[j];
-        if (db == NULL || !kvstoreNumAllocatedHashtables(db->keys)) continue;
+        if (db == NULL) continue;
+        /* Even if kvstoreNumAllocatedHashtables() is zero, kvstoreCreate() still allocated significant memory. */
 
         unsigned long long keyscount = kvstoreSize(db->keys);
 

--- a/src/server.c
+++ b/src/server.c
@@ -3115,9 +3115,11 @@ void InitServerLast(void) {
     initIOThreads();
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
 
-    server.initial_memory_usage = 0; /* first set initial_memory_usage to zero as baseline for getMemoryOverheadData() */
+    /* First set initial_memory_usage to zero as baseline for getMemoryOverheadData(). */
+    server.initial_memory_usage = 0; 
     struct serverMemOverhead *mh = getMemoryOverheadData();
-    server.initial_memory_usage = zmalloc_used_memory() - mh->overhead_total; /* exclude current overhead memory to avoid double counting in the future */
+    /* Exclude current overhead memory to avoid double counting in the future. */
+    server.initial_memory_usage = zmalloc_used_memory() - mh->overhead_total;
     freeMemoryOverheadData(mh);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -2889,7 +2889,16 @@ void initServer(void) {
 
     server.dbnum = server.cluster_enabled ? server.config_databases_cluster : server.config_databases;
     server.db = zcalloc(sizeof(serverDb *) * server.dbnum);
+
+    /* Save the current zmalloc_used_memory() gauge to calculate server.db memory usage later. */
+    server.initial_memory_usage = zmalloc_used_memory();
+
     createDatabaseIfNeeded(0); /* The default database should always exist */
+
+    /* Here initial_memory_usage is borrowed to store the memory usage of server.db,
+     * and its value will be eventually determined in InitServerLast().
+     */
+    server.initial_memory_usage = zmalloc_used_memory() - server.initial_memory_usage;
 
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     /* Note that server.pubsub_channels was chosen to be a kvstore (with only one dict, which
@@ -3114,7 +3123,12 @@ void InitServerLast(void) {
     bioInit();
     initIOThreads();
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
-    server.initial_memory_usage = zmalloc_used_memory();
+
+    /* The value of initial_memory_usage was temporarily set to the memory usage of server.db in initServer().
+     * Now we record the initial memory usage EXCLUDING server.db, which is nessesary for
+     * getMemoryOverheadData() to prevent initial server.db memory from being double-counted into used_memory_overhead.
+     */
+    server.initial_memory_usage = zmalloc_used_memory() - server.initial_memory_usage;
 }
 
 /* The purpose of this function is to try to "glue" consecutive range

--- a/src/server.c
+++ b/src/server.c
@@ -2889,16 +2889,7 @@ void initServer(void) {
 
     server.dbnum = server.cluster_enabled ? server.config_databases_cluster : server.config_databases;
     server.db = zcalloc(sizeof(serverDb *) * server.dbnum);
-
-    /* Save the current zmalloc_used_memory() gauge to calculate server.db memory usage later. */
-    server.initial_memory_usage = zmalloc_used_memory();
-
     createDatabaseIfNeeded(0); /* The default database should always exist */
-
-    /* Here initial_memory_usage is borrowed to store the memory usage of server.db,
-     * and its value will be eventually determined in InitServerLast().
-     */
-    server.initial_memory_usage = zmalloc_used_memory() - server.initial_memory_usage;
 
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     /* Note that server.pubsub_channels was chosen to be a kvstore (with only one dict, which
@@ -3124,11 +3115,10 @@ void InitServerLast(void) {
     initIOThreads();
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
 
-    /* The value of initial_memory_usage was temporarily set to the memory usage of server.db in initServer().
-     * Now we record the initial memory usage EXCLUDING server.db, which is necessary for
-     * getMemoryOverheadData() to prevent initial server.db memory from being double-counted into used_memory_overhead.
-     */
-    server.initial_memory_usage = zmalloc_used_memory() - server.initial_memory_usage;
+    server.initial_memory_usage = 0; /* first set initial_memory_usage to zero as baseline for getMemoryOverheadData() */
+    struct serverMemOverhead *mh = getMemoryOverheadData();
+    server.initial_memory_usage = zmalloc_used_memory() - mh->overhead_total; /* exclude current overhead memory to avoid double counting in the future */
+    freeMemoryOverheadData(mh);
 }
 
 /* The purpose of this function is to try to "glue" consecutive range

--- a/src/server.c
+++ b/src/server.c
@@ -3116,7 +3116,7 @@ void InitServerLast(void) {
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
 
     /* First set initial_memory_usage to zero as baseline for getMemoryOverheadData(). */
-    server.initial_memory_usage = 0; 
+    server.initial_memory_usage = 0;
     struct serverMemOverhead *mh = getMemoryOverheadData();
     /* Exclude current overhead memory to avoid double counting in the future. */
     server.initial_memory_usage = zmalloc_used_memory() - mh->overhead_total;

--- a/src/server.c
+++ b/src/server.c
@@ -3125,7 +3125,7 @@ void InitServerLast(void) {
     set_jemalloc_bg_thread(server.jemalloc_bg_thread);
 
     /* The value of initial_memory_usage was temporarily set to the memory usage of server.db in initServer().
-     * Now we record the initial memory usage EXCLUDING server.db, which is nessesary for
+     * Now we record the initial memory usage EXCLUDING server.db, which is necessary for
      * getMemoryOverheadData() to prevent initial server.db memory from being double-counted into used_memory_overhead.
      */
     server.initial_memory_usage = zmalloc_used_memory() - server.initial_memory_usage;


### PR DESCRIPTION
# Describe the bug

The metric `used_memory_dataset` turned into an insanely large number close to 2^64 (actually overflowed negative value),
as reported in <https://github.com/valkey-io/valkey/issues/2994#issuecomment-3706853079>.

Versions affected include 8.x and 9.x. (Should i submit multiple PRs?)

# Analysis

We found that miscalculated `used_memory_overhead` is the core reason.

## Double-Counted database memory

When server starts, the global variable `server.initial_memory_usage` is used to record a memory baseline in [InitServerLast()](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/server.c#L3117). This `server.initial_memory_usage` has clearly included initial database memory, since databases are created in [initServer()](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/server.c#L2892).

In function [getMemoryOverheadData()](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/object.c#L1304), the `mem_total` is [firstly assigned the baseline](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/object.c#L1325), which includes initial database memory. And then [all extra memory usage of databases are added](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/object.c#L1374) to mem_total. The initial database memory are therefore counted TWICE.

This eventually caused wrongly larger `used_memory_overhead`. For a database with only a couple of keys, the `used_memory_overhead` is easily larger than `used_memory` and causes an overflowed `used_memory_dataset`.

## Missed Empty Databases

In function [getMemoryOverheadData()](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/object.c#L1304), kvstores without any allocated hashtable are ignored from calculation,

```c
if (db == NULL || !kvstoreNumAllocatedHashtables(db->keys)) continue;
```

However, even the kvstore has no allocated hashtable, there are still some memory allocated by [kvstoreCreate()](https://github.com/valkey-io/valkey/blob/e4a3e9f0a298fbaa7320e76dbdd4b790425c148e/src/kvstore.c#L286), including `hashtable_size_index`, which can be larger than 128 KiB.

On the contrary, this caused wrongly smaller `used_memory_overhead` for an empty database. When we insert only ONE key to the database, the database is suddenly taken into account, and `used_memory_overhead` will increase (for `used_memory_dataset` decrease) by more than 128 KiB due to the single key insertion.

# Proposed Fix

In this PR,

a) We record the zmalloc_used_memory() change before and after database creation during server initialization. And later when we decide the baseline `server.initial_memory_usage`, the initial database memory usage is excluded.

b) We remove the condition  kvstoreNumAllocatedHashtables() in getMemoryOverheadData(), to make the `used_memory_overhead` reasonable for both empty and non-empty kvstores.