### PR TITLE
Track request payload distribution in INFO stats

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -240,6 +240,7 @@ void unblockClient(client *c, int queue_for_reprocessing) {
          * unblockClientOnKey is called, which eventually calls processCommand,
          * which calls reqresAppendResponse) */
         reqresAppendResponse(c);
+        trackPayloadBytesBuckets(c);
         resetClient(c);
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3652,11 +3652,6 @@ static int parseMultibulk(client *c,
     return 0;
 }
 
-/* Perform necessary tasks after a command was executed:
- *
- * 1. The client is reset unless there are reasons to avoid doing it.
- * 2. In the case of primary clients, the replication offset is updated.
- * 3. Propagate commands we got from our primary to replicas down the line. */
 void trackPayloadBytesBuckets(client *c) {
     if (getClientType(c) != CLIENT_TYPE_NORMAL) return;
     if (c->flag.reply_off || c->flag.reply_skip) return;
@@ -3665,6 +3660,11 @@ void trackPayloadBytesBuckets(client *c) {
     server.stat_reply_payload_bytes_bucket[payloadBytesBucketIndex((size_t)c->net_output_bytes_curr_cmd)]++;
 }
 
+/* Perform necessary tasks after a command was executed:
+ *
+ * 1. The client is reset unless there are reasons to avoid doing it.
+ * 2. In the case of primary clients, the replication offset is updated.
+ * 3. Propagate commands we got from our primary to replicas down the line. */
 void commandProcessed(client *c) {
     /* If client is blocked(including paused), just return avoid reset and replicate.
      *

--- a/src/networking.c
+++ b/src/networking.c
@@ -3657,6 +3657,14 @@ static int parseMultibulk(client *c,
  * 1. The client is reset unless there are reasons to avoid doing it.
  * 2. In the case of primary clients, the replication offset is updated.
  * 3. Propagate commands we got from our primary to replicas down the line. */
+void trackPayloadBytesBuckets(client *c) {
+    if (getClientType(c) != CLIENT_TYPE_NORMAL) return;
+    if (c->flag.reply_off || c->flag.reply_skip) return;
+
+    server.stat_request_payload_bytes_bucket[payloadBytesBucketIndex((size_t)c->net_input_bytes_curr_cmd)]++;
+    server.stat_reply_payload_bytes_bucket[payloadBytesBucketIndex((size_t)c->net_output_bytes_curr_cmd)]++;
+}
+
 void commandProcessed(client *c) {
     /* If client is blocked(including paused), just return avoid reset and replicate.
      *
@@ -3669,6 +3677,7 @@ void commandProcessed(client *c) {
 
     reqresAppendResponse(c);
     clusterSlotStatsAddNetworkBytesInForUserClient(c);
+    trackPayloadBytesBuckets(c);
     resetClient(c);
 
     if (!c->repl_data) return;

--- a/src/server.c
+++ b/src/server.c
@@ -2759,6 +2759,8 @@ void resetServerStats(void) {
     server.stat_net_repl_output_bytes = 0;
     server.stat_net_cluster_slot_export_bytes = 0;
     server.stat_net_cluster_slot_import_bytes = 0;
+    memset(server.stat_request_payload_bytes_bucket, 0, sizeof(server.stat_request_payload_bytes_bucket));
+    memset(server.stat_reply_payload_bytes_bucket, 0, sizeof(server.stat_reply_payload_bytes_bucket));
     server.stat_unexpected_error_replies = 0;
     server.stat_total_error_replies = 0;
     server.stat_dump_payload_sanitizations = 0;
@@ -6144,6 +6146,16 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "instantaneous_ops_per_sec:%lld\r\n", getInstantaneousMetric(STATS_METRIC_COMMAND),
                 "total_net_input_bytes:%lld\r\n", server.stat_net_input_bytes + server.stat_net_repl_input_bytes + server.bio_stat_net_repl_input_bytes + server.stat_net_cluster_slot_import_bytes,
                 "total_net_output_bytes:%lld\r\n", server.stat_net_output_bytes + server.stat_net_repl_output_bytes + server.stat_net_cluster_slot_export_bytes,
+                "request_payload_bytes_bucket_lt_64kb:%llu\r\n", server.stat_request_payload_bytes_bucket[0],
+                "request_payload_bytes_bucket_64kb_256kb:%llu\r\n", server.stat_request_payload_bytes_bucket[1],
+                "request_payload_bytes_bucket_256kb_1mb:%llu\r\n", server.stat_request_payload_bytes_bucket[2],
+                "request_payload_bytes_bucket_1mb_5mb:%llu\r\n", server.stat_request_payload_bytes_bucket[3],
+                "request_payload_bytes_bucket_gt_5mb:%llu\r\n", server.stat_request_payload_bytes_bucket[4],
+                "reply_payload_bytes_bucket_lt_64kb:%llu\r\n", server.stat_reply_payload_bytes_bucket[0],
+                "reply_payload_bytes_bucket_64kb_256kb:%llu\r\n", server.stat_reply_payload_bytes_bucket[1],
+                "reply_payload_bytes_bucket_256kb_1mb:%llu\r\n", server.stat_reply_payload_bytes_bucket[2],
+                "reply_payload_bytes_bucket_1mb_5mb:%llu\r\n", server.stat_reply_payload_bytes_bucket[3],
+                "reply_payload_bytes_bucket_gt_5mb:%llu\r\n", server.stat_reply_payload_bytes_bucket[4],
                 "total_net_repl_input_bytes:%lld\r\n", server.stat_net_repl_input_bytes + server.bio_stat_net_repl_input_bytes,
                 "total_net_repl_output_bytes:%lld\r\n", server.stat_net_repl_output_bytes,
                 "total_net_cluster_slot_import_bytes:%lld\r\n", server.stat_net_cluster_slot_import_bytes,

--- a/src/server.h
+++ b/src/server.h
@@ -201,6 +201,20 @@ typedef enum {
 #define PROTO_REPLY_MIN_BYTES (1024)           /* the lower limit on reply buffer size */
 #define REDIS_AUTOSYNC_BYTES (1024 * 1024 * 4) /* Sync file every 4MB. */
 
+#define PAYLOAD_BUCKET_COUNT 5
+#define PAYLOAD_BUCKET_64KB (64 * 1024)
+#define PAYLOAD_BUCKET_256KB (256 * 1024)
+#define PAYLOAD_BUCKET_1MB (1024 * 1024)
+#define PAYLOAD_BUCKET_5MB (5 * 1024 * 1024)
+
+static inline int payloadBytesBucketIndex(size_t bytes) {
+    if (bytes < PAYLOAD_BUCKET_64KB) return 0;
+    if (bytes < PAYLOAD_BUCKET_256KB) return 1;
+    if (bytes < PAYLOAD_BUCKET_1MB) return 2;
+    if (bytes < PAYLOAD_BUCKET_5MB) return 3;
+    return 4;
+}
+
 #define REPLY_BUFFER_DEFAULT_PEAK_RESET_TIME 5000     /* 5 seconds */
 #define REPLY_BUFFER_SIZE_UNAUTHENTICATED_CLIENT 1024 /* 1024 bytes */
 
@@ -1828,6 +1842,8 @@ struct valkeyServer {
     long long stat_net_repl_output_bytes;
     long long stat_net_cluster_slot_import_bytes;       /* Bytes read from slot import sources. */
     long long stat_net_cluster_slot_export_bytes;       /* Bytes written to slot export sources. */
+    unsigned long long stat_request_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
+    unsigned long long stat_reply_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
     size_t stat_current_cow_peak;                       /* Peak size of copy on write bytes. */
     size_t stat_current_cow_bytes;                      /* Copy on write bytes while child is active. */
     monotime stat_current_cow_updated;                  /* Last update time of stat_current_cow_bytes */
@@ -3320,6 +3336,7 @@ void unprepareCommand(client *c);
 int processCommand(client *c);
 int processPendingCommandAndInputBuffer(client *c);
 int processCommandAndResetClient(client *c);
+void trackPayloadBytesBuckets(client *c);
 void setupSignalHandlers(void);
 int createSocketAcceptHandler(connListener *sfd, aeFileProc *accept_handler);
 connListener *listenerByType(int type);

--- a/src/server.h
+++ b/src/server.h
@@ -1842,8 +1842,8 @@ struct valkeyServer {
     long long stat_net_repl_output_bytes;
     long long stat_net_cluster_slot_import_bytes;       /* Bytes read from slot import sources. */
     long long stat_net_cluster_slot_export_bytes;       /* Bytes written to slot export sources. */
-    unsigned long long stat_request_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
-    unsigned long long stat_reply_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
+    unsigned long long stat_request_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT]; /* Per-command request size buckets. */
+    unsigned long long stat_reply_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];   /* Per-command reply size buckets. */
     size_t stat_current_cow_peak;                       /* Peak size of copy on write bytes. */
     size_t stat_current_cow_bytes;                      /* Copy on write bytes while child is active. */
     monotime stat_current_cow_updated;                  /* Last update time of stat_current_cow_bytes */

--- a/src/server.h
+++ b/src/server.h
@@ -1842,8 +1842,6 @@ struct valkeyServer {
     long long stat_net_repl_output_bytes;
     long long stat_net_cluster_slot_import_bytes;       /* Bytes read from slot import sources. */
     long long stat_net_cluster_slot_export_bytes;       /* Bytes written to slot export sources. */
-    unsigned long long stat_request_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT]; /* Per-command request size buckets. */
-    unsigned long long stat_reply_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];   /* Per-command reply size buckets. */
     size_t stat_current_cow_peak;                       /* Peak size of copy on write bytes. */
     size_t stat_current_cow_bytes;                      /* Copy on write bytes while child is active. */
     monotime stat_current_cow_updated;                  /* Last update time of stat_current_cow_bytes */
@@ -1871,6 +1869,9 @@ struct valkeyServer {
     long long stat_client_outbuf_limit_disconnections; /* Total number of clients reached output buf length limit */
     long long stat_total_prefetch_entries;             /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;             /* Total number of prefetched batches */
+    /* Per-command payload size buckets (normal clients only). */
+    unsigned long long stat_request_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
+    unsigned long long stat_reply_payload_bytes_bucket[PAYLOAD_BUCKET_COUNT];
     /* The following two are used to track instantaneous metrics, like
      * number of operations per second, network traffic. */
     struct {

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -569,4 +569,77 @@ start_server {tags {"info" "external:skip"}} {
         assert_range [dict get $mem_stats overhead.db.hashtable.rehashing] 1 64
         assert_equal [dict get $mem_stats db.dict.rehashing.count] {1}
     }
+
+    test {payload buckets: info fields exist} {
+        set info [r INFO stats]
+        foreach field {request_payload_bytes_bucket_lt_64kb
+                       request_payload_bytes_bucket_64kb_256kb
+                       request_payload_bytes_bucket_256kb_1mb
+                       request_payload_bytes_bucket_1mb_5mb
+                       request_payload_bytes_bucket_gt_5mb
+                       reply_payload_bytes_bucket_lt_64kb
+                       reply_payload_bytes_bucket_64kb_256kb
+                       reply_payload_bytes_bucket_256kb_1mb
+                       reply_payload_bytes_bucket_1mb_5mb
+                       reply_payload_bytes_bucket_gt_5mb} {
+            set value [getInfoProperty $info $field]
+            assert {[string is integer -strict $value]}
+        }
+    }
+
+    test {payload buckets: request and reply increments} {
+        r config resetstat
+        set sizes {32768 131072 524288 2097152 6291456}
+        set req_fields {request_payload_bytes_bucket_lt_64kb
+                        request_payload_bytes_bucket_64kb_256kb
+                        request_payload_bytes_bucket_256kb_1mb
+                        request_payload_bytes_bucket_1mb_5mb
+                        request_payload_bytes_bucket_gt_5mb}
+        set rep_fields {reply_payload_bytes_bucket_lt_64kb
+                        reply_payload_bytes_bucket_64kb_256kb
+                        reply_payload_bytes_bucket_256kb_1mb
+                        reply_payload_bytes_bucket_1mb_5mb
+                        reply_payload_bytes_bucket_gt_5mb}
+
+        for {set i 0} {$i < [llength $sizes]} {incr i} {
+            set size [lindex $sizes $i]
+            set key "pbk:$i"
+            set val [string repeat x $size]
+            set req_field [lindex $req_fields $i]
+            set rep_field [lindex $rep_fields $i]
+
+            set info1 [r INFO stats]
+            set before_req [getInfoProperty $info1 $req_field]
+            assert {[string is integer -strict $before_req]}
+
+            r set $key $val
+
+            set info2 [r INFO stats]
+            set after_req [getInfoProperty $info2 $req_field]
+            assert {[string is integer -strict $after_req]}
+
+            if {$i == 0} {
+                assert {$after_req >= $before_req + 1}
+            } else {
+                assert_equal [expr {$before_req + 1}] $after_req
+            }
+
+            set before_rep [getInfoProperty $info2 $rep_field]
+            assert {[string is integer -strict $before_rep]}
+
+            r get $key
+
+            set info3 [r INFO stats]
+            set after_rep [getInfoProperty $info3 $rep_field]
+            assert {[string is integer -strict $after_rep]}
+
+            if {$i == 0} {
+                assert {$after_rep >= $before_rep + 1}
+            } else {
+                assert_equal [expr {$before_rep + 1}] $after_rep
+            }
+
+            r del $key
+        }
+    }
 }

--- a/tests/unit/info.tcl
+++ b/tests/unit/info.tcl
@@ -588,7 +588,9 @@ start_server {tags {"info" "external:skip"}} {
     }
 
     test {payload buckets: request and reply increments} {
-        r config resetstat
+        set c [valkey_client]
+        $c ping
+        $c config resetstat
         set sizes {32768 131072 524288 2097152 6291456}
         set req_fields {request_payload_bytes_bucket_lt_64kb
                         request_payload_bytes_bucket_64kb_256kb
@@ -608,13 +610,13 @@ start_server {tags {"info" "external:skip"}} {
             set req_field [lindex $req_fields $i]
             set rep_field [lindex $rep_fields $i]
 
-            set info1 [r INFO stats]
+            set info1 [$c INFO stats]
             set before_req [getInfoProperty $info1 $req_field]
             assert {[string is integer -strict $before_req]}
 
-            r set $key $val
+            $c set $key $val
 
-            set info2 [r INFO stats]
+            set info2 [$c INFO stats]
             set after_req [getInfoProperty $info2 $req_field]
             assert {[string is integer -strict $after_req]}
 
@@ -627,9 +629,9 @@ start_server {tags {"info" "external:skip"}} {
             set before_rep [getInfoProperty $info2 $rep_field]
             assert {[string is integer -strict $before_rep]}
 
-            r get $key
+            $c get $key
 
-            set info3 [r INFO stats]
+            set info3 [$c INFO stats]
             set after_rep [getInfoProperty $info3 $rep_field]
             assert {[string is integer -strict $after_rep]}
 
@@ -639,7 +641,9 @@ start_server {tags {"info" "external:skip"}} {
                 assert_equal [expr {$before_rep + 1}] $after_rep
             }
 
-            r del $key
+            $c del $key
         }
+
+        $c close
     }
 }


### PR DESCRIPTION
request/reply payload bucket counters (5 size ranges) to INFO stats
issue reference: https://github.com/valkey-io/valkey/issues/3099

New KPI fields in INFO stats:
```
request_payload_bytes_bucket_lt_64kb
request_payload_bytes_bucket_64kb_256kb
request_payload_bytes_bucket_256kb_1mb
request_payload_bytes_bucket_1mb_5mb
request_payload_bytes_bucket_gt_5mb
```

```
reply_payload_bytes_bucket_lt_64kb
reply_payload_bytes_bucket_64kb_256kb
reply_payload_bytes_bucket_256kb_1mb
reply_payload_bytes_bucket_1mb_5mb
reply_payload_bytes_bucket_gt_5mb
```
Benefits: exposes payload size distribution over time, revealing shifts in median/shape that throughput alone hides; helps correlate large payload trends with event loop pressure and latency; enables quick differentiation of small‑vs‑large traffic mixes for read vs write workloads.