### PR TITLE
Add remaining_repl_size field in CLUSTER GETSLOTMIGRATIONS output

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1444,8 +1444,7 @@ int slotExportTryDoPause(slotMigrationJob *job) {
 
     if (server.debug_slot_migration_prevent_pause ||
         (server.slot_migration_max_failover_repl_bytes >= 0 &&
-         getClientOutputBufferMemoryUsage(job->client) >
-             (size_t)server.slot_migration_max_failover_repl_bytes)) {
+         job->client->reply_bytes > (size_t)server.slot_migration_max_failover_repl_bytes)) {
         return C_ERR;
     }
     serverLog(LL_NOTICE,
@@ -2418,7 +2417,7 @@ void clusterCommandGetSlotMigrations(client *c) {
         addReplyLongLong(c, (long long)job->stat_cow_bytes);
         addReplyBulkCString(c, "remaining_repl_size");
         if (job->type == SLOT_MIGRATION_EXPORT && job->client) {
-            addReplyLongLong(c, (long long)getClientOutputBufferMemoryUsage(job->client));
+            addReplyLongLong(c, (long long)job->client->reply_bytes);
         } else {
             addReplyLongLong(c, 0);
         }

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -2389,7 +2389,7 @@ void clusterCommandGetSlotMigrations(client *c) {
     listRewind(server.cluster->slot_migration_jobs, &li);
     while ((ln = listNext(&li)) != NULL) {
         slotMigrationJob *job = ln->value;
-        addReplyMapLen(c, job->is_tracking_only ? 9 : 11);
+        addReplyMapLen(c, job->is_tracking_only ? 10 : 12);
         addReplyBulkCString(c, "name");
         addReplyBulkCBuffer(c, job->name, CLUSTER_NAMELEN);
         addReplyBulkCString(c, "operation");
@@ -2416,6 +2416,12 @@ void clusterCommandGetSlotMigrations(client *c) {
         addReplyBulkCString(c, job->status_msg ? job->status_msg : "");
         addReplyBulkCString(c, "cow_size");
         addReplyLongLong(c, (long long)job->stat_cow_bytes);
+        addReplyBulkCString(c, "remaining_repl_size");
+        if (job->type == SLOT_MIGRATION_EXPORT && job->client) {
+            addReplyLongLong(c, (long long)getClientOutputBufferMemoryUsage(job->client));
+        } else {
+            addReplyLongLong(c, 0);
+        }
     }
 }
 

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -325,6 +325,9 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
         assert_equal [dict get $import_migration create_time] $import_create_time
         assert_equal [dict get $export_migration create_time] $export_create_time
 
+        assert_equal [dict get $export_migration remaining_repl_size] 0
+        assert_equal [dict get $import_migration remaining_repl_size] 0
+
         set_debug_prevent_pause 0
     }
 
@@ -2427,5 +2430,45 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster aofrw} overrides {
         assert_match "500" [R 5 CLUSTER COUNTKEYSINSLOT 16383]
         assert_equal $slots_start [R 0 CLUSTER SLOTS]
         assert_match "OK" [R 2 FLUSHDB SYNC]
+    }
+}
+
+start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluster-require-full-coverage no slot-migration-max-failover-repl-bytes 0}} {
+    test "Slot migration remaining_repl_size on the source node" {
+        set 16383_slot_tag "{6ZJ}"
+        set_debug_prevent_pause 1
+
+        # Move 16383 from R0 to R2
+        assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE [R 0 CLUSTER MYID]]
+        set jobname [get_job_name 2 16383]
+        wait_for_migration_field 2 $jobname state waiting-to-pause
+
+        # Check before the migration.
+        set import_migration [get_migration_by_name 0 $jobname]
+        set export_migration [get_migration_by_name 2 $jobname]
+        assert_equal [dict get $export_migration remaining_repl_size] 0
+        assert_equal [dict get $import_migration remaining_repl_size] 0
+
+        # Pause R0 and generate some data to populate the buffer.
+        pause_process [srv 0 pid]
+        set bigstr [string repeat x 1000000]
+        for {set j 0} {$j < 50} {incr j} {
+            R 2 set "$16383_slot_tag:key:" $bigstr
+        }
+
+        # Check R0 remaining repl size is OK.
+        set export_migration [get_migration_by_name 2 $jobname]
+        assert_morethan_equal [dict get $export_migration remaining_repl_size] [expr 1024000 * 25]
+
+        # Resume R0 and wait for R0 to finish the migration.
+        resume_process [srv 0 pid]
+        set_debug_prevent_pause 0
+        wait_for_migration 0 16383
+
+        # Check after the migration.
+        set import_migration [get_migration_by_name 0 $jobname]
+        set export_migration [get_migration_by_name 2 $jobname]
+        assert_equal [dict get $export_migration remaining_repl_size] 0
+        assert_equal [dict get $import_migration remaining_repl_size] 0
     }
 }

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2451,7 +2451,7 @@ start_cluster 3 0 {tags {logreqres:skip external:skip cluster} overrides {cluste
 
         # Pause R0 and generate some data to populate the buffer.
         pause_process [srv 0 pid]
-        set bigstr [string repeat x 1000000]
+        set bigstr [string repeat x 1024000]
         for {set j 0} {$j < 50} {incr j} {
             R 2 set "$16383_slot_tag:key:" $bigstr
         }

--- a/valkey.conf
+++ b/valkey.conf
@@ -2029,10 +2029,14 @@ aof-timestamp-enabled no
 # During the CLUSTER MIGRATESLOTS command execution, the source node needs to pause itself and allow all
 # writes to be fully processed by the target node. The amount of data remaining in the buffer on the
 # source node when this pause happens will affect how long this pause takes.
+#
 # 'slot-migration-max-failover-repl-bytes' allows the pause to wait until there are at most this
 # many bytes in the output buffer. Setting this to -1 will disable this limit, and 0 will require
-# no data be in the source output buffer (although this is not a guaranatee the data is fully
-# received by the target). 
+# no data be in the source output buffer (although this is not a guarantee the data is fully
+# received by the target).
+#
+# You can check the remaining buffer data size by examining the 'remaining_repl_size' field in the
+# 'CLUSTER MIGRATESLOTS' command output on the source node.
 #
 # slot-migration-max-failover-repl-bytes 0
 


### PR DESCRIPTION
There should be a way for people to monitor the amount of output buffer
data accumulating at the source node during the migration process.

This PR also do a change in slotExportTryDoPause, previously, we used 
`getClientOutputBufferMemoryUsage` to determine if the offset was sufficient
to trigger the pause, it also adding the listNode overhead. Now we use
client->bytes.