### PR TITLE
Allow comments in ACL files

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2430,15 +2430,13 @@ static int ACLLoadConfiguredUsers(void) {
 }
 
 /* This function loads the ACL from the specified filename: every line
- * is validated and should be either empty or in the format used to specify
+ * is validated and should be either empty, a comment, or in the format used to specify
  * users in the valkey.conf or in the ACL file, that is:
  *
  *  user <username> ... rules ...
  *
- * Note that this function considers comments starting with '#' as errors
- * because the ACL file is meant to be rewritten, and comments would be
- * lost after the rewrite. Yet empty lines are allowed to avoid being too
- * strict.
+ * Any line starting with # is ignored as a comment. 
+ * Comments will not be preserved after an ACL SAVE. Empty lines are allowed.
  *
  * One important part of implementing ACL LOAD, that uses this function, is
  * to avoid ending with broken rules if the ACL file is invalid for some
@@ -2488,7 +2486,7 @@ static sds ACLLoadFromFile(const char *filename) {
         lines[i] = sdstrim(lines[i], " \t\r\n");
 
         /* Skip blank lines */
-        if (lines[i][0] == '\0') continue;
+        if (lines[i][0] == '\0' || lines[i][0] == '#') continue;
 
         /* Split into arguments */
         argv = sdssplitlen(lines[i], sdslen(lines[i]), " ", 1, &argc);

--- a/src/acl.c
+++ b/src/acl.c
@@ -2435,7 +2435,7 @@ static int ACLLoadConfiguredUsers(void) {
  *
  *  user <username> ... rules ...
  *
- * Any line starting with # is ignored as a comment. 
+ * Any line starting with # is ignored as a comment.
  * Comments will not be preserved after an ACL SAVE. Empty lines are allowed.
  *
  * One important part of implementing ACL LOAD, that uses this function, is

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1254,6 +1254,27 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         catch {exec $::VALKEY_SERVER_BIN --user default --user default} err
         assert_match {*Duplicate user*} $err
     } {} {external:skip}
+
+    test {Test loading an ACL file with comments} {
+        exec cp -f tests/assets/user.acl $server_path
+
+        # Add comments to the ACL file
+        # set acl_content "# Initial comment at the top of the file user alice on allcommands allkeys &* >alice\n# Comment placed between user definitions user bob on -@all +@set +acl ~set* &* >bob\n\n# Comment following an empty line user doug on resetchannels &test +@all ~* >doug user default on nopass ~* &* +@all\n# Final comment at the bottom"
+        set acl_content "# This is a comment at the beginning\nuser alice on allcommands allkeys &* >alice\n# Comment between users\nuser bob on -@all +@set +acl ~set* &* >bob\n\n# Comment with blank line above\nuser doug on resetchannels &test +@all ~* >doug\nuser default on nopass ~* &* +@all\n# Comment at the end"
+        set fd [open $server_path/user.acl w]
+        puts $fd $acl_content
+        close $fd
+
+        # Load the ACL file with comments
+        assert_match {OK} [r ACL LOAD]
+
+        # Verify all users loaded correctly
+        assert {[r ACL GETUSER alice] != ""}
+        assert_equal [dict get [r ACL GETUSER alice] commands] "+@all"
+        assert {[r ACL GETUSER bob] != ""}
+        assert {[r ACL GETUSER doug] != ""}
+        assert {[r ACL GETUSER default] != ""}
+    }
 }
 
 start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl external:skip}} {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1259,7 +1259,6 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user.acl"] tags
         exec cp -f tests/assets/user.acl $server_path
 
         # Add comments to the ACL file
-        # set acl_content "# Initial comment at the top of the file user alice on allcommands allkeys &* >alice\n# Comment placed between user definitions user bob on -@all +@set +acl ~set* &* >bob\n\n# Comment following an empty line user doug on resetchannels &test +@all ~* >doug user default on nopass ~* &* +@all\n# Final comment at the bottom"
         set acl_content "# This is a comment at the beginning\nuser alice on allcommands allkeys &* >alice\n# Comment between users\nuser bob on -@all +@set +acl ~set* &* >bob\n\n# Comment with blank line above\nuser doug on resetchannels &test +@all ~* >doug\nuser default on nopass ~* &* +@all\n# Comment at the end"
         set fd [open $server_path/user.acl w]
         puts $fd $acl_content


### PR DESCRIPTION
This PR allows ACL files to include comment lines starting with `#`. 