### PR TITLE
Make CMake test also run tls tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           CFLAGS='-Werror' ./runtest-moduleapi --tags needs:other-server --verbose --dump-logs \
             --other-server-path tests/tmp/valkey-${{ matrix.server.version }}-noble-x86_64/bin/valkey-server
 
-  test-ubuntu-latest-cmake:
+  test-ubuntu-latest-cmake-tls:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -91,14 +91,15 @@ jobs:
           make -j$(nproc)
       - name: test
         run: |
-          sudo apt-get install -y tcl8.6 tclx
+          sudo apt-get install -y tcl8.6 tclx tcl-tls
+          ./utils/gen-test-certs.sh
           ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-server
           ln -sf $(pwd)/build-release/bin/valkey-cli $(pwd)/src/valkey-cli
           ln -sf $(pwd)/build-release/bin/valkey-benchmark $(pwd)/src/valkey-benchmark
           ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-check-aof
           ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-check-rdb
           ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-sentinel
-          ./runtest --verbose --tags -slow --dump-logs
+          ./runtest --verbose --tags -slow --dump-logs --tls
       - name: unit tests
         run: |
           ./build-release/bin/valkey-unit-tests


### PR DESCRIPTION
We are already double running the tests with CMake, and we are building CMake with TLS, so just making it so we run the tests with TLS. This seems like an simple update so that we are always running the TLS tests.

Can wait until after https://github.com/valkey-io/valkey/pull/3094 is merged so the CI is green.