### PR TITLE
Check expiration time first before lookup the key in GETEX command

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -324,18 +324,18 @@ void getexCommand(client *c) {
         return;
     }
 
+    /* Validate the expiration time value first */
+    long long milliseconds = 0;
+    if (expire && getExpireMillisecondsOrReply(c, expire, flags, unit, &milliseconds) != C_OK) {
+        return;
+    }
+
     robj *o;
 
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.null[c->resp])) == NULL)
         return;
 
     if (checkType(c, o, OBJ_STRING)) {
-        return;
-    }
-
-    /* Validate the expiration time value first */
-    long long milliseconds = 0;
-    if (expire && getExpireMillisecondsOrReply(c, expire, flags, unit, &milliseconds) != C_OK) {
         return;
     }
 

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -294,7 +294,11 @@ start_server {tags {"expire"}} {
         r del foo
         assert_error {ERR value is not an integer or out of range} {r getex foo ex abcd}
         r set foo bar
-        assert_error {ERR value is not an integer or out of range} {r getex foo ex -abcd}
+        assert_error {ERR value is not an integer or out of range} {r getex foo px -abcd}
+        r del foo
+        r hset foo f v
+        assert_error {ERR value is not an integer or out of range} {r getex foo exat -abcd}
+        r del foo
     }
 
     test {EXPIRE with big integer overflows when converted to milliseconds} {

--- a/tests/unit/expire.tcl
+++ b/tests/unit/expire.tcl
@@ -290,6 +290,13 @@ start_server {tags {"expire"}} {
         set e
     } {ERR invalid expire time in 'getex' command}
 
+    test {GETEX with error expiration time} {
+        r del foo
+        assert_error {ERR value is not an integer or out of range} {r getex foo ex abcd}
+        r set foo bar
+        assert_error {ERR value is not an integer or out of range} {r getex foo ex -abcd}
+    }
+
     test {EXPIRE with big integer overflows when converted to milliseconds} {
         r set foo bar
 


### PR DESCRIPTION
We should check expiration time value before we lookup the key,
otherwise we will return nil in this wrong case:
```
> getex key ex abcd
(nil)
> set key value
OK
> getex key ex abcd
(error) ERR value is not an integer or out of range

> hset foo f v
(integer) 1
> getex foo ex abcdef
(error) WRONGTYPE Operation against a key holding the wrong kind of value
```