### PR TITLE
Automatic TLS reload

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -70,6 +70,7 @@
 #include "connection.h"
 #include "bio.h"
 #include "mutexqueue.h"
+#include "tls.h"
 #include <stdatomic.h>
 
 static unsigned int bio_job_to_worker[] = {

--- a/src/bio.c
+++ b/src/bio.c
@@ -78,6 +78,9 @@ static unsigned int bio_job_to_worker[] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+    [BIO_TLS_RELOAD] = 4,
+#endif
 };
 
 typedef struct {
@@ -91,6 +94,9 @@ static bio_worker_data bio_workers[] = {
     {"bio_aof"},
     {"bio_lazy_free"},
     {"bio_rdb_save"},
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+    {"bio_tls_reload"},
+#endif
 };
 static const bio_worker_data *const bio_worker_end = bio_workers + (sizeof bio_workers / sizeof *bio_workers);
 
@@ -133,6 +139,10 @@ typedef union bio_job {
         connection *conn;    /* Connection to download the RDB from */
         int is_dual_channel; /* Single vs dual channel */
     } save_to_disk_args;
+
+    struct {
+        int type;
+    } tls_reload_args;
 } bio_job;
 
 void *bioProcessBackgroundJobs(void *arg);
@@ -227,6 +237,11 @@ void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
     bioSubmitJob(BIO_RDB_SAVE, job);
 }
 
+void bioCreateTlsReloadJob(void) {
+    bio_job *job = zmalloc(sizeof(*job));
+    bioSubmitJob(BIO_TLS_RELOAD, job);
+}
+
 void *bioProcessBackgroundJobs(void *arg) {
     bio_worker_data *const bwd = arg;
     sigset_t sigset;
@@ -291,6 +306,12 @@ void *bioProcessBackgroundJobs(void *arg) {
             job->free_args.free_fn(job->free_args.free_args);
         } else if (job_type == BIO_RDB_SAVE) {
             replicaReceiveRDBFromPrimaryToDisk(job->save_to_disk_args.conn, job->save_to_disk_args.is_dual_channel);
+        } else if (job_type == BIO_TLS_RELOAD) {
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+            tlsConfigureAsync();
+#else
+            serverPanic("BIO_TLS_RELOAD job type requires built-in TLS (BUILD_TLS=yes).");
+#endif
         } else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }

--- a/src/bio.h
+++ b/src/bio.h
@@ -42,6 +42,7 @@ void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...);
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel);
+void bioCreateTlsReloadJob(void);
 int inBioThread(void);
 
 /* Background job opcodes */
