### PR TITLE
Skip active io time test if valgrind is used

### DIFF
--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -39,6 +39,9 @@ start_server {config "minimal.conf" tags {"external:skip"} overrides {enable-deb
     # Skip if non io-threads mode - as it is relevant only for io-threads mode
     assert_equal {io-threads 5} [r config get io-threads]
     test {Force the use of IO threads and assert active IO thread usage} {
+        if {$::valgrind} {
+            skip "Too slow with Valgrind"
+        }
         activate_io_threads_and_wait
         set info [r info]
         set io_threads_count [dict get [r config get io-threads] io-threads]


### PR DESCRIPTION
If valgrind is used then test for used_active_time_io_thread fails because valgrind is slow, so skip it
```
[err]: Force the use of IO threads and assert active IO thread usage in tests/unit/io-threads.tcl                                                                                                                     
Expected (7.941596 - 5.876588) < (1000/1000) (context: type eval line 53 cmd {assert {($used_active_time - $initial_active_times($i)) < ($sleep_time_ms/1000)}} proc ::test)
```