### PR TITLE
Revert #3088

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -14127,7 +14127,6 @@ int *VM_GetCommandKeysWithFlags(ValkeyModuleCtx *ctx,
         if (out_flags) (*out_flags)[i] = moduleConvertKeySpecsFlags(result.keys[i].flags, 0);
     }
 
-    getKeysFreeResult(&result);
     return res;
 }
 

--- a/tests/unit/moduleapi/getkeys.tcl
+++ b/tests/unit/moduleapi/getkeys.tcl
@@ -74,18 +74,6 @@ start_server {tags {"modules"}} {
         assert_match {*has no permissions to access the 'write' key*} [r ACL DRYRUN testuser getkeys.command_with_flags key write]
     }
 
-    test "introspect with > MAX_KEYS_BUFFER keys triggers VM_GetCommandKeysWithFlags heap alloc" {
-        set args {}
-        for {set i 0} {$i < 300} {incr i} {
-            lappend args key k$i
-        }
-        set reply [r getkeys.introspect 1 getkeys.command_with_flags {*}$args]
-        assert_equal {300} [llength $reply]
-        foreach pair $reply {
-            assert_equal {2} [llength $pair]
-        }
-    }
-
     test "Unload the module - getkeys" {
         assert_equal {OK} [r module unload getkeys]
     }


### PR DESCRIPTION
Reverts "Fix the memory leak in the VM_GetCommandKeysWithFlags function (#3088)"

This reverts commit 2e2eb418f97ee8ac0dcccd1d5d790697bd0fa43e.