### PR TITLE
Fix weekly workflow to continue after failure in releases branches

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -51,6 +51,7 @@ jobs:
     needs: determine-release-branches
     if: needs.determine-release-branches.outputs.has-branches == 'true' && github.repository == 'valkey-io/valkey'
     strategy:
+      fail-fast: false
       matrix:
         release-branch: ${{ fromJson(needs.determine-release-branches.outputs.branches) }}
       max-parallel: 1


### PR DESCRIPTION
Currently, the weekly runs do not progress if there is a failed workflow as github CI treats `fail-fast` to be true by default. With this change, we continue to test all the branches even after failure. 

Last week's run: https://github.com/valkey-io/valkey/actions/runs/21107098709
Documentation on fail-fast: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast