### PR TITLE
Fix Lua Module Build For MacOS Compatibility

### DIFF
--- a/deps/fpconv/CMakeLists.txt
+++ b/deps/fpconv/CMakeLists.txt
@@ -2,3 +2,5 @@ project(fpconv)
 
 set(SRCS "${CMAKE_CURRENT_LIST_DIR}/fpconv_dtoa.c" "${CMAKE_CURRENT_LIST_DIR}/fpconv_dtoa.h")
 add_library(fpconv STATIC ${SRCS})
+# Add -fPIC
+set_target_properties(fpconv PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,9 +21,12 @@ if (BUILD_LUA)
     add_subdirectory(modules/lua)
     add_dependencies(valkey-server valkeylua)
     target_compile_definitions(valkey-server PRIVATE LUA_ENABLED)
-    target_compile_definitions(valkey-server PRIVATE LUA_LIB=libvalkeylua.so)
-    target_link_options(valkey-server PRIVATE -Wl,--disable-new-dtags)
-
+    if (UNIX AND NOT APPLE)
+        target_compile_definitions(valkey-server PRIVATE LUA_LIB=libvalkeylua.so)
+        target_link_options(valkey-server PRIVATE -Wl,--disable-new-dtags)
+    else ()
+        target_compile_definitions(valkey-server PRIVATE LUA_LIB=libvalkeylua.dylib)
+    endif ()
     set(VALKEY_INSTALL_RPATH "")
     set_target_properties(valkey-server PROPERTIES
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR};${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"

--- a/src/modules/lua/CMakeLists.txt
+++ b/src/modules/lua/CMakeLists.txt
@@ -11,12 +11,13 @@ set(LUA_ENGINE_SRCS
     script_lua.c
     function_lua.c
     debug_lua.c
-    list.c)
+    list.c
+    ../../sha1.c
+    ../../rand.c)
 
 add_library(valkeylua SHARED "${LUA_ENGINE_SRCS}")
 
-add_dependencies(valkeylua lualib)
-target_link_libraries(valkeylua PRIVATE lualib)
+target_link_libraries(valkeylua PRIVATE lualib fpconv)
 target_include_directories(valkeylua PRIVATE ../../../deps/lua/src)
 
 install(TARGETS valkeylua


### PR DESCRIPTION
This PR fixes various issues with Lua module built on macOS using CMake / Apple Clang.

## Summary of changes

The Lua module build configuration has been updated to support macOS in addition to Linux. Two key changes were made to resolve build issues on Apple platforms.

First, the valkeylua shared library now explicitly includes `sha1.c` and `rand.c` source files and links against the fpconv library, ensuring all required symbols are available at link time.

Second, the --disable-new-dtags linker flag is now conditionally applied only on Unix systems excluding macOS, since this flag is not supported by the Apple linker.

In addition, enable position independent code compilation for the fpconv static library by setting the `POSITION_INDEPENDENT_CODE` property. This allows the library to be linked into shared libraries and position-independent executables.

Last, the Lua library filename definition was previously hardcoded to use the `.so` extension for all platforms. This change conditionally sets the library name based on the target platform: `.so` for Linux/Unix systems and `.dylib` for macOS (and other non-Linux Unix systems). This ensures that the correct dynamic library extension is used when loading the Lua module at runtime.

** Generated by CodeLite. **