### PR TITLE
Use standard helper function for verifying that the TLS rotation worked

### DIFF
--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -202,15 +202,8 @@ start_server {tags {"tls"}} {
                 file copy -force $valkey_key $server_key
 
                 # Wait for reload to actually complete by checking server logs
-                set logfile [srv 0 stdout]
-                wait_for_condition 50 100 {
-                    set fd [open $logfile r]
-                    set logs [read $fd]
-                    close $fd
-                    [string match {*TLS materials reloaded successfully*} $logs]
-                } else {
-                    fail "TLS reload did not complete in time"
-                }
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
+                set log_line [count_log_lines 0]
 
                 # Verify connection still works after reload
                 set s [valkey_client]
@@ -222,16 +215,7 @@ start_server {tags {"tls"}} {
                 file copy -force $backup_key $server_key
 
                 # Clear log position and wait for second reload to complete
-                set log_size_before [file size $logfile]
-                wait_for_condition 50 100 {
-                    set fd [open $logfile r]
-                    seek $fd $log_size_before
-                    set new_logs [read $fd]
-                    close $fd
-                    [string match {*TLS materials reloaded successfully*} $new_logs]
-                } else {
-                    fail "TLS reload back to original did not complete in time"
-                }
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} $log_line 50 100
 
                 # Verify connection still works after restore
                 set s [valkey_client]
@@ -250,20 +234,8 @@ start_server {tags {"tls"}} {
             # Enable auto-reload with 1 second interval
             r CONFIG SET tls-auto-reload-interval 1
 
-            # Get server log file
-            set logfile [srv 0 stdout]
-            set size_before [file size $logfile]
-
             # Wait for at least one reload check cycle
-            wait_for_condition 50 100 {
-                set fd [open $logfile r]
-                seek $fd $size_before
-                set new_logs [read $fd]
-                close $fd
-                [string match {*materials unchanged*} $new_logs]
-            } else {
-                fail "Did not find 'materials unchanged' log message"
-            }
+            wait_for_log_messages 0 {"*materials unchanged*"} 0 50 100
 
             # Disable auto-reload
             r CONFIG SET tls-auto-reload-interval 0
@@ -300,15 +272,7 @@ start_server {tags {"tls"}} {
                     r CONFIG SET tls-auto-reload-interval 1
 
                     # Wait for reload to actually complete by checking server logs
-                    set logfile [srv 0 stdout]
-                    wait_for_condition 50 100 {
-                        set fd [open $logfile r]
-                        set logs [read $fd]
-                        close $fd
-                        [string match {*TLS materials reloaded successfully*} $logs]
-                    } else {
-                        fail "TLS reload did not complete after CA cert directory change"
-                    }
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
 
                     # Verify connection still works after reload
                     set s [valkey_client]

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -202,7 +202,7 @@ start_server {tags {"tls"}} {
                 file copy -force $valkey_key $server_key
 
                 # Wait for reload to actually complete by checking server logs
-                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 100 100
                 set log_line [count_log_lines 0]
 
                 # Verify connection still works after reload


### PR DESCRIPTION
The test was previously rolling it's own log checking, but we have helper functions. I noticed a few other instances, but there are active test failures so just targeting that right now.