### PR TITLE
Improve performance during rehashing

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -540,10 +540,37 @@ static void rehashEntry(hashtable *ht, void *entry, uint64_t hash, uint8_t h2) {
     ht->used[1]++;
 }
 
+/* After migrating entries in a bucket chain from the old table
+ * to the new one, this function should be called immediately to
+ * handle the cleanup of old buckets, such as clearing presence bits. */
+static void rehashStepFinalize(hashtable *ht) {
+    size_t idx = ht->rehash_idx;
+    /* Free child bucket. */
+    bucket *b = getChildBucket(ht->tables[0] + idx);
+    while (b != NULL) {
+        bucket *next = getChildBucket(b);
+        zfree(b);
+        if (ht->type->trackMemUsage) ht->type->trackMemUsage(ht, -sizeof(bucket));
+        ht->child_buckets[0]--;
+        b = next;
+    }
+
+    /* Reset the bucket after clearing its child buckets. */
+    b = ht->tables[0] + idx;
+    b->chained = 0;
+    b->presence = 0;
+
+    /* Advance to the next bucket. */
+    ht->rehash_idx++;
+    if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0])) {
+        rehashingCompleted(ht);
+    }
+}
+
 /* Fetches entries from a bucket chain for batch processing. */
-static bucket *fetchEntryForExpand(bucket *b, void *buf[], int *size, int max_fetch_count) {
+static bucket *fetchEntriesForExpand(bucket *b, void *buf[], int *size, int max_bucket_count) {
     *size = 0;
-    for (int idx = 0; idx < max_fetch_count && b != NULL; idx += 1) {
+    for (int idx = 0; idx < max_bucket_count && b != NULL; idx += 1) {
         for (int pos = 0; pos < numBucketPositions(b); pos++) {
             if (!isPositionFilled(b, pos)) continue; /* empty */
             buf[*size] = b->entries[pos];
@@ -563,7 +590,7 @@ static void rehashStepExpand(hashtable *ht) {
     bucket *b = ht->tables[0] + idx;
     int size = 0;
     while (b != NULL) {
-        b = fetchEntryForExpand(b, entry_buf, &size, FETCH_BUCKET_COUNT_WHEN_EXPAND);
+        b = fetchEntriesForExpand(b, entry_buf, &size, FETCH_BUCKET_COUNT_WHEN_EXPAND);
 
         /* Key optimization: no loop-carried dependency enables concurrent memory access,
          * reducing CPU stall cycles. */
@@ -576,6 +603,8 @@ static void rehashStepExpand(hashtable *ht) {
             rehashEntry(ht, entry_buf[i], hash, highBits(hash));
         }
     }
+
+    rehashStepFinalize(ht);
 }
 
 /* Rehashes a bucket during table shrinkage. */
@@ -601,45 +630,17 @@ static void rehashStepShrink(hashtable *ht) {
         rehashBucketShrink(ht, b);
         b = next;
     }
-}
 
-/* Finalizes a single rehash step. */
-static void rehashStepFinalize(hashtable *ht) {
-    size_t idx = ht->rehash_idx;
-    /* Free child bucket. */
-    bucket *b = getChildBucket(ht->tables[0] + idx);
-    while (b != NULL) {
-        bucket *next = getChildBucket(b);
-        zfree(b);
-        if (ht->type->trackMemUsage) ht->type->trackMemUsage(ht, -sizeof(bucket));
-        ht->child_buckets[0]--;
-        b = next;
-    }
-
-    /* Reset the bucket after clearing its child buckets. */
-    b = ht->tables[0] + idx;
-    b->chained = 0;
-    b->presence = 0;
-
-    /* Advance to the next bucket. */
-    ht->rehash_idx++;
-    if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0])) {
-        rehashingCompleted(ht);
-    }
+    rehashStepFinalize(ht);
 }
 
 static void rehashStep(hashtable *ht) {
     assert(hashtableIsRehashing(ht));
-    /* Note: rehashStepShrink and rehashStepExpand are responsible only for
-     * migrating entries from the old table to the new one. The cleanup of
-     * old buckets is handled separately in rehashStepFinalize. */
     if (ht->bucket_exp[1] < ht->bucket_exp[0]) {
         rehashStepShrink(ht);
-        rehashStepFinalize(ht);
         return;
     }
     rehashStepExpand(ht);
-    rehashStepFinalize(ht);
 }
 
 /* Called internally on lookup and other reads to the table. */

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -93,6 +93,14 @@ static hashtableResizePolicy resize_policy = HASHTABLE_RESIZE_ALLOW;
 #define MIN_FILL_PERCENT_SOFT 13
 #define MIN_FILL_PERCENT_HARD 3
 
+/* --- Rehash policy --- */
+
+/* We reduce memory access time during rehashing (in the scenario of expansion)
+ * through batch processing. The following parameters are used to set the batch size. */
+
+#define FETCH_BUCKET_COUNT_WHEN_EXPAND 4
+#define FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND (FETCH_BUCKET_COUNT_WHEN_EXPAND * ENTRIES_PER_BUCKET)
+
 /* --- Hash function API --- */
 
 /* The seed needs to be 16 bytes. */
@@ -408,11 +416,6 @@ static inline uint64_t hashKey(hashtable *ht, const void *key) {
     }
 }
 
