### PR TITLE
Workaround for fifo to better support memcheck

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -319,6 +319,9 @@ void bioKillThreads(void) {
     int err;
 
     for (bio_worker_data *bwd = bio_workers; bwd != bio_worker_end; ++bwd) {
+        // Uncleanly terminate the mutexQueue, preparing it for memcheck.
+        mutexQueuePrepareForMemcheck(bwd->bio_jobs);
+
         if (pthread_equal(bwd->bio_thread_id, pthread_self())) continue;
         if (bwd->bio_thread_id && pthread_cancel(bwd->bio_thread_id) == 0) {
             if ((err = pthread_join(bwd->bio_thread_id, NULL)) != 0) {

--- a/src/fifo.c
+++ b/src/fifo.c
@@ -351,3 +351,16 @@ fifo *fifoPopAll(fifo *q) {
     overwriteFifoContents(newQ, q);
     return newQ;
 }
+
+void fifoPrepareForMemcheck(fifo *q) {
+    /* Just mask out the tagging bits - ensuring that the pointers between blocks are valid.  This
+     * ensures that the blocks will be properly recognized by memcheck.  However, with the tagging
+     * bits gone, the queue itself becomes invalid as we don't know where it starts & ends.  */
+    if (q->length > 0) {
+        fifoBlock *cur = q->first;
+        while (cur != NULL) {
+            cur->u.last_or_first_idx &= ~IDX_MASK; /* zero out the last 3 bits */
+            cur = cur->u.next;
+        }
+    }
+}

--- a/src/fifo.h
+++ b/src/fifo.h
@@ -71,4 +71,11 @@ void fifoJoin(fifo *q, fifo *other);
  *          // Process batch, then fifoRelease(batch) when done */
 fifo *fifoPopAll(fifo *q);
 
+/* Prepare for memcheck
+ * This is a destructive operation which renders all future operations as undefined.  This removes
+ * internal pointer tagging, preparing the data structure to be scanned by memcheck.  This should
+ * only be used during shutdown/crash as there is no mechanism for safely traversing the queue or
+ * freeing memory after calling this API.  */
+void fifoPrepareForMemcheck(fifo *q);
+
 #endif

--- a/src/mutexqueue.c
+++ b/src/mutexqueue.c
@@ -157,3 +157,9 @@ fifo *mutexQueuePopAll(mutexQueue *theQueue, bool blocking) {
     pthread_mutex_unlock(&mq->mutex);
     return result;
 }
+
+
+void mutexQueuePrepareForMemcheck(mutexQueue *theQueue) {
+    fifoPrepareForMemcheck(theQueue->priority_fifo);
+    fifoPrepareForMemcheck(theQueue->normal_fifo);
+}

--- a/src/mutexqueue.h
+++ b/src/mutexqueue.h
@@ -63,4 +63,11 @@ void *mutexQueuePop(mutexQueue *theQueue, bool blocking);
 /* Retrieves all items from the mutexQueue as a fifo (or NULL if the mutexQueue is empty). */
 fifo *mutexQueuePopAll(mutexQueue *theQueue, bool blocking);
 
+/* Prepare for memcheck
+ * This is a destructive operation which renders all future operations as undefined.  This removes
+ * internal pointer tagging, preparing the data structure to be scanned by memcheck.  This should
+ * only be used during shutdown/crash as there is no mechanism for safely traversing the queue or
+ * freeing memory after calling this API.  */
+void mutexQueuePrepareForMemcheck(mutexQueue *theQueue);
+
 #endif


### PR DESCRIPTION
The memcheck utility has difficulty with tagged or internal pointers.  This update provides a workaround in `fifo` to untag the pointers (helping memcheck).  This leaves further operations on the queue undefined.

It is only suitable to utilize this API while in the process of terminating/crashing as it eliminates the possibility of cleanly deallocating the queue.

The update is provided for `fifo`.  It is wrapped in `mutexQueue`.  It is utilized from `bio::bioKillThreads`.

See: https://github.com/valkey-io/valkey/actions/runs/20733311391/job/59525607904
Ref: https://github.com/valkey-io/valkey/pull/3011

Note: this is marked draft until we get some idea if we want to uglify our code to work around this memcheck deficiency.