### PR TITLE
Fix arr bound err in test-sanitizer-undefined (gcc)

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -79,9 +79,7 @@ static unsigned int bio_job_to_worker[] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     [BIO_TLS_RELOAD] = 4,
-#endif
 };
 
 typedef struct {
@@ -95,9 +93,7 @@ static bio_worker_data bio_workers[] = {
     {"bio_aof"},
     {"bio_lazy_free"},
     {"bio_rdb_save"},
-#if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     {"bio_tls_reload"},
-#endif
 };
 static const bio_worker_data *const bio_worker_end = bio_workers + (sizeof bio_workers / sizeof *bio_workers);
 

--- a/src/bio.c
+++ b/src/bio.c
@@ -79,7 +79,7 @@ static unsigned int bio_job_to_worker[] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
-    [BIO_TLS_RELOAD] = 4,
+    [BIO_TLS_RELOAD] = 4, /* only used when BUILD_TLS=yes */
 };
 
 typedef struct {
@@ -93,7 +93,7 @@ static bio_worker_data bio_workers[] = {
     {"bio_aof"},
     {"bio_lazy_free"},
     {"bio_rdb_save"},
-    {"bio_tls_reload"},
+    {"bio_tls_reload"}, /* only used when BUILD_TLS=yes */
 };
 static const bio_worker_data *const bio_worker_end = bio_workers + (sizeof bio_workers / sizeof *bio_workers);
 


### PR DESCRIPTION
Thanks @dvkashapov for identifying the issue and helping with the fix attempts.

**Issue**
- The `ifdef` in `bio.c` caused array bound err in daily job [test-sanitizer-undefined (gcc)](https://github.com/valkey-io/valkey/actions/runs/21573028934/job/62155215297). It’s still unclear to me why this is the only job that catches the issue during make, I’d appreciate any insights.
- This CI job is currently skipped for PRs even with the `run-extra-tests` label, should we consider enabling it?

**Verification**
Confirmed that this issue is fixed by temporarily enabling the [test-sanitizer-undefined (gcc) job in my fork](https://github.com/yang-z-o/valkey/actions/runs/21618706272/job/62303009722).