### PR TITLE
Fix minor inconsistency in connFormatAddr size argument

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1766,7 +1766,7 @@ void acceptCommonHandler(connection *conn, struct ClientFlags flags, char *ip) {
     char addr[CONN_ADDR_STR_LEN] = {0};
     char laddr[CONN_ADDR_STR_LEN] = {0};
     connFormatAddr(conn, addr, sizeof(addr), 1);
-    connFormatAddr(conn, laddr, sizeof(addr), 0);
+    connFormatAddr(conn, laddr, sizeof(laddr), 0);
 
     if (connGetState(conn) != CONN_STATE_ACCEPTING) {
         serverLog(LL_VERBOSE, "Accepted client connection in error state: %s (addr=%s laddr=%s)",


### PR DESCRIPTION
**Type**: Refactoring / Code Cleanup

**Description**: While reviewing the connection layer logic, I noticed a minor inconsistency in how buffer sizes are passed to `connFormatAddr`.

In the error handling block of `acceptCommonHandler`, `sizeof(addr)` is currently used for both the remote address and the local address buffers. While both addr and laddr are defined with the same size (`NET_ADDR_STR_LEN`), it is more idiomatic and safer to use the sizeof of the actual buffer being populated.

**This change ensures:**
- Defensive Programming: Prevents potential buffer overflows or truncation issues if the array sizes are changed independently in the future.
- Code Clarity: Removes ambiguity for future maintainers and ensures the logic is self-consistent.


**Code Comparison:**
```c
// Before
char addr[NET_ADDR_STR_LEN] = {0};
char laddr[NET_ADDR_STR_LEN] = {0};
connFormatAddr(conn, addr, sizeof(addr), 1);
connFormatAddr(conn, laddr, sizeof(addr), 0); // Using size of the wrong buffer

// After
char addr[NET_ADDR_STR_LEN] = {0};
char laddr[NET_ADDR_STR_LEN] = {0};
connFormatAddr(conn, addr, sizeof(addr), 1);
connFormatAddr(conn, laddr, sizeof(laddr), 0); // Correctly uses sizeof(laddr)
```