### PR TITLE
Fix perf regression from #2652

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1399,14 +1399,8 @@ static int tryAvoidBulkStrCopyToReply(client *c, robj *obj) {
 /* Add an Object as a bulk reply */
 void addReplyBulk(client *c, robj *obj) {
     if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
-        /* If copy avoidance allowed, then we explicitly maintain net_output_bytes_curr_cmd. */
-        serverAssert(obj->encoding == OBJ_ENCODING_RAW);
-        size_t str_len = sdslen(objectGetVal(obj));
-        uint32_t num_len = digits10(str_len);
-        /* RESP encodes bulk strings as $<length>\r\n<data>\r\n */
-        c->net_output_bytes_curr_cmd += (num_len + 3); /* $<length>\r\n */
-        c->net_output_bytes_curr_cmd += str_len;       /* <data> */
-        c->net_output_bytes_curr_cmd += 2;             /* \r\n */
+        /* If copy avoidance allowed, net_output_bytes_curr_cmd will be updated later
+         * in releaseBufReferences() using the reply_len calculated by the IO thread. */
         return;
     }
     addReplyBulkLen(c, obj);
@@ -2757,8 +2751,9 @@ void resetLastWrittenBuf(client *c) {
     c->io_last_written.data_len = 0;
 }
 
-/* Release references to string objects inside an encoded buffer */
-static void releaseBufReferences(char *buf, size_t bufpos) {
+/* Release references to string objects inside an encoded buffer
+ * and accumulate network bytes for slot/cmd stats */
+static void releaseBufReferences(client *c, char *buf, size_t bufpos) {
     char *ptr = buf;
     while (ptr < buf + bufpos) {
         payloadHeader *header = (payloadHeader *)ptr;
@@ -2766,6 +2761,7 @@ static void releaseBufReferences(char *buf, size_t bufpos) {
 
         if (header->payload_type == BULK_STR_REF) {
             clusterSlotStatsAddNetworkBytesOutForSlot(header->slot, header->reply_len);
+            c->net_output_bytes_curr_cmd += header->reply_len;
 
             bulkStrRef *str_ref = (bulkStrRef *)ptr;
             size_t len = header->payload_len;
@@ -2785,7 +2781,7 @@ static void releaseBufReferences(char *buf, size_t bufpos) {
 
 void releaseReplyReferences(client *c) {
     if (c->bufpos > 0 && c->flag.buf_encoded) {
-        releaseBufReferences(c->buf, c->bufpos);
+        releaseBufReferences(c, c->buf, c->bufpos);
     }
 
     listIter iter;
@@ -2794,7 +2790,7 @@ void releaseReplyReferences(client *c) {
     while ((next = listNext(&iter))) {
         clientReplyBlock *o = (clientReplyBlock *)listNodeValue(next);
         if (o->flag.buf_encoded) {
-            releaseBufReferences(o->buf, o->used);
+            releaseBufReferences(c, o->buf, o->used);
         }
     }
 }
@@ -2814,7 +2810,7 @@ static void _postWriteToClient(client *c) {
         /* If buffer is completely written */
         if (!last_written || c->bufpos == c->io_last_written.bufpos) {
             /* If encoded then release references to bulk string objects */
-            if (c->flag.buf_encoded) releaseBufReferences(c->buf, c->bufpos);
+            if (c->flag.buf_encoded) releaseBufReferences(c, c->buf, c->bufpos);
             /* Reset buffer metadata */
             c->bufpos = 0;
             c->flag.buf_encoded = 0;
@@ -2836,7 +2832,7 @@ static void _postWriteToClient(client *c) {
         if (!last_written || o->used == c->io_last_written.bufpos) {
             c->reply_bytes -= o->size;
             /* If encoded then release references to bulk string objects */
-            if (o->flag.buf_encoded) releaseBufReferences(o->buf, o->used);
+            if (o->flag.buf_encoded) releaseBufReferences(c, o->buf, o->used);
             listDelNode(c->reply, next);
             /* If completely written buffer is last written then reset last written state */
             if (last_written) resetLastWrittenBuf(c);


### PR DESCRIPTION
**UPD:** With this approach we update c->net_output_bytes_curr_cmd in releaseBufReferences() but it will be attributed to the next command because this happens after resetClient(). This is incorrect and looks like we can't defer the accounting...

In #2652 performance regression was introduced in reply copy avoidance path. To fix it account `net_output_bytes_curr_cmd` in `releaseBufReferences()` where we can use `header->reply_len` that was already calculated by the IO thread in `addBulkStringToReplyIOV()`. This eliminates the expensive memory dereference from the main thread's hot path.
Benchmarked GET locally with `io-threads 9 and 96 byte values`:
Unstable:
```
Summary:
  throughput summary: 1612618.38 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        2.365     0.072     2.423     2.583     3.103     5.759
```

This PR:
```
Summary:
  throughput summary: 2128534.50 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        1.786     0.056     1.791     1.911     2.663     3.991
```

Resolves #2926