### PR TITLE
Avoid duplicate calculations of network-bytes-out in slot stats with copy-avoidance

### DIFF
--- a/src/cluster_slot_stats.h
+++ b/src/cluster_slot_stats.h
@@ -12,8 +12,6 @@ void clusterSlotStatsAddCpuDuration(client *c, ustime_t duration);
 
 /* network-bytes-in metric. */
 void clusterSlotStatsAddNetworkBytesInForUserClient(client *c);
-void clusterSlotStatsSetClusterMsgLength(uint32_t len);
-void clusterSlotStatsResetClusterMsgLength(void);
 
 /* network-bytes-out metric. */
 void clusterSlotStatsAddNetworkBytesOutForSlot(int slot, unsigned long long net_bytes_out);

--- a/src/networking.c
+++ b/src/networking.c
@@ -2765,7 +2765,13 @@ static void releaseBufReferences(char *buf, size_t bufpos) {
         ptr += sizeof(payloadHeader);
 
         if (header->payload_type == BULK_STR_REF) {
-            clusterSlotStatsAddNetworkBytesOutForSlot(header->slot, header->reply_len);
+            /* Here clusterSlotStatsAddNetworkBytesOutForSlot() is called in
+             * the IO thread after writing the reply to the client, and after
+             * #2652 it is also done in the normal code path in the main thread
+             * (afterCommand() -> clusterSlotStatsAddNetworkBytesOutForUserClient()).
+             * Before we come up with a better solution (see #2652), we need to
+             * comment it out to avoid the duplicate calculations. */
+            /* clusterSlotStatsAddNetworkBytesOutForSlot(header->slot, header->reply_len); */
 
             bulkStrRef *str_ref = (bulkStrRef *)ptr;
             size_t len = header->payload_len;

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -538,6 +538,28 @@ start_cluster 1 0 {tags {external:skip cluster}} {
     R 0 CONFIG RESETSTAT
     R 0 FLUSHALL
 
+    test "CLUSTER SLOT-STATS network-bytes-out, for slot specific commands, for reply copy avoidance" {
+        set copy_avoid [lindex [R 0 config get min-string-size-avoid-copy-reply] 1]
+        R 0 config set min-string-size-avoid-copy-reply 1
+
+        set value [string repeat A 1024] ;# Make sure it is a RAW string
+        R 0 set $key $value ;# +OK\r\n --> 5 bytes
+        R 0 get $key        ;# $1024\r\nAA..AA\r\n -> 1033 bytes
+
+        set expected_slot_stats [
+            dict create $key_slot [
+                dict create network-bytes-out 1038
+            ]
+        ]
+        set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE $key_slot $key_slot]
+        puts $slot_stats
+        assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
+
+        R 0 config set min-string-size-avoid-copy-reply $copy_avoid
+    }
+    R 0 CONFIG RESETSTAT
+    R 0 FLUSHALL
+
     test "CLUSTER SLOT-STATS network-bytes-out, blocking commands." {
         set rd [valkey_deferring_client]
         $rd BLPOP $key 0

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -552,7 +552,6 @@ start_cluster 1 0 {tags {external:skip cluster}} {
             ]
         ]
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE $key_slot $key_slot]
-        puts $slot_stats
         assert_empty_slot_stats_with_exception $slot_stats $expected_slot_stats $metrics_to_assert
 
         R 0 config set min-string-size-avoid-copy-reply $copy_avoid

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -525,7 +525,7 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         # +OK\r\n --> 5 bytes
 
         R 0 GET $key
-        # $3\r\nvalue\r\n -> 11 bytes
+        # $5\r\nvalue\r\n -> 11 bytes
 
         set expected_slot_stats [
             dict create $key_slot [


### PR DESCRIPTION
In releaseBufReferences(), clusterSlotStatsAddNetworkBytesOutForSlot() is called in the IO
thread after writing the reply to the client, and (since #2652) it's also done in the normal
code path in the main thread (afterCommand() -> clusterSlotStatsAddNetworkBytesOutForUserClient()).
This means the output bytes are recorded twice in the cluster slot stats.

Fixes #3043. Bug was introduced in #2652 (9.0.1).