### PR TITLE
Fix array bounds error for non-tls build

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -73,7 +73,7 @@
 #include "tls.h"
 #include <stdatomic.h>
 
-static unsigned int bio_job_to_worker[] = {
+static unsigned int bio_job_to_worker[BIO_NUM_OPS] = {
     [BIO_CLOSE_FILE] = 0,
     [BIO_AOF_FSYNC] = 1,
     [BIO_CLOSE_AOF] = 1,
@@ -238,10 +238,12 @@ void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
     bioSubmitJob(BIO_RDB_SAVE, job);
 }
 
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 void bioCreateTlsReloadJob(void) {
     bio_job *job = zmalloc(sizeof(*job));
     bioSubmitJob(BIO_TLS_RELOAD, job);
 }
+#endif
 
 void *bioProcessBackgroundJobs(void *arg) {
     bio_worker_data *const bwd = arg;
@@ -307,13 +309,13 @@ void *bioProcessBackgroundJobs(void *arg) {
             job->free_args.free_fn(job->free_args.free_args);
         } else if (job_type == BIO_RDB_SAVE) {
             replicaReceiveRDBFromPrimaryToDisk(job->save_to_disk_args.conn, job->save_to_disk_args.is_dual_channel);
-        } else if (job_type == BIO_TLS_RELOAD) {
+        }
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+        else if (job_type == BIO_TLS_RELOAD) {
             tlsConfigureAsync();
-#else
-            serverPanic("BIO_TLS_RELOAD job type requires built-in TLS (BUILD_TLS=yes).");
+        }
 #endif
-        } else {
+        else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
         zfree(job);

--- a/src/bio.c
+++ b/src/bio.c
@@ -79,10 +79,7 @@ static unsigned int bio_job_to_worker[BIO_NUM_OPS] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
-#if defined(USE_OPENSSL) &&                    \
-    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
-     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
-      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     [BIO_TLS_RELOAD] = 4,
 #endif
 };
@@ -241,10 +238,7 @@ void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
     bioSubmitJob(BIO_RDB_SAVE, job);
 }
 
-#if defined(USE_OPENSSL) &&                    \
-    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
-     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
-      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 void bioCreateTlsReloadJob(void) {
     bio_job *job = zmalloc(sizeof(*job));
     bioSubmitJob(BIO_TLS_RELOAD, job);
@@ -316,10 +310,7 @@ void *bioProcessBackgroundJobs(void *arg) {
         } else if (job_type == BIO_RDB_SAVE) {
             replicaReceiveRDBFromPrimaryToDisk(job->save_to_disk_args.conn, job->save_to_disk_args.is_dual_channel);
         }
-#if defined(USE_OPENSSL) &&                    \
-    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
-     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
-      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
         else if (job_type == BIO_TLS_RELOAD) {
             tlsConfigureAsync();
         }

--- a/src/bio.c
+++ b/src/bio.c
@@ -79,7 +79,10 @@ static unsigned int bio_job_to_worker[BIO_NUM_OPS] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
     [BIO_TLS_RELOAD] = 4,
 #endif
 };
@@ -238,7 +241,10 @@ void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
     bioSubmitJob(BIO_RDB_SAVE, job);
 }
 
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
 void bioCreateTlsReloadJob(void) {
     bio_job *job = zmalloc(sizeof(*job));
     bioSubmitJob(BIO_TLS_RELOAD, job);
@@ -310,7 +316,10 @@ void *bioProcessBackgroundJobs(void *arg) {
         } else if (job_type == BIO_RDB_SAVE) {
             replicaReceiveRDBFromPrimaryToDisk(job->save_to_disk_args.conn, job->save_to_disk_args.is_dual_channel);
         }
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
         else if (job_type == BIO_TLS_RELOAD) {
             tlsConfigureAsync();
         }

--- a/src/bio.h
+++ b/src/bio.h
@@ -42,7 +42,9 @@ void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...);
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel);
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 void bioCreateTlsReloadJob(void);
+#endif
 int inBioThread(void);
 
 /* Background job opcodes */
