### PR TITLE
Skip MPTCP test on platforms without MPTCP

### DIFF
--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -273,6 +273,11 @@ proc tags_acceptable {tags err_return} {
         return 0
     }
 
+    if {[lsearch $tags "mptcp"] >= 0 && ![is_mptcp_available]} {
+        set err "MPTCP not available on this system"
+        return 0
+    }
+
     return 1
 }
 

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1020,13 +1020,13 @@ proc is_ipv6_available {} {
 
 # MPTCP detection
 proc is_mptcp_available {} {
-    if {[catch {exec ../src/valkey-cli --mptcp ping}]} {
-        # Typical error output:
-        # Could not connect to Valkey at 127.0.0.1:6379: MPTCP is not supported on this platform
+    # Typical error output from valkey-cli --mptcp:
+    # Could not connect to Valkey at 127.0.0.1:6379: MPTCP is not supported on this platform
+    if {[catch {exec $::VALKEY_CLI_BIN --mptcp ping} e] &&
+        [string match "*MPTCP is not supported on this platform*" $e]} {
         return 0
-    } else {
-        return 1
     }
+    return 1
 }
 
 # With the parallel test running multiple server instances at the same time

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1018,6 +1018,17 @@ proc is_ipv6_available {} {
     return 0
 }
 
+# MPTCP detection
+proc is_mptcp_available {} {
+    if {[catch {exec ../src/valkey-cli --mptcp ping}]} {
+        # Typical error output:
+        # Could not connect to Valkey at 127.0.0.1:6379: MPTCP is not supported on this platform
+        return 0
+    } else {
+        return 1
+    }
+}
+
 # With the parallel test running multiple server instances at the same time
 # we need a fast enough computer, otherwise a lot of tests may generate
 # false positives.


### PR DESCRIPTION
The test case added in #3042 fails on platforms without MPTCP support.

This change automatically skips the MPTCP tests on platforms without MTPCP.