### PR TITLE
Reset maxmemory after OOM scripting tests

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2642,6 +2642,7 @@ start_server {tags {"scripting"}} {
             server.call('set', KEYS[1], ARGV[1])
         } 1 foo bar
        assert_equal bar [r get foo]
+       r config set maxmemory 0
     }
 
     test "Stop the non-dirty scripts when an OOM occurs midway through execution" {
@@ -2654,5 +2655,6 @@ start_server {tags {"scripting"}} {
             } 1 foo bar
         }
        assert_equal {} [r get foo]
+       r config set maxmemory 0
     }
 }


### PR DESCRIPTION
This change restores maxmemory to 0 at the end of both OOM scripting tests, preventing memory configuration from leaking into subsequent tests.