### PR TITLE
latency doctor: report last seen timestamp for latency events

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -236,6 +236,8 @@ sds createLatencyReport(void) {
         char *event = dictGetKey(de);
         struct latencyTimeSeries *ts = dictGetVal(de);
         struct latencyStats ls;
+        int last;
+        int32_t last_time;
 
         if (ts == NULL) continue;
         eventnum++;
@@ -244,11 +246,8 @@ sds createLatencyReport(void) {
         }
         analyzeLatencyForEvent(event, &ls);
 
-        time_t last_time = 0;
-        int j;
-        for (j = 0; j < LATENCY_TS_LEN; j++) {
-            if (ts->samples[j].time > last_time) last_time = ts->samples[j].time;
-        }
+        last = (ts->idx + LATENCY_TS_LEN - 1) % LATENCY_TS_LEN;
+        last_time = ts->samples[last].time;
 
         report = sdscatprintf(
             report, "%d. %s: %d latency spikes (average %lums, mean deviation %lums, period %.2f sec).\n",

--- a/src/latency.c
+++ b/src/latency.c
@@ -244,11 +244,22 @@ sds createLatencyReport(void) {
         }
         analyzeLatencyForEvent(event, &ls);
 
-        report = sdscatprintf(report,
-                              "%d. %s: %d latency spikes (average %lums, mean deviation %lums, period %.2f sec). Worst "
-                              "all time event %lums.",
-                              eventnum, event, ls.samples, (unsigned long)ls.avg, (unsigned long)ls.mad,
-                              (double)ls.period / ls.samples, (unsigned long)ts->max);
+        time_t last_time = 0;
+        int j;
+        for (j = 0; j < LATENCY_TS_LEN; j++) {
+            if (ts->samples[j].time > last_time) last_time = ts->samples[j].time;
+        }
+
+        report = sdscatprintf(
+            report, "%d. %s: %d latency spikes (average %lums, mean deviation %lums, period %.2f sec).\n",
+            eventnum, event, ls.samples, (unsigned long)ls.avg, (unsigned long)ls.mad,
+            (double)ls.period / ls.samples);
+        if (last_time) {
+            report = sdscatprintf(report, "Last spike: %lds ago (%ld).\n",
+                                  (long)(time(NULL) - last_time), (long)last_time);
+        }
+        report = sdscatprintf(report, "Worst all time event: %lums.",
+                              (unsigned long)ts->max);
 
         /* Fork */
         if (!strcasecmp(event, "fork")) {

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -144,6 +144,18 @@ tags {"needs:debug"} {
         assert_morethan_equal $low 300
     }
 
+    test {LATENCY DOCTOR includes last spike info when samples exist} {
+        # Ensure "Xs ago" is at least 1s to avoid 0s in output.
+        after 1100
+        set res [r latency doctor]
+        if {$::verbose} {
+            puts "LATENCY DOCTOR data:"
+            puts $res
+        }
+        assert_match {*Last spike:*} $res
+        assert_match {*Worst all time event:*} $res
+    }
+
     r config set latency-monitor-threshold $old_threshold_value
 } ;# tag
 

--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -147,6 +147,10 @@ tags {"needs:debug"} {
     test {LATENCY DOCTOR includes last spike info when samples exist} {
         # Ensure "Xs ago" is at least 1s to avoid 0s in output.
         after 1100
+        # Create a fresh latency sample so the latest slot is populated.
+        r config set latency-monitor-threshold 200
+        r debug sleep 0.3
+        r config set latency-monitor-threshold 0
         set res [r latency doctor]
         if {$::verbose} {
             puts "LATENCY DOCTOR data:"


### PR DESCRIPTION
LATENCY DOCTOR reports the severity of latency spikes, but it does not indicate when a latency event last occurred. As a result, operators often need to run additional commands (such as LATENCY HISTORY) to determine whether a reported issue is ongoing or purely historical.

This change adds a last-spike timestamp to the LATENCY DOCTOR output for each latency event type that has recorded samples.

Example
```
LATENCY DOCTOR data:
Latency spikes are observed in this Valkey instance.

1. command: 3 latency spikes (average 403ms, mean deviation 66ms, period 1.67 sec).
Last spike: 2s ago (1769470127).
Worst all time event: 502ms.
```

This allows operators to quickly distinguish active latency issues from historical spikes without running separate commands.