### PR TITLE
Fix how hash is handling overriding of expired fields overwrite

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1986,12 +1986,15 @@ void propagateDeletion(serverDb *db, robj *key, int lazy, int slot) {
  *
  * This function builds and propagates a single HDEL command with multiple fields
  * for the given hash object `o`. It temporarily enables replication (if needed),
- * constructs the command using the field names, and sends it via alsoPropagate(). */
-static void propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields[], int didx) {
+ * constructs the command using the field names, and sends it via alsoPropagate().
+ * Returns how many fields where propagated */
+int propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields[], int didx) {
     int prev_replication_allowed = server.replication_allowed;
     server.replication_allowed = 1;
 
     robj *argv[EXPIRE_BULK_LIMIT + 2]; /* HDEL + key + fields */
+    if (n_fields > EXPIRE_BULK_LIMIT - 2) n_fields = EXPIRE_BULK_LIMIT - 2;
+
     int argc = 0;
     robj *keyobj = createStringObjectFromSds(objectGetKey(o));
     argv[argc++] = shared.hdel; // HDEL command
@@ -2006,6 +2009,7 @@ static void propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj
     for (int i = 0; i < argc; i++) {
         decrRefCount(argv[i]);
     }
+    return n_fields;
 }
 
 /* Process expired fields for a hash delete them and propagate changes to replicas and AOF.

--- a/src/db.c
+++ b/src/db.c
@@ -1993,7 +1993,7 @@ int propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields
     server.replication_allowed = 1;
 
     robj *argv[EXPIRE_BULK_LIMIT + 2]; /* HDEL + key + fields */
-    if (n_fields > EXPIRE_BULK_LIMIT - 2) n_fields = EXPIRE_BULK_LIMIT - 2;
+    if (n_fields > EXPIRE_BULK_LIMIT) n_fields = EXPIRE_BULK_LIMIT;
 
     int argc = 0;
     robj *keyobj = createStringObjectFromSds(objectGetKey(o));

