### PR TITLE
Fix mixup of reply-larger-than and request-larger-than

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -575,7 +575,7 @@ static size_t _addReplyPayloadToBuffer(client *c, const void *payload, size_t le
     size_t available = c->buf_usable_size - c->bufpos;
     size_t reply_len = min(available, len);
     if (c->flag.buf_encoded) {
-        int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold != -1);
+        int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
         reply_len = upsertPayloadHeader(c->buf, &c->bufpos, &c->last_header, payload_type, len, c->slot, track_bytes, available);
     }
     if (!reply_len) return 0;
@@ -626,7 +626,7 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         size_t copy = avail >= len ? len : avail;
 
         if (tail->flag.buf_encoded) {
-            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold != -1);
+            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
             copy = upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, avail);
         } else if (encoded) {
             /* If encoded buffer is required but tail is unencoded then pretend nothing can be added to it
@@ -655,7 +655,7 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         tail->flag.buf_encoded = encoded;
         tail->last_header = NULL;
         if (tail->flag.buf_encoded) {
-            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold != -1);
+            int track_bytes = (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1);
             upsertPayloadHeader(tail->buf, &tail->used, &tail->last_header, payload_type, len, c->slot, track_bytes, tail->size);
         }
         memcpy(tail->buf + tail->used, payload, len);
@@ -1416,7 +1416,7 @@ void addReplyBulk(client *c, robj *obj) {
     if (tryAvoidBulkStrCopyToReply(c, obj) == C_OK) {
         /* If copy avoidance allowed, then we explicitly maintain net_output_bytes_curr_cmd.
          * We determine per-reply if tracking is enabled by checking the config in the main thread. */
-        if (server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold != -1) {
+        if (server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold != -1) {
             serverAssert(obj->encoding == OBJ_ENCODING_RAW);
             size_t str_len = sdslen(objectGetVal(obj));
             uint32_t num_len = digits10(str_len);
@@ -2783,7 +2783,7 @@ static void releaseBufReferences(char *buf, size_t bufpos) {
         ptr += sizeof(payloadHeader);
 
         if (header->payload_type == BULK_STR_REF) {
-            /* When net byte tracking was disabled in the main thread (commandlog-request-larger-than -1)
+            /* When net byte tracking was disabled in the main thread (commandlog-reply-larger-than -1)
              * at the time this reply was added, we account for cluster slot stats here in the IO thread
              * after writing the reply. When tracking was enabled, it's already accounted in the main thread
              * via afterCommand() -> clusterSlotStatsAddNetworkBytesOutForUserClient(). */

--- a/tests/unit/cluster/slot-stats.tcl
+++ b/tests/unit/cluster/slot-stats.tcl
@@ -1009,7 +1009,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         R 0 config set min-string-size-avoid-copy-reply 1
         
         # Disable commandlog tracking
-        R 0 config set commandlog-request-larger-than -1
+        R 0 config set commandlog-reply-larger-than -1
         R 0 config resetstat
         
         set value [string repeat A 2048]
@@ -1033,7 +1033,7 @@ start_cluster 1 0 {tags {external:skip cluster} overrides {cluster-slot-stats-en
         assert_equal $network_bytes_out 2057
         
         # Re-enable commandlog
-        R 0 config set commandlog-request-larger-than 1024
+        R 0 config set commandlog-reply-larger-than 1024
         R 0 config resetstat
         
         # Get should still track correctly

--- a/tests/unit/commandlog.tcl
+++ b/tests/unit/commandlog.tcl
@@ -381,8 +381,8 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         set copy_avoid [lindex [r config get min-string-size-avoid-copy-reply] 1]
         r config set min-string-size-avoid-copy-reply 1
         
-        # Disable request tracking
-        r config set commandlog-request-larger-than -1
+        # Disable reply tracking
+        r config set commandlog-reply-larger-than -1
         r commandlog reset large-reply
         
         set value [string repeat A 2048]
@@ -393,7 +393,7 @@ start_server {tags {"commandlog"} overrides {commandlog-execution-slower-than 10
         assert_equal [r commandlog len large-reply] 0
         
         # Enable tracking
-        r config set commandlog-request-larger-than 1024
+        r config set commandlog-reply-larger-than 1024
         r commandlog reset large-reply
         
         # Get the value again, should be tracked

--- a/valkey.conf
+++ b/valkey.conf
@@ -2157,9 +2157,6 @@ commandlog-slow-execution-max-len 128
 #
 # The threshold is measured in bytes.
 # Note that -1 disables the large request log, while 0 forces logging of every command.
-# Enabling this feature (values other than -1) has performance implications
-# when I/O threads are used due to additional tracking overhead.
-# Consider using -1 to disable if large request monitoring is not needed.
 commandlog-request-larger-than 1048576
 # Record the number of commands.
 # There is no limit to this length. Just be aware that it will consume memory.
@@ -2174,6 +2171,9 @@ commandlog-large-request-max-len 128
 #
 # The threshold is measured in bytes.
 # Note that -1 disables the large reply log, while 0 forces logging of every command.
+# Enabling this feature (values other than -1) has performance implications
+# when I/O threads are used due to additional tracking overhead.
+# Consider using -1 to disable if large request monitoring is not needed.
 commandlog-reply-larger-than 1048576
 # Record the number of commands.
 # There is no limit to this length. Just be aware that it will consume memory.

--- a/valkey.conf
+++ b/valkey.conf
@@ -2173,7 +2173,7 @@ commandlog-large-request-max-len 128
 # Note that -1 disables the large reply log, while 0 forces logging of every command.
 # Enabling this feature (values other than -1) has performance implications
 # when I/O threads are used due to additional tracking overhead.
-# Consider using -1 to disable if large request monitoring is not needed.
+# Consider using -1 to disable if large reply monitoring is not needed.
 commandlog-reply-larger-than 1048576
 # Record the number of commands.
 # There is no limit to this length. Just be aware that it will consume memory.


### PR DESCRIPTION
This change amends #3086 in which `commandlog-request-larger-than` was mixed up with `commandlog-reply-larger-than` while checking for config values and in tests.