### PR TITLE
fix(cluster): Resolve serverAssert(link != sender->link) crash in large cluster failover

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3929,7 +3929,15 @@ int clusterProcessPacket(clusterLink *link) {
                  * might still be trying to complete the handshake. */
 
                 /* We should always receive a MEET packet on an inbound link. */
-                serverAssert(link != sender->link);
+                if (link == sender->link) {
+                    /* This indicates a cluster state inconsistency. The link where we
+                     * received the MEET is our outbound link. We should free it
+                     * and return, as the link is no longer valid. */
+                    serverLog(LL_WARNING, "Received MEET from node %.40s on the outbound link. "
+                                          "Closing link to recover.", sender->name);
+                    freeClusterLink(link);
+                    return 0; /* Must return, link is now invalid. */
+                }
                 serverLog(LL_NOTICE, "Freeing outbound link to node %.40s (%s) after receiving a MEET packet "
                                      "from this known node",
                           sender->name, humanNodename(sender));


### PR DESCRIPTION
Title
fix(cluster): Resolve serverAssert(link != sender->link) crash in large cluster failover
Body
1. What problem does this PR solve?
Root Cause:
In 2000-node large clusters, during failover (high Gossip message throughput), the clusterGossipSendToNode function may attempt to use a duplicate link pointer (the same link for both the target node and sender->link). This violates the serverAssert(link != sender->link) check and triggers a fatal assertion failure, which crashes the node and leads to cascading cluster downtime.