### PR TITLE
Fixing Weekly Tests Workflow on Released Branches

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: write
 concurrency:
   group: weekly-release-tests
   cancel-in-progress: false


### PR DESCRIPTION
The patch fixes the error by adding `pull‑requests: write` to the permissions block of `weekly.yml`. Github rejects if the reusable workflow's (here daily.yml) permissions are not provided.

We recently changed the permissions in `daily.yml` where we gave write permissions in https://github.com/valkey-io/valkey/pull/2907
With this change, we bring parity to the permissions since `weekly.yml` uses calls `daily.yml` workflow call method.

Fixes: https://github.com/valkey-io/valkey/actions/runs/20890545320