### PR TITLE
Add waits in test-ubuntu-reclaim-cache

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -557,10 +557,10 @@ jobs:
           CACHE0=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
           echo "$CACHE0"
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080 --repl-diskless-sync no --pidfile /tmp/master/valkey.pid --rdbcompression no --enable-debug-command yes
-          until ./src/valkey-cli -p 8080 ping > /dev/null 2>&1; do sleep 0.1; done
+          sleep 1 # wait for server startup
           ./src/valkey-cli -p 8080 debug populate 10000 k 102400
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/slave --port 8081 --repl-diskless-load disabled --rdbcompression no
-          until ./src/valkey-cli -p 8081 ping > /dev/null 2>&1; do sleep 0.1; done
+          sleep 1 # wait for server startup
           ./src/valkey-cli -p 8080 save > /dev/null
           VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
           echo $VMOUT
@@ -587,7 +587,7 @@ jobs:
           kill -15 $PID
           while [ -x /proc/${PID} ]; do sleep 1; done
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080
-          until ./src/valkey-cli -p 8080 ping > /dev/null 2>&1; do sleep 0.1; done
+          sleep 1 # wait for server startup
           while [ $(./src/valkey-cli -p 8080 info persistence | grep "loading:1") ]; do sleep 1; done;
           sleep 1 # wait for the completion of cache reclaim bio
           VMOUT=$(vmtouch -v /tmp/master/dump.rdb)

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -557,8 +557,10 @@ jobs:
           CACHE0=$(grep -w file /sys/fs/cgroup/memory.stat | awk '{print $2}')
           echo "$CACHE0"
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080 --repl-diskless-sync no --pidfile /tmp/master/valkey.pid --rdbcompression no --enable-debug-command yes
+          until ./src/valkey-cli -p 8080 ping > /dev/null 2>&1; do sleep 0.1; done
           ./src/valkey-cli -p 8080 debug populate 10000 k 102400
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/slave --port 8081 --repl-diskless-load disabled --rdbcompression no
+          until ./src/valkey-cli -p 8081 ping > /dev/null 2>&1; do sleep 0.1; done
           ./src/valkey-cli -p 8080 save > /dev/null
           VMOUT=$(vmtouch -v /tmp/master/dump.rdb)
           echo $VMOUT
@@ -585,6 +587,7 @@ jobs:
           kill -15 $PID
           while [ -x /proc/${PID} ]; do sleep 1; done
           ./src/valkey-server --daemonize yes --logfile /dev/null --dir /tmp/master --port 8080
+          until ./src/valkey-cli -p 8080 ping > /dev/null 2>&1; do sleep 0.1; done
           while [ $(./src/valkey-cli -p 8080 info persistence | grep "loading:1") ]; do sleep 1; done;
           sleep 1 # wait for the completion of cache reclaim bio
           VMOUT=$(vmtouch -v /tmp/master/dump.rdb)


### PR DESCRIPTION
After #3103 time sensitive `test-ubuntu-reclaim-cache` started to fail because now startup always includes 30ms of calibration of HW clock, that's why we get this output:
```
Run echo "test SAVE doesn't increase cache"
test SAVE doesn't increase cache
2460491776
Could not connect to Valkey at 127.0.0.1:8080: Connection refused
```

Added waits for server to start, locally run, it helps