### PR TITLE
Fix HEXPIRE should not delete items when GT rule is used and expiration is in the past

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1779,7 +1779,10 @@ void hexpireGenericCommand(client *c, long long basetime, int unit) {
 
     for (i = 0; i < num_fields; i++) {
         expiryModificationResult result = EXPIRATION_MODIFICATION_NOT_EXIST;
-        if (set_expired) {
+        /* If the flags included the GT flag, we cannot delete the entries since existing entries
+         * MUST have expiration time bigger than a past time.*/
+        if (set_expired && !(flag & EXPIRE_GT)) {
+            /* In case the expiration time is past, we have no items to apply this change. */
             if (obj && hashTypeDelete(obj, objectGetVal(c->argv[fields_index + i]))) {
                 /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
                 if (new_argv == NULL) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1780,9 +1780,8 @@ void hexpireGenericCommand(client *c, long long basetime, int unit) {
     for (i = 0; i < num_fields; i++) {
         expiryModificationResult result = EXPIRATION_MODIFICATION_NOT_EXIST;
         /* If the flags included the GT flag, we cannot delete the entries since existing entries
-         * MUST have expiration time bigger than a past time.*/
+         * MUST have expiration time bigger than a past time. */
         if (set_expired && !(flag & EXPIRE_GT)) {
-            /* In case the expiration time is past, we have no items to apply this change. */
             if (obj && hashTypeDelete(obj, objectGetVal(c->argv[fields_index + i]))) {
                 /* In case we are expiring all the elements prepare a new argv since we are going to delete all the expired fields. */
                 if (new_argv == NULL) {

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -885,6 +885,14 @@ start_server {tags {"hashexpire"}} {
         assert_equal {0} $res2
     }
 
+    test {HEXPIRE GT - Do not expire items when expiration in the past} {
+        r FLUSHALL
+        r HSETEX myhash EX 600 FIELDS 1 field1 val1
+        assert_equal {1} [r HLEN myhash]
+        assert_equal {0 -2} [r HEXPIRE myhash 0 GT FIELDS 2 field1 field2]
+        assert_equal {1} [r HLEN myhash]
+    }
+
     # Conditionals: LT
     test {HEXPIRE LT - only set if new TTL < existing TTL} {
         r FLUSHALL


### PR DESCRIPTION
 if an expired time is used, the condition is ignored, and it directly becomes the effect of the `hdel` command.
This is mainly important for cases where the user would like to protect deleting the data in case the `HEXPIREAT` command is used and the user would like to protect delay execution of this command to delete fields.

fixes: https://github.com/valkey-io/valkey/issues/3021