### PR TITLE
Fix unit test for TLS auto reload

### DIFF
--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -202,15 +202,7 @@ start_server {tags {"tls"}} {
                 file copy -force $valkey_key $server_key
 
                 # Wait for reload to actually complete by checking server logs
-                set logfile [srv 0 stdout]
-                wait_for_condition 50 100 {
-                    set fd [open $logfile r]
-                    set logs [read $fd]
-                    close $fd
-                    [string match {*TLS materials reloaded successfully*} $logs]
-                } else {
-                    fail "TLS reload did not complete in time"
-                }
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 100 100
 
                 # Verify connection still works after reload
                 set s [valkey_client]
@@ -222,16 +214,7 @@ start_server {tags {"tls"}} {
                 file copy -force $backup_key $server_key
 
                 # Clear log position and wait for second reload to complete
-                set log_size_before [file size $logfile]
-                wait_for_condition 50 100 {
-                    set fd [open $logfile r]
-                    seek $fd $log_size_before
-                    set new_logs [read $fd]
-                    close $fd
-                    [string match {*TLS materials reloaded successfully*} $new_logs]
-                } else {
-                    fail "TLS reload back to original did not complete in time"
-                }
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
 
                 # Verify connection still works after restore
                 set s [valkey_client]
@@ -249,21 +232,10 @@ start_server {tags {"tls"}} {
         test {TLS: Auto-reload skips unchanged materials} {
             # Enable auto-reload with 1 second interval
             r CONFIG SET tls-auto-reload-interval 1
-
-            # Get server log file
-            set logfile [srv 0 stdout]
-            set size_before [file size $logfile]
+            r CONFIG SET loglevel debug
 
             # Wait for at least one reload check cycle
-            wait_for_condition 50 100 {
-                set fd [open $logfile r]
-                seek $fd $size_before
-                set new_logs [read $fd]
-                close $fd
-                [string match {*materials unchanged*} $new_logs]
-            } else {
-                fail "Did not find 'materials unchanged' log message"
-            }
+            wait_for_log_messages 0 {"*materials unchanged*"} 0 50 100
 
             # Disable auto-reload
             r CONFIG SET tls-auto-reload-interval 0
@@ -277,7 +249,7 @@ start_server {tags {"tls"}} {
 
             # Invalid intervals should fail
             catch {r CONFIG SET tls-auto-reload-interval -1} e
-            assert_match {*invalid*} $e
+            assert_match {*ERR CONFIG SET failed*} $e
 
             # Reset to disabled
             r CONFIG SET tls-auto-reload-interval 0
@@ -300,15 +272,7 @@ start_server {tags {"tls"}} {
                     r CONFIG SET tls-auto-reload-interval 1
 
                     # Wait for reload to actually complete by checking server logs
-                    set logfile [srv 0 stdout]
-                    wait_for_condition 50 100 {
-                        set fd [open $logfile r]
-                        set logs [read $fd]
-                        close $fd
-                        [string match {*TLS materials reloaded successfully*} $logs]
-                    } else {
-                        fail "TLS reload did not complete after CA cert directory change"
-                    }
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
 
                     # Verify connection still works after reload
                     set s [valkey_client]

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -174,146 +174,158 @@ start_server {tags {"tls"}} {
             $s close
         }
 
-        # Skip auto-reload tests if TLS is loaded as a module
-        # Auto-reload requires built-in TLS
-        if {!$::tls_module} {
-            test {TLS: Auto-reload detects changes} {
-                # Get current certificate files
-                set orig_server_crt [lindex [r config get tls-cert-file] 1]
-                set orig_server_key [lindex [r config get tls-key-file] 1]
+        test {TLS: Auto-reload detects changes} {
+            if {$::tls_module} {
+                # Auto-reload requires built-in TLS
+                skip "Not supported with TLS built as a module"
+            }
+            # Get current certificate files
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
 
-                # Create temporary certificate files (copies of current ones)
-                set temp_crt "$orig_server_crt.temp"
-                set temp_key "$orig_server_key.temp"
+            # Create temporary certificate files (copies of current ones)
+            set temp_crt "$orig_server_crt.temp"
+            set temp_key "$orig_server_key.temp"
+            file copy -force $orig_server_crt $temp_crt
+            file copy -force $orig_server_key $temp_key
+
+            # Ensure cleanup happens even if test fails
+            try {
+                # Update server to use temporary certificate files
+                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key
+
+                # Enable auto-reload with 1 second interval for faster testing
+                r CONFIG SET tls-auto-reload-interval 1
+
+                # Verify initial connection works
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+
+                # Wait for at least one auto-reload cycle to complete
+                after 1100
+
+                # Update temporary files with different certificate
+                set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+                set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+                file copy -force $valkey_crt $temp_crt
+                file copy -force $valkey_key $temp_key
+
+                # Wait for reload to actually complete by checking server logs
+                # Use generous timeout for slow/busy CI systems
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+
+                # Verify connection still works after reload
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+
+                # Wait again to ensure filesystem timestamp will be different
+                # for the second modification and next reload cycle can detect it
+                after 1100
+
+                # Restore original certificate content to temporary files
                 file copy -force $orig_server_crt $temp_crt
                 file copy -force $orig_server_key $temp_key
 
+                # Wait for second reload to complete
+                # Use generous timeout for slow/busy CI systems
+                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+
+                # Verify connection still works after restore
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+            } finally {
+                # Restore original configuration
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
+
+                # Disable auto-reload
+                r CONFIG SET tls-auto-reload-interval 0
+
+                # Clean up temporary files
+                file delete -force $temp_crt $temp_key
+            }
+        }
+
+        test {TLS: Auto-reload skips unchanged materials} {
+            if {$::tls_module} {
+                # Auto-reload requires built-in TLS
+                skip "Not supported with TLS built as a module"
+            }
+            # Save original loglevel
+            set orig_loglevel [lindex [r config get loglevel] 1]
+
+            try {
+                # Enable auto-reload with 1 second interval
+                r CONFIG SET loglevel debug
+                r CONFIG SET tls-auto-reload-interval 1
+
+                # Wait for at least one cron cycle to ensure reload check happens
+                after 1100
+
+                # Wait for at least one reload check cycle
+                # Use generous timeout for slow/busy CI systems
+                wait_for_log_messages 0 {"*materials unchanged*"} 0 150 100
+            } finally {
+                # Disable auto-reload and restore loglevel
+                r CONFIG SET tls-auto-reload-interval 0 loglevel $orig_loglevel
+            }
+        }
+
+        test {TLS: Auto-reload interval validation} {
+            if {$::tls_module} {
+                # Auto-reload requires built-in TLS
+                skip "Not supported with TLS built as a module"
+            }
+            try {
+                # Valid intervals
+                r CONFIG SET tls-auto-reload-interval 0
+                r CONFIG SET tls-auto-reload-interval 5
+                r CONFIG SET tls-auto-reload-interval 3600
+
+                # Invalid intervals should fail
+                catch {r CONFIG SET tls-auto-reload-interval -1} e
+                assert_match {*ERR CONFIG SET failed*} $e
+            } finally {
+                # Reset to disabled
+                r CONFIG SET tls-auto-reload-interval 0
+            }
+        }
+
+        test {TLS: Auto-reload with CA cert directory} {
+            if {$::tls_module} {
+                # Auto-reload requires built-in TLS
+                skip "Not supported with TLS built as a module"
+            }
+            # Get current CA cert directory
+            set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
+
+            if {$ca_cert_dir ne ""} {
+                # Touch a file in the directory to trigger change detection
+                set test_file "$ca_cert_dir/test_marker"
+                set fd [open $test_file w]
+                puts $fd "test"
+                close $fd
+
                 # Ensure cleanup happens even if test fails
                 try {
-                    # Update server to use temporary certificate files
-                    r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key
-
-                    # Enable auto-reload with 1 second interval for faster testing
+                    # Enable auto-reload with 1 second interval
                     r CONFIG SET tls-auto-reload-interval 1
 
-                    # Verify initial connection works
-                    set s [valkey_client]
-                    assert_equal "PONG" [$s PING]
-                    $s close
-
-                    # Wait for at least one auto-reload cycle to complete
-                    after 2500
-
-                    # Update temporary files with different certificate
-                    set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
-                    set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-                    file copy -force $valkey_crt $temp_crt
-                    file copy -force $valkey_key $temp_key
-
                     # Wait for reload to actually complete by checking server logs
-                    # Use generous timeout for slow/busy CI systems
-                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
 
                     # Verify connection still works after reload
                     set s [valkey_client]
                     assert_equal "PONG" [$s PING]
                     $s close
-
-                    # Wait again to ensure filesystem timestamp will be different
-                    # for the second modification and next reload cycle can detect it
-                    after 2500
-
-                    # Restore original certificate content to temporary files
-                    file copy -force $orig_server_crt $temp_crt
-                    file copy -force $orig_server_key $temp_key
-
-                    # Wait for second reload to complete
-                    # Use generous timeout for slow/busy CI systems
-                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
-
-                    # Verify connection still works after restore
-                    set s [valkey_client]
-                    assert_equal "PONG" [$s PING]
-                    $s close
                 } finally {
-                    # Restore original configuration
-                    r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
-
                     # Disable auto-reload
                     r CONFIG SET tls-auto-reload-interval 0
 
-                    # Clean up temporary files
-                    file delete -force $temp_crt $temp_key
-                }
-            }
-
-            test {TLS: Auto-reload skips unchanged materials} {
-                # Save original loglevel
-                set orig_loglevel [lindex [r config get loglevel] 1]
-
-                try {
-                    # Enable auto-reload with 1 second interval
-                    r CONFIG SET loglevel debug
-                    r CONFIG SET tls-auto-reload-interval 1
-
-                    # Wait for at least one cron cycle to ensure reload check happens
-                    after 2500
-
-                    # Wait for at least one reload check cycle
-                    # Use generous timeout for slow/busy CI systems
-                    wait_for_log_messages 0 {"*materials unchanged*"} 0 150 100
-                } finally {
-                    # Disable auto-reload and restore loglevel
-                    r CONFIG SET tls-auto-reload-interval 0 loglevel $orig_loglevel
-                }
-            }
-
-            test {TLS: Auto-reload interval validation} {
-                try {
-                    # Valid intervals
-                    r CONFIG SET tls-auto-reload-interval 0
-                    r CONFIG SET tls-auto-reload-interval 5
-                    r CONFIG SET tls-auto-reload-interval 3600
-
-                    # Invalid intervals should fail
-                    catch {r CONFIG SET tls-auto-reload-interval -1} e
-                    assert_match {*ERR CONFIG SET failed*} $e
-                } finally {
-                    # Reset to disabled
-                    r CONFIG SET tls-auto-reload-interval 0
-                }
-            }
-
-            test {TLS: Auto-reload with CA cert directory} {
-                # Get current CA cert directory
-                set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
-
-                if {$ca_cert_dir ne ""} {
-                    # Touch a file in the directory to trigger change detection
-                    set test_file "$ca_cert_dir/test_marker"
-                    set fd [open $test_file w]
-                    puts $fd "test"
-                    close $fd
-
-                    # Ensure cleanup happens even if test fails
-                    try {
-                        # Enable auto-reload with 1 second interval
-                        r CONFIG SET tls-auto-reload-interval 1
-
-                        # Wait for reload to actually complete by checking server logs
-                        wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
-
-                        # Verify connection still works after reload
-                        set s [valkey_client]
-                        assert_equal "PONG" [$s PING]
-                        $s close
-                    } finally {
-                        # Disable auto-reload
-                        r CONFIG SET tls-auto-reload-interval 0
-
-                        # Clean up test file
-                        file delete -force $test_file
-                    }
+                    # Clean up test file
+                    file delete -force $test_file
                 }
             }
         }

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -174,116 +174,146 @@ start_server {tags {"tls"}} {
             $s close
         }
 
-        test {TLS: Auto-reload detects changes} {
-            # Get current certificate files
-            set server_crt [lindex [r config get tls-cert-file] 1]
-            set server_key [lindex [r config get tls-key-file] 1]
+        # Skip auto-reload tests if TLS is loaded as a module
+        # Auto-reload requires built-in TLS
+        if {!$::tls_module} {
+            test {TLS: Auto-reload detects changes} {
+                # Get current certificate files
+                set orig_server_crt [lindex [r config get tls-cert-file] 1]
+                set orig_server_key [lindex [r config get tls-key-file] 1]
 
-            # Save original certificates
-            set backup_crt "$server_crt.backup"
-            set backup_key "$server_key.backup"
-            file copy -force $server_crt $backup_crt
-            file copy -force $server_key $backup_key
-
-            # Ensure cleanup happens even if test fails
-            try {
-                # Enable auto-reload with 1 second interval for faster testing
-                r CONFIG SET tls-auto-reload-interval 1
-
-                # Verify initial connection works
-                set s [valkey_client]
-                assert_equal "PONG" [$s PING]
-                $s close
-
-                # Replace with different certificate
-                set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
-                set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
-                file copy -force $valkey_crt $server_crt
-                file copy -force $valkey_key $server_key
-
-                # Wait for reload to actually complete by checking server logs
-                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 100 100
-
-                # Verify connection still works after reload
-                set s [valkey_client]
-                assert_equal "PONG" [$s PING]
-                $s close
-
-                # Restore original certificates
-                file copy -force $backup_crt $server_crt
-                file copy -force $backup_key $server_key
-
-                # Clear log position and wait for second reload to complete
-                wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
-
-                # Verify connection still works after restore
-                set s [valkey_client]
-                assert_equal "PONG" [$s PING]
-                $s close
-
-                # Disable auto-reload
-                r CONFIG SET tls-auto-reload-interval 0
-            } finally {
-                # Always clean up backup files
-                file delete -force $backup_crt $backup_key
-            }
-        }
-
-        test {TLS: Auto-reload skips unchanged materials} {
-            # Enable auto-reload with 1 second interval
-            r CONFIG SET tls-auto-reload-interval 1
-            r CONFIG SET loglevel debug
-
-            # Wait for at least one reload check cycle
-            wait_for_log_messages 0 {"*materials unchanged*"} 0 50 100
-
-            # Disable auto-reload
-            r CONFIG SET tls-auto-reload-interval 0
-        }
-
-        test {TLS: Auto-reload interval validation} {
-            # Valid intervals
-            r CONFIG SET tls-auto-reload-interval 0
-            r CONFIG SET tls-auto-reload-interval 5
-            r CONFIG SET tls-auto-reload-interval 3600
-
-            # Invalid intervals should fail
-            catch {r CONFIG SET tls-auto-reload-interval -1} e
-            assert_match {*ERR CONFIG SET failed*} $e
-
-            # Reset to disabled
-            r CONFIG SET tls-auto-reload-interval 0
-        }
-
-        test {TLS: Auto-reload with CA cert directory} {
-            # Get current CA cert directory
-            set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
-
-            if {$ca_cert_dir ne ""} {
-                # Touch a file in the directory to trigger change detection
-                set test_file "$ca_cert_dir/test_marker"
-                set fd [open $test_file w]
-                puts $fd "test"
-                close $fd
+                # Create temporary certificate files (copies of current ones)
+                set temp_crt "$orig_server_crt.temp"
+                set temp_key "$orig_server_key.temp"
+                file copy -force $orig_server_crt $temp_crt
+                file copy -force $orig_server_key $temp_key
 
                 # Ensure cleanup happens even if test fails
                 try {
-                    # Enable auto-reload with 1 second interval
+                    # Update server to use temporary certificate files
+                    r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key
+
+                    # Enable auto-reload with 1 second interval for faster testing
                     r CONFIG SET tls-auto-reload-interval 1
 
+                    # Verify initial connection works
+                    set s [valkey_client]
+                    assert_equal "PONG" [$s PING]
+                    $s close
+
+                    # Wait for at least one auto-reload cycle to complete
+                    after 2500
+
+                    # Update temporary files with different certificate
+                    set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+                    set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+                    file copy -force $valkey_crt $temp_crt
+                    file copy -force $valkey_key $temp_key
+
                     # Wait for reload to actually complete by checking server logs
-                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
+                    # Use generous timeout for slow/busy CI systems
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
 
                     # Verify connection still works after reload
                     set s [valkey_client]
                     assert_equal "PONG" [$s PING]
                     $s close
 
+                    # Wait again to ensure filesystem timestamp will be different
+                    # for the second modification and next reload cycle can detect it
+                    after 2500
+
+                    # Restore original certificate content to temporary files
+                    file copy -force $orig_server_crt $temp_crt
+                    file copy -force $orig_server_key $temp_key
+
+                    # Wait for second reload to complete
+                    # Use generous timeout for slow/busy CI systems
+                    wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 150 100
+
+                    # Verify connection still works after restore
+                    set s [valkey_client]
+                    assert_equal "PONG" [$s PING]
+                    $s close
+                } finally {
+                    # Restore original configuration
+                    r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
+
                     # Disable auto-reload
                     r CONFIG SET tls-auto-reload-interval 0
+
+                    # Clean up temporary files
+                    file delete -force $temp_crt $temp_key
+                }
+            }
+
+            test {TLS: Auto-reload skips unchanged materials} {
+                # Save original loglevel
+                set orig_loglevel [lindex [r config get loglevel] 1]
+
+                try {
+                    # Enable auto-reload with 1 second interval
+                    r CONFIG SET loglevel debug
+                    r CONFIG SET tls-auto-reload-interval 1
+
+                    # Wait for at least one cron cycle to ensure reload check happens
+                    after 2500
+
+                    # Wait for at least one reload check cycle
+                    # Use generous timeout for slow/busy CI systems
+                    wait_for_log_messages 0 {"*materials unchanged*"} 0 150 100
                 } finally {
-                    # Always clean up test file
-                    file delete -force $test_file
+                    # Disable auto-reload and restore loglevel
+                    r CONFIG SET tls-auto-reload-interval 0 loglevel $orig_loglevel
+                }
+            }
+
+            test {TLS: Auto-reload interval validation} {
+                try {
+                    # Valid intervals
+                    r CONFIG SET tls-auto-reload-interval 0
+                    r CONFIG SET tls-auto-reload-interval 5
+                    r CONFIG SET tls-auto-reload-interval 3600
+
+                    # Invalid intervals should fail
+                    catch {r CONFIG SET tls-auto-reload-interval -1} e
+                    assert_match {*ERR CONFIG SET failed*} $e
+                } finally {
+                    # Reset to disabled
+                    r CONFIG SET tls-auto-reload-interval 0
+                }
+            }
+
+            test {TLS: Auto-reload with CA cert directory} {
+                # Get current CA cert directory
+                set ca_cert_dir [lindex [r config get tls-ca-cert-dir] 1]
+
+                if {$ca_cert_dir ne ""} {
+                    # Touch a file in the directory to trigger change detection
+                    set test_file "$ca_cert_dir/test_marker"
+                    set fd [open $test_file w]
+                    puts $fd "test"
+                    close $fd
+
+                    # Ensure cleanup happens even if test fails
+                    try {
+                        # Enable auto-reload with 1 second interval
+                        r CONFIG SET tls-auto-reload-interval 1
+
+                        # Wait for reload to actually complete by checking server logs
+                        wait_for_log_messages 0 {"*TLS materials reloaded successfully*"} 0 50 100
+
+                        # Verify connection still works after reload
+                        set s [valkey_client]
+                        assert_equal "PONG" [$s PING]
+                        $s close
+                    } finally {
+                        # Disable auto-reload
+                        r CONFIG SET tls-auto-reload-interval 0
+
+                        # Clean up test file
+                        file delete -force $test_file
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
 % ./runtest --single tests/unit/tls.tcl --tls 
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 95019
Testing unit/tls
Port 21111 was already busy, trying another port...
Port 21113 was already busy, trying another port...
[ok]: TLS: Not accepting non-TLS connections on a TLS port (0 ms)
[ok]: TLS: Verify tls-auth-clients behaves as expected (31 ms)
[ok]: TLS: Verify tls-protocols behaves as expected (16 ms)
[ok]: TLS: Verify tls-ciphers behaves as expected (27 ms)
[ok]: TLS: Verify tls-prefer-server-ciphers behaves as expected (21 ms)
[ok]: TLS: Verify tls-cert-file is also used as a client cert if none specified (1178 ms)
[ok]: TLS: switch between tcp and tls ports (25 ms)
[ok]: TLS: Working with an encrypted keyfile (12 ms)
[ok]: TLS: Auto-authenticate using tls-auth-clients-user (CN) (12 ms)
[ok]: TLS: Auto-reload detects changes (2700 ms)
[ok]: TLS: Auto-reload skips unchanged materials (1903 ms)
[ok]: TLS: Auto-reload interval validation (6 ms)
[ok]: TLS: Auto-reload with CA cert directory (0 ms)
[ok]: Check for memory leaks (pid 95029) (667 ms)
[1/1 done]: unit/tls (7 seconds)

                   The End

Execution time of different units:
  7 seconds - unit/tls

Test Summary: 14 passed, 0 failed

\o/ All tests passed without errors!

Cleanup: may take some time... OK

```