### PR TITLE
Cluster: Reproduce sub-replica and prevent empty primary when replica is blocked at replication and has inbound/outbound link race

### DIFF
--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -356,6 +356,104 @@ start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 
     test_sub_replica "sigstop"
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 
+# This test demonstrates a race condition where a replica of a failed primary
+# does not correctly follow the new primary in the same shard.
+#
+# The race condition scenario:
+# 1. Node 7 is a replica of node 0 (after slot migration)
+# 2. Node 0 fails, node 4 becomes the new primary via failover
+# 3. Node 7 learns that node 0 is FAIL, but hasn't yet received the slot
+#    configuration update from node 4
+# 4. Node 7 should follow node 4 (the new primary in the same shard), but
+#    instead it remains a replica of the failed node 0
+#
+# CURRENT BEHAVIOR (BUG):
+# Node 7 stays as replica of failed node 0 instead of following node 4.
+# This can lead to node 7 starting an election and becoming an empty primary,
+# creating duplicate primaries in the same shard.
+#
+# EXPECTED BEHAVIOR (after fix):
+# Node 7 should detect that its primary (node 0) is failed and that there's
+# a new primary (node 4) in the same shard, and reconfigure to follow node 4.
+proc test_replica_of_failed_primary_behavior {} {
+    test "Replica of failed primary - current behavior" {
+        R 3 config set cluster-replica-validity-factor 0
+        R 7 config set cluster-replica-validity-factor 0
+        R 3 config set cluster-allow-replica-migration yes
+        # In the test_sub_replica test case above, the config cluster-allow-replica-migration
+        # is turned off and thus R7 could become sub-replica. Here, we show that even with this
+        # config turned on, R7 could also become sub-replica.
+        R 7 config set cluster-allow-replica-migration yes
+
+        # Write some data to primary 0, slot 1, make a small repl_offset.
+        for {set i 0} {$i < 1024} {incr i} {
+            R 0 incr key_991803
+        }
+        assert_equal {1024} [R 0 get key_991803]
+
+        # Write some data to primary 3, slot 0, make a big repl_offset.
+        for {set i 0} {$i < 10240} {incr i} {
+            R 3 incr key_977613
+        }
+        assert_equal {10240} [R 3 get key_977613]
+
+        # 10s delay per key, make sure primary 0 will hang in the RDB save.
+        R 0 config set rdb-key-save-delay 100000000
+
+        # Move slot 0 from primary 3 to primary 0.
+        set addr "[srv 0 host]:[srv 0 port]"
+        set src_node_id [R 3 CLUSTER MYID]
+        set code [catch {
+            exec src/valkey-cli {*}[valkeycli_tls_config "./tests"] --cluster rebalance $addr --cluster-weight $src_node_id=0
+        } result]
+        if {$code != 0} {
+            fail "valkey-cli --cluster rebalance returns non-zero exit code, output below:\n$result"
+        }
+
+        # Make sure server 3 and server 7 become replicas of primary 0.
+        set R0_id [R 0 CLUSTER MYID]
+        wait_for_log_messages -3 [list "*Configuration change detected. Reconfiguring myself as a replica of node $R0_id*"] 0 1000 10
+        wait_for_log_messages -7 [list "*Lost my last slot during slot migration. Reconfiguring myself as a replica of $R0_id*"] 0 1000 10
+
+        # Stop primary 0 to start a failover.
+        set primary0_pid [s 0 process_id]
+        pause_process $primary0_pid
+
+        # Wait for the replica 4 to become a primary.
+        set R4_id [R 4 CLUSTER MYID]
+        wait_for_log_messages -4 {"*Failover election won: I'm the new primary*"} 0 1000 10
+        wait_for_log_messages -3 [list "*Configuration change detected. Reconfiguring myself as a replica of node $R4_id*"] 0 1000 10
+
+        # Wait for node 7 to receive the FAIL message about node 0.
+        wait_for_log_messages -7 [list "*FAIL message received from * about $R0_id*"] 0 2000 50
+
+        # Isolate node 7 immediately after it learns node 0 is FAIL but before
+        # it processes any slot configuration updates from node 4.
+        R 7 DEBUG DROP-CLUSTER-PACKET-FILTER -2
+
+        # Small delay to ensure isolation is in effect.
+        after 100
+
+        # Re-enable packet reception on node 7.
+        R 7 DEBUG DROP-CLUSTER-PACKET-FILTER -1
+
+        # Wait for node 7 to become a primary (the buggy behavior).
+        wait_for_condition 1000 50 {
+            [s -7 role] eq {master}
+        } else {
+            puts "R 7 role: [R 7 role]"
+            fail "Node 7 did not become a primary (unexpected)"
+        }
+        # At this point, we have two primaries in the same shard:
+        # - Node 4: the legitimate new primary (won the failover election)
+        # - Node 7: an empty primary (buggy behavior)
+    }
+}
+
+start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
+    test_replica_of_failed_primary_behavior
+} my_slot_allocation cluster_allocate_replicas ;# start_cluster
+
 proc test_cluster_setslot {type} {
     test "valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT - $type" {
         R 3 config set cluster-allow-replica-migration no

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -427,16 +427,6 @@ proc test_replica_of_failed_primary_behavior {} {
         # Wait for node 7 to receive the FAIL message about node 0.
         wait_for_log_messages -7 [list "*FAIL message received from * about $R0_id*"] 0 2000 50
 
-        # Isolate node 7 immediately after it learns node 0 is FAIL but before
-        # it processes any slot configuration updates from node 4.
-        R 7 DEBUG DROP-CLUSTER-PACKET-FILTER -2
-
-        # Small delay to ensure isolation is in effect.
-        after 100
-
-        # Re-enable packet reception on node 7.
-        R 7 DEBUG DROP-CLUSTER-PACKET-FILTER -1
-
         # Wait for node 7 to become a primary (the buggy behavior).
         wait_for_condition 1000 50 {
             [s -7 role] eq {master}
@@ -450,9 +440,13 @@ proc test_replica_of_failed_primary_behavior {} {
     }
 }
 
+# Skip for now due to flakiness - we can't control the exact ordering between two TCP streams
+# to consistently reproduce the buggy behavior.
+if {0} {
 start_cluster 4 4 {tags {external:skip cluster} overrides {cluster-node-timeout 1000 cluster-migration-barrier 999}} {
     test_replica_of_failed_primary_behavior
 } my_slot_allocation cluster_allocate_replicas ;# start_cluster
+}
 
 proc test_cluster_setslot {type} {
     test "valkey-cli make source node ignores NOREPLICAS error when doing the last CLUSTER SETSLOT - $type" {


### PR DESCRIPTION
When node 7 times out and reconnects, its outbound links are still valid, so it sends
PINGs and receives a PONG from node 4, correctly identifying 4 as the new primary.
However, inbound connections were previously closed by peers while node 7 was blocked.
As node 7 reestablishes inbound sockets, it may receive delayed, stale cluster
messages from node 4 — messages sent before failover, when 4 was still a replica of 0.

Upon processing these stale messages, node 7 incorrectly believes node 4 is still
following 0, reconfigures itself as a sub-replica of 0, and immediately starts a new
election when it sees 0 marked as FAILED. Since it is now the only "replica" of 0,
node 7 wins and becomes an empty primary in the same shard as node 4.

---



However, I can't find a way to consistently reproduce this. 

`DEBUG DROP-CLUSTER-PACKET-FILTER` is not useful because it only drops packets, but doesn't control when packets are sent or the ordering of packet arrival.

We're hoping for this ordering [1] latest PONG from node 4 via outbound link, [2] stale PING from node 4 via inbound link.

However, if [2] happens before [1], whatever packets we choose to drop, we're not gonna be able to trigger the buggy behavior of empty primary. Thus `DROP-CLUSTER-PACKET-FILTER` is not applicable here.