@@ -52,7 +54,9 @@ enum {
     BIO_LAZY_FREE,      /* Deferred objects freeing. */
     BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
     BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     BIO_TLS_RELOAD,     /* Deferred TLS reload. */
+#endif
     BIO_NUM_OPS
 };
 

--- a/src/bio.h
+++ b/src/bio.h
@@ -42,10 +42,7 @@ void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...);
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel);
-#if defined(USE_OPENSSL) &&                    \
-    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
-     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
-      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 void bioCreateTlsReloadJob(void);
 #endif
 int inBioThread(void);
@@ -57,10 +54,7 @@ enum {
     BIO_LAZY_FREE,      /* Deferred objects freeing. */
     BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
     BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
-#if defined(USE_OPENSSL) &&                    \
-    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
-     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
-      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     BIO_TLS_RELOAD, /* Deferred TLS reload. */
 #endif
     BIO_NUM_OPS

--- a/src/bio.h
+++ b/src/bio.h
@@ -49,13 +49,13 @@ int inBioThread(void);
 
 /* Background job opcodes */
 enum {
-    BIO_CLOSE_FILE = 0, /* Deferred close(2) syscall. */
-    BIO_AOF_FSYNC,      /* Deferred AOF fsync. */
-    BIO_LAZY_FREE,      /* Deferred objects freeing. */
-    BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
-    BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
+    BIO_CLOSE_FILE = 0,                      /* Deferred close(2) syscall. */
+    BIO_AOF_FSYNC,                           /* Deferred AOF fsync. */
+    BIO_LAZY_FREE,                           /* Deferred objects freeing. */
+    BIO_CLOSE_AOF,                           /* Deferred close for AOF files. */
+    BIO_RDB_SAVE,                            /* Deferred save RDB to disk on replica */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
-    BIO_TLS_RELOAD, /* Deferred TLS reload. */
+    BIO_TLS_RELOAD,                          /* Deferred TLS reload. */
 #endif
     BIO_NUM_OPS
 };

--- a/src/bio.h
+++ b/src/bio.h
@@ -42,7 +42,10 @@ void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...);
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel);
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
 void bioCreateTlsReloadJob(void);
 #endif
 int inBioThread(void);
@@ -54,8 +57,11 @@ enum {
     BIO_LAZY_FREE,      /* Deferred objects freeing. */
     BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
     BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
-    BIO_TLS_RELOAD,     /* Deferred TLS reload. */
+#if defined(USE_OPENSSL) &&                    \
+    ((USE_OPENSSL == 1 /* BUILD_YES */) ||     \
+     ((USE_OPENSSL == 2 /* BUILD_MODULE */) && \
+      (defined(BUILD_TLS_MODULE) && BUILD_TLS_MODULE == 2)))
+    BIO_TLS_RELOAD, /* Deferred TLS reload. */
 #endif
     BIO_NUM_OPS
 };

--- a/src/tls.c
+++ b/src/tls.c
@@ -706,6 +706,7 @@ static int tlsConfigureSync(void *priv, int reconfigure) {
     return tlsConfigure(priv, reconfigure, false);
 }
 
+#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
 /* Asynchronous TLS configuration - runs in background thread.
  * Does CPU-intensive certificate loading without blocking main thread.
  * The main thread will later call tlsApplyPendingReload() to swap in the new contexts. */
@@ -762,6 +763,7 @@ void tlsReconfigureIfNeeded(void) {
     }
     bioCreateTlsReloadJob();
 }
+#endif
 
 static ConnectionType CT_TLS;
 


### PR DESCRIPTION
Fix array bounds error in [test-sanitizer-undefined (gcc)](https://github.com/valkey-io/valkey/actions/runs/21573028934/job/62155215297#logs) by:

- Setting size of `bio_job_to_worker` array to `BIO_NUM_OPS`

- Making `BIO_TLS_RELOAD` enum, function declaration/definition, and job conditional on `USE_OPENSSL`

- Guarding TLS reload function implementations (`tlsConfigureAsync, tlsApplyPendingReload, tlsReconfigureIfNeeded`) for built-in TLS only

- Without tls `BIO_TLS_RELOAD` does not exist, so deleting `serverPanic("BIO_TLS_RELOAD...")`