### PR TITLE
Fix valkey-benchmark hanging in single-thread duration mode

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -2062,7 +2062,12 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
         }
     } else if (isBenchmarkFinished(requests_finished)) {
         aeStop(eventLoop);
-        return AE_NOMORE;
+        /* In multi-threaded mode, return AE_NOMORE to delete the timer since
+         * the thread's event loop will be destroyed. In single-threaded mode,
+         * we must keep the timer alive for subsequent benchmark tests */
+        if (config.num_threads) {
+            return AE_NOMORE;
+        }
     }
     if (config.csv) return SHOW_THROUGHPUT_INTERVAL;
     /* only first thread output throughput */

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -2060,7 +2060,7 @@ long long showThroughput(struct aeEventLoop *eventLoop, long long id, void *clie
             atomic_store_explicit(&config.previous_requests_finished, 0, memory_order_relaxed);
             hdr_reset(config.latency_histogram);
         }
-    } else if (config.num_threads && isBenchmarkFinished(requests_finished)) {
+    } else if (isBenchmarkFinished(requests_finished)) {
         aeStop(eventLoop);
         return AE_NOMORE;
     }


### PR DESCRIPTION
In single-thread mode with --duration, the benchmark could hang indefinitely after the duration elapsed. 

## Root Cause
Consider the following scenario: 

**Step 1** (T = 0.99s, duration = 1s):
- `readHandler` receives response, calls `clientDone()`
- `isBenchmarkFinished()` returns `false` (0.99s < 1s)
- `clientDone()` calls `resetClient()`

**Step 2** (T = 1.01s):
- `writeHandler` is called
- `isBenchmarkFinished()` returns `true` (1.01s >= 1s)
- `writeHandler` returns early, **no request sent, no read event registered**

**Result**:
- `readHandler` never triggers → `clientDone()` never called → no `aeStop()`
- `showThroughput()` checks `num_threads && isBenchmarkFinished()`, skipping single-thread mode
- **Event loop never terminates**

Fixes #2893, fixes #2843