@@ -51,6 +52,7 @@ enum {
     BIO_LAZY_FREE,      /* Deferred objects freeing. */
     BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
     BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
+    BIO_TLS_RELOAD,     /* Deferred TLS reload. */
     BIO_NUM_OPS
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -3423,6 +3423,7 @@ standardConfig static_configs[] = {
     createIntConfig("tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.tls_port, 0, INTEGER_CONFIG, NULL, applyTLSPort), /* TCP port. */
     createIntConfig("tls-session-cache-size", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_size, 20 * 1024, INTEGER_CONFIG, NULL, applyTlsCfg),
     createIntConfig("tls-session-cache-timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.session_cache_timeout, 300, INTEGER_CONFIG, NULL, applyTlsCfg),
+    createIntConfig("tls-auto-reload-interval", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.tls_ctx_config.auto_reload_interval, 0, INTEGER_CONFIG, NULL, applyTlsCfg),
     createBoolConfig("tls-cluster", NULL, MODIFIABLE_CONFIG, server.tls_cluster, 0, NULL, applyTlsCfg),
     createBoolConfig("tls-replication", NULL, MODIFIABLE_CONFIG, server.tls_replication, 0, NULL, applyTlsCfg),
     createEnumConfig("tls-auth-clients", NULL, MODIFIABLE_CONFIG, tls_auth_clients_enum, server.tls_auth_clients, TLS_CLIENT_AUTH_YES, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -47,6 +47,7 @@
 #include "threads_mngr.h"
 #include "fmtargs.h"
 #include "io_threads.h"
+#include "tls.h"
 #include "sds.h"
 #include "module.h"
 #include "scripting_engine.h"

--- a/src/server.c
+++ b/src/server.c
@@ -1685,6 +1685,17 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
             server.rdb_bgsave_scheduled = 0;
     }
 
+    /* TLS auto-reload if enabled (only when TLS is built-in). */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+    if ((server.tls_port || server.tls_replication || server.tls_cluster) &&
+        server.tls_ctx_config.auto_reload_interval > 0) {
+        run_with_period(1000) {
+            tlsReconfigureIfNeeded();
+            tlsApplyPendingReload();
+        }
+    }
+#endif
+
     if (moduleCount()) {
         run_with_period(100) modulesCron();
     }

--- a/src/server.h
+++ b/src/server.h
@@ -4204,13 +4204,6 @@ void debugPauseProcess(void);
 
 int iAmPrimary(void);
 
-/* TLS reload functions - only available when TLS is built-in, not as a module */
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
-void tlsReconfigureIfNeeded(void);
-void tlsApplyPendingReload(void);
-void tlsConfigureAsync(void);
-#endif
-
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 

--- a/src/server.h
+++ b/src/server.h
@@ -1647,6 +1647,7 @@ typedef struct serverTLSContextConfig {
     int session_caching;
     int session_cache_size;
     int session_cache_timeout;
+    int auto_reload_interval;
 } serverTLSContextConfig;
 
 /*-----------------------------------------------------------------------------
@@ -4202,6 +4203,13 @@ void debugPauseProcess(void);
 #define serverDebugMark() printf("-- MARK %s:%d --\n", __FILE__, __LINE__)
 
 int iAmPrimary(void);
+
+/* TLS reload functions - only available when TLS is built-in, not as a module */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+void tlsReconfigureIfNeeded(void);
+void tlsApplyPendingReload(void);
+void tlsConfigureAsync(void);
+#endif
 
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)

--- a/src/tls.c
+++ b/src/tls.c
@@ -414,19 +414,32 @@ error:
     return C_ERR;
 }
 
-/* Last known TLS materials metadata to detect changes */
-static unsigned char last_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
-static unsigned int last_cert_fingerprint_len = 0;
-static unsigned char last_client_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
-static unsigned int last_client_cert_fingerprint_len = 0;
-static unsigned char last_ca_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
-static unsigned int last_ca_cert_fingerprint_len = 0;
-static ino_t last_ca_cert_dir_inode = 0;
-static time_t last_ca_cert_dir_mtime = 0;
-static ino_t last_key_file_inode = 0;
-static time_t last_key_file_mtime = 0;
-static ino_t last_client_key_file_inode = 0;
-static time_t last_client_key_file_mtime = 0;
+/* TLS materials metadata for change detection */
+typedef struct {
+    unsigned char cert_fingerprint[EVP_MAX_MD_SIZE];
+    unsigned int cert_fingerprint_len;
+    unsigned char client_cert_fingerprint[EVP_MAX_MD_SIZE];
+    unsigned int client_cert_fingerprint_len;
+    unsigned char ca_cert_fingerprint[EVP_MAX_MD_SIZE];
+    unsigned int ca_cert_fingerprint_len;
+    ino_t ca_cert_dir_inode;
+    time_t ca_cert_dir_mtime;
+    ino_t key_file_inode;
+    time_t key_file_mtime;
+    ino_t client_key_file_inode;
+    time_t client_key_file_mtime;
+} tlsMaterialsMetadata;
+
+/* Pending TLS reload that holds both SSL contexts and their metadata.
+ * Updated serially by BIO thread, applied atomically by main thread. */
+typedef struct {
+    SSL_CTX *ctx;
+    SSL_CTX *client_ctx;
+    tlsMaterialsMetadata metadata;
+} tlsPendingReload;
+
+/* Last known (active) TLS materials metadata */
+static tlsMaterialsMetadata active_metadata = {0};
 
 /* Compute certificate fingerprint from file. */
 static int getCertFingerprint(const char *cert_file, unsigned char *fingerprint, unsigned int *fingerprint_len) {
@@ -456,77 +469,68 @@ static int getCertFingerprint(const char *cert_file, unsigned char *fingerprint,
     return C_OK;
 }
 
-/* Check if a single TLS cert file fingerprint changed and update cached value. */
-static int checkAndUpdateFingerprint(const char *file,
-                                     unsigned char *last_fingerprint,
-                                     unsigned int *last_len) {
-    unsigned char current[EVP_MAX_MD_SIZE];
-    unsigned int current_len;
-
-    if (!file) return 0;
-    if (getCertFingerprint(file, current, &current_len) != C_OK) return 0;
-
-    if (*last_len == 0 || *last_len != current_len || memcmp(last_fingerprint, current, current_len) != 0) {
-        memcpy(last_fingerprint, current, current_len);
-        *last_len = current_len;
-        return 1;
-    }
-    return 0;
-}
-
-/* Check if a file/directory stat changed and update cached inode/mtime. */
-static int checkAndUpdateStat(const char *path, ino_t *last_inode, time_t *last_mtime) {
-    if (!path) return 0;
-
-    struct stat st;
-    if (stat(path, &st) != 0) return 0;
-
-    if (*last_inode == 0 || *last_inode != st.st_ino || *last_mtime != st.st_mtime) {
-        *last_inode = st.st_ino;
-        *last_mtime = st.st_mtime;
-        return 1;
-    }
-    return 0;
-}
-
-/* Check if TLS materials have changed and update cached metadata. */
-static int tlsCheckMaterialsAndUpdateCache(serverTLSContextConfig *ctx_config) {
-    int changed = 0;
+/* Capture current metadata from files into a metadata structure. */
+static void captureMetadata(serverTLSContextConfig *ctx_config, tlsMaterialsMetadata *metadata) {
+    memset(metadata, 0, sizeof(*metadata));
 
     /* Certificate files: fingerprint-based detection */
-    if (checkAndUpdateFingerprint(ctx_config->cert_file, last_cert_fingerprint, &last_cert_fingerprint_len)) {
-        changed = 1;
-    }
+    getCertFingerprint(ctx_config->cert_file, metadata->cert_fingerprint, &metadata->cert_fingerprint_len);
+    getCertFingerprint(ctx_config->client_cert_file, metadata->client_cert_fingerprint, &metadata->client_cert_fingerprint_len);
+    getCertFingerprint(ctx_config->ca_cert_file, metadata->ca_cert_fingerprint, &metadata->ca_cert_fingerprint_len);
 
-    if (checkAndUpdateFingerprint(ctx_config->client_cert_file, last_client_cert_fingerprint, &last_client_cert_fingerprint_len)) {
-        changed = 1;
+    /* Key files and CA dir: inode + mtime */
+    struct stat st;
+    if (ctx_config->ca_cert_dir && stat(ctx_config->ca_cert_dir, &st) == 0) {
+        metadata->ca_cert_dir_inode = st.st_ino;
+        metadata->ca_cert_dir_mtime = st.st_mtime;
     }
-
-    if (checkAndUpdateFingerprint(ctx_config->ca_cert_file, last_ca_cert_fingerprint, &last_ca_cert_fingerprint_len)) {
-        changed = 1;
+    if (ctx_config->key_file && stat(ctx_config->key_file, &st) == 0) {
+        metadata->key_file_inode = st.st_ino;
+        metadata->key_file_mtime = st.st_mtime;
     }
-
-    /* Remaining: inode + mtime */
-    if (checkAndUpdateStat(ctx_config->ca_cert_dir, &last_ca_cert_dir_inode, &last_ca_cert_dir_mtime)) {
-        changed = 1;
+    if (ctx_config->client_key_file && stat(ctx_config->client_key_file, &st) == 0) {
+        metadata->client_key_file_inode = st.st_ino;
+        metadata->client_key_file_mtime = st.st_mtime;
     }
-
-    if (checkAndUpdateStat(ctx_config->key_file, &last_key_file_inode, &last_key_file_mtime)) {
-        changed = 1;
-    }
-
-    if (checkAndUpdateStat(ctx_config->client_key_file, &last_client_key_file_inode, &last_client_key_file_mtime)) {
-        changed = 1;
-    }
-
-    return changed;
 }
+
+/* Compare two metadata structures to detect changes. */
+static int metadataChanged(const tlsMaterialsMetadata *old, const tlsMaterialsMetadata *new) {
+    /* Check certificate fingerprints */
+    if (old->cert_fingerprint_len != new->cert_fingerprint_len ||
+        (new->cert_fingerprint_len > 0 && memcmp(old->cert_fingerprint, new->cert_fingerprint, new->cert_fingerprint_len) != 0)) {
+        return 1;
+    }
+
+    if (old->client_cert_fingerprint_len != new->client_cert_fingerprint_len ||
+        (new->client_cert_fingerprint_len > 0 && memcmp(old->client_cert_fingerprint, new->client_cert_fingerprint, new->client_cert_fingerprint_len) != 0)) {
+        return 1;
+    }
+
+    if (old->ca_cert_fingerprint_len != new->ca_cert_fingerprint_len ||
+        (new->ca_cert_fingerprint_len > 0 && memcmp(old->ca_cert_fingerprint, new->ca_cert_fingerprint, new->ca_cert_fingerprint_len) != 0)) {
+        return 1;
+    }
+
+    /* Check inode/mtime */
+    if (old->ca_cert_dir_inode != new->ca_cert_dir_inode || old->ca_cert_dir_mtime != new->ca_cert_dir_mtime) {
+        return 1;
+    }
+    if (old->key_file_inode != new->key_file_inode || old->key_file_mtime != new->key_file_mtime) {
+        return 1;
+    }
+    if (old->client_key_file_inode != new->client_key_file_inode || old->client_key_file_mtime != new->client_key_file_mtime) {
+        return 1;
+    }
+
+    return 0;
+}
+
 
 /* TLS background reload state */
 static _Atomic long long lastTlsConfigureTime = 0;
-static SSL_CTX *pending_tls_ctx = NULL;
-static SSL_CTX *pending_tls_client_ctx = NULL;
-static _Atomic int tls_reload_pending = 0;
+static tlsPendingReload pending_reload = {0};
+static pthread_mutex_t pending_reload_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Attempt to configure/reconfigure TLS. This operation is atomic and will
  * leave the SSL_CTX unchanged if it fails.
@@ -534,8 +538,8 @@ static _Atomic int tls_reload_pending = 0;
  * If reconfigure is true, always reconfigure; if false, only configure if
  * valkey_tls_ctx is NULL.
  *
- * If background is true, do heavy work in background thread and store in
- * pending variables; if false, do work synchronously and swap immediately.
+ * If background is true, check for changes and do heavy work in background thread;
+ * if false, do work synchronously and swap immediately.
  */
 static int tlsConfigure(void *priv, int reconfigure, int background) {
     serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
@@ -552,34 +556,47 @@ static int tlsConfigure(void *priv, int reconfigure, int background) {
         serverLog(LL_DEBUG, "Configuring TLS");
     }
 
-    atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
+    if (background && reconfigure) {
+        tlsMaterialsMetadata new_metadata;
+        captureMetadata(ctx_config, &new_metadata);
 
-    if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
-        if (background) {
+        if (!metadataChanged(&active_metadata, &new_metadata)) {
+            serverLog(LL_DEBUG, "TLS reload skipped: materials unchanged");
+            atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
+            return C_OK;
+        }
+        serverLog(LL_NOTICE, "TLS materials changed, reloading in background");
+
+        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
             serverLog(LL_WARNING, "Background TLS reload failed");
+            return C_ERR;
         }
-        return C_ERR;
-    }
 
-    if (background) {
-        if (atomic_load_explicit(&tls_reload_pending, memory_order_relaxed)) {
-            SSL_CTX_free(ctx);
-            SSL_CTX_free(client_ctx);
-            serverLog(LL_DEBUG, "TLS reload already pending, discarding result");
-        } else {
-            pending_tls_ctx = ctx;
-            pending_tls_client_ctx = client_ctx;
-            atomic_store_explicit(&tls_reload_pending, 1, memory_order_release);
-            serverLog(LL_DEBUG, "Background TLS reload parsed TLS materials successfully");
+        pthread_mutex_lock(&pending_reload_mutex);
+        if (pending_reload.ctx) {
+            SSL_CTX_free(pending_reload.ctx);
+            SSL_CTX_free(pending_reload.client_ctx);
+            serverLog(LL_DEBUG, "Replacing previous pending TLS reload");
         }
+        pending_reload.ctx = ctx;
+        pending_reload.client_ctx = client_ctx;
+        pending_reload.metadata = new_metadata;
+        pthread_mutex_unlock(&pending_reload_mutex);
+
+        serverLog(LL_DEBUG, "Background TLS reload parsed TLS materials successfully");
     } else {
+        if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
+            return C_ERR;
+        }
+
         SSL_CTX_free(valkey_tls_ctx);
         SSL_CTX_free(valkey_tls_client_ctx);
         valkey_tls_ctx = ctx;
         valkey_tls_client_ctx = client_ctx;
-        (void)tlsCheckMaterialsAndUpdateCache(ctx_config);
+        captureMetadata(ctx_config, &active_metadata);
     }
 
+    atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
     return C_OK;
 }
 
@@ -597,29 +614,44 @@ void tlsConfigureAsync(void) {
 }
 
 /* This function runs in the main thread and applies the TLS contexts
- * that were prepared by the background thread. This is a quick operation
- * that just swaps pointers and frees old contexts. */
+ * that were prepared by the background thread atomically. This is a quick operation
+ * that just swaps pointers, updates metadata, and frees old contexts. */
 void tlsApplyPendingReload(void) {
-    if (!atomic_load_explicit(&tls_reload_pending, memory_order_acquire)) {
+    tlsPendingReload local_pending;
+    pthread_mutex_lock(&pending_reload_mutex);
+    if (!pending_reload.ctx) {
+        pthread_mutex_unlock(&pending_reload_mutex);
         return;
     }
+
+    if (!metadataChanged(&active_metadata, &pending_reload.metadata)) {
+        SSL_CTX_free(pending_reload.ctx);
+        SSL_CTX_free(pending_reload.client_ctx);
+        memset(&pending_reload, 0, sizeof(pending_reload));
+        pthread_mutex_unlock(&pending_reload_mutex);
+        serverLog(LL_DEBUG, "Discarding pending TLS reload with unchanged materials");
+        return;
+    }
+
+    local_pending = pending_reload;
+    memset(&pending_reload, 0, sizeof(pending_reload));
+    pthread_mutex_unlock(&pending_reload_mutex);
+
     SSL_CTX *old_ctx = valkey_tls_ctx;
     SSL_CTX *old_client_ctx = valkey_tls_client_ctx;
 
-    valkey_tls_ctx = pending_tls_ctx;
-    valkey_tls_client_ctx = pending_tls_client_ctx;
+    valkey_tls_ctx = local_pending.ctx;
+    valkey_tls_client_ctx = local_pending.client_ctx;
 
-    pending_tls_ctx = NULL;
-    pending_tls_client_ctx = NULL;
+    active_metadata = local_pending.metadata;
 
     SSL_CTX_free(old_ctx);
     SSL_CTX_free(old_client_ctx);
 
-    atomic_store_explicit(&tls_reload_pending, 0, memory_order_release);
     serverLog(LL_NOTICE, "TLS materials reloaded successfully");
 }
 
-/* Check if TLS materials need reloading and trigger background reload if needed. */
+/* Check if it's time to trigger a background TLS reload check. */
 void tlsReconfigureIfNeeded(void) {
     long long lastConfigureTime = atomic_load_explicit(&lastTlsConfigureTime, memory_order_relaxed);
     const long long configAgeMicros = server.ustime - lastConfigureTime;
@@ -628,14 +660,6 @@ void tlsReconfigureIfNeeded(void) {
         configAgeSeconds < server.tls_ctx_config.auto_reload_interval) {
         return;
     }
-
-    if (!tlsCheckMaterialsAndUpdateCache(&server.tls_ctx_config)) {
-        serverLog(LL_DEBUG, "TLS reload skipped: materials unchanged");
-        atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
-        return;
-    }
-
-    serverLog(LL_NOTICE, "TLS materials changed, triggering background reload");
     bioCreateTlsReloadJob();
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -541,7 +541,7 @@ static pthread_mutex_t pending_reload_mutex = PTHREAD_MUTEX_INITIALIZER;
  * If background is true, check for changes and do heavy work in background thread;
  * if false, do work synchronously and swap immediately.
  */
-static int tlsConfigure(void *priv, int reconfigure, int background) {
+static int tlsConfigure(void *priv, int reconfigure, bool background) {
     serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
     SSL_CTX *ctx = NULL;
     SSL_CTX *client_ctx = NULL;
@@ -603,14 +603,14 @@ static int tlsConfigure(void *priv, int reconfigure, int background) {
 /* Synchronous TLS configuration - blocks until complete.
  * Called from CONFIG SET commands and server initialization. */
 static int tlsConfigureSync(void *priv, int reconfigure) {
-    return tlsConfigure(priv, reconfigure, 0);
+    return tlsConfigure(priv, reconfigure, false);
 }
 
 /* Asynchronous TLS configuration - runs in background thread.
  * Does CPU-intensive certificate loading without blocking main thread.
  * The main thread will later call tlsApplyPendingReload() to swap in the new contexts. */
 void tlsConfigureAsync(void) {
-    tlsConfigure(&server.tls_ctx_config, 1, 1);
+    tlsConfigure(&server.tls_ctx_config, 1, true);
 }
 
 /* This function runs in the main thread and applies the TLS contexts

--- a/src/tls.c
+++ b/src/tls.c
@@ -33,6 +33,7 @@
 #include "connhelpers.h"
 #include "adlist.h"
 #include "io_threads.h"
+#include "bio.h"
 
 #if defined(USE_OPENSSL) &&                    \
     ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
@@ -48,6 +49,7 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/decoder.h>
 #endif
+#include <sys/stat.h>
 #include <sys/uio.h>
 #include <arpa/inet.h>
 
@@ -284,21 +286,15 @@ error:
     return NULL;
 }
 
-/* Attempt to configure/reconfigure TLS. This operation is atomic and will
- * leave the SSL_CTX unchanged if fails.
- * @priv: config of serverTLSContextConfig.
- * @reconfigure: if true, ignore the previous configure; if false, only
- *               configure from @ctx_config if valkey_tls_ctx is NULL.
- */
-static int tlsConfigure(void *priv, int reconfigure) {
-    serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
+/* Helper function to create SSL contexts from config.
+ * This does the CPU-intensive work of parsing certificates and creating SSL contexts.
+ * Returns C_OK on success, C_ERR on failure.
+ * On success, *ctx and *client_ctx are set (client_ctx may be NULL).
+ * On failure, both are set to NULL. */
+static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_ctx, SSL_CTX **out_client_ctx) {
     char errbuf[256];
     SSL_CTX *ctx = NULL;
     SSL_CTX *client_ctx = NULL;
-
-    if (!reconfigure && valkey_tls_ctx) {
-        return C_OK;
-    }
 
     if (!ctx_config->cert_file) {
         serverLog(LL_WARNING, "No tls-cert-file configured!");
@@ -406,18 +402,238 @@ static int tlsConfigure(void *priv, int reconfigure) {
         if (!client_ctx) goto error;
     }
 
-    SSL_CTX_free(valkey_tls_ctx);
-    SSL_CTX_free(valkey_tls_client_ctx);
-    valkey_tls_ctx = ctx;
-    valkey_tls_client_ctx = client_ctx;
-
+    *out_ctx = ctx;
+    *out_client_ctx = client_ctx;
     return C_OK;
 
 error:
     if (ctx) SSL_CTX_free(ctx);
     if (client_ctx) SSL_CTX_free(client_ctx);
+    *out_ctx = NULL;
+    *out_client_ctx = NULL;
     return C_ERR;
 }
+
+/* Last known TLS materials metadata to detect changes */
+static unsigned char last_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
+static unsigned int last_cert_fingerprint_len = 0;
+static unsigned char last_client_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
+static unsigned int last_client_cert_fingerprint_len = 0;
+static unsigned char last_ca_cert_fingerprint[EVP_MAX_MD_SIZE] = {0};
+static unsigned int last_ca_cert_fingerprint_len = 0;
+static ino_t last_ca_cert_dir_inode = 0;
+static time_t last_ca_cert_dir_mtime = 0;
+static ino_t last_key_file_inode = 0;
+static time_t last_key_file_mtime = 0;
+static ino_t last_client_key_file_inode = 0;
+static time_t last_client_key_file_mtime = 0;
+
+/* Compute certificate fingerprint from file. */
+static int getCertFingerprint(const char *cert_file, unsigned char *fingerprint, unsigned int *fingerprint_len) {
+    if (!cert_file) return C_ERR;
+
+    FILE *fp = fopen(cert_file, "r");
+    if (!fp) return C_ERR;
+
+    X509 *cert = PEM_read_X509(fp, NULL, NULL, NULL);
+    fclose(fp);
+    if (!cert) return C_ERR;
+
+    const EVP_MD *digest = EVP_sha256();
+    if (X509_digest(cert, digest, fingerprint, fingerprint_len) != 1) {
+        X509_free(cert);
+        return C_ERR;
+    }
+
+    X509_free(cert);
+    return C_OK;
+}
+
+/* Check if a single TLS cert file fingerprint changed and update cached value. */
+static int checkAndUpdateFingerprint(const char *file,
+                                     unsigned char *last_fingerprint,
+                                     unsigned int *last_len) {
+    unsigned char current[EVP_MAX_MD_SIZE];
+    unsigned int current_len;
+
+    if (!file) return 0;
+    if (getCertFingerprint(file, current, &current_len) != C_OK) return 0;
+
+    if (*last_len == 0 || *last_len != current_len || memcmp(last_fingerprint, current, current_len) != 0) {
+        memcpy(last_fingerprint, current, current_len);
+        *last_len = current_len;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check if a file/directory stat changed and update cached inode/mtime. */
+static int checkAndUpdateStat(const char *path, ino_t *last_inode, time_t *last_mtime) {
+    if (!path) return 0;
+
+    struct stat st;
+    if (stat(path, &st) != 0) return 0;
+
+    if (*last_inode == 0 || *last_inode != st.st_ino || *last_mtime != st.st_mtime) {
+        *last_inode = st.st_ino;
+        *last_mtime = st.st_mtime;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check if TLS materials have changed and update cached metadata. */
+static int tlsCheckMaterialsAndUpdateCache(serverTLSContextConfig *ctx_config) {
+    int changed = 0;
+
+    /* Certificate files: fingerprint-based detection */
+    if (checkAndUpdateFingerprint(ctx_config->cert_file, last_cert_fingerprint, &last_cert_fingerprint_len)) {
+        changed = 1;
+    }
+
+    if (checkAndUpdateFingerprint(ctx_config->client_cert_file, last_client_cert_fingerprint, &last_client_cert_fingerprint_len)) {
+        changed = 1;
+    }
+
+    if (checkAndUpdateFingerprint(ctx_config->ca_cert_file, last_ca_cert_fingerprint, &last_ca_cert_fingerprint_len)) {
+        changed = 1;
+    }
+
+    /* Remaining: inode + mtime */
+    if (checkAndUpdateStat(ctx_config->ca_cert_dir, &last_ca_cert_dir_inode, &last_ca_cert_dir_mtime)) {
+        changed = 1;
+    }
+
+    if (checkAndUpdateStat(ctx_config->key_file, &last_key_file_inode, &last_key_file_mtime)) {
+        changed = 1;
+    }
+
+    if (checkAndUpdateStat(ctx_config->client_key_file, &last_client_key_file_inode, &last_client_key_file_mtime)) {
+        changed = 1;
+    }
+
+    return changed;
+}
+
+/* TLS background reload state */
+static _Atomic long long lastTlsConfigureTime = 0;
+static SSL_CTX *pending_tls_ctx = NULL;
+static SSL_CTX *pending_tls_client_ctx = NULL;
+static _Atomic int tls_reload_pending = 0;
+
+/* Attempt to configure/reconfigure TLS. This operation is atomic and will
+ * leave the SSL_CTX unchanged if fails.
+ * @priv: config of serverTLSContextConfig.
+ * @reconfigure: if true, ignore the previous configure; if false, only
+ *               configure from @ctx_config if valkey_tls_ctx is NULL.
+ * @background: if true, do heavy work in background thread and store in pending;
+ *              if false, do work synchronously and swap immediately.
+ */
+static int tlsConfigure(void *priv, int reconfigure, int background) {
+    serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
+    SSL_CTX *ctx = NULL;
+    SSL_CTX *client_ctx = NULL;
+
+    if (!reconfigure && valkey_tls_ctx) {
+        return C_OK;
+    }
+
+    if (reconfigure) {
+        serverLog(LL_DEBUG, background ? "Background TLS reconfiguration started" : "Reconfiguring TLS");
+    } else {
+        serverLog(LL_DEBUG, "Configuring TLS");
+    }
+
+    atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
+
+    if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
+        if (background) {
+            serverLog(LL_WARNING, "Background TLS reload failed");
+        }
+        return C_ERR;
+    }
+
+    if (background) {
+        if (atomic_load_explicit(&tls_reload_pending, memory_order_relaxed)) {
+            SSL_CTX_free(ctx);
+            SSL_CTX_free(client_ctx);
+            serverLog(LL_DEBUG, "TLS reload already pending, discarding result");
+        } else {
+            pending_tls_ctx = ctx;
+            pending_tls_client_ctx = client_ctx;
+            atomic_store_explicit(&tls_reload_pending, 1, memory_order_release);
+            serverLog(LL_DEBUG, "Background TLS reload completed successfully");
+        }
+    } else {
+        SSL_CTX_free(valkey_tls_ctx);
+        SSL_CTX_free(valkey_tls_client_ctx);
+        valkey_tls_ctx = ctx;
+        valkey_tls_client_ctx = client_ctx;
+        (void)tlsCheckMaterialsAndUpdateCache(ctx_config);
+    }
+
+    return C_OK;
+}
+
+/* Synchronous TLS configuration - blocks until complete.
+ * Called from CONFIG SET commands and server initialization. */
+static int tlsConfigureSync(void *priv, int reconfigure) {
+    return tlsConfigure(priv, reconfigure, 0);
+}
+
+#if !defined(BUILD_TLS_MODULE) || BUILD_TLS_MODULE != 2
+/* Auto-reload functions are only available when TLS is built-in, not as a module. */
+
+/* Asynchronous TLS configuration - runs in background thread.
+ * Does CPU-intensive certificate loading without blocking main thread.
+ * The main thread will later call tlsApplyPendingReload() to swap in the new contexts. */
+void tlsConfigureAsync(void) {
+    tlsConfigure(&server.tls_ctx_config, 1, 1);
+}
+
+/* This function runs in the main thread and applies the TLS contexts
+ * that were prepared by the background thread. This is a quick operation
+ * that just swaps pointers and frees old contexts. */
+void tlsApplyPendingReload(void) {
+    if (!atomic_load_explicit(&tls_reload_pending, memory_order_acquire)) {
+        return;
+    }
+    SSL_CTX *old_ctx = valkey_tls_ctx;
+    SSL_CTX *old_client_ctx = valkey_tls_client_ctx;
+
+    valkey_tls_ctx = pending_tls_ctx;
+    valkey_tls_client_ctx = pending_tls_client_ctx;
+
+    pending_tls_ctx = NULL;
+    pending_tls_client_ctx = NULL;
+
+    SSL_CTX_free(old_ctx);
+    SSL_CTX_free(old_client_ctx);
+
+    atomic_store_explicit(&tls_reload_pending, 0, memory_order_release);
+    serverLog(LL_NOTICE, "TLS materials reloaded successfully");
+}
+
+/* Check if TLS materials need reloading and trigger background reload if needed. */
+void tlsReconfigureIfNeeded(void) {
+    long long lastConfigureTime = atomic_load_explicit(&lastTlsConfigureTime, memory_order_relaxed);
+    const long long configAgeMicros = server.ustime - lastConfigureTime;
+    const long long configAgeSeconds = (configAgeMicros / 1000) / 1000;
+    if (server.tls_ctx_config.auto_reload_interval == 0 ||
+        configAgeSeconds < server.tls_ctx_config.auto_reload_interval) {
+        return;
+    }
+
+    if (!tlsCheckMaterialsAndUpdateCache(&server.tls_ctx_config)) {
+        serverLog(LL_DEBUG, "TLS reload skipped: materials unchanged");
+        atomic_store_explicit(&lastTlsConfigureTime, server.ustime, memory_order_relaxed);
+        return;
+    }
+
+    serverLog(LL_NOTICE, "TLS materials changed, triggering background reload");
+    bioCreateTlsReloadJob();
+}
+#endif /* !BUILD_TLS_MODULE */
 
 static ConnectionType CT_TLS;
 
@@ -1223,7 +1439,7 @@ static ConnectionType CT_TLS = {
     /* connection type initialize & finalize & configure */
     .init = tlsInit,
     .cleanup = tlsCleanup,
-    .configure = tlsConfigure,
+    .configure = tlsConfigureSync,
 
     /* ae & accept & listen & error & address handler */
     .ae_handler = tlsEventHandler,

--- a/src/tls.c
+++ b/src/tls.c
@@ -433,14 +433,21 @@ static int getCertFingerprint(const char *cert_file, unsigned char *fingerprint,
     if (!cert_file) return C_ERR;
 
     FILE *fp = fopen(cert_file, "r");
-    if (!fp) return C_ERR;
+    if (!fp) {
+        serverLog(LL_WARNING, "Failed to open certificate file '%s': %s", cert_file, strerror(errno));
+        return C_ERR;
+    }
 
     X509 *cert = PEM_read_X509(fp, NULL, NULL, NULL);
     fclose(fp);
-    if (!cert) return C_ERR;
+    if (!cert) {
+        serverLog(LL_WARNING, "Failed to parse X509 certificate from '%s'", cert_file);
+        return C_ERR;
+    }
 
     const EVP_MD *digest = EVP_sha256();
     if (X509_digest(cert, digest, fingerprint, fingerprint_len) != 1) {
+        serverLog(LL_WARNING, "Failed to compute certificate fingerprint for '%s'", cert_file);
         X509_free(cert);
         return C_ERR;
     }
@@ -522,12 +529,13 @@ static SSL_CTX *pending_tls_client_ctx = NULL;
 static _Atomic int tls_reload_pending = 0;
 
 /* Attempt to configure/reconfigure TLS. This operation is atomic and will
- * leave the SSL_CTX unchanged if fails.
- * @priv: config of serverTLSContextConfig.
- * @reconfigure: if true, ignore the previous configure; if false, only
- *               configure from @ctx_config if valkey_tls_ctx is NULL.
- * @background: if true, do heavy work in background thread and store in pending;
- *              if false, do work synchronously and swap immediately.
+ * leave the SSL_CTX unchanged if it fails.
+ *
+ * If reconfigure is true, always reconfigure; if false, only configure if
+ * valkey_tls_ctx is NULL.
+ *
+ * If background is true, do heavy work in background thread and store in
+ * pending variables; if false, do work synchronously and swap immediately.
  */
 static int tlsConfigure(void *priv, int reconfigure, int background) {
     serverTLSContextConfig *ctx_config = (serverTLSContextConfig *)priv;
@@ -562,7 +570,7 @@ static int tlsConfigure(void *priv, int reconfigure, int background) {
             pending_tls_ctx = ctx;
             pending_tls_client_ctx = client_ctx;
             atomic_store_explicit(&tls_reload_pending, 1, memory_order_release);
-            serverLog(LL_DEBUG, "Background TLS reload completed successfully");
+            serverLog(LL_DEBUG, "Background TLS reload parsed TLS materials successfully");
         }
     } else {
         SSL_CTX_free(valkey_tls_ctx);
@@ -580,9 +588,6 @@ static int tlsConfigure(void *priv, int reconfigure, int background) {
 static int tlsConfigureSync(void *priv, int reconfigure) {
     return tlsConfigure(priv, reconfigure, 0);
 }
-
-#if !defined(BUILD_TLS_MODULE) || BUILD_TLS_MODULE != 2
-/* Auto-reload functions are only available when TLS is built-in, not as a module. */
 
 /* Asynchronous TLS configuration - runs in background thread.
  * Does CPU-intensive certificate loading without blocking main thread.
@@ -633,7 +638,6 @@ void tlsReconfigureIfNeeded(void) {
     serverLog(LL_NOTICE, "TLS materials changed, triggering background reload");
     bioCreateTlsReloadJob();
 }
-#endif /* !BUILD_TLS_MODULE */
 
 static ConnectionType CT_TLS;
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __VALKEY_TLS_H
+#define __VALKEY_TLS_H
+
+/* TLS reload functions - only available when TLS is built-in, not as a module */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+void tlsReconfigureIfNeeded(void);
+void tlsApplyPendingReload(void);
+void tlsConfigureAsync(void);
+#endif
+
+#endif /* __VALKEY_TLS_H */

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -185,51 +185,65 @@ start_server {tags {"tls"}} {
             file copy -force $server_crt $backup_crt
             file copy -force $server_key $backup_key
 
-            # Enable auto-reload with 1 second interval for faster testing
-            r CONFIG SET tls-auto-reload-interval 1
+            # Ensure cleanup happens even if test fails
+            try {
+                # Enable auto-reload with 1 second interval for faster testing
+                r CONFIG SET tls-auto-reload-interval 1
 
-            # Verify initial connection works
-            set s [valkey_client]
-            assert_equal "PONG" [$s PING]
-            $s close
+                # Verify initial connection works
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
 
-            # Replace with different certificate
-            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
-            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-            file copy -force $valkey_crt $server_crt
-            file copy -force $valkey_key $server_key
+                # Replace with different certificate
+                set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+                set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+                file copy -force $valkey_crt $server_crt
+                file copy -force $valkey_key $server_key
 
-            # Wait for auto-reload to trigger and verify connection works
-            wait_for_condition 50 100 {
-                [catch {
-                    set s [valkey_client]
-                    set result [$s PING]
-                    $s close
-                    expr {$result eq "PONG"}
-                } err] == 0
-            } else {
-                fail "Connection failed after certificate reload: $err"
+                # Wait for reload to actually complete by checking server logs
+                set logfile [srv 0 stdout]
+                wait_for_condition 50 100 {
+                    set fd [open $logfile r]
+                    set logs [read $fd]
+                    close $fd
+                    [string match {*TLS materials reloaded successfully*} $logs]
+                } else {
+                    fail "TLS reload did not complete in time"
+                }
+
+                # Verify connection still works after reload
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+
+                # Restore original certificates
+                file copy -force $backup_crt $server_crt
+                file copy -force $backup_key $server_key
+
+                # Clear log position and wait for second reload to complete
+                set log_size_before [file size $logfile]
+                wait_for_condition 50 100 {
+                    set fd [open $logfile r]
+                    seek $fd $log_size_before
+                    set new_logs [read $fd]
+                    close $fd
+                    [string match {*TLS materials reloaded successfully*} $new_logs]
+                } else {
+                    fail "TLS reload back to original did not complete in time"
+                }
+
+                # Verify connection still works after restore
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+
+                # Disable auto-reload
+                r CONFIG SET tls-auto-reload-interval 0
+            } finally {
+                # Always clean up backup files
+                file delete -force $backup_crt $backup_key
             }
-
-            # Restore original certificates
-            file copy -force $backup_crt $server_crt
-            file copy -force $backup_key $server_key
-            file delete $backup_crt $backup_key
-
-            # Wait for reload back to original and verify
-            wait_for_condition 50 100 {
-                [catch {
-                    set s [valkey_client]
-                    set result [$s PING]
-                    $s close
-                    expr {$result eq "PONG"}
-                } err] == 0
-            } else {
-                fail "Connection failed after restoring certificates: $err"
-            }
-
-            # Disable auto-reload
-            r CONFIG SET tls-auto-reload-interval 0
         }
 
         test {TLS: Auto-reload skips unchanged materials} {
@@ -246,9 +260,9 @@ start_server {tags {"tls"}} {
                 seek $fd $size_before
                 set new_logs [read $fd]
                 close $fd
-                [string match {*certificates unchanged*} $new_logs]
+                [string match {*materials unchanged*} $new_logs]
             } else {
-                fail "Did not find 'certificates unchanged' log message"
+                fail "Did not find 'materials unchanged' log message"
             }
 
             # Disable auto-reload
@@ -274,32 +288,39 @@ start_server {tags {"tls"}} {
             set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
 
             if {$ca_cert_dir ne ""} {
-                # Enable auto-reload with 1 second interval
-                r CONFIG SET tls-auto-reload-interval 1
-
                 # Touch a file in the directory to trigger change detection
                 set test_file "$ca_cert_dir/test_marker"
                 set fd [open $test_file w]
                 puts $fd "test"
                 close $fd
 
-                # Wait for reload and verify connection works
-                wait_for_condition 50 100 {
-                    [catch {
-                        set s [valkey_client]
-                        set result [$s PING]
-                        $s close
-                        expr {$result eq "PONG"}
-                    } err] == 0
-                } else {
-                    fail "Connection failed after CA cert directory change: $err"
+                # Ensure cleanup happens even if test fails
+                try {
+                    # Enable auto-reload with 1 second interval
+                    r CONFIG SET tls-auto-reload-interval 1
+
+                    # Wait for reload to actually complete by checking server logs
+                    set logfile [srv 0 stdout]
+                    wait_for_condition 50 100 {
+                        set fd [open $logfile r]
+                        set logs [read $fd]
+                        close $fd
+                        [string match {*TLS materials reloaded successfully*} $logs]
+                    } else {
+                        fail "TLS reload did not complete after CA cert directory change"
+                    }
+
+                    # Verify connection still works after reload
+                    set s [valkey_client]
+                    assert_equal "PONG" [$s PING]
+                    $s close
+
+                    # Disable auto-reload
+                    r CONFIG SET tls-auto-reload-interval 0
+                } finally {
+                    # Always clean up test file
+                    file delete -force $test_file
                 }
-
-                # Clean up
-                file delete $test_file
-
-                # Disable auto-reload
-                r CONFIG SET tls-auto-reload-interval 0
             }
         }
     }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -173,5 +173,134 @@ start_server {tags {"tls"}} {
 
             $s close
         }
+
+        test {TLS: Auto-reload detects changes} {
+            # Get current certificate files
+            set server_crt [lindex [r config get tls-cert-file] 1]
+            set server_key [lindex [r config get tls-key-file] 1]
+
+            # Save original certificates
+            set backup_crt "$server_crt.backup"
+            set backup_key "$server_key.backup"
+            file copy -force $server_crt $backup_crt
+            file copy -force $server_key $backup_key
+
+            # Enable auto-reload with 1 second interval for faster testing
+            r CONFIG SET tls-auto-reload-interval 1
+
+            # Verify initial connection works
+            set s [valkey_client]
+            assert_equal "PONG" [$s PING]
+            $s close
+
+            # Replace with different certificate
+            set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+            set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+            file copy -force $valkey_crt $server_crt
+            file copy -force $valkey_key $server_key
+
+            # Wait for auto-reload to trigger and verify connection works
+            wait_for_condition 50 100 {
+                [catch {
+                    set s [valkey_client]
+                    set result [$s PING]
+                    $s close
+                    expr {$result eq "PONG"}
+                } err] == 0
+            } else {
+                fail "Connection failed after certificate reload: $err"
+            }
+
+            # Restore original certificates
+            file copy -force $backup_crt $server_crt
+            file copy -force $backup_key $server_key
+            file delete $backup_crt $backup_key
+
+            # Wait for reload back to original and verify
+            wait_for_condition 50 100 {
+                [catch {
+                    set s [valkey_client]
+                    set result [$s PING]
+                    $s close
+                    expr {$result eq "PONG"}
+                } err] == 0
+            } else {
+                fail "Connection failed after restoring certificates: $err"
+            }
+
+            # Disable auto-reload
+            r CONFIG SET tls-auto-reload-interval 0
+        }
+
+        test {TLS: Auto-reload skips unchanged materials} {
+            # Enable auto-reload with 1 second interval
+            r CONFIG SET tls-auto-reload-interval 1
+
+            # Get server log file
+            set logfile [srv 0 stdout]
+            set size_before [file size $logfile]
+
+            # Wait for at least one reload check cycle
+            wait_for_condition 50 100 {
+                set fd [open $logfile r]
+                seek $fd $size_before
+                set new_logs [read $fd]
+                close $fd
+                [string match {*certificates unchanged*} $new_logs]
+            } else {
+                fail "Did not find 'certificates unchanged' log message"
+            }
+
+            # Disable auto-reload
+            r CONFIG SET tls-auto-reload-interval 0
+        }
+
+        test {TLS: Auto-reload interval validation} {
+            # Valid intervals
+            r CONFIG SET tls-auto-reload-interval 0
+            r CONFIG SET tls-auto-reload-interval 5
+            r CONFIG SET tls-auto-reload-interval 3600
+
+            # Invalid intervals should fail
+            catch {r CONFIG SET tls-auto-reload-interval -1} e
+            assert_match {*invalid*} $e
+
+            # Reset to disabled
+            r CONFIG SET tls-auto-reload-interval 0
+        }
+
+        test {TLS: Auto-reload with CA cert directory} {
+            # Get current CA cert directory
+            set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
+
+            if {$ca_cert_dir ne ""} {
+                # Enable auto-reload with 1 second interval
+                r CONFIG SET tls-auto-reload-interval 1
+
+                # Touch a file in the directory to trigger change detection
+                set test_file "$ca_cert_dir/test_marker"
+                set fd [open $test_file w]
+                puts $fd "test"
+                close $fd
+
+                # Wait for reload and verify connection works
+                wait_for_condition 50 100 {
+                    [catch {
+                        set s [valkey_client]
+                        set result [$s PING]
+                        $s close
+                        expr {$result eq "PONG"}
+                    } err] == 0
+                } else {
+                    fail "Connection failed after CA cert directory change: $err"
+                }
+
+                # Clean up
+                file delete $test_file
+
+                # Disable auto-reload
+                r CONFIG SET tls-auto-reload-interval 0
+            }
+        }
     }
 }

--- a/valkey.conf
+++ b/valkey.conf
@@ -324,6 +324,14 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
+# Change the default interval of TLS material reloading. The default value
+# is 0 (disabled, no automatic reload). When set to a value greater than 0,
+# the server will periodically check and reload TLS certificates, private keys,
+# and CA files if they have changed. The interval is specified in seconds.
+#
+# For example, to reload TLS materials daily:
+# tls-auto-reload-interval 86400
+
 ################################### RDMA ######################################
 
 # Valkey Over RDMA is experimental, it may be changed or be removed in any minor or major version.

--- a/valkey.conf
+++ b/valkey.conf
@@ -324,10 +324,11 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
-# Change the default interval of TLS material reloading. The default value
-# is 0 (disabled, no automatic reload). When set to a value greater than 0,
-# the server will periodically check and reload TLS certificates, private keys,
-# and CA files if they have changed. The interval is specified in seconds.
+# Change the default interval of TLS material reloading in seconds.
+# The default value is 0 (disabled, no automatic reload).
+# When set to a value greater than 0, the server will periodically check and reload TLS materials.
+# Note: TLS reload work is performed in a background thread, so it does not block the main thread.
+# It may use some CPU resources while running.
 #
 # For example, to reload TLS materials daily:
 # tls-auto-reload-interval 86400

--- a/valkey.conf
+++ b/valkey.conf
@@ -324,11 +324,12 @@ tcp-keepalive 300
 #
 # tls-session-cache-timeout 60
 
-# Change the default interval of TLS material reloading in seconds.
+# Interval of TLS material reloading in seconds.
 # The default value is 0 (disabled, no automatic reload).
-# When set to a value greater than 0, the server will periodically check and reload TLS materials.
-# Note: TLS reload work is performed in a background thread, so it does not block the main thread.
-# It may use some CPU resources while running.
+# When set to a value greater than 0, the server will periodically check the
+# certificate and key files and, if modified, reload the TLS materials. The
+# reload work is performed in a background thread, so it does not block the main
+# thread.
 #
 # For example, to reload TLS materials daily:
 # tls-auto-reload-interval 86400


### PR DESCRIPTION
### Overview
This PR adds support for automatic background TLS reloading, closes https://github.com/valkey-io/valkey/issues/2649
TLS validity checks and fail-fast behavior on invalid certificates are handled separately in #2999. 
- New configuration
  - `tls-auto-reload-interval <seconds>`
  - `0` disabled (default, backward compatible)
  - `>0` check interval in seconds
- TLS materials change detection in background
  - SHA-256 fingerprint checking for certificate files
  - `inode + mtime` checking for CA certificate directories and key files
  - Skips reload if materials haven't changed `tlsCheckMaterialsAndUpdateCache`
- TLS contexts reload
  - CPU-intensive certificate parsing happens in dedicated BIO worker thread `BIO_TLS_RELOAD`
  - Main thread never blocks, atomically swaps SSL contexts
  - Two-phase reload: background preparation `tlsConfigureAsync` + main thread application `tlsApplyPendingReload`


**Note**: Original TLS load and reload still remain in main thread using `tlsConfigureSync`, including:
- Initial TLS load (server startup)
- Runtime reload via CONFIG SET

### Test results
```
# Server starts with TLS enabled and accepts connections
43123:M 08 Jan 2026 01:41:01.184 * Ready to accept connections tls
43123:M 08 Jan 2026 01:41:01.184 . Total: 0 clients connected (0 replicas), 1131840 (1.08M) bytes in use
43123:M 08 Jan 2026 01:41:03.196 - Accepted 127.0.0.1:65152

#  Certificate change detected, background reload triggered, reload completed and applied
43123:M 08 Jan 2026 01:41:06.236 * TLS materials changed, triggering background reload
43123:M 08 Jan 2026 01:41:06.236 . Background TLS reconfiguration started
43123:M 08 Jan 2026 01:41:06.237 . Background TLS reload completed successfully
43123:M 08 Jan 2026 01:41:07.249 * TLS materials reloaded successfully

# Connection after reload: Connections continue working after the reload
43123:M 08 Jan 2026 01:41:08.244 - Accepted 127.0.0.1:65156
```