-static inline uint64_t hashEntry(hashtable *ht, const void *entry) {
-    return hashKey(ht, entryGetKey(ht, entry));
-}
-
-
 /* For the hash bits stored in the bucket, we use the highest bits of the hash
  * value, since these are not used for selecting the bucket. */
 static inline uint8_t highBits(uint64_t hash) {
@@ -526,59 +529,118 @@ static bucket *bucketDefrag(bucket *prev, bucket *b, void *(*defragfn)(void *)) 
     return reallocated;
 }
 
-/* Rehashes one bucket. */
-static void rehashBucket(hashtable *ht, bucket *b) {
-    int pos;
-    for (pos = 0; pos < numBucketPositions(b); pos++) {
+/* Rehashes a single entry from the old table to the new table. */
+static void rehashEntry(hashtable *ht, void *entry, uint64_t hash, uint8_t h2) {
+    int pos_in_dst_bucket;
+    bucket *dst = findBucketForInsert(ht, hash, &pos_in_dst_bucket, NULL);
+    dst->entries[pos_in_dst_bucket] = entry;
+    dst->hashes[pos_in_dst_bucket] = h2;
+    dst->presence |= (1 << pos_in_dst_bucket);
+    ht->used[0]--;
+    ht->used[1]++;
+}
+
+/* Fetches entries from a bucket chain for batch processing. */
+static bucket *fetchEntryForExpand(bucket *b, void *buf[], int *size, int max_fetch_count) {
+    *size = 0;
+    for (int idx = 0; idx < max_fetch_count && b != NULL; idx += 1) {
+        for (int pos = 0; pos < numBucketPositions(b); pos++) {
+            if (!isPositionFilled(b, pos)) continue; /* empty */
+            buf[*size] = b->entries[pos];
+            (*size)++;
+        }
+        b = getChildBucket(b);
+    }
+    return b;
+}
+
+/* Performs one step of incremental rehashing during table expansion. */
+static void rehashStepWhenExpand(hashtable *ht) {
+    /* To reduce CPU stall time caused by random memory access (when accessing entries),
+     * we employ a batch processing and phase separation approach to leverage CPU multi-issue capability,
+     * achieving concurrent memory access to entries, thereby reducing the execution time of rehashing. */
+    void *entry_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
+    const void *key_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
+    size_t idx = ht->rehash_idx;
+    bucket *b = ht->tables[0] + idx;
+    int size = 0;
+    while (b != NULL) {
+        /* Fetch a batch of entries from the bucket chain. */
+        b = fetchEntryForExpand(b, entry_buf, &size, FETCH_BUCKET_COUNT_WHEN_EXPAND);
+
+        /* Since there is no dependency between loop iterations, the CPU can leverage
+         * its multi-issue capability to perform concurrent memory accesses. */
+        for (int i = 0; i < size; i++) {
+            key_buf[i] = entryGetKey(ht, entry_buf[i]);
+        }
+
+        /* Recompute entry hash and rehash entry. */
+        for (int i = 0; i < size; i++) {
+            uint64_t hash = hashKey(ht, key_buf[i]);
+            rehashEntry(ht, entry_buf[i], hash, highBits(hash));
+        }
+    }
+}
+
+/* Rehashes a single bucket during table shrinkage. */
+static void rehashBucketWhenShrink(hashtable *ht, bucket *b) {
+    for (int pos = 0; pos < numBucketPositions(b); pos++) {
         if (!isPositionFilled(b, pos)) continue; /* empty */
         void *entry = b->entries[pos];
         uint8_t h2 = b->hashes[pos];
-        /* Insert into table 1. */
-        uint64_t hash;
         /* When shrinking, it's possible to avoid computing the hash. We can
          * just use idx has the hash. */
-        if (ht->bucket_exp[1] < ht->bucket_exp[0]) {
-            hash = ht->rehash_idx;
-        } else {
-            hash = hashEntry(ht, entry);
-        }
-        int pos_in_dst_bucket;
-        bucket *dst = findBucketForInsert(ht, hash, &pos_in_dst_bucket, NULL);
-        dst->entries[pos_in_dst_bucket] = entry;
-        dst->hashes[pos_in_dst_bucket] = h2;
-        dst->presence |= (1 << pos_in_dst_bucket);
-        ht->used[0]--;
-        ht->used[1]++;
+        uint64_t hash = ht->rehash_idx;
+        /* Reinsert the entry into the new table using the derived hash. */
+        rehashEntry(ht, entry, hash, h2);
     }
-    /* Mark the source bucket as empty. */
-    b->presence = 0;
 }
 
-static void rehashStep(hashtable *ht) {
-    assert(hashtableIsRehashing(ht));
+/* Performs one step of incremental rehashing during table shrinkage. */
+static void rehashStepWhenShrink(hashtable *ht) {
     size_t idx = ht->rehash_idx;
-    bucket *b = &ht->tables[0][idx];
-    rehashBucket(ht, b);
-    if (b->chained) {
-        /* Rehash and free child buckets. */
+    bucket *b = ht->tables[0] + idx;
+    while (b != NULL) {
         bucket *next = getChildBucket(b);
-        b->chained = 0;
+        rehashBucketWhenShrink(ht, b);
         b = next;
-        while (b != NULL) {
-            rehashBucket(ht, b);
-            next = getChildBucket(b);
-            zfree(b);
-            if (ht->type->trackMemUsage) ht->type->trackMemUsage(ht, -sizeof(bucket));
-            ht->child_buckets[0]--;
-            b = next;
-        }
     }
+}
+
+/* Finalizes a single rehash step. */
+static void finalizeRehashStep(hashtable *ht) {
+    size_t idx = ht->rehash_idx;
+    /* Free child bucket. */
+    bucket *b = getChildBucket(ht->tables[0] + idx);
+    while (b != NULL) {
+        bucket *next = getChildBucket(b);
+        zfree(b);
+        if (ht->type->trackMemUsage) ht->type->trackMemUsage(ht, -sizeof(bucket));
+        ht->child_buckets[0]--;
+        b = next;
+    }
+
+    /* Reset the bucket after clearing its child buckets. */
+    b = ht->tables[0] + idx;
+    b->chained = 0;
+    b->presence = 0;
 
     /* Advance to the next bucket. */
     ht->rehash_idx++;
     if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0])) {
         rehashingCompleted(ht);
     }
+}
+
+static void rehashStep(hashtable *ht) {
+    assert(hashtableIsRehashing(ht));
+    if (ht->bucket_exp[1] < ht->bucket_exp[0]) {
+        rehashStepWhenShrink(ht);
+        finalizeRehashStep(ht);
+        return;
+    }
+    rehashStepWhenExpand(ht);
+    finalizeRehashStep(ht);
 }
 
 /* Called internally on lookup and other reads to the table. */

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -554,27 +554,23 @@ static bucket *fetchEntryForExpand(bucket *b, void *buf[], int *size, int max_fe
     return b;
 }
 
-/* Performs one step of incremental rehashing during table expansion. */
-static void rehashStepWhenExpand(hashtable *ht) {
-    /* To reduce CPU stall time caused by random memory access (when accessing entries),
-     * we employ a batch processing and phase separation approach to leverage CPU multi-issue capability,
-     * achieving concurrent memory access to entries, thereby reducing the execution time of rehashing. */
+/* Processes one bucket chain during incremental table expansion.
+ * Uses batch processing to optimize memory access patterns. */
+static void rehashStepExpand(hashtable *ht) {
     void *entry_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
     const void *key_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
     size_t idx = ht->rehash_idx;
     bucket *b = ht->tables[0] + idx;
     int size = 0;
     while (b != NULL) {
-        /* Fetch a batch of entries from the bucket chain. */
         b = fetchEntryForExpand(b, entry_buf, &size, FETCH_BUCKET_COUNT_WHEN_EXPAND);
 
-        /* Since there is no dependency between loop iterations, the CPU can leverage
-         * its multi-issue capability to perform concurrent memory accesses. */
+        /* Key optimization: no loop-carried dependency enables concurrent memory access,
+         * reducing CPU stall cycles. */
         for (int i = 0; i < size; i++) {
             key_buf[i] = entryGetKey(ht, entry_buf[i]);
         }
 
-        /* Recompute entry hash and rehash entry. */
         for (int i = 0; i < size; i++) {
             uint64_t hash = hashKey(ht, key_buf[i]);
             rehashEntry(ht, entry_buf[i], hash, highBits(hash));
@@ -582,8 +578,8 @@ static void rehashStepWhenExpand(hashtable *ht) {
     }
 }
 
-/* Rehashes a single bucket during table shrinkage. */
-static void rehashBucketWhenShrink(hashtable *ht, bucket *b) {
+/* Rehashes a bucket during table shrinkage. */
+static void rehashBucketShrink(hashtable *ht, bucket *b) {
     for (int pos = 0; pos < numBucketPositions(b); pos++) {
         if (!isPositionFilled(b, pos)) continue; /* empty */
         void *entry = b->entries[pos];
@@ -596,19 +592,19 @@ static void rehashBucketWhenShrink(hashtable *ht, bucket *b) {
     }
 }
 
-/* Performs one step of incremental rehashing during table shrinkage. */
-static void rehashStepWhenShrink(hashtable *ht) {
+/* Processes one bucket chain during incremental table shrinkage. */
+static void rehashStepShrink(hashtable *ht) {
     size_t idx = ht->rehash_idx;
     bucket *b = ht->tables[0] + idx;
     while (b != NULL) {
         bucket *next = getChildBucket(b);
-        rehashBucketWhenShrink(ht, b);
+        rehashBucketShrink(ht, b);
         b = next;
     }
 }
 
 /* Finalizes a single rehash step. */
-static void finalizeRehashStep(hashtable *ht) {
+static void rehashStepFinalize(hashtable *ht) {
     size_t idx = ht->rehash_idx;
     /* Free child bucket. */
     bucket *b = getChildBucket(ht->tables[0] + idx);
@@ -634,13 +630,16 @@ static void finalizeRehashStep(hashtable *ht) {
 
 static void rehashStep(hashtable *ht) {
     assert(hashtableIsRehashing(ht));
+    /* Note: rehashStepShrink and rehashStepExpand are responsible only for
+     * migrating entries from the old table to the new one. The cleanup of
+     * old buckets is handled separately in rehashStepFinalize. */
     if (ht->bucket_exp[1] < ht->bucket_exp[0]) {
-        rehashStepWhenShrink(ht);
-        finalizeRehashStep(ht);
+        rehashStepShrink(ht);
+        rehashStepFinalize(ht);
         return;
     }
-    rehashStepWhenExpand(ht);
-    finalizeRehashStep(ht);
+    rehashStepExpand(ht);
+    rehashStepFinalize(ht);
 }
 
 /* Called internally on lookup and other reads to the table. */


### PR DESCRIPTION
### Description

As the hashtable grows, rehash is triggered. Rehash consumes a significant amount of CPU time, resulting in noticeable performance degradation. Much of this CPU time is spent on random memory access (when accessing hashtable entries). This CPU usage can be optimized through concurrent memory access.

```
//  The original rehash process:
For each bucket and its child buckets, all entries are processed as follows:
    1) Access the entry, which involves random memory access.
    2) Compute the hash value of the entry.
    3) Based on the hash value, insert the entries into the new hashtable.

//  The optimized rehash process:
The original steps are transformed into batch processing and phased execution, leveraging
the CPU's multi-issue capability to achieve concurrent memory access. The steps are as follows:
    1) Access multiple entries serially within a for loop. Since each entry access is independent,
       modern CPU architectures can perform concurrent memory access.
    2) Compute the hash values for all entries.
    3) Based on the hash values, insert the entries into the new hashtable.
```

### Benchmark

#### Benchmark step

Write a batch of data into the server and record the QPS with the following commands.

```
// Write command
valkey-benchmark  -n 75000000 -r 75000000 --sequential --threads 2 set key:__rand_int__ __data__

// Record QPS
for((x=0;x<100000;x+=1));do valkey-cli info|grep ops;sleep 1;done
```

#### Benchmark result

The benchmark results are shown below, with the Y-axis representing the recorded QPS and the X-axis representing time (in seconds). The green line indicates the optimized performance, while the blue line represents the original performance.

<img width="1570" height="1086" alt="7bf815feb63c014872a63636112a79c1" src="https://github.com/user-attachments/assets/566c4e57-2177-44b9-991a-89f6a20f9f2b" />

#### Benchmark env

CPU: Intel(R) Xeon(R) 6983P-C * 8
OS: Ubuntu Server 24.04 LTS 64bit
Memory: 32GB
VM: Tencent Cloud | S9e.2XLARGE32
Server start command: valkey-server --save '' --appendonly no