### PR TITLE
Increase valkey-benchmark max latency bucket to 30 seconds

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -68,10 +68,10 @@
 #define MAX_LATENCY_PRECISION 4
 #define MAX_THREADS 500
 #define CLUSTER_SLOTS 16384
-#define CONFIG_LATENCY_HISTOGRAM_MIN_VALUE 10L              /* >= 10 usecs */
-#define CONFIG_LATENCY_HISTOGRAM_MAX_VALUE 3000000L         /* <= 3 secs(us precision) */
-#define CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE 3000000L /* <= 3 secs(us precision) */
-#define SHOW_THROUGHPUT_INTERVAL 250                        /* 250ms */
+#define CONFIG_LATENCY_HISTOGRAM_MIN_VALUE 10L               /* >= 10 usecs */
+#define CONFIG_LATENCY_HISTOGRAM_MAX_VALUE 30000000L         /* <= 30 secs(us precision) */
+#define CONFIG_LATENCY_HISTOGRAM_INSTANT_MAX_VALUE 30000000L /* <= 30 secs(us precision) */
+#define SHOW_THROUGHPUT_INTERVAL 250                         /* 250ms */
 
 #define CLIENT_GET_EVENTLOOP(c) (c->thread_id >= 0 ? config.threads[c->thread_id]->el : config.el)
 


### PR DESCRIPTION
## Summary

Increase the maximum latency histogram value in valkey-benchmark from 3 seconds to 30 seconds.

## Problem

When requests experience latencies greater than 3 seconds, they are capped at `CONFIG_LATENCY_HISTOGRAM_MAX_VALUE` (3,000,000 μsec) before being recorded in the HDR histogram. Due to HDR histogram bucket boundaries, these capped values are reported as ~3,000,319 μsec.

This causes two issues:

1. **Loss of precision**: All latencies above 3 seconds appear as the same value (~3,000,319 μsec), making it impossible to distinguish between a 4-second and a 30-second latency.

2. **Misleading metrics**: When benchmarking under stress conditions, slow queries, or network issues, the reported p99/p100 latencies significantly underrepresent the actual latency experienced.