### PR TITLE
remove unneeded include of expire.h

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -32,7 +32,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "expire.h"
 #include "hashtable.h"
 #include "rax.h"
 #include "sds.h"


### PR DESCRIPTION
This caused some unaligned load of server values on 32bit compilations.

Example: https://github.com/valkey-io/valkey/actions/runs/21352969942/job/61491923381?pr=3111#step:6:3064

Some insights here: https://github.com/valkey-io/valkey/pull/3111#issuecomment-3805700959