### PR TITLE
Remove empty list dead code condition in lmoveGenericCommand code

### DIFF
--- a/src/t_list.c
+++ b/src/t_list.c
@@ -1109,28 +1109,22 @@ void lmoveGenericCommand(client *c, int wherefrom, int whereto) {
     if ((sobj = lookupKeyWriteOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, sobj, OBJ_LIST))
         return;
 
-    if (listTypeLength(sobj) == 0) {
-        /* This may only happen after loading very old RDB files. Recent
-         * versions of the server delete keys of empty lists. */
-        addReplyNull(c);
-    } else {
-        robj *dobj = lookupKeyWrite(c->db, c->argv[2]);
-        robj *touchedkey = c->argv[1];
+    robj *dobj = lookupKeyWrite(c->db, c->argv[2]);
+    robj *touchedkey = c->argv[1];
 
-        if (checkType(c, dobj, OBJ_LIST)) return;
-        value = listTypePop(sobj, wherefrom);
-        serverAssert(value); /* assertion for valgrind (avoid NPD) */
-        lmoveHandlePush(c, c->argv[2], dobj, value, whereto);
-        listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, NULL);
+    if (checkType(c, dobj, OBJ_LIST)) return;
+    value = listTypePop(sobj, wherefrom);
+    serverAssert(value); /* assertion for valgrind (avoid NPD) */
+    lmoveHandlePush(c, c->argv[2], dobj, value, whereto);
+    listElementsRemoved(c, touchedkey, wherefrom, sobj, 1, NULL);
 
-        /* listTypePop returns an object with its refcount incremented */
-        decrRefCount(value);
+    /* listTypePop returns an object with its refcount incremented */
+    decrRefCount(value);
 
-        if (c->cmd->proc == blmoveCommand) {
-            rewriteClientCommandVector(c, 5, shared.lmove, c->argv[1], c->argv[2], c->argv[3], c->argv[4]);
-        } else if (c->cmd->proc == brpoplpushCommand) {
-            rewriteClientCommandVector(c, 3, shared.rpoplpush, c->argv[1], c->argv[2]);
-        }
+    if (c->cmd->proc == blmoveCommand) {
+        rewriteClientCommandVector(c, 5, shared.lmove, c->argv[1], c->argv[2], c->argv[3], c->argv[4]);
+    } else if (c->cmd->proc == brpoplpushCommand) {
+        rewriteClientCommandVector(c, 3, shared.rpoplpush, c->argv[1], c->argv[2]);
     }
 }
 


### PR DESCRIPTION
Since commit cbda492909cd2fff25263913cd2e1f00bc48a541, we will no
longer load empty lists from the RDB.