### PR TITLE
Skip flaky test cases in client-eviction.tcl when in TLS mode

### DIFF
--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -502,7 +502,7 @@ start_server {} {
         r debug replybuffer resizing 1
 
         foreach rr $rrs {$rr close}
-    } {} {needs:debug}
+    } {} {needs:debug tls:skip}
 }
 
 start_server {} {
@@ -574,7 +574,7 @@ start_server {} {
         r debug replybuffer resizing 1
 
         foreach rr $rrs {$rr close}
-    } {} {needs:debug}
+    } {} {needs:debug tls:skip}
 }
 
 start_server {} {


### PR DESCRIPTION
Closes #3146

The following two test cases are flaky

  - `evict clients only until below limit` - uses exact math expecting exactly half the clients evicted                   
  - `evict clients in right order (large to small)` - uses exact math expecting specific clients evicted in order    

It's fine to skip them in TLS because the core logic being tested (client eviction) doesn't change based on TLS vs non-TLS.

The `decrease maxmemory-clients causes client eviction` test case could potentially be flaky as well (has not shown flakiness on CI yet), but since it has more tolerant assertion: `connected_clients > 0 && connected_clients < $client_count`, I think it's okay not to bother skipping it.

Other test cases are not flaky because they use large thresholds or check binary outcomes (yes/no eviction), not exact counts.



