### PR TITLE
Fix bio jobs leak on server crash

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -327,6 +327,11 @@ void bioKillThreads(void) {
                 serverLog(LL_WARNING, "Bio worker thread #%zu terminated", bioWorkerNum(bwd));
             }
         }
+
+        bio_job *job;
+        while ((job = mutexQueuePop(bwd->bio_jobs, false)) != NULL) {
+            zfree(job);
+        }
     }
 }
 


### PR DESCRIPTION
If there are jobs still in the queue that haven't been processed yet, those jobs will never be freed because the threads are killed before they can process them.
Introduced: #2895
Daily run: https://github.com/valkey-io/valkey/actions/runs/20733311391/job/59525607904