### PR TITLE
Bugfix for GIL deadlock while unloading script engine, reenable memory test in crash report

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2257,7 +2257,7 @@ void printCrashReport(void) {
     logConfigDebugInfo();
 
     /* Run memory test in case the crash was triggered by memory corruption. */
-    // doFastMemoryTest();
+    doFastMemoryTest();
 }
 
 void bugReportEnd(int killViaSignal, int sig) {

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -192,8 +192,11 @@ int scriptingEngineManagerUnregister(const char *engine_name) {
 
     /* We need to ensure that any pending async flush of eval scripts or
      * functions have completed before freeing the engine resources, which
-     * may be used by the async jobs. */
+     * may be used by the async jobs. Release the GIL first since the lazy
+     * free jobs need to acquire it to call scriptingEngineCallFreeFunction. */
+    moduleReleaseGIL();
     bioDrainWorker(BIO_LAZY_FREE);
+    moduleAcquireGIL();
 
     sdsfree(e->name);
 

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -190,12 +190,12 @@ int scriptingEngineManagerUnregister(const char *engine_name) {
                                        sdsAllocSize(e->name) +
                                        mem_info.engine_memory_overhead;
 
-    sdsfree(e->name);
-
     /* We need to ensure that any pending async flush of eval scripts or
-     * functions have completed before freeing the module context cache, which
+     * functions have completed before freeing the engine resources, which
      * may be used by the async jobs. */
     bioDrainWorker(BIO_LAZY_FREE);
+
+    sdsfree(e->name);
 
     for (size_t i = 0; i < MODULE_CTX_CACHE_SIZE; i++) {
         serverAssert(e->module_ctx_cache[i] != NULL);


### PR DESCRIPTION
note: Originally this PR only uncommented the crash report memory test, but I rewrote the PR for the GIL bug I uncovered and fixed. I added it to Valkey 9.1 since it's a follow-up bugfix for a 9.1 change.

The memory test was commented out in #2858 and should have been reenabled. On further investigation I found that the server hangs during shutdown inside the `bioDrainWorker(BIO_LAZY_FREE)` call. This causes deadlock because the lock was acquired for shutdown but lazy free jobs require the GIL too:

- main thread: `serverCron()` acquires GIL via `afterSleep()` then calls `finishShutdown()`, which eventually calls our script module unload code that calls `bioDrainWorker()`.
- bio threads: Pending lazy free jobs such as `lazyFreeEvalScripts()` call `scriptingEngineCallFreeFunction()` which requires the GIL.