### PR TITLE
Don't exit the process when locale-collate fails to be set from env during startup

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2881,8 +2881,15 @@ void initServer(void) {
 
     /* Make sure the locale is set on startup based on the config file. */
     if (setlocale(LC_COLLATE, server.locale_collate) == NULL) {
-        serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name.");
-        exit(1);
+        if (server.locale_collate[0] == '\0') {
+            /* If we fail to set the locale_collate through environment variables, we maintain
+             * backward compatibility and do not exit. */
+            serverLog(LL_WARNING, "Warning: Failed to configure LOCALE derived from the environment variables, "
+                                  "using the default locale '%s'.", setlocale(LC_COLLATE, NULL));
+        } else {
+            serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name: '%s'.", server.locale_collate);
+            exit(1);
+        }
     }
 
     createSharedObjects();
@@ -7404,7 +7411,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
 
     if (argc == 1) {
         serverLog(LL_WARNING,
-                  "Warning: no config file specified, using the default config. In order to specify a config file use "
+                  "Warning: No config file specified, using the default config. In order to specify a config file use "
                   "%s /path/to/valkey.conf",
                   argv[0]);
     } else {

--- a/src/server.c
+++ b/src/server.c
@@ -2884,8 +2884,10 @@ void initServer(void) {
         if (server.locale_collate[0] == '\0') {
             /* If we fail to set the locale_collate through environment variables, we maintain
              * backward compatibility and do not exit. */
-            serverLog(LL_WARNING, "Warning: Failed to configure LOCALE derived from the environment variables, "
-                                  "using the default locale '%s'.", setlocale(LC_COLLATE, NULL));
+            serverLog(LL_WARNING,
+                      "Warning: Failed to configure LOCALE derived from the environment variables, "
+                      "using the default locale '%s'.",
+                      setlocale(LC_COLLATE, NULL));
         } else {
             serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name: '%s'.", server.locale_collate);
             exit(1);

--- a/valkey.conf
+++ b/valkey.conf
@@ -511,6 +511,13 @@ proc-title-template "{title} {listen-addr} {server-mode}"
 # Set the local environment which is used for string comparison operations, and
 # also affect the performance of Lua scripts. Empty String indicates the locale
 # is derived from the environment variables.
+#
+# During server startup, if setting the locale-collate fails, the server will
+# exit, except when the value is an empty string (for compatibility with
+# environment-derived settings), in which case the process will not exit.
+# CONFIG SET will never cause the server to exit, it will only return an error
+# if the setting fails.
+#
 locale-collate ""
 
 # Valkey is largely compatible with Redis OSS, apart from a few cases where

--- a/valkey.conf
+++ b/valkey.conf
@@ -511,13 +511,6 @@ proc-title-template "{title} {listen-addr} {server-mode}"
 # Set the local environment which is used for string comparison operations, and
 # also affect the performance of Lua scripts. Empty String indicates the locale
 # is derived from the environment variables.
-#
-# During server startup, if setting the locale-collate fails, the server will
-# exit, except when the value is an empty string (for compatibility with
-# environment-derived settings), in which case the process will not exit.
-# CONFIG SET will never cause the server to exit, it will only return an error
-# if the setting fails.
-#
 locale-collate ""
 
 # Valkey is largely compatible with Redis OSS, apart from a few cases where


### PR DESCRIPTION
Before ca6aeadfbef8a0da8817f9f74a7bde1f5df004f7, even if setlocale fails, we
won't do anything.
```
setlocale(LC_COLLATE,"");
```

And now we will exit the process if the setlocale fails, this resulted in process
startup failures on some machines. (some kind of breaking change?)
```
if (setlocale(LC_COLLATE,server.locale_collate) == NULL) {
    serverLog(LL_WARNING, "Failed to configure LOCALE for invalid locale name.");
    exit(1);
}
```

In this commit, if we fail to set the locale_collate through environment variables,
we maintain backward compatibility and do not exit.

In a case where we did exit before, we don't exit now, seems safe. It's not a breaking
change and the behavior in this case was undocumented.