### PR TITLE
Fix race condition in TIME overflow test

### DIFF
--- a/tests/unit/introspection-2.tcl
+++ b/tests/unit/introspection-2.tcl
@@ -17,7 +17,7 @@ start_server {tags {"introspection"}} {
     test {The microsecond part of the TIME command will not overflow} {
         set now [r time]
         set microseconds [lindex $now 1]
-        assert_morethan $microseconds 0
+        assert_morethan_equal $microseconds 0
         assert_lessthan $microseconds 1000000
     }
 


### PR DESCRIPTION
As we can see, it is entirely possible for the microseconds to have a value of 0:
```
*** [err]: The microsecond part of the TIME command will not overflow in tests/unit/introspection-2.tcl
Expected '0' to be more than '0' (context: type eval line 4 cmd {assert_morethan $microseconds 0} proc ::test)
```