### PR TITLE
HFE make zero a valid ttl during import mode and data loading 

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2254,7 +2254,7 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                 return NULL;
             }
 
-            if (rdbtype == RDB_TYPE_HASH_2 && itemexpiry > 0) {
+            if (rdbtype == RDB_TYPE_HASH_2 && itemexpiry != EXPIRY_NONE) {
                 hashTypeTrackEntry(o, entry);
             }
         }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -372,7 +372,7 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags) {
      * This is needed for HINCRBY* case since in other commands this is handled early by
      * hashTypeTryConversion, so this check will be a NOP. */
     if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        if (expiry > 0 || sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value)
+        if (expiry != EXPIRY_NONE || sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value)
             hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
     }
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -965,6 +965,25 @@ start_server {tags {"expire"}} {
             fail "key wasn't expired"
         }
     }
+
+    test {Zero is a valid ttl in HFE} {
+        r flushall
+        r hset myhash f1 v1
+        assert_equal [r OBJECT ENCODING myhash] "listpack"
+        assert_equal [r hsetex myhash exat 0 fields 2 f2 v2 f3 v3] 0
+        assert_equal [r hlen myhash] 1
+        assert_equal [r OBJECT ENCODING myhash] "listpack"
+        r config set import-mode yes
+        assert_equal [r hsetex myhash exat 0 fields 2 f2 v2 f3 v3] 1
+        assert_equal [r hlen myhash] 3
+        assert_equal [r OBJECT ENCODING myhash] "hashtable"
+        r config set import-mode no
+        wait_for_condition 30 100 {
+            [r hlen myhash] == 1
+        } else {
+            fail "field wasn't expired"
+        }
+    }
 }
 
 start_server {tags {expire} overrides {hz 100}} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -965,25 +965,6 @@ start_server {tags {"expire"}} {
             fail "key wasn't expired"
         }
     }
-
-    test {Zero is a valid ttl in HFE} {
-        r flushall
-        r hset myhash f1 v1
-        assert_equal [r OBJECT ENCODING myhash] "listpack"
-        assert_equal [r hsetex myhash exat 0 fields 2 f2 v2 f3 v3] 0
-        assert_equal [r hlen myhash] 1
-        assert_equal [r OBJECT ENCODING myhash] "listpack"
-        r config set import-mode yes
-        assert_equal [r hsetex myhash exat 0 fields 2 f2 v2 f3 v3] 1
-        assert_equal [r hlen myhash] 3
-        assert_equal [r OBJECT ENCODING myhash] "hashtable"
-        r config set import-mode no
-        wait_for_condition 30 100 {
-            [r hlen myhash] == 1
-        } else {
-            fail "field wasn't expired"
-        }
-    }
 }
 
 start_server {tags {expire} overrides {hz 100}} {


### PR DESCRIPTION
The HFE uses EXPIRY_NONE(-1) for fields without a TTL. A bug exists in `HSETEX` and RDB loading where `expiry > 0` is used to check for an expiration. This is problematic because `0` might be treated as no expiry in `import-mode`, instead of an already expired timestamp, leading to incorrect behavior.