--- a/src/module.c
+++ b/src/module.c
@@ -5467,7 +5467,7 @@ int VM_HashSet(ValkeyModuleKey *key, int flags, ...) {
 
         robj *argv[2] = {field, value};
         hashTypeTryConversion(key->value, argv, 0, 1);
-        int updated = hashTypeSet(key->value, objectGetVal(field), objectGetVal(value), EXPIRY_NONE, low_flags);
+        int updated = hashTypeSet(key->value, objectGetVal(field), objectGetVal(value), EXPIRY_NONE, low_flags, NULL);
         count += (flags & VALKEYMODULE_HASH_COUNT_ALL) ? 1 : updated;
 
         /* If CFIELDS is active, SDS string ownership is now of hashTypeSet(),

--- a/src/server.c
+++ b/src/server.c
@@ -2135,6 +2135,7 @@ void createSharedObjects(void) {
     shared.multi = createSharedString("MULTI");
     shared.exec = createSharedString("EXEC");
     shared.hset = createSharedString("HSET");
+    shared.hsetex = createSharedString("HSETEX");
     shared.hdel = createSharedString("HDEL");
     shared.hpexpireat = createSharedString("HPEXPIREAT");
     shared.hpersist = createSharedString("HPERSIST");

--- a/src/server.h
+++ b/src/server.h
@@ -3525,7 +3525,7 @@ char *hashTypeCurrentFromHashTable(hashTypeIterator *hi, int what, size_t *len);
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
 robj *hashTypeLookupWriteOrCreate(client *c, robj *key);
 robj *hashTypeGetValueObject(robj *o, sds field);
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *lazy_expired);
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overitten);
 robj *hashTypeDup(robj *o);
 bool hashTypeHasVolatileFields(robj *o);
 int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len);

--- a/src/server.h
+++ b/src/server.h
@@ -1467,7 +1467,7 @@ struct sharedObjectsStruct {
         *bgsaveerr_variants[2],
         *execaborterr, *noautherr, *noreplicaserr, *busykeyerr, *oomerr, *plus, *messagebulk, *pmessagebulk,
         *subscribebulk, *unsubscribebulk, *psubscribebulk, *punsubscribebulk, *del, *unlink, *rpop, *lpop, *lpush, *zadd,
-        *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax, *emptyscan, *multi, *exec, *left, *right, *hset, *hdel, *hpexpireat, *hpersist, *srem,
+        *rpoplpush, *lmove, *blmove, *zpopmin, *zpopmax, *emptyscan, *multi, *exec, *left, *right, *hset, *hsetex, *hdel, *hpexpireat, *hpersist, *srem,
         *xgroup, *xclaim, *script, *replconf, *eval, *cluster, *syncslots, *persist, *set, *pexpireat, *pexpire, *time, *pxat, *absttl,
         *retrycount, *force, *justid, *entriesread, *lastid, *ping, *setid, *keepttl, *load, *createconsumer, *getack,
         *special_asterisk, *special_equals, *default_username, *redacted, *ssubscribebulk, *sunsubscribebulk, *fields,
@@ -3525,7 +3525,7 @@ char *hashTypeCurrentFromHashTable(hashTypeIterator *hi, int what, size_t *len);
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
 robj *hashTypeLookupWriteOrCreate(client *c, robj *key);
 robj *hashTypeGetValueObject(robj *o, sds field);
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags);
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *lazy_expired);
 robj *hashTypeDup(robj *o);
 bool hashTypeHasVolatileFields(robj *o);
 int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len);
@@ -3645,6 +3645,7 @@ void deleteExpiredKeyAndPropagate(serverDb *db, robj *keyobj);
 void deleteExpiredKeyAndPropagateWithDictIndex(serverDb *db, robj *keyobj, int dict_index);
 void deleteExpiredKeyFromOverwriteAndPropagate(client *c, robj *keyobj);
 void propagateDeletion(serverDb *db, robj *key, int lazy, int slot);
+int propagateFieldsDeletion(serverDb *db, robj *o, size_t n_fields, robj *fields[], int slot);
 size_t dbReclaimExpiredFields(robj *o, serverDb *db, mstime_t now, unsigned long max_entries, int didx);
 int keyIsExpired(serverDb *db, robj *key);
 long long getExpire(serverDb *db, robj *key);

--- a/src/server.h
+++ b/src/server.h
@@ -3525,7 +3525,7 @@ char *hashTypeCurrentFromHashTable(hashTypeIterator *hi, int what, size_t *len);
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
 robj *hashTypeLookupWriteOrCreate(client *c, robj *key);
 robj *hashTypeGetValueObject(robj *o, sds field);
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overitten);
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overwritten);
 robj *hashTypeDup(robj *o);
 bool hashTypeHasVolatileFields(robj *o);
 int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -433,7 +433,7 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool
             long long entry_expiry = entryGetExpiry(existing);
             /* It is possible that the entry is already expired. In this case we can override it, but we need to make sure to expire it first
              * and treat it like it did not exist. */
-            is_expired = timestampIsExpired(entry_expiry);
+            is_expired = entry_expiry != EXPIRY_NONE && checkAlreadyExpired(entry_expiry);
             if (!is_expired && flags & HASH_SET_KEEP_EXPIRY) {
                 /* In case the HASH_SET_KEEP_EXPIRY will force keeping the existing entry expiry. */
                 expiry = entry_expiry;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1356,6 +1356,9 @@ void hsetexCommand(client *c) {
     int new_argc = 0;
     int need_rewrite_argv = 0;
 
+    robj **keepttl_fields = NULL;
+    int expired_overriten = 0;
+
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(objectGetVal(c->argv[fields_index]), "fields")) {
             /* checking optional flags */
@@ -1461,7 +1464,6 @@ void hsetexCommand(client *c) {
         }
     }
 
-    int expired_overriten = 0;
     for (i = fields_index; i < c->argc; i += 2) {
         if (set_expired) {
             if (hashTypeDelete(o, objectGetVal(c->argv[i]))) {
@@ -1474,17 +1476,28 @@ void hsetexCommand(client *c) {
         } else {
             bool expired;
             hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags, &expired);
-            if (expired) expired_overriten++;
             changes++;
+
+            /* When KEEPTTL is used, we need to track all fields to propagate them
+             * individually with their actual timestamps */
+            if ((flags & ARGS_KEEPTTL) && expired) {
+                if (keepttl_fields == NULL) {
+                    keepttl_fields = zmalloc(sizeof(robj *) * num_fields);
+                }
+                keepttl_fields[expired_overriten] = c->argv[i];
+                incrRefCount(c->argv[i]);
+            } 
+
             if (need_rewrite_argv) {
                 new_argv[new_argc++] = c->argv[i];
                 incrRefCount(c->argv[i]);
                 new_argv[new_argc++] = c->argv[i + 1];
                 incrRefCount(c->argv[i + 1]);
             }
+
+            if (expired) expired_overriten++;
         }
     }
-
 
     if (changes) {
         if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
@@ -1495,11 +1508,25 @@ void hsetexCommand(client *c) {
             /* We would like to reduce the number of hexpired events in case there are potential many expired fields. */
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
-            if (expired_overriten) {
+            if (expired_overriten > 0) {
                 server.stat_expiredfields += expired_overriten;
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
             }
+
+            /* Propagate deletions for expired/non-existent fields in batches */
+            if (keepttl_fields != NULL) {
+                /* Propagate individual fields deletions */
+                int idx = 0;
+                while (idx < expired_overriten) {
+                    idx += propagateFieldsDeletion(c->db, o, expired_overriten - idx,
+                                                   &keepttl_fields[idx], c->slot);
+                }
+                zfree(keepttl_fields);
+                keepttl_fields = NULL;
+            }
+
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
+
             if (need_rewrite_argv) {
                 replaceClientCommandVector(c, new_argc, new_argv);
             }
@@ -1514,6 +1541,8 @@ void hsetexCommand(client *c) {
         if (set_expired)
             decrRefCount(c->argv[1]);
         if (new_argv) zfree(new_argv);
+
+        serverAssert(keepttl_fields == NULL);
     }
 
     /* Delete the object in case it was left empty or created with all expired items. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -366,7 +366,7 @@ int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len) {
  * semantics of copying the values if needed.
  *
  */
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overitten) {
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overwritten) {
     int update = 0;
     bool is_expired = false;
     /* Check if the field is too long for listpack, and convert before adding the item.
@@ -460,7 +460,7 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool
     if (flags & HASH_SET_TAKE_FIELD && field) sdsfree(field);
     if (flags & HASH_SET_TAKE_VALUE && value) sdsfree(value);
     /* Update that we lazy expired the old entry */
-    if (expired_overitten) *expired_overitten = is_expired;
+    if (expired_overwritten) *expired_overwritten = is_expired;
     return update;
 }
 
@@ -932,14 +932,14 @@ void hincrbyCommand(client *c) {
     value += incr;
     new = sdsfromlonglong(value);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    bool expired_overitten = false;
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overitten);
+    bool expired_overwritten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overwritten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
     /* In case we overitten an expired field, we need to act as if it was just expired */
-    if (expired_overitten) {
+    if (expired_overwritten) {
         server.stat_expiredfields++;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
@@ -1016,14 +1016,14 @@ void hincrbyfloatCommand(client *c) {
     int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
     new = sdsnewlen(buf, len);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    bool expired_overitten = false;
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overitten);
+    bool expired_overwritten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overwritten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
     /* In case we overitten an expired field, we need to act as if it was just expired */
-    if (expired_overitten) {
+    if (expired_overwritten) {
         server.stat_expiredfields++;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
@@ -1230,14 +1230,14 @@ void hsetnxCommand(client *c) {
         addReply(c, shared.czero);
     } else {
         hashTypeTryConversion(o, c->argv, 2, 3);
-        bool has_volatile_fields = hashTypeHasVolatileFields(o), expired_overitten = false;
-        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY, &expired_overitten);
+        bool has_volatile_fields = hashTypeHasVolatileFields(o), expired_overwritten = false;
+        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY, &expired_overwritten);
         if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
             dbUpdateObjectWithVolatileItemsTracking(c->db, o);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
         /* In case we overitten an expired field, we need to act as if it was just expired */
-        if (expired_overitten) {
+        if (expired_overwritten) {
             server.stat_expiredfields++;
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         }
@@ -1264,21 +1264,21 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    int expired_overitten = 0;
+    int expired_overwritten = 0;
     for (i = 2; i < c->argc; i += 2) {
         bool expired = false;
         created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY, &expired);
         /* NOTE - We do not need to track all expired items which are overitten in order to propagate them, since the replica will surely just override them
          * we just need to remember that we had such items to report the keyspace notification and update the stats */
-        if (expired) expired_overitten++;
+        if (expired) expired_overwritten++;
     }
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
     /* In case we overitten an expired field, we need to act as if it was just expired */
-    if (expired_overitten) {
-        server.stat_expiredfields += expired_overitten;
+    if (expired_overwritten) {
+        server.stat_expiredfields += expired_overwritten;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
@@ -1355,7 +1355,7 @@ void hsetexCommand(client *c) {
     int new_argc = 0;
     int need_rewrite_argv = 0;
     robj **keepttl_fields = NULL;
-    int expired_overitten = 0;
+    int expired_overwritten = 0;
 
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(objectGetVal(c->argv[fields_index]), "fields")) {
@@ -1483,10 +1483,10 @@ void hsetexCommand(client *c) {
                     if (keepttl_fields == NULL) {
                         keepttl_fields = zmalloc(sizeof(robj *) * num_fields);
                     }
-                    keepttl_fields[expired_overitten] = c->argv[i];
+                    keepttl_fields[expired_overwritten] = c->argv[i];
                     incrRefCount(c->argv[i]);
                 }
-                expired_overitten++;
+                expired_overwritten++;
             }
 
             if (need_rewrite_argv) {
@@ -1508,8 +1508,8 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             /* In case we overwritten fields which were expired we need to act as if we actively expired them */
-            if (expired_overitten > 0) {
-                server.stat_expiredfields += expired_overitten;
+            if (expired_overwritten > 0) {
+                server.stat_expiredfields += expired_overwritten;
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
                 /* Propagate deletions for expired/non-existent fields in batches.
                  * When KEEPTTL is used the replica has noway telling if, at the time the primary was executing the command,
@@ -1518,8 +1518,8 @@ void hsetexCommand(client *c) {
                 if (keepttl_fields != NULL) {
                     /* Propagate individual fields deletions */
                     int idx = 0;
-                    while (idx < expired_overitten) {
-                        idx += propagateFieldsDeletion(c->db, o, expired_overitten - idx,
+                    while (idx < expired_overwritten) {
+                        idx += propagateFieldsDeletion(c->db, o, expired_overwritten - idx,
                                                        &keepttl_fields[idx], c->slot);
                     }
                     zfree(keepttl_fields);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -366,7 +366,7 @@ int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len) {
  * semantics of copying the values if needed.
  *
  */
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overriten) {
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overitten) {
     int update = 0;
     bool is_expired = false;
     /* Check if the field is too long for listpack, and convert before adding the item.
@@ -460,7 +460,7 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool
     if (flags & HASH_SET_TAKE_FIELD && field) sdsfree(field);
     if (flags & HASH_SET_TAKE_VALUE && value) sdsfree(value);
     /* Update that we lazy expired the old entry */
-    if (expired_overriten) *expired_overriten = is_expired;
+    if (expired_overitten) *expired_overitten = is_expired;
     return update;
 }
 
@@ -932,14 +932,14 @@ void hincrbyCommand(client *c) {
     value += incr;
     new = sdsfromlonglong(value);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    bool expired_overriten = false;
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overriten);
+    bool expired_overitten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overitten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
-    /* In case we overriten an expired field, we need to act as if it was just expired */
-    if (expired_overriten) {
+    /* In case we overitten an expired field, we need to act as if it was just expired */
+    if (expired_overitten) {
         server.stat_expiredfields++;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
@@ -1017,14 +1017,14 @@ void hincrbyfloatCommand(client *c) {
     int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
     new = sdsnewlen(buf, len);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    bool expired_overriten = false;
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overriten);
+    bool expired_overitten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overitten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
-    /* In case we overriten an expired field, we need to act as if it was just expired */
-    if (expired_overriten) {
+    /* In case we overitten an expired field, we need to act as if it was just expired */
+    if (expired_overitten) {
         server.stat_expiredfields++;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
@@ -1231,14 +1231,14 @@ void hsetnxCommand(client *c) {
         addReply(c, shared.czero);
     } else {
         hashTypeTryConversion(o, c->argv, 2, 3);
-        bool has_volatile_fields = hashTypeHasVolatileFields(o), expired_overriten = false;
-        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY, &expired_overriten);
+        bool has_volatile_fields = hashTypeHasVolatileFields(o), expired_overitten = false;
+        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY, &expired_overitten);
         if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
             dbUpdateObjectWithVolatileItemsTracking(c->db, o);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
-        /* In case we overriten an expired field, we need to act as if it was just expired */
-        if (expired_overriten) {
+        /* In case we overitten an expired field, we need to act as if it was just expired */
+        if (expired_overitten) {
             server.stat_expiredfields++;
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         }
@@ -1265,21 +1265,21 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    int expired_overriten = 0;
+    int expired_overitten = 0;
     for (i = 2; i < c->argc; i += 2) {
         bool expired = false;
         created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY, &expired);
-        /* NOTE - We do not need to track all expired items which are overriten in order to propagate them, since the replica will surely just override them
+        /* NOTE - We do not need to track all expired items which are overitten in order to propagate them, since the replica will surely just override them
          * we just need to remember that we had such items to report the keyspace notification and update the stats */
-        if (expired) expired_overriten++;
+        if (expired) expired_overitten++;
     }
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
-    /* In case we overriten an expired field, we need to act as if it was just expired */
-    if (expired_overriten) {
-        server.stat_expiredfields += expired_overriten;
+    /* In case we overitten an expired field, we need to act as if it was just expired */
+    if (expired_overitten) {
+        server.stat_expiredfields += expired_overitten;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
@@ -1357,7 +1357,7 @@ void hsetexCommand(client *c) {
     int need_rewrite_argv = 0;
 
     robj **keepttl_fields = NULL;
-    int expired_overriten = 0;
+    int expired_overitten = 0;
 
     for (; fields_index < c->argc - 1; fields_index++) {
         if (!strcasecmp(objectGetVal(c->argv[fields_index]), "fields")) {
@@ -1485,10 +1485,10 @@ void hsetexCommand(client *c) {
                     if (keepttl_fields == NULL) {
                         keepttl_fields = zmalloc(sizeof(robj *) * num_fields);
                     }
-                    keepttl_fields[expired_overriten] = c->argv[i];
+                    keepttl_fields[expired_overitten] = c->argv[i];
                     incrRefCount(c->argv[i]);
                 }
-                expired_overriten++;
+                expired_overitten++;
             }
 
             if (need_rewrite_argv) {
@@ -1510,8 +1510,8 @@ void hsetexCommand(client *c) {
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
             /* In case we overwritten fields which were expired we need to act as if we actively expired them */
-            if (expired_overriten > 0) {
-                server.stat_expiredfields += expired_overriten;
+            if (expired_overitten > 0) {
+                server.stat_expiredfields += expired_overitten;
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
                 /* Propagate deletions for expired/non-existent fields in batches.
                  * When KEEPTTL is used the replica has noway telling if, at the time the primary was executing the command,
@@ -1520,8 +1520,8 @@ void hsetexCommand(client *c) {
                 if (keepttl_fields != NULL) {
                     /* Propagate individual fields deletions */
                     int idx = 0;
-                    while (idx < expired_overriten) {
-                        idx += propagateFieldsDeletion(c->db, o, expired_overriten - idx,
+                    while (idx < expired_overitten) {
+                        idx += propagateFieldsDeletion(c->db, o, expired_overitten - idx,
                                                        &keepttl_fields[idx], c->slot);
                     }
                     zfree(keepttl_fields);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1355,7 +1355,6 @@ void hsetexCommand(client *c) {
     robj **new_argv = NULL;
     int new_argc = 0;
     int need_rewrite_argv = 0;
-
     robj **keepttl_fields = NULL;
     int expired_overitten = 0;
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -941,13 +941,41 @@ void hincrbyCommand(client *c) {
     /* In case we overriten an expired field, we need to act as if it was just expired */
     if (expired_overriten) {
         server.stat_expiredfields++;
-        incrRefCount(c->argv[2]);
-        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrby", c->argv[1], c->db->id);
     server.dirty++;
     addReplyLongLong(c, value);
+
+    /* Always replicate HINCRBY as an HSET or HSETEX command with the final value
+     * when hash has volatile item, since we do not know what will the field state be when the command reach the replica.
+     * HSET is used to override the resulting value and HSETEX is used in order to maintain the expiration time on the target. */
+    if (has_volatile_fields) {
+        char buf[MAX_LONG_DOUBLE_CHARS];
+        int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
+        robj *newobj;
+        newobj = createRawStringObject(buf, len);
+        if (expiry == EXPIRY_NONE) {
+            rewriteClientCommandArgument(c, 0, shared.hset);
+            rewriteClientCommandArgument(c, 3, newobj);
+            decrRefCount(newobj);
+        } else {
+            int new_argc = 8; /* HSETEX(1) + key(2) + PXAT(3) + unix-time-milliseconds(4) + FIELDS(5) + numfields(6) + field(7) + value(8) */
+            robj **new_argv = zmalloc(sizeof(robj *) * (8));
+            robj *milliseconds_obj = createStringObjectFromLongLong(expiry);
+            new_argv[0] = shared.hsetex;
+            new_argv[1] = c->argv[1];
+            incrRefCount(c->argv[1]);
+            new_argv[2] = shared.pxat;
+            new_argv[3] = milliseconds_obj;
+            new_argv[4] = shared.fields;
+            new_argv[5] = shared.integers[1];
+            new_argv[6] = c->argv[2];
+            incrRefCount(c->argv[2]);
+            new_argv[7] = newobj;
+            replaceClientCommandVector(c, new_argc, new_argv);
+        }
+    }
 }
 
 void hincrbyfloatCommand(client *c) {
@@ -998,8 +1026,6 @@ void hincrbyfloatCommand(client *c) {
     /* In case we overriten an expired field, we need to act as if it was just expired */
     if (expired_overriten) {
         server.stat_expiredfields++;
-        incrRefCount(c->argv[2]);
-        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrbyfloat", c->argv[1], c->db->id);
@@ -1214,12 +1240,15 @@ void hsetnxCommand(client *c) {
         /* In case we overriten an expired field, we need to act as if it was just expired */
         if (expired_overriten) {
             server.stat_expiredfields++;
-            incrRefCount(c->argv[2]);
-            propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         }
         notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
         server.dirty++;
+        /* we always have to propagate the effect of the command when we have volatile items,
+         * since on the replica side it might find that the fields was expired */
+        if (has_volatile_fields) {
+            rewriteClientCommandArgument(c, 0, shared.hset);
+        }
         addReply(c, shared.cone);
     }
 }
@@ -1236,9 +1265,13 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    bool expired_overriten = false;
+    int expired_overriten = 0;
     for (i = 2; i < c->argc; i += 2) {
-        created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY, &expired_overriten);
+        bool expired = false;
+        created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY, &expired);
+        /* NOTE - We do not need to track all expired items which are overriten in order to propagate them, since the replica will surely just override them
+         * we just need to remember that we had such items to report the keyspace notification and update the stats */
+        if (expired) expired_overriten++;
     }
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
@@ -1246,9 +1279,7 @@ void hsetCommand(client *c) {
     signalModifiedKey(c, c->db, c->argv[1]);
     /* In case we overriten an expired field, we need to act as if it was just expired */
     if (expired_overriten) {
-        server.stat_expiredfields++;
-        incrRefCount(c->argv[2]);
-        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
+        server.stat_expiredfields += expired_overriten;
         notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
     }
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
@@ -1430,6 +1461,7 @@ void hsetexCommand(client *c) {
         }
     }
 
+    int expired_overriten = 0;
     for (i = fields_index; i < c->argc; i += 2) {
         if (set_expired) {
             if (hashTypeDelete(o, objectGetVal(c->argv[i]))) {
@@ -1440,7 +1472,9 @@ void hsetexCommand(client *c) {
                 changes++;
             }
         } else {
-            hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags, NULL);
+            bool expired;
+            hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags, &expired);
+            if (expired) expired_overriten++;
             changes++;
             if (need_rewrite_argv) {
                 new_argv[new_argc++] = c->argv[i];
@@ -1461,6 +1495,10 @@ void hsetexCommand(client *c) {
             /* We would like to reduce the number of hexpired events in case there are potential many expired fields. */
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
+            if (expired_overriten) {
+                server.stat_expiredfields += expired_overriten;
+                notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
+            }
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
             if (need_rewrite_argv) {
                 replaceClientCommandVector(c, new_argc, new_argv);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -953,8 +953,7 @@ void hincrbyCommand(client *c) {
     if (has_volatile_fields) {
         char buf[MAX_LONG_DOUBLE_CHARS];
         int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
-        robj *newobj;
-        newobj = createRawStringObject(buf, len);
+        robj *newobj = createRawStringObject(buf, len);
         if (expiry == EXPIRY_NONE) {
             rewriteClientCommandArgument(c, 0, shared.hset);
             rewriteClientCommandArgument(c, 3, newobj);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1478,15 +1478,18 @@ void hsetexCommand(client *c) {
             hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags, &expired);
             changes++;
 
-            /* When KEEPTTL is used, we need to track all fields to propagate them
-             * individually with their actual timestamps */
-            if ((flags & ARGS_KEEPTTL) && expired) {
-                if (keepttl_fields == NULL) {
-                    keepttl_fields = zmalloc(sizeof(robj *) * num_fields);
+            if (expired) {
+                /* When KEEPTTL is used, we need to track all fields to propagate them
+                 * individually with their actual timestamps */
+                if ((flags & ARGS_KEEPTTL)) {
+                    if (keepttl_fields == NULL) {
+                        keepttl_fields = zmalloc(sizeof(robj *) * num_fields);
+                    }
+                    keepttl_fields[expired_overriten] = c->argv[i];
+                    incrRefCount(c->argv[i]);
                 }
-                keepttl_fields[expired_overriten] = c->argv[i];
-                incrRefCount(c->argv[i]);
-            } 
+                expired_overriten++;
+            }
 
             if (need_rewrite_argv) {
                 new_argv[new_argc++] = c->argv[i];
@@ -1494,8 +1497,6 @@ void hsetexCommand(client *c) {
                 new_argv[new_argc++] = c->argv[i + 1];
                 incrRefCount(c->argv[i + 1]);
             }
-
-            if (expired) expired_overriten++;
         }
     }
 
@@ -1508,21 +1509,24 @@ void hsetexCommand(client *c) {
             /* We would like to reduce the number of hexpired events in case there are potential many expired fields. */
             notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
         } else {
+            /* In case we overwritten fields which were expired we need to act as if we actively expired them */
             if (expired_overriten > 0) {
                 server.stat_expiredfields += expired_overriten;
                 notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
-            }
-
-            /* Propagate deletions for expired/non-existent fields in batches */
-            if (keepttl_fields != NULL) {
-                /* Propagate individual fields deletions */
-                int idx = 0;
-                while (idx < expired_overriten) {
-                    idx += propagateFieldsDeletion(c->db, o, expired_overriten - idx,
-                                                   &keepttl_fields[idx], c->slot);
+                /* Propagate deletions for expired/non-existent fields in batches.
+                 * When KEEPTTL is used the replica has noway telling if, at the time the primary was executing the command,
+                 * the fields were expired or not. When the replica executes the command it will ALWAYS overwrite the field, so
+                 * we need to propagate hdel explicitly to prevent the replica from keeping the TTL on it's side. */
+                if (keepttl_fields != NULL) {
+                    /* Propagate individual fields deletions */
+                    int idx = 0;
+                    while (idx < expired_overriten) {
+                        idx += propagateFieldsDeletion(c->db, o, expired_overriten - idx,
+                                                       &keepttl_fields[idx], c->slot);
+                    }
+                    zfree(keepttl_fields);
+                    keepttl_fields = NULL;
                 }
-                zfree(keepttl_fields);
-                keepttl_fields = NULL;
             }
 
             notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
@@ -1541,8 +1545,6 @@ void hsetexCommand(client *c) {
         if (set_expired)
             decrRefCount(c->argv[1]);
         if (new_argv) zfree(new_argv);
-
-        serverAssert(keepttl_fields == NULL);
     }
 
     /* Delete the object in case it was left empty or created with all expired items. */
@@ -1550,7 +1552,8 @@ void hsetexCommand(client *c) {
         dbDelete(c->db, c->argv[1]);
         notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
     }
-
+    /* make sure that if we ever allocated this it was freed */
+    serverAssert(keepttl_fields == NULL);
     addReplyLongLong(c, changes == num_fields ? 1 : 0);
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -32,6 +32,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "expire.h"
 #include "hashtable.h"
 #include "rax.h"
 #include "sds.h"
@@ -365,9 +366,9 @@ int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len) {
  * semantics of copying the values if needed.
  *
  */
-int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags) {
+int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags, bool *expired_overriten) {
     int update = 0;
-
+    bool is_expired = false;
     /* Check if the field is too long for listpack, and convert before adding the item.
      * This is needed for HINCRBY* case since in other commands this is handled early by
      * hashTypeTryConversion, so this check will be a NOP. */
@@ -432,7 +433,7 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags) {
             long long entry_expiry = entryGetExpiry(existing);
             /* It is possible that the entry is already expired. In this case we can override it, but we need to make sure to expire it first
              * and treat it like it did not exist. */
-            bool is_expired = timestampIsExpired(entry_expiry);
+            is_expired = timestampIsExpired(entry_expiry);
             if (!is_expired && flags & HASH_SET_KEEP_EXPIRY) {
                 /* In case the HASH_SET_KEEP_EXPIRY will force keeping the existing entry expiry. */
                 expiry = entry_expiry;
@@ -458,6 +459,8 @@ int hashTypeSet(robj *o, sds field, sds value, long long expiry, int flags) {
      * want this function to be responsible. */
     if (flags & HASH_SET_TAKE_FIELD && field) sdsfree(field);
     if (flags & HASH_SET_TAKE_VALUE && value) sdsfree(value);
+    /* Update that we lazy expired the old entry */
+    if (expired_overriten) *expired_overriten = is_expired;
     return update;
 }
 
@@ -906,6 +909,7 @@ void hincrbyCommand(client *c) {
     unsigned char *vstr;
     unsigned int vlen;
     long long expiry = EXPIRY_NONE;
+
     if (getLongLongFromObjectOrReply(c, c->argv[3], &incr, NULL) != C_OK) return;
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
     if (hashTypeGetValue(o, objectGetVal(c->argv[2]), &vstr, &vlen, &value, &expiry) == C_OK) {
@@ -928,11 +932,19 @@ void hincrbyCommand(client *c) {
     value += incr;
     new = sdsfromlonglong(value);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE);
+    bool expired_overriten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overriten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
+    /* In case we overriten an expired field, we need to act as if it was just expired */
+    if (expired_overriten) {
+        server.stat_expiredfields++;
+        incrRefCount(c->argv[2]);
+        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
+        notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
+    }
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrby", c->argv[1], c->db->id);
     server.dirty++;
     addReplyLongLong(c, value);
@@ -977,23 +989,49 @@ void hincrbyfloatCommand(client *c) {
     int len = ld2string(buf, sizeof(buf), value, LD_STR_HUMAN);
     new = sdsnewlen(buf, len);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
-    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE);
+    bool expired_overriten = false;
+    hashTypeSet(o, objectGetVal(c->argv[2]), new, expiry, HASH_SET_TAKE_VALUE, &expired_overriten);
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
+    /* In case we overriten an expired field, we need to act as if it was just expired */
+    if (expired_overriten) {
+        server.stat_expiredfields++;
+        incrRefCount(c->argv[2]);
+        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
+        notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
+    }
     notifyKeyspaceEvent(NOTIFY_HASH, "hincrbyfloat", c->argv[1], c->db->id);
     server.dirty++;
     addReplyBulkCBuffer(c, buf, len);
 
-    /* Always replicate HINCRBYFLOAT as an HSET command with the final value
+    /* Always replicate HINCRBYFLOAT as an HSET or HSETEX command with the final value
      * in order to make sure that differences in float precision or formatting
-     * will not create differences in replicas or after an AOF restart. */
+     * will not create differences in replicas or after an AOF restart.
+     * HSETEX is used in order to maintain the expiration time on the target. */
     robj *newobj;
     newobj = createRawStringObject(buf, len);
-    rewriteClientCommandArgument(c, 0, shared.hset);
-    rewriteClientCommandArgument(c, 3, newobj);
-    decrRefCount(newobj);
+    if (expiry == EXPIRY_NONE) {
+        rewriteClientCommandArgument(c, 0, shared.hset);
+        rewriteClientCommandArgument(c, 3, newobj);
+        decrRefCount(newobj);
+    } else {
+        int new_argc = 8; /* HSETEX(1) + key(2) + PXAT(3) + unix-time-milliseconds(4) + FIELDS(5) + numfields(6) + field(7) + value(8) */
+        robj **new_argv = zmalloc(sizeof(robj *) * (8));
+        robj *milliseconds_obj = createStringObjectFromLongLong(expiry);
+        new_argv[0] = shared.hsetex;
+        new_argv[1] = c->argv[1];
+        incrRefCount(c->argv[1]);
+        new_argv[2] = shared.pxat;
+        new_argv[3] = milliseconds_obj;
+        new_argv[4] = shared.fields;
+        new_argv[5] = shared.integers[1];
+        new_argv[6] = c->argv[2];
+        incrRefCount(c->argv[2]);
+        new_argv[7] = newobj;
+        replaceClientCommandVector(c, new_argc, new_argv);
+    }
 }
 
 static void addHashFieldToReply(client *c, robj *o, sds field) {
@@ -1167,12 +1205,19 @@ void hsetnxCommand(client *c) {
         addReply(c, shared.czero);
     } else {
         hashTypeTryConversion(o, c->argv, 2, 3);
-        bool has_volatile_fields = hashTypeHasVolatileFields(o);
-        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY | HASH_SET_KEEP_EXPIRY);
+        bool has_volatile_fields = hashTypeHasVolatileFields(o), expired_overriten = false;
+        hashTypeSet(o, objectGetVal(c->argv[2]), objectGetVal(c->argv[3]), EXPIRY_NONE, HASH_SET_COPY, &expired_overriten);
         if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
             dbUpdateObjectWithVolatileItemsTracking(c->db, o);
         }
         signalModifiedKey(c, c->db, c->argv[1]);
+        /* In case we overriten an expired field, we need to act as if it was just expired */
+        if (expired_overriten) {
+            server.stat_expiredfields++;
+            incrRefCount(c->argv[2]);
+            propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
+            notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
+        }
         notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
         server.dirty++;
         addReply(c, shared.cone);
@@ -1191,13 +1236,21 @@ void hsetCommand(client *c) {
     if ((o = hashTypeLookupWriteOrCreate(c, c->argv[1])) == NULL) return;
     hashTypeTryConversion(o, c->argv, 2, c->argc - 1);
     bool has_volatile_fields = hashTypeHasVolatileFields(o);
+    bool expired_overriten = false;
     for (i = 2; i < c->argc; i += 2) {
-        created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY);
+        created += !hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), EXPIRY_NONE, HASH_SET_COPY, &expired_overriten);
     }
     if (has_volatile_fields != hashTypeHasVolatileFields(o)) {
         dbUpdateObjectWithVolatileItemsTracking(c->db, o);
     }
     signalModifiedKey(c, c->db, c->argv[1]);
+    /* In case we overriten an expired field, we need to act as if it was just expired */
+    if (expired_overriten) {
+        server.stat_expiredfields++;
+        incrRefCount(c->argv[2]);
+        propagateFieldsDeletion(c->db, o, 1, &c->argv[2], c->slot);
+        notifyKeyspaceEvent(NOTIFY_HASH, "hexpired", c->argv[1], c->db->id);
+    }
     notifyKeyspaceEvent(NOTIFY_HASH, "hset", c->argv[1], c->db->id);
     server.dirty += (c->argc - 2) / 2;
 
@@ -1387,7 +1440,7 @@ void hsetexCommand(client *c) {
                 changes++;
             }
         } else {
-            hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags);
+            hashTypeSet(o, objectGetVal(c->argv[i]), objectGetVal(c->argv[i + 1]), when, set_flags, NULL);
             changes++;
             if (need_rewrite_argv) {
                 new_argv[new_argc++] = c->argv[i];

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1477,8 +1477,9 @@ void hsetexCommand(client *c) {
             changes++;
 
             if (expired) {
-                /* When KEEPTTL is used, we need to track all fields to propagate them
-                 * individually with their actual timestamps */
+                /* When KEEPTTL is used, we need to track all fields to propagate hdel per each of them
+                 * Replicas will not ignore expired fields on the replication stream. This is why we have to explicitly delete them,
+                 * so the replica will take the new field expiration time. */
                 if ((flags & ARGS_KEEPTTL)) {
                     if (keepttl_fields == NULL) {
                         keepttl_fields = zmalloc(sizeof(robj *) * num_fields);

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4546,7 +4546,7 @@ start_server {tags {"hashexpire external:skip"}} {
                 assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
 
                 assert_keyevent_patterns $primary_ksn myhash $primary_ksn_event($command) hexpire hexpired $primary_ksn_event($command)
-                assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hdel del $replica_ksn_event($command)
+                assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hexpired hset
                 $primary_ksn close
                 $replica_ksn close
                 $primary debug set-active-expire 1
@@ -4609,7 +4609,44 @@ start_server {tags {"hashexpire external:skip"}} {
             assert_equal {v2} [$replica hget myhash f1]
             assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
             assert_keyevent_patterns $primary_ksn myhash hset hexpire hexpired hset
-            assert_keyevent_patterns $replica_ksn myhash hset hexpire hdel del hset
+            assert_keyevent_patterns $replica_ksn myhash hset hexpire hexpired hset
+            $primary debug set-active-expire 1
+        } {OK} {needs:debug}
+
+        test {HMSET reports hexpired when overwrites expired fields} {
+            lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            # Initialize deferred clients and subscribe to keyspace notifications
+            foreach instance [list $primary $replica] {
+                $instance config set notify-keyspace-events KEA
+            }
+            set primary_ksn [valkey_deferring_client -1]
+            set replica_ksn [valkey_deferring_client $replica_host $replica_port]
+            foreach rd [list $primary_ksn $replica_ksn] {
+                assert_equal {1} [psubscribe $rd __keyevent@*]
+            }
+            $primary debug set-active-expire 0
+            $primary flushall
+            
+            $primary hsetex myhash px 1 fields 5 f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+
+            wait_for_condition 50 100 {
+                [$primary hgetall myhash] eq {}
+            } else {
+                fail "Fields were not logically expired on primary"
+            }
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {5} [$primary hlen myhash]
+            assert_equal {5} [$replica hlen myhash]
+            assert_equal {} [$replica hgetall myhash]
+        
+            $primary hmset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
+
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal [$primary hgetall myhash] [$replica hgetall myhash]
+            assert_keyevent_patterns $primary_ksn myhash hset hexpire hexpired hset
+            assert_keyevent_patterns $replica_ksn myhash hset hexpire hexpired hset
             $primary debug set-active-expire 1
         } {OK} {needs:debug}
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4506,6 +4506,75 @@ start_server {tags {"hashexpire external:skip"}} {
             $rd_primary close
             $rd_replica close
         }
+
+        foreach command {HINCRBY HINCRBYFLOAT} {
+            test "$command is executed on repilca's expired fields" {
+                lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+                $primary debug set-active-expire 0
+                
+                $primary flushall
+                
+                $primary $command myhash f1 1
+                wait_for_ofs_sync $primary $replica
+                assert_equal 1 [$primary hpexpire myhash 1 fields 1 f1]
+                after 1
+                $primary $command myhash f1 1
+                wait_for_ofs_sync $primary $replica
+
+                assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
+                $primary debug set-active-expire 1
+            } {OK} {needs:debug}
+        }
+
+        test {HINCRBYFLOAT maintains TTL on repilca's fields} {
+            lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            $primary debug set-active-expire 0
+            $primary flushall
+            set long_expiry [get_long_expire_value HEXPIRE]
+            $primary hsetex myhash ex $long_expiry fields 1 f1 1
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {1} [$primary hget myhash f1]
+            assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
+            assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
+
+            $primary hincrbyfloat myhash f1 1.0
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {2} [$primary hget myhash f1]
+            assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
+            assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
+
+            $primary debug set-active-expire 1
+        } {OK} {needs:debug}
+
+        test {HSETNX set the value for expired replica field} {
+            lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            $primary debug set-active-expire 0
+            $primary flushall
+            
+            $primary hsetex myhash px 1 fields 1 f1 v1
+
+            wait_for_condition 50 100 {
+                [$primary hexists myhash f1] == 0
+            } else {
+                fail "Field was not logically expired on primary"
+            }
+            wait_for_ofs_sync $primary $replica
+            
+            assert_equal {1} [$primary hlen myhash]
+            assert_equal {1} [$replica hlen myhash]
+            assert_equal {0} [$replica hexists myhash f1]
+        
+            $primary hsetnx myhash f1 v2
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {v2} [$primary hget myhash f1]
+            assert_equal {v2} [$replica hget myhash f1]
+            assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
+            
+            $primary debug set-active-expire 1
+        } {OK} {needs:debug}
     }
 }
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4642,7 +4642,7 @@ start_server {tags {"hashexpire external:skip"}} {
             assert_equal {5} [$primary hlen myhash]
             assert_equal {5} [$replica hlen myhash]
             assert_equal {} [$replica hgetall myhash]
-        
+
             $primary hmset myhash f1 v1 f2 v2 f3 v3 f4 v4 f5 v5
 
             wait_for_ofs_sync $primary $replica

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4546,7 +4546,12 @@ start_server {tags {"hashexpire external:skip"}} {
                 $primary $command myhash f1 1
                 wait_for_ofs_sync $primary $replica
 
-                assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
+                # verify the value is freshly incremented on the primary and replica
+                assert_equal {1} [$primary hget myhash f1]
+                assert_equal {1} [$replica hget myhash f1]
+                # verify the entry has no expiry on the primary and the replica
+                assert_equal {-1} [$primary httl myhash fields 1 f1]
+                assert_equal {-1} [$replica httl myhash fields 1 f1]
 
                 assert_keyevent_patterns $primary_ksn myhash $primary_ksn_event($command) hexpire hexpired $primary_ksn_event($command)
                 assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hset

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -4508,8 +4508,26 @@ start_server {tags {"hashexpire external:skip"}} {
         }
 
         foreach command {HINCRBY HINCRBYFLOAT} {
+            array set primary_ksn_event {
+                HINCRBY  hincrby
+                HINCRBYFLOAT hincrbyfloat
+            }
+            array set replica_ksn_event {
+                HINCRBY  hincrby
+                HINCRBYFLOAT hset
+            }
             test "$command is executed on repilca's expired fields" {
                 lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+                # Initialize deferred clients and subscribe to keyspace notifications
+                foreach instance [list $primary $replica] {
+                    $instance config set notify-keyspace-events KEA
+                }
+                set primary_ksn [valkey_deferring_client -1]
+                set replica_ksn [valkey_deferring_client $replica_host $replica_port]
+                foreach rd [list $primary_ksn $replica_ksn] {
+                    assert_equal {1} [psubscribe $rd __keyevent@*]
+                }
+
                 $primary debug set-active-expire 0
                 
                 $primary flushall
@@ -4517,11 +4535,20 @@ start_server {tags {"hashexpire external:skip"}} {
                 $primary $command myhash f1 1
                 wait_for_ofs_sync $primary $replica
                 assert_equal 1 [$primary hpexpire myhash 1 fields 1 f1]
-                after 1
+                wait_for_condition 50 100 {
+                    [$primary hexists myhash f1] == 0
+                } else {
+                    fail "Field was not logically expired on primary"
+                }
                 $primary $command myhash f1 1
                 wait_for_ofs_sync $primary $replica
 
                 assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
+
+                assert_keyevent_patterns $primary_ksn myhash $primary_ksn_event($command) hexpire hexpired $primary_ksn_event($command)
+                assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hdel del $replica_ksn_event($command)
+                $primary_ksn close
+                $replica_ksn close
                 $primary debug set-active-expire 1
             } {OK} {needs:debug}
         }
@@ -4550,6 +4577,15 @@ start_server {tags {"hashexpire external:skip"}} {
 
         test {HSETNX set the value for expired replica field} {
             lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            # Initialize deferred clients and subscribe to keyspace notifications
+            foreach instance [list $primary $replica] {
+                $instance config set notify-keyspace-events KEA
+            }
+            set primary_ksn [valkey_deferring_client -1]
+            set replica_ksn [valkey_deferring_client $replica_host $replica_port]
+            foreach rd [list $primary_ksn $replica_ksn] {
+                assert_equal {1} [psubscribe $rd __keyevent@*]
+            }
             $primary debug set-active-expire 0
             $primary flushall
             
@@ -4561,7 +4597,7 @@ start_server {tags {"hashexpire external:skip"}} {
                 fail "Field was not logically expired on primary"
             }
             wait_for_ofs_sync $primary $replica
-            
+
             assert_equal {1} [$primary hlen myhash]
             assert_equal {1} [$replica hlen myhash]
             assert_equal {0} [$replica hexists myhash f1]
@@ -4572,7 +4608,8 @@ start_server {tags {"hashexpire external:skip"}} {
             assert_equal {v2} [$primary hget myhash f1]
             assert_equal {v2} [$replica hget myhash f1]
             assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
-            
+            assert_keyevent_patterns $primary_ksn myhash hset hexpire hexpired hset
+            assert_keyevent_patterns $replica_ksn myhash hset hexpire hdel del hset
             $primary debug set-active-expire 1
         } {OK} {needs:debug}
     }

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -116,7 +116,9 @@ proc wait_for_active_expiry {r key expected_len initial_expired expected_increme
     wait_for_condition $timeout $interval {
         [check_myhash_and_expired_subkeys $r $key $expected_len $initial_expired $expected_increment]
     } else {
-        fail "Active expiry did not occur as expected"
+        set expired_fields [info_field [$r info stats] expired_fields]
+        set expected_expired [expr {$initial_expired + $expected_increment}]
+        fail "Active expiry did not occur as expected expected: $expected_expired ststs: $expired_fields"
     }
 }
 
@@ -4389,6 +4391,7 @@ start_server {tags {"hashexpire external:skip"}} {
         set replica [srv 0 client]
         set replica_host [srv 0 host]
         set replica_port [srv 0 port]
+        set replica_pid [srv 0 pid]
 
         test {expired_fields metric increments only on primary not replica during field expiry} {
             lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
@@ -4546,7 +4549,7 @@ start_server {tags {"hashexpire external:skip"}} {
                 assert_equal [$replica hget myhash f1] [$primary hget myhash f1]
 
                 assert_keyevent_patterns $primary_ksn myhash $primary_ksn_event($command) hexpire hexpired $primary_ksn_event($command)
-                assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hexpired hset
+                assert_keyevent_patterns $replica_ksn myhash $replica_ksn_event($command) hexpire hset
                 $primary_ksn close
                 $replica_ksn close
                 $primary debug set-active-expire 1
@@ -4609,7 +4612,7 @@ start_server {tags {"hashexpire external:skip"}} {
             assert_equal {v2} [$replica hget myhash f1]
             assert_equal [$primary HPEXPIRETIME myhash FIELDS 1 f1] [$replica HPEXPIRETIME myhash FIELDS 1 f1]
             assert_keyevent_patterns $primary_ksn myhash hset hexpire hexpired hset
-            assert_keyevent_patterns $replica_ksn myhash hset hexpire hexpired hset
+            assert_keyevent_patterns $replica_ksn myhash hset hexpire hset
             $primary debug set-active-expire 1
         } {OK} {needs:debug}
 
@@ -4646,7 +4649,61 @@ start_server {tags {"hashexpire external:skip"}} {
 
             assert_equal [$primary hgetall myhash] [$replica hgetall myhash]
             assert_keyevent_patterns $primary_ksn myhash hset hexpire hexpired hset
-            assert_keyevent_patterns $replica_ksn myhash hset hexpire hexpired hset
+            assert_keyevent_patterns $replica_ksn myhash hset hexpire hset
+            $primary debug set-active-expire 1
+        } {OK} {needs:debug}
+
+        test {HSETEX KEEPTTL replica should preserve ttl when field is not expired on primary} {
+            lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            $primary debug set-active-expire 0
+
+            $primary hset myhash f1 v1
+
+            wait_for_ofs_sync $primary $replica
+
+            pause_process $replica_pid
+            
+            $primary multi
+            $primary hpexpire myhash 1 fields 1 f1
+            $primary hsetex myhash KEEPTTL fields 1 f1 v2
+            $primary exec
+
+            # wait for f1 to expired
+            wait_for_condition 50 100 {
+                [$primary httl myhash fields 1 f1] == -2
+            } else {
+                fail "Field was not logically expired on primary"
+            }
+
+            resume_process $replica_pid
+
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {-2} [$primary httl myhash fields 1 f1]
+            assert_equal {-2} [$replica httl myhash fields 1 f1]
+            $primary debug set-active-expire 1
+        } {OK} {needs:debug}
+
+        test {HSETEX KEEPTTL replica should NOT preserve ttl when field is expired on primary} {
+            lassign [setup_replication_test $primary $replica $primary_host $primary_port] primary_initial_expired replica_initial_expired
+            $primary debug set-active-expire 0
+
+            # write a short lived field on the primary and wait for the propagation
+            $primary hsetex myhash PX 1 fields 1 f1 v1
+        
+            # wait for f1 to expired
+            wait_for_condition 50 100 {
+                [$primary httl myhash fields 1 f1] == -2
+            } else {
+                fail "Field was not logically expired on primary"
+            }
+
+            # Now overite the expired field on the primary and wait for it to propagate to the replica
+            $primary hsetex myhash KEEPTTL fields 1 f1 v2
+            wait_for_ofs_sync $primary $replica
+
+            assert_equal {v2} [$primary hget myhash f1]
+            assert_equal {v2} [$replica hget myhash f1]
             $primary debug set-active-expire 1
         } {OK} {needs:debug}
     }


### PR DESCRIPTION
There are currently several issues with the existing hash field expiration mechanism:
1. `HINCRBY` is propagated to the replica "as-is". It mean it relies on the fact that the state of the hash is the same on the primary and the replica. HFE did change this assumption as the field might be expired only when the replica will handle the propagated `hincrby`. the problem is that the replica does not "expire" fields by it's own. it needs to respect the request from the primary and always try to use the existing field. This can lead to either miss-alignment with the value on the primary and the replica AND even a disconnection since the replica might hold and "expired" field which is not in "integer" format... 
2. HINCRBYFLOAT is currently ALWAYS propagating `hset` - this means that the expiration time of an entry will always be removed on the replica side (it needs to propagate HSETEX when expiration time needs to be maintained)
3. Currently all hash write commands which are mutating values might overwrite an expired field. In such cases the existing implementation will "silently" do so. The problem is that the user will not get any key-space-notificaiton explaining the reason for the behavior. For example, when `hincrby` is issued overwriting an expired field which was not yet "cleaned" by active-expiration it will reset the counter to '0' before incrementing it. this means that the user might ask: why is the value '1' and not bigger, "I did not see any notification that the old value expired"... 
4. HSETEX with KEEPTTL suffers from a "somewhat" similar problem as #(1). the replica will receive the propagated command, but will not know if the primary "replaced" the entry which is expired now but might not have been expired when the primary applied it. 

There are 2 options for a solution:
1. we could propagate `hdel` for every entry we are "overwritting" (batch them if we can)
2. propagate the commands "by effect". For example - have `hincrby` always propagate either HSET or HSETEX. This will not solve the '#(4)' problem above though, for which we might HAVE to propagate `hdel`  

I tend to go with the second option. The reason is that it is expected to have less impact on replication stream and should include less processing time on the replicas and network traffic.  Specifically for HSETEX with KEEPTTL we will have to propagate the `hdel` in case we overwritten an expired field, but that would help limit the impact of this propagation.