### PR TITLE
Skips the internal clients from logresreq checks

### DIFF
--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -77,11 +77,16 @@
 static int reqresShouldLog(client *c) {
     if (!server.req_res_logfile) return 0;
 
+    /* Only log real network clients. */
+    if (c->flag.fake || c->conn == NULL) return 0;
+
     /* Ignore client with streaming non-standard response */
     if (c->flag.pubsub || c->flag.monitor || c->flag.replica) return 0;
 
-    /* We only work on primaries (didn't implement reqresAppendResponse to work on shared replica buffers) */
-    if (getClientType(c) == CLIENT_TYPE_PRIMARY) return 0;
+    /* We only log normal user clients.
+     * Internal clients (slot migration etc.) may use shared buffers or emit commands that
+     * intentionally have no replies (e.g. CLUSTER SYNCSLOTS ACK), which would break the request/response log format. */
+    if (getClientType(c) != CLIENT_TYPE_NORMAL) return 0;
 
     return 1;
 }


### PR DESCRIPTION
The request/response logging assumes every command produces a reply. This breaks for slot migration clients that execute internal commands like `CLUSTER SYNCSLOTS ACK`, which intentionally have no reply.

Fixes frequent daily failures: https://github.com/valkey-io/valkey/actions/runs/21573028934/job/62155215296#step:6:5241