### PR TITLE
Extend test helper wait_for_cluster_propagation to support ignoring certain node

### DIFF
--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -89,20 +89,42 @@ proc fix_cluster {addr} {
 # Check if cluster configuration is consistent.
 # All the nodes in the cluster should show same slots configuration and have health
 # state "online" to be considered as consistent.
-proc cluster_config_consistent {} {
+proc cluster_config_consistent {{ignored_idx {}}} {
+    set base_cfg "undefined"
+
+    set ignored_port -1
+    if {$ignored_idx ne {}} {
+        set ignored_port [srv $ignored_idx port]
+    }
+
     for {set j 0} {$j < [llength $::servers]} {incr j} {
-        # Check if all the nodes are online
+        if {$j == $ignored_idx} {
+            continue
+        }
+
+        # Ensure all nodes believe the cluster is ok
+        set state [CI $j cluster_state]
+        if {$state ne "ok"} {
+            return 0
+        }
+
+        # Check if all the nodes are online, except the one
+        # we optionally ignore.
         set shards_cfg [R $j CLUSTER SHARDS]
         foreach shard_cfg $shards_cfg {
             set nodes [dict get $shard_cfg nodes]
             foreach node $nodes {
+                set node_port [dict get $node port]
+                if {$node_port == $ignored_port} {
+                    continue
+                }
                 if {[dict get $node health] ne "online"} {
                     return 0
                 }
             }
         }
 
-        if {$j == 0} {
+        if {$base_cfg eq "undefined"} {
             set base_cfg [R $j cluster slots]
         } else {
             if {[R $j cluster slots] != $base_cfg} {
@@ -125,9 +147,11 @@ proc cluster_size_consistent {cluster_size} {
 }
 
 # Wait for cluster configuration to propagate and be consistent across nodes.
-proc wait_for_cluster_propagation {} {
+# Optionally ignore a single node by passing its index. This is useful when we
+# deliberately stop a server and wait for the remaining nodes to converge.
+proc wait_for_cluster_propagation {{ignored_idx {}}} {
     wait_for_condition 1000 50 {
-        [cluster_config_consistent] eq 1
+        [cluster_config_consistent $ignored_idx] eq 1
     } else {
         for {set j 0} {$j < [llength $::servers]} {incr j} {
             puts "R $j cluster slots output: [R $j cluster slots]"

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -27,27 +27,6 @@ proc get_my_primary_peer {srv_idx} {
     return $primary_peer
 }
 
-# Check if all given nodes have the expected key/value pairs.
-proc keys_match {nodes kv_pairs} {
-    foreach node $nodes {
-        dict for {key val} $kv_pairs {
-            if {[R $node get $key] ne $val} {
-                return 0
-            }
-        }
-    }
-    return 1
-}
-
-# Wait until all given nodes have the expected key/value pairs.
-proc wait_for_key_consistent {nodes kv_pairs} {
-    wait_for_condition 1000 50 {
-        [keys_match $nodes $kv_pairs]
-    } else {
-        fail "Keys not consistent"
-    }
-}
-
 proc test_migrated_replica {type} {
     test "Migrated replica reports zero repl offset and rank, and fails to win election - $type" {
         # Write some data to primary 0, slot 1, make a small repl_offset.
@@ -123,7 +102,16 @@ proc test_migrated_replica {type} {
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
-        wait_for_key_consistent {3 4 7} {key_991803 1024 key_977613 10240}
+        wait_for_condition 1000 50 {
+            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+        } else {
+            puts "R 3: [R 3 keys *]"
+            puts "R 4: [R 4 keys *]"
+            puts "R 7: [R 7 keys *]"
+            fail "Key not consistent"
+        }
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid
@@ -201,7 +189,14 @@ proc test_nonempty_replica {type} {
 
         # Make sure the key exists and is consistent.
         R 7 readonly
-        wait_for_key_consistent {4 7} {key_991803 1024}
+        wait_for_condition 1000 50 {
+            [R 4 get key_991803] == 1024 &&
+            [R 7 get key_991803] == 1024
+        } else {
+            puts "R 4: [R 4 get key_991803]"
+            puts "R 7: [R 7 get key_991803]"
+            fail "Key not consistent"
+        }
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid
@@ -307,7 +302,16 @@ proc test_sub_replica {type} {
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
-        wait_for_key_consistent {3 4 7} {key_991803 1024 key_977613 10240}
+        wait_for_condition 1000 50 {
+            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+        } else {
+            puts "R 3: [R 3 keys *]"
+            puts "R 4: [R 4 keys *]"
+            puts "R 7: [R 7 keys *]"
+            fail "Key not consistent"
+        }
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -1,3 +1,11 @@
+# Most test cases in this file would involve the following setup design:
+#
+# Replica 4 follows primary 0. Replica 7 follows primary 3, and they have
+# only one slot. We migrate this slot to shard 0, thus making server 3 and 7
+# become primary 0's new replicas. At this point all these 4 servers are
+# in the same shard. Then we stop primary 0 to trigger failover, and test
+# how the remaining three servers would behave.
+
 # Allocate slot 0 to the last primary and evenly distribute the remaining
 # slots to the remaining primaries.
 proc my_slot_allocation {masters replicas} {
@@ -17,6 +25,27 @@ proc get_my_primary_peer {srv_idx} {
     set primary_port [lindex $role_response 2]
     set primary_peer "$primary_ip:$primary_port"
     return $primary_peer
+}
+
+# Check if all given nodes have the expected key/value pairs.
+proc keys_match {nodes kv_pairs} {
+    foreach node $nodes {
+        dict for {key val} $kv_pairs {
+            if {[R $node get $key] ne $val} {
+                return 0
+            }
+        }
+    }
+    return 1
+}
+
+# Wait until all given nodes have the expected key/value pairs.
+proc wait_for_key_consistent {nodes kv_pairs} {
+    wait_for_condition 1000 50 {
+        [keys_match $nodes $kv_pairs]
+    } else {
+        fail "Keys not consistent"
+    }
 }
 
 proc test_migrated_replica {type} {
@@ -89,32 +118,12 @@ proc test_migrated_replica {type} {
         verify_log_message -4 "*Start of election*rank #0*" 0
 
         # Wait for the cluster to be ok.
-        wait_for_condition 1000 50 {
-            [R 3 cluster slots] eq [R 4 cluster slots] &&
-            [R 4 cluster slots] eq [R 7 cluster slots] &&
-            [CI 3 cluster_state] eq "ok" &&
-            [CI 4 cluster_state] eq "ok" &&
-            [CI 7 cluster_state] eq "ok"
-        } else {
-            puts "R 3: [R 3 cluster info]"
-            puts "R 4: [R 4 cluster info]"
-            puts "R 7: [R 7 cluster info]"
-            fail "Cluster is down"
-        }
+        wait_for_cluster_propagation 0
 
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
-        wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
-        } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
-            fail "Key not consistent"
-        }
+        wait_for_key_consistent {3 4 7} {key_991803 1024 key_977613 10240}
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid
@@ -188,26 +197,11 @@ proc test_nonempty_replica {type} {
         }
 
         # Wait for the cluster to be ok.
-        wait_for_condition 1000 50 {
-            [R 4 cluster slots] eq [R 7 cluster slots] &&
-            [CI 4 cluster_state] eq "ok" &&
-            [CI 7 cluster_state] eq "ok"
-        } else {
-            puts "R 4: [R 4 cluster info]"
-            puts "R 7: [R 7 cluster info]"
-            fail "Cluster is down"
-        }
+        wait_for_cluster_propagation 0
 
         # Make sure the key exists and is consistent.
         R 7 readonly
-        wait_for_condition 1000 50 {
-            [R 4 get key_991803] == 1024 &&
-            [R 7 get key_991803] == 1024
-        } else {
-            puts "R 4: [R 4 get key_991803]"
-            puts "R 7: [R 7 get key_991803]"
-            fail "Key not consistent"
-        }
+        wait_for_key_consistent {4 7} {key_991803 1024}
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid
@@ -308,32 +302,12 @@ proc test_sub_replica {type} {
         }
 
         # Wait for the cluster to be ok.
-        wait_for_condition 1000 50 {
-            [R 3 cluster slots] eq [R 4 cluster slots] &&
-            [R 4 cluster slots] eq [R 7 cluster slots] &&
-            [CI 3 cluster_state] eq "ok" &&
-            [CI 4 cluster_state] eq "ok" &&
-            [CI 7 cluster_state] eq "ok"
-        } else {
-            puts "R 3: [R 3 cluster info]"
-            puts "R 4: [R 4 cluster info]"
-            puts "R 7: [R 7 cluster info]"
-            fail "Cluster is down"
-        }
+        wait_for_cluster_propagation 0
 
         # Make sure the key exists and is consistent.
         R 3 readonly
         R 7 readonly
-        wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
-        } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
-            fail "Key not consistent"
-        }
+        wait_for_key_consistent {3 4 7} {key_991803 1024 key_977613 10240}
 
         if {$type == "sigstop"} {
             resume_process $primary0_pid

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -1,11 +1,3 @@
-# Most test cases in this file would involve the following setup design:
-#
-# Replica 4 follows primary 0. Replica 7 follows primary 3, and they have
-# only one slot. We migrate this slot to shard 0, thus making server 3 and 7
-# become primary 0's new replicas. At this point all these 4 servers are
-# in the same shard. Then we stop primary 0 to trigger failover, and test
-# how the remaining three servers would behave.
-
 # Allocate slot 0 to the last primary and evenly distribute the remaining
 # slots to the remaining primaries.
 proc my_slot_allocation {masters replicas} {


### PR DESCRIPTION
Enhanced the popular helper `wait_for_cluster_propagation` to support the scenario where we intentionally stop a server and wait for the other nodes to converge without it.