### PR TITLE
Fix flaky tests related to deferring client timing issues

### DIFF
--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -373,6 +373,8 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         # SET key value\r\n --> 15 bytes.
         $rd write "SET $key value\r\n"
         $rd flush
+        # Wait for response to ensure command is fully processed.
+        $rd read
 
         set slot_stats [R 0 CLUSTER SLOT-STATS SLOTSRANGE 0 16383]
         set expected_slot_stats [

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1086,8 +1086,14 @@ start_server {tags {"introspection"}} {
         wait_for_blocked_clients_count 0
         r lpush mylist 2
 
+        # we scan out all the info commands
+        set monitor_output [$rd read]
+        while { [string match {*"info"*} $monitor_output] } {
+            set monitor_output [$rd read]
+        }
+
         # we expect to see the blpop on the monitor first
-        assert_match {*"blpop"*"mylist"*"0"*} [$rd read]
+        assert_match {*"blpop"*"mylist"*"0"*} $monitor_output
 
         # we scan out all the info commands on the monitor
         set monitor_output [$rd read]


### PR DESCRIPTION
Fix flaky tests in `slot-stats.tcl` and `introspection.tcl`.

Both tests share a similar flaky issue - when using a deferring client, after `$rd <command>` returns, we **cannot** guarantee that the server has already executed the command. 


#### 1. "CLUSTER SLOT-STATS network-bytes-in, in-line buffer processing"

Add `$rd read` after `$rd flush` to wait for the server response, ensuring the command is fully processed before checking slot stats.

#### 2. "MONITOR log blocked command only once"

Skip any leading `info` commands from MONITOR output before asserting `blpop`. Since we cannot guarantee command execution order from the deferring client's perspective, `info` commands triggered by `wait_for_blocked_clients_count` may appear before the expected `blpop`.
