### PR TITLE
Untrack key based on old->hasembkey

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -373,6 +373,9 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
 
     /* If overwriting a hash object, un-track it from the volatile items tracking if it contains volatile items.*/
     if (old->type == OBJ_HASH && hashTypeHasVolatileFields(old)) {
+        /* Some commands create a new value (with NO key) and use setKey to change the value of an existing key.
+         * In this case the old can be replaced with the provided value and be left without a key
+         * however it is still a hashObject with optional volatile items and we need to untrack it. */
         dbUntrackKeyWithVolatileItems(db, old->hasembkey ? old : new);
     }
     /* If the new object is a hash with volatile items we need to track it again */

--- a/src/db.c
+++ b/src/db.c
@@ -373,7 +373,7 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
 
     /* If overwriting a hash object, un-track it from the volatile items tracking if it contains volatile items.*/
     if (old->type == OBJ_HASH && hashTypeHasVolatileFields(old)) {
-        dbUntrackKeyWithVolatileItems(db, old);
+        dbUntrackKeyWithVolatileItems(db, old->hasembkey ? old : new);
     }
     /* If the new object is a hash with volatile items we need to track it again */
     dbTrackKeyWithVolatileItems(db, new);


### PR DESCRIPTION
In `dbSetValue()` the `old` pointer may be reassigned to point to the incoming value object which was created without an embedded key, so calling `dbUntrackKeyWithVolatileItems()` would call `objectGetKey()` which returns NULL, causing a crash in `hashtableSdsHash()` when trying to hash the NULL key.

Idea is to assign `old_was_hash_with_volatile` before the swap and use `new` instead of `old` for untracking when theres no embedded key.

Introduced in #3003 
Run with NULL ptr dereference: https://github.com/valkey-io/valkey/actions/runs/20701343184/job/59424029880