### PR TITLE
CI: Stop using symlinks for tests with CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,7 @@ jobs:
         run: |
           sudo apt-get install -y tcl8.6 tclx tcl-tls
           ./utils/gen-test-certs.sh
-          ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-server
-          ln -sf $(pwd)/build-release/bin/valkey-cli $(pwd)/src/valkey-cli
-          ln -sf $(pwd)/build-release/bin/valkey-benchmark $(pwd)/src/valkey-benchmark
-          ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-check-aof
-          ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-check-rdb
-          ln -sf $(pwd)/build-release/bin/valkey-server $(pwd)/src/valkey-sentinel
-          ./runtest --verbose --tags -slow --dump-logs --tls
+          ./build-release/runtest --verbose --tags -slow --dump-logs --tls
       - name: unit tests
         run: |
           ./build-release/bin/valkey-unit-tests

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -87,7 +87,7 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
 
         if {$::tls} {
             if {$::tls_module} {
-                puts $cfg [format "loadmodule %s/../../../src/valkey-tls.so" [pwd]]
+                puts $cfg "loadmodule $::VALKEY_TLS_MODULE"
             }
 
             puts $cfg "tls-port $port"

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -545,7 +545,7 @@ proc start_server {options {code undefined}} {
     set config {}
     if {$::tls} {
         if {$::tls_module} {
-            lappend config_lines [list "loadmodule" [format "%s/src/valkey-tls.so" [pwd]]]
+            lappend config_lines [list "loadmodule" $::VALKEY_TLS_MODULE]
         }
         dict set config "tls-cert-file" [format "%s/tests/tls/server.crt" [pwd]]
         dict set config "tls-key-file" [format "%s/tests/tls/server.key" [pwd]]

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -27,6 +27,14 @@ set ::VALKEY_CHECK_AOF_BIN [valkey_bin_absolute_path "valkey-check-aof"]
 set ::VALKEY_CHECK_RDB_BIN [valkey_bin_absolute_path "valkey-check-rdb"]
 set ::VALKEY_SENTINEL_BIN  [valkey_bin_absolute_path "valkey-sentinel"]
 
+# TLS module path: in CMake builds it's in lib/, in Make builds it's in src/
+if {[info exists ::env(VALKEY_BIN_DIR)]} {
+    # CMake build: lib/ is sibling to bin/
+    set ::VALKEY_TLS_MODULE [file join [file dirname $::VALKEY_BIN_DIR] "lib" "valkey-tls.so"]
+} else {
+    set ::VALKEY_TLS_MODULE "[pwd]/src/valkey-tls.so"
+}
+
 if {![file executable $::VALKEY_SERVER_BIN]} {
     error "Binary not found or not executable: $::VALKEY_SERVER_BIN"
 }

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -30,9 +30,9 @@ set ::VALKEY_SENTINEL_BIN  [valkey_bin_absolute_path "valkey-sentinel"]
 # TLS module path: in CMake builds it's in lib/, in Make builds it's in src/
 if {[info exists ::env(VALKEY_BIN_DIR)]} {
     # CMake build: lib/ is sibling to bin/
-    set ::VALKEY_TLS_MODULE [file join [file dirname $::VALKEY_BIN_DIR] "lib" "valkey-tls.so"]
+    set ::VALKEY_TLS_MODULE [file join [file dirname $::VALKEY_BIN_DIR] "lib" "valkey-tls${::VALKEY_PROG_SUFFIX}.so"]
 } else {
-    set ::VALKEY_TLS_MODULE "[pwd]/src/valkey-tls.so"
+    set ::VALKEY_TLS_MODULE "[pwd]/src/valkey-tls${::VALKEY_PROG_SUFFIX}.so"
 }
 
 if {![file executable $::VALKEY_SERVER_BIN]} {

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -290,10 +290,10 @@ test {Migrate the last slot away from a node using valkey-cli} {
         # waiting for cluster_state to be okay is an independent check that all the
         # nodes actually believe each other are healthy, prevent cluster down error.
         wait_for_condition 1000 50 {
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
-            [catch {exec src/valkey-cli --cluster check 127.0.0.1:[srv -3 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv 0 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -1 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -2 port]}] == 0 &&
+            [catch {exec $::VALKEY_CLI_BIN --cluster check 127.0.0.1:[srv -3 port]}] == 0 &&
             [CI 0 cluster_state] eq {ok} &&
             [CI 1 cluster_state] eq {ok} &&
             [CI 2 cluster_state] eq {ok} &&
@@ -502,7 +502,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
         # 4 batches to migrate 100 keys
         for {set i 0} {$i < 4} {incr i} {
             if {$use_atomic_slot_migration} {
-                exec src/valkey-cli --cluster-yes --cluster reshard 127.0.0.1:[srv 0 port] \
+                exec $::VALKEY_CLI_BIN --cluster-yes --cluster reshard 127.0.0.1:[srv 0 port] \
                                     --cluster-to [$node3 cluster myid] \
                                     --cluster-from [$node1 cluster myid] \
                                     --cluster-pipeline 25 \

--- a/tests/unit/fuzzer.tcl
+++ b/tests/unit/fuzzer.tcl
@@ -3,7 +3,7 @@ tags {"slow"} {
         start_server {} {
             test {FUZZ stresser with valkey-benchmark} {
                 assert_equal [r ping] {PONG}
-                set err [catch {exec src/valkey-benchmark  -p [srv 0 port] -c 20 -n 100000 --fuzz --fuzz-loglevel info} output]
+                set err [catch {exec $::VALKEY_BENCHMARK_BIN -p [srv 0 port] -c 20 -n 100000 --fuzz --fuzz-loglevel info} output]
                 if {$err && $::verbose} {
                     # For now, if the server is still responsive, we don't consider the test a failure even if the fuzzer failed.
                     puts $output

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -332,7 +332,7 @@ start_server {tags {"tls"}} {
 
         proc test_tls_cert_rejection {cert_type cert_path expected_error} {
             set tlsdir [file normalize ./tests/tls]
-            set server_path [file normalize ./src/valkey-server]
+            set server_path $::VALKEY_SERVER_BIN
             set server_cert $tlsdir/server.crt
             set server_key $tlsdir/server.key
             set client_cert $tlsdir/client.crt
@@ -355,7 +355,7 @@ start_server {tags {"tls"}} {
             if {$ca_cert_dir ne ""}  { lappend cmd --tls-ca-cert-dir  $ca_cert_dir }
 
             if {$::tls_module} {
-                lappend cmd --loadmodule [file normalize ./src/valkey-tls.so]
+                lappend cmd --loadmodule $::VALKEY_TLS_MODULE
             }
 
             catch {exec {*}$cmd 2>@1} err


### PR DESCRIPTION
Follow-up to my previous CMake PR https://github.com/valkey-io/valkey/pull/2816.

**Changes:**

1. **`.github/workflows/ci.yml`** - Removed symlinks, use `./build-release/runtest` instead of `./runtest`
2. **`tests/support/set_executable_path.tcl`** - Added `::VALKEY_TLS_MODULE` variable
3. **Fixed hardcoded paths in 5 test files:**
   - `tests/unit/tls.tcl` - server and TLS module paths
   - `tests/unit/fuzzer.tcl` - benchmark path
   - `tests/unit/cluster/cli.tcl` - CLI path
   - `tests/support/server.tcl` - TLS module path
   - `tests/instances.tcl` - TLS module path

**Result:** All tests passed. The only failure was an unrelated flaky test (`client-eviction.tcl`) that's been failing since TLS was added to the cmake job - tracked in issue #3146.