### PR TITLE
Add test-tls-only CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: show-kernel-log
         run: sudo dmesg -c
 
-  test-tls:
+  test-tls-only:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
   test-tls-only:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: generate-test-certificates
         run: ./utils/gen-test-certs.sh
       - name: install-test-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,25 @@ jobs:
       - name: show-kernel-log
         run: sudo dmesg -c
 
+  test-tls:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: generate-test-certificates
+        run: ./utils/gen-test-certs.sh
+      - name: install-test-dependencies
+        run: sudo apt-get install -y tcl8.6 tclx tcl-tls
+      - name: make-tls-module
+        run: make -j4 BUILD_TLS=module SERVER_CFLAGS='-Werror'
+      - name: test-tls-module
+        run: ./runtest --verbose --single unit/tls --dump-logs --tls-module
+      - name: make-tls-builtin
+        run: |
+          make distclean
+          make -j4 BUILD_TLS=yes SERVER_CFLAGS='-Werror'
+      - name: test-tls-builtin
+        run: ./runtest --verbose --single unit/tls --dump-logs --tls
+
   build-debian-old:
     runs-on: ubuntu-latest
     container: debian:bullseye


### PR DESCRIPTION
Similar to `test-rdma`, add a CI specifically for TLS to build and test both built-in and module modes.