### PR TITLE
Fix the memory leak in the VM_GetCommandKeysWithFlags function

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -14126,7 +14126,7 @@ int *VM_GetCommandKeysWithFlags(ValkeyModuleCtx *ctx,
         res[i] = result.keys[i].pos;
         if (out_flags) (*out_flags)[i] = moduleConvertKeySpecsFlags(result.keys[i].flags, 0);
     }
-     
+
     getKeysFreeResult(&result);
     return res;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -14126,7 +14126,8 @@ int *VM_GetCommandKeysWithFlags(ValkeyModuleCtx *ctx,
         res[i] = result.keys[i].pos;
         if (out_flags) (*out_flags)[i] = moduleConvertKeySpecsFlags(result.keys[i].flags, 0);
     }
-
+     
+    getKeysFreeResult(&result);
     return res;
 }
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -83,7 +83,6 @@ start_server {tags {"modules"}} {
         assert_equal {300} [llength $reply]
         foreach pair $reply {
             assert_equal {2} [llength $pair]
-            
         }
     }
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -80,9 +80,10 @@ start_server {tags {"modules"}} {
             lappend args key k$i
         }
         set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
-        assert {[llength $reply] == 300}
+        assert_equal {300} [llength $reply]
         foreach pair $reply {
-            assert {[llength $pair] == 2}
+            assert_equal {2} [llength $pair]
+            
         }
     }
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -89,5 +89,4 @@ start_server {tags {"modules"}} {
     test "Unload the module - getkeys" {
         assert_equal {OK} [r module unload getkeys]
     }
-    
 }

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -79,9 +79,6 @@ start_server {tags {"modules"}} {
         for {set i 0} {$i < 300} {incr i} {
             lappend args key k$i
         }
-        
-        set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
- 
         set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
         assert {[llength $reply] == 300}
         foreach pair $reply {

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -74,7 +74,23 @@ start_server {tags {"modules"}} {
         assert_match {*has no permissions to access the 'write' key*} [r ACL DRYRUN testuser getkeys.command_with_flags key write]
     }
 
+    test "introspect with > MAX_KEYS_BUFFER keys triggers VM_GetCommandKeysWithFlags heap alloc" {
+        set args {}
+        for {set i 0} {$i < 300} {incr i} {
+            lappend args key k$i
+        }
+        
+        set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
+ 
+        set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
+        assert {[llength $reply] == 300}
+        foreach pair $reply {
+            assert {[llength $pair] == 2}
+        }
+    }
+
     test "Unload the module - getkeys" {
         assert_equal {OK} [r module unload getkeys]
     }
+    
 }


### PR DESCRIPTION
Memory leak in the VM_GetCommandKeysWithFlags function when MAX_KEYS_BUFFER is reached.
We will malloc the memory so we should always free the getKeysResult.
```
    /* Resize if necessary */
    if (numkeys > result->size) {
        if (result->keys != result->keysbuf) {
            /* We're not using a static buffer, just (re)alloc */
            result->keys = zrealloc(result->keys, numkeys * sizeof(keyReference));
        } else {
            /* We are using a static buffer, copy its contents */
            result->keys = zmalloc(numkeys * sizeof(keyReference));
            if (result->numkeys) memcpy(result->keys, result->keysbuf, result->numkeys * sizeof(keyReference));
        }
        result->size = numkeys;
    }
```

Closes #3087.