### PR TITLE
Optimize rehash completion check for empty hash table

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -562,7 +562,9 @@ static void rehashStepFinalize(hashtable *ht) {
 
     /* Advance to the next bucket. */
     ht->rehash_idx++;
-    if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0])) {
+
+    /* Check if we already rehashed the whole table. */
+    if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0]) || ht->used[0] == 0) {
         rehashingCompleted(ht);
     }
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -564,7 +564,7 @@ static void rehashStepFinalize(hashtable *ht) {
     ht->rehash_idx++;
 
     /* Check if we already rehashed the whole table. */
-    if ((size_t)ht->rehash_idx >= numBuckets(ht->bucket_exp[0]) || ht->used[0] == 0) {
+    if (ht->used[0] == 0 && ht->child_buckets[0] == 0) {
         rehashingCompleted(ht);
     }
 }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -566,6 +566,8 @@ static void rehashStepFinalize(hashtable *ht) {
     /* Check if we already rehashed the whole table. */
     if (ht->used[0] == 0 && ht->child_buckets[0] == 0) {
         rehashingCompleted(ht);
+    } else {
+        assert((size_t)ht->rehash_idx < numBuckets(ht->bucket_exp[0]));
     }
 }
 


### PR DESCRIPTION
It is possible to have an empty table with only empty buckets
remaining, and we are still rehashing those empty buckets. If
table 0 is empty (both used and child_buckets are empty), we can
simply finish the rehashing process, since we no longer have any
elements (buckets) to rehash.