### PR TITLE
Update dual channel replication conf to mention primary should also enable repl-diskless-sync

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -828,7 +828,12 @@ repl-diskless-load disabled
 # When toggling this configuration on or off during an ongoing synchronization process,
 # it does not change the already running sync method. The new configuration will take
 # effect only for subsequent synchronization processes.
-
+#
+# To enable dual channel replication, both the primary and its replicas should have
+# dual-channel-replication-enabled set to yes. Additionally, the primary is required
+# to have repl-diskless-sync enabled, as this allows the RDB snapshot to be streamed
+# directly over the connection for the dual channel mechanism to function properly.
+#
 dual-channel-replication-enabled no
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to


### PR DESCRIPTION
We should mention it in valkey.conf otherwise people may got it wrong.

Also, when the primary node receives a REPLCONF CAPA dual-channel but
repl-diskless-sync is not enabled (we will ignore the capa in this case),
we will also print a notice message so that people can be aware of it from
the logs. We believe if a user enables dual-channel-replication-enabled,
they intend to use dual channel replication.

Closes #3044.