### PR TITLE
Fix unnecessary recompilation in gtest Makefile

### DIFF
--- a/src/gtest/Makefile
+++ b/src/gtest/Makefile
@@ -85,9 +85,10 @@ ifdef FORCE_RUN_SKIPPED_TESTS
 endif
 
 # Track compilation flags to force rebuild when they change
-.PHONY: .flags
-.flags:
+.flags: FORCE
 	@echo '$(TEST_CFLAGS)' | cmp -s - $@ || echo '$(TEST_CFLAGS)' > $@
+
+.PHONY: FORCE
 
 # Valkey server library dependencies
 VALKEY_SERVER_LIB := ../libvalkey.a
@@ -137,7 +138,7 @@ $(VALKEY_SERVER_WRAP_LIB): $(VALKEY_SERVER_LIB) $(ENGINE_SERVER_WRAP_OBJ) genera
 endif
 
 # Ensure Valkey server library is built
-$(VALKEY_SERVER_LIB):
+$(VALKEY_SERVER_LIB): make-prerequisites
 	cd .. && $(MAKE) libvalkey.a
 
 # Ensure parent prerequisites are built
@@ -152,12 +153,13 @@ ifeq ($(MALLOC),libc)
 	JEMALLOC_LIB :=
 endif
 
-# Default target to compile against Valkey, LUA, jemalloc (as Valkey does) as well as gmock
-%.o: %.cpp make-prerequisites generated_wrappers.cpp .flags
+# Compile C++ test files, recompile if generated_wrappers or compiler flags change
+%.o: %.cpp generated_wrappers.cpp .flags
 	$(CXX) -MD -MP -std=c++17 -faligned-new -Wno-write-strings -fpermissive $(GCC_FLAGS) $(OPT) $(DEBUG) $(TEST_CFLAGS) -Wall -Wno-deprecated-declarations -c \
 	-isystem .. -I ../../deps/lua/src/ -I ../../deps/hdr_histogram/ -I ../../deps/fpconv/ $(JEMALLOC_CFLAGS) \
 	$(GTEST_CFLAGS) $<
 
+$(ALL_OBJECTS): generated_wrappers.o
 $(ALL_OBJECTS): OPT := $(OPT) $(MORE_WARNINGS)
 
 # Obtain the list of function calls for which we are generating mocks using the gmock library.  We assume they are defined in
@@ -171,7 +173,7 @@ else
 endif
 
 # Generate a new set of wrappers every time our header changes.
-generated_wrappers.cpp: wrappers.h generate-wrappers.py
+generated_wrappers.cpp: make-prerequisites wrappers.h generate-wrappers.py
 	./generate-wrappers.py
 
 generated_wrappers.o: generated_wrappers.cpp

--- a/src/gtest/generate-wrappers.py
+++ b/src/gtest/generate-wrappers.py
@@ -31,6 +31,12 @@ def generate_header(header_file, methods):
 using namespace ::testing;
 using ::testing::StrictMock;
 
+#ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
+    // Older versions and transition versions have 'TestCase' naming available.
+    #define SetUpTestSuite SetUpTestCase
+    #define TearDownTestSuite TearDownTestCase
+#endif
+
 extern "C" {
 ''')
 


### PR DESCRIPTION
This PR fixes the issue where changes to src files did not trigger a rebuild of
libvalkey.a when rerunning `make test-gtest`.

It also resolves the problem where unchanged .cpp test files were unnecessarily recompiled
during make test-gtest.

Now:

If nothing changed:
- Nothing rebuilds, no relinking occurs.

If only C++ test files changed:
- Both libvalkey.a and C++ test files recompile (because release.o changes)
- Test executable relinks

If only src code changed:
- Only libvalkey.a rebuilds
- C++ test files do not recompile
- Test executable relinks

If both changed:
- Both libvalkey.a and C++ test files rebuild
- Test executable relinks