### PR TITLE
Add availability-zone field support to CLUSTER SHARDS / CLUSTER SLOTS

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1402,7 +1402,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
 
 void addNodeToNodeReply(client *c, clusterNode *node) {
     char *hostname = clusterNodeHostname(node);
-    addReplyArrayLen(c, 5);
+    addReplyArrayLen(c, 4);
     if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_IP) {
         addReplyBulkCString(c, clusterNodeIp(node, c));
     } else if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_HOSTNAME) {
@@ -1433,6 +1433,11 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         hostname[0] != '\0') {
         length++;
     }
+
+    if (sdslen(node->availability_zone) != 0) {
+        length++;
+    }
+
     addReplyMapLen(c, length);
 
     if (server.cluster_preferred_endpoint_type != CLUSTER_ENDPOINT_TYPE_IP) {
@@ -1446,13 +1451,14 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         addReplyBulkCString(c, hostname);
         length--;
     }
-    serverAssert(length == 0);
 
     if (sdslen(node->availability_zone) != 0) {
-        addReplyBulkCBuffer(c, node->availability_zone, sdslen(node->availability_zone));
-    } else {
-        addReplyNull(c);
+        addReplyBulkCString(c, "availability-zone");
+        addReplyBulkCString(c, node->availability_zone);
+        length--;
     }
+
+    serverAssert(length == 0);
 }
 
 /* Returns an indication if the node is fully available

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1402,7 +1402,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
 
 void addNodeToNodeReply(client *c, clusterNode *node) {
     char *hostname = clusterNodeHostname(node);
-    addReplyArrayLen(c, 4);
+    addReplyArrayLen(c, 5);
     if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_IP) {
         addReplyBulkCString(c, clusterNodeIp(node, c));
     } else if (server.cluster_preferred_endpoint_type == CLUSTER_ENDPOINT_TYPE_HOSTNAME) {
@@ -1447,6 +1447,12 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         length--;
     }
     serverAssert(length == 0);
+
+    if (sdslen(node->availability_zone) != 0) {
+        addReplyBulkCBuffer(c, node->availability_zone, sdslen(node->availability_zone));
+    } else {
+        addReplyNull(c);
+    }
 }
 
 /* Returns an indication if the node is fully available

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -67,6 +67,7 @@ void clusterUpdateMyselfClientIpV6(void);
 void clusterUpdateMyselfHostname(void);
 void clusterUpdateMyselfAnnouncedPorts(void);
 void clusterUpdateMyselfHumanNodename(void);
+void clusterUpdateMyselfAvailabilityZone(void);
 
 void clusterPropagatePublish(robj *channel, robj *message, int sharded);
 void clusterBroadcastPong(int target);

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1303,6 +1303,10 @@ static void updateAnnouncedHumanNodename(clusterNode *node, char *value) {
     updateSdsExtensionField(&node->human_nodename, value);
 }
 
+static void updateAvailabilityZone(clusterNode *node, char *value) {
+    updateSdsExtensionField(&node->availability_zone, value);
+}
+
 static void updateAnnouncedClientIpV4(clusterNode *node, char *value) {
     updateSdsExtensionField(&node->announce_client_ipv4, value);
 }
@@ -1386,6 +1390,11 @@ void clusterUpdateMyselfHostname(void) {
 void clusterUpdateMyselfHumanNodename(void) {
     if (!myself) return;
     updateAnnouncedHumanNodename(myself, server.cluster_announce_human_nodename);
+}
+
+void clusterUpdateMyselfAvailabilityZone(void) {
+    if (!myself) return;
+    updateAvailabilityZone(myself, server.availability_zone);
 }
 
 void clusterUpdateMyselfClientIpV4(void) {
@@ -1495,6 +1504,7 @@ void clusterInit(void) {
     clusterUpdateMyselfClientIpV6();
     clusterUpdateMyselfHostname();
     clusterUpdateMyselfHumanNodename();
+    clusterUpdateMyselfAvailabilityZone();
     resetClusterStats();
 }
 
@@ -1917,6 +1927,7 @@ clusterNode *createClusterNode(char *nodename, int flags) {
     node->announce_client_ipv6 = sdsempty();
     node->hostname = sdsempty();
     node->human_nodename = sdsempty();
+    node->availability_zone = sdsempty();
     node->tcp_port = 0;
     node->cport = 0;
     node->tls_port = 0;
@@ -2155,6 +2166,7 @@ void freeClusterNode(clusterNode *n) {
     /* Free these members after links are freed, as freeClusterLink may access them. */
     sdsfree(n->hostname);
     sdsfree(n->human_nodename);
+    sdsfree(n->availability_zone);
     sdsfree(n->announce_client_ipv4);
     sdsfree(n->announce_client_ipv6);
     raxFree(n->fail_reports);
@@ -3381,6 +3393,9 @@ static uint32_t writePingExtensions(clusterMsg *hdr, int gossipcount) {
         writePortPingExtIfNonzero(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_CLIENT_PORT, myself->announce_client_tcp_port);
     extensions +=
         writePortPingExtIfNonzero(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_CLIENT_TLS_PORT, myself->announce_client_tls_port);
+    extensions +=
+        writeSdsPingExtIfNonempty(&totlen, &cursor, CLUSTERMSG_EXT_TYPE_AVAILABILITY_ZONE, myself->availability_zone);
+
 
     /* Gossip forgotten nodes */
     if (dictSize(server.cluster->nodes_black_list) > 0) {
@@ -3430,6 +3445,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     clusterNode *sender = link->node ? link->node : clusterLookupNode(hdr->sender, CLUSTER_NAMELEN);
     char *ext_hostname = NULL;
     char *ext_humannodename = NULL;
+    char *ext_availability_zone = NULL;
     char *ext_clientipv4 = NULL;
     char *ext_clientipv6 = NULL;
     int ext_clientport = 0;
@@ -3481,6 +3497,10 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
         } else if (type == CLUSTERMSG_EXT_TYPE_SHARDID) {
             clusterMsgPingExtShardId *shardid_ext = (clusterMsgPingExtShardId *)&(ext->ext[0].shard_id);
             ext_shardid = shardid_ext->shard_id;
+        } else if (type == CLUSTERMSG_EXT_TYPE_AVAILABILITY_ZONE) {
+            clusterMsgPingExtAvailabilityZone *availability_zone_ext =
+                (clusterMsgPingExtAvailabilityZone *)&(ext->ext[0].availability_zone);
+            ext_availability_zone = availability_zone_ext->availability_zone;
         } else {
             /* Unknown type, we will ignore it but log what happened. */
             serverLog(LL_WARNING, "Received unknown extension type %d", type);
@@ -3499,6 +3519,7 @@ void clusterProcessPingExtensions(clusterMsg *hdr, clusterLink *link) {
     updateAnnouncedClientIpV6(sender, ext_clientipv6);
     updateAnnouncedClientPort(sender, ext_clientport);
     updateAnnouncedClientTlsPort(sender, ext_clienttlsport);
+    updateAvailabilityZone(sender, ext_availability_zone);
     /* If the node did not send us a shard-id extension, it means the sender
      * does not support it (old version), node->shard_id is randomly generated.
      * A cluster-wide consensus for the node's shard_id is not necessary.
@@ -6788,6 +6809,11 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
             }
         }
     }
+
+    /* Append availability zone at the end for client output. */
+    if (c != NULL && sdslen(node->availability_zone) != 0) {
+        ci = sdscatfmt(ci, " %s", node->availability_zone);
+    }
     return ci;
 }
 
@@ -7043,12 +7069,6 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     addReplyBulkCString(c, clusterNodePreferredEndpoint(node, c));
     reply_count++;
 
-    if (sdslen(node->hostname) != 0) {
-        addReplyBulkCString(c, "hostname");
-        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
-        reply_count++;
-    }
-
     long long node_offset = getNodeReplicationOffset(node);
 
     addReplyBulkCString(c, "role");
@@ -7070,6 +7090,17 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     }
     addReplyBulkCString(c, health_msg);
     reply_count++;
+
+    if (sdslen(node->hostname) != 0) {
+        addReplyBulkCString(c, "hostname");
+        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
+        reply_count++;
+    }
+    if (sdslen(node->availability_zone) != 0) {
+        addReplyBulkCString(c, "availability_zone");
+        addReplyBulkCBuffer(c, node->availability_zone, sdslen(node->availability_zone));
+        reply_count++;
+    }
 
     setDeferredMapLen(c, node_replylen, reply_count);
 }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -6809,11 +6809,6 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
             }
         }
     }
-
-    /* Append availability zone at the end for client output. */
-    if (c != NULL && sdslen(node->availability_zone) != 0) {
-        ci = sdscatfmt(ci, " %s", node->availability_zone);
-    }
     return ci;
 }
 
@@ -7069,6 +7064,12 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     addReplyBulkCString(c, clusterNodePreferredEndpoint(node, c));
     reply_count++;
 
+    if (sdslen(node->hostname) != 0) {
+        addReplyBulkCString(c, "hostname");
+        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
+        reply_count++;
+    }
+
     long long node_offset = getNodeReplicationOffset(node);
 
     addReplyBulkCString(c, "role");
@@ -7091,13 +7092,8 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
     addReplyBulkCString(c, health_msg);
     reply_count++;
 
-    if (sdslen(node->hostname) != 0) {
-        addReplyBulkCString(c, "hostname");
-        addReplyBulkCBuffer(c, node->hostname, sdslen(node->hostname));
-        reply_count++;
-    }
     if (sdslen(node->availability_zone) != 0) {
-        addReplyBulkCString(c, "availability_zone");
+        addReplyBulkCString(c, "availability-zone");
         addReplyBulkCBuffer(c, node->availability_zone, sdslen(node->availability_zone));
         reply_count++;
     }

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -109,6 +109,9 @@ int auxShardIdPresent(clusterNode *n);
 int auxHumanNodenameSetter(clusterNode *n, void *value, size_t length);
 sds auxHumanNodenameGetter(clusterNode *n, sds s);
 int auxHumanNodenamePresent(clusterNode *n);
+int auxAvailabilityZoneSetter(clusterNode *n, void *value, size_t length);
+sds auxAvailabilityZoneGetter(clusterNode *n, sds s);
+int auxAvailabilityZonePresent(clusterNode *n);
 int auxAnnounceClientIpV4Setter(clusterNode *n, void *value, size_t length);
 sds auxAnnounceClientIpV4Getter(clusterNode *n, sds s);
 int auxAnnounceClientIpV4Present(clusterNode *n);
@@ -421,6 +424,7 @@ typedef enum {
     af_announce_client_ipv6,
     af_announce_client_tcp_port,
     af_announce_client_tls_port,
+    af_availability_zone,
     af_count, /* must be the last field */
 } auxFieldIndex;
 
@@ -437,6 +441,7 @@ auxFieldHandler auxFieldHandlers[] = {
     {"client-ipv6", auxAnnounceClientIpV6Setter, auxAnnounceClientIpV6Getter, auxAnnounceClientIpV6Present},
     {"client-tcp-port", auxAnnounceClientTcpPortSetter, auxAnnounceClientTcpPortGetter, auxAnnounceClientTcpPortPresent},
     {"client-tls-port", auxAnnounceClientTlsPortSetter, auxAnnounceClientTlsPortGetter, auxAnnounceClientTlsPortPresent},
+    {"availability-zone", auxAvailabilityZoneSetter, auxAvailabilityZoneGetter, auxAvailabilityZonePresent},
 };
 
 int auxShardIdSetter(clusterNode *n, void *value, size_t length) {
@@ -484,6 +489,22 @@ sds auxHumanNodenameGetter(clusterNode *n, sds s) {
 
 int auxHumanNodenamePresent(clusterNode *n) {
     return sdslen(n->human_nodename);
+}
+
+int auxAvailabilityZoneSetter(clusterNode *n, void *value, size_t length) {
+    if (sdslen(n->availability_zone) == length && !strncmp(value, n->availability_zone, length)) {
+        return C_OK;
+    }
+    n->availability_zone = sdscpylen(n->availability_zone, value, length);
+    return C_OK;
+}
+
+sds auxAvailabilityZoneGetter(clusterNode *n, sds s) {
+    return sdscat(s, n->availability_zone);
+}
+
+int auxAvailabilityZonePresent(clusterNode *n) {
+    return sdslen(n->availability_zone);
 }
 
 int auxAnnounceClientIpV4Setter(clusterNode *n, void *value, size_t length) {

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -166,6 +166,7 @@ typedef enum {
     CLUSTERMSG_EXT_TYPE_CLIENT_IPV6,
     CLUSTERMSG_EXT_TYPE_CLIENT_PORT,
     CLUSTERMSG_EXT_TYPE_CLIENT_TLS_PORT,
+    CLUSTERMSG_EXT_TYPE_AVAILABILITY_ZONE,
 } clusterMsgPingtypes;
 
 /* Helper function for making sure extensions are eight byte aligned. */
@@ -178,6 +179,10 @@ typedef struct {
 typedef struct {
     char human_nodename[1]; /* The announced nodename, ends with \0. */
 } clusterMsgPingExtHumanNodename;
+
+typedef struct {
+    char availability_zone[1]; /* The availability zone, ends with \0. */
+} clusterMsgPingExtAvailabilityZone;
 
 typedef struct {
     char name[CLUSTER_NAMELEN]; /* Node name. */
@@ -219,6 +224,7 @@ typedef struct {
         clusterMsgPingExtClientIpV6 announce_client_ipv6;
         clusterMsgPingExtClientPort announce_client_port;
         clusterMsgPingExtClientTlsPort announce_client_tls_port;
+        clusterMsgPingExtAvailabilityZone availability_zone;
     } ext[]; /* Actual extension information, formatted so that the data is 8
               * byte aligned, regardless of its content. */
 } clusterMsgPingExt;
@@ -392,6 +398,7 @@ struct _clusterNode {
     sds announce_client_ipv6;               /* IPv6 for clients only. */
     sds hostname;                           /* The known hostname for this node */
     sds human_nodename;                     /* The known human readable nodename for this node */
+    sds availability_zone;                  /* The known availability zone for this node */
     int tcp_port;                           /* Latest known clients TCP port. */
     int tls_port;                           /* Latest known clients TLS port */
     int cport;                              /* Latest known cluster port of this node. */

--- a/src/config.c
+++ b/src/config.c
@@ -2741,6 +2741,7 @@ int updateClusterHumanNodename(const char **err) {
 static int updateClusterAvailabilityZone(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfAvailabilityZone();
+    invalidateClusterSlotsResp(err);
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2738,6 +2738,12 @@ int updateClusterHumanNodename(const char **err) {
     return 1;
 }
 
+static int updateClusterAvailabilityZone(const char **err) {
+    UNUSED(err);
+    clusterUpdateMyselfAvailabilityZone();
+    return 1;
+}
+
 static int applyTlsCfg(const char **err) {
     UNUSED(err);
 
@@ -3287,7 +3293,7 @@ standardConfig static_configs[] = {
     /* SDS Configs */
     createSDSConfig("primaryauth", "masterauth", MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.primary_auth, NULL, NULL, NULL),
     createSDSConfig("requirepass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, server.requirepass, NULL, NULL, updateRequirePass),
-    createSDSConfig("availability-zone", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.availability_zone, "", NULL, NULL),
+    createSDSConfig("availability-zone", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, server.availability_zone, "", NULL, updateClusterAvailabilityZone),
     createSDSConfig("hash-seed", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, server.hash_seed, NULL, isValidDbHashSeed, NULL),
 
     /* Enum Configs */

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,41 +1,11 @@
-proc slots_map_has_az_last {slots_resp} {
-    foreach entry $slots_resp {
-        foreach node [lrange $entry 2 end] {
-            set extra_map [lindex $node 3]
-            if {[llength $extra_map] == 0} {
-                return 0
-            }
-            if {[lindex $extra_map end-1] ne "availability-zone"} {
-                return 0
-            }
-        }
-    }
-    return 1
-}
-
-proc shards_map_has_az_last {shards_resp} {
-    foreach shard $shards_resp {
-        set nodes_index [lsearch -exact $shard "nodes"]
-        if {$nodes_index < 0} {
-            return 0
-        }
-        set nodes [lindex $shard [expr {$nodes_index + 1}]]
-        foreach node $nodes {
-            if {[lindex $node end-1] ne "availability-zone"} {
-                return 0
-            }
-        }
-    }
-    return 1
-}
-
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
     test "Availability zone appears in SLOTS/SHARDS" {
         R 0 CONFIG SET availability-zone zone-a
         R 1 CONFIG SET availability-zone zone-b
 
         wait_for_condition 50 100 {
-            [slots_map_has_az_last [R 0 CLUSTER SLOTS]]
+            [string match "*zone-a*" [join [R 0 CLUSTER SLOTS] " "]] &&
+            [string match "*zone-b*" [join [R 0 CLUSTER SLOTS] " "]]
         } else {
             fail "Availability zone was not propagated in CLUSTER SLOTS"
         }
@@ -47,7 +17,8 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*zone-b*" $slots_str
 
         wait_for_condition 50 100 {
-            [shards_map_has_az_last [R 0 CLUSTER SHARDS]]
+            [string match "*zone-a*" [join [R 0 CLUSTER SHARDS] " "]] &&
+            [string match "*zone-b*" [join [R 0 CLUSTER SHARDS] " "]]
         } else {
             fail "Availability zone was not propagated in CLUSTER SHARDS"
         }
@@ -65,7 +36,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         R 0 CONFIG SET availability-zone zone-c
 
         wait_for_condition 50 100 {
-            [slots_map_has_az_last [R 1 CLUSTER SLOTS]] &&
             [string match "*zone-c*" [join [R 1 CLUSTER SLOTS] " "]]
         } else {
             fail "Availability zone was not propagated in CLUSTER SLOTS"
@@ -77,7 +47,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*zone-c*" $slots_str
 
         wait_for_condition 50 100 {
-            [shards_map_has_az_last [R 1 CLUSTER SHARDS]] &&
             [string match "*zone-c*" [join [R 1 CLUSTER SHARDS] " "]]
         } else {
             fail "Availability zone was not propagated in CLUSTER SHARDS"

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,5 +1,20 @@
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
     test "Availability zone appears in SLOTS/SHARDS" {
+        set slots_resp [R 0 CLUSTER SLOTS]
+        set slots_str [join $slots_resp " "]
+
+        assert_no_match "*zone-a*" $slots_str
+        assert_no_match "*zone-b*" $slots_str
+        assert_no_match "*zone-c*" $slots_str
+
+        set shards_resp [R 0 CLUSTER SHARDS]
+        set shards_str [join $shards_resp " "]
+
+        assert_no_match "*zone-a*" $shards_str
+        assert_no_match "*zone-b*" $shards_str
+        assert_no_match "*zone-c*" $shards_str
+
+        # Empty AZ -> Non Empty AZ
         R 0 CONFIG SET availability-zone zone-a
         R 1 CONFIG SET availability-zone zone-b
 
@@ -29,10 +44,7 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*zone-a*" $shards_str
         assert_match "*zone-b*" $shards_str
 
-    }
-
-    test "Availability zone updates at runtime" {
-        R 0 CONFIG SET availability-zone zone-a
+        # Non Empty AZ -> Non Empty AZ
         R 0 CONFIG SET availability-zone zone-c
 
         wait_for_condition 50 100 {
@@ -56,7 +68,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         set shards_str [join $shards_resp " "]
         assert_match "*availability-zone*" $shards_str
         assert_match "*zone-c*" $shards_str
-
     }
 
     test "Availability zone removed when set to empty string" {
@@ -72,13 +83,13 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
 
         set slots_resp [R 0 CLUSTER SLOTS]
         set slots_str [join $slots_resp " "]
-        assert {[string match "*availability-zone*" $slots_str] == 0}
-        assert {[string match "*zone-a*" $slots_str] == 0}
-        assert {[string match "*zone-b*" $slots_str] == 0}
-        assert {[string match "*zone-c*" $slots_str] == 0}
+        assert_no_match "*availability-zone*" $slots_str
+        assert_no_match "*zone-a*" $slots_str
+        assert_no_match "*zone-b*" $slots_str
+        assert_no_match "*zone-c*" $slots_str
 
         set shards_resp [R 0 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
-        assert {[string match "*availability-zone*" $shards_str] == 0}
+        assert_no_match "*availability-zone*" $shards_str
     }
 }

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,0 +1,102 @@
+start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
+    test "Availability zone appears in CLUSTER NODES/SLOTS/SHARDS" {
+        R 0 CONFIG SET availability-zone zone-a
+        R 1 CONFIG SET availability-zone zone-b
+
+        wait_for_condition 50 100 {
+            [string match "* zone-a*" [R 1 CLUSTER NODES]] &&
+            [string match "* zone-b*" [R 0 CLUSTER NODES]]
+        } else {
+            fail "Availability zone was not propagated in CLUSTER NODES"
+        }
+
+        puts "CLUSTER NODES (after initial set):"
+        puts [R 0 CLUSTER NODES]
+
+        set slots_resp [R 0 CLUSTER SLOTS]
+        set slots_str [join $slots_resp " "]
+        assert_match "*zone-a*" $slots_str
+        assert_match "*zone-b*" $slots_str
+
+        puts "CLUSTER SLOTS (after initial set):"
+        puts $slots_resp
+
+        set shards_resp [R 0 CLUSTER SHARDS]
+        set shards_str [join $shards_resp " "]
+        assert_match "*availability_zone*" $shards_str
+        assert_match "*zone-a*" $shards_str
+        assert_match "*zone-b*" $shards_str
+
+        puts "CLUSTER SHARDS (after initial set):"
+        puts $shards_resp
+    }
+
+    test "Availability zone updates at runtime" {
+        R 0 CONFIG SET availability-zone zone-a
+        wait_for_condition 50 100 {
+            [string match "* zone-a*" [R 1 CLUSTER NODES]]
+        } else {
+            fail "Initial availability zone not propagated in CLUSTER NODES"
+        }
+
+        R 0 CONFIG SET availability-zone zone-c
+        wait_for_condition 50 100 {
+            [string match "* zone-c*" [R 1 CLUSTER NODES]]
+        } else {
+            fail "Updated availability zone not propagated in CLUSTER NODES"
+        }
+
+        puts "CLUSTER NODES (after update to zone-c):"
+        puts [R 1 CLUSTER NODES]
+
+        set slots_resp [R 1 CLUSTER SLOTS]
+        set slots_str [join $slots_resp " "]
+        assert_match "*zone-c*" $slots_str
+
+        puts "CLUSTER SLOTS (after update to zone-c):"
+        puts $slots_resp
+
+        set shards_resp [R 1 CLUSTER SHARDS]
+        set shards_str [join $shards_resp " "]
+        assert_match "*availability_zone*" $shards_str
+        assert_match "*zone-c*" $shards_str
+
+        puts "CLUSTER SHARDS (after update to zone-c):"
+        puts $shards_resp
+    }
+
+    test "Availability zone removed when set to empty string" {
+        R 0 CONFIG SET availability-zone ""
+        R 1 CONFIG SET availability-zone ""
+
+        wait_for_condition 50 100 {
+            ![string match "* zone-a*" [R 0 CLUSTER NODES]] &&
+            ![string match "* zone-b*" [R 0 CLUSTER NODES]] &&
+            ![string match "* zone-c*" [R 0 CLUSTER NODES]] &&
+            ![string match "* zone-a*" [R 1 CLUSTER NODES]] &&
+            ![string match "* zone-b*" [R 1 CLUSTER NODES]] &&
+            ![string match "* zone-c*" [R 1 CLUSTER NODES]]
+        } else {
+            fail "Availability zone was not cleared from CLUSTER NODES"
+        }
+
+        puts "CLUSTER NODES (after clearing availability zone):"
+        puts [R 0 CLUSTER NODES]
+
+        set slots_resp [R 0 CLUSTER SLOTS]
+        set slots_str [join $slots_resp " "]
+        assert {[string match "*zone-a*" $slots_str] == 0}
+        assert {[string match "*zone-b*" $slots_str] == 0}
+        assert {[string match "*zone-c*" $slots_str] == 0}
+
+        puts "CLUSTER SLOTS (after clearing availability zone):"
+        puts $slots_resp
+
+        set shards_resp [R 0 CLUSTER SHARDS]
+        set shards_str [join $shards_resp " "]
+        assert {[string match "*availability_zone*" $shards_str] == 0}
+
+        puts "CLUSTER SHARDS (after clearing availability zone):"
+        puts $shards_resp
+    }
+}

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -46,9 +46,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*zone-a*" $slots_str
         assert_match "*zone-b*" $slots_str
 
-        puts "CLUSTER SLOTS (after initial set):"
-        puts $slots_resp
-
         wait_for_condition 50 100 {
             [shards_map_has_az_last [R 0 CLUSTER SHARDS]]
         } else {
@@ -61,8 +58,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*zone-a*" $shards_str
         assert_match "*zone-b*" $shards_str
 
-        puts "CLUSTER SHARDS (after initial set):"
-        puts $shards_resp
     }
 
     test "Availability zone updates at runtime" {
@@ -81,9 +76,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*availability-zone*" $slots_str
         assert_match "*zone-c*" $slots_str
 
-        puts "CLUSTER SLOTS (after update to zone-c):"
-        puts $slots_resp
-
         wait_for_condition 50 100 {
             [shards_map_has_az_last [R 1 CLUSTER SHARDS]] &&
             [string match "*zone-c*" [join [R 1 CLUSTER SHARDS] " "]]
@@ -96,8 +88,6 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert_match "*availability-zone*" $shards_str
         assert_match "*zone-c*" $shards_str
 
-        puts "CLUSTER SHARDS (after update to zone-c):"
-        puts $shards_resp
     }
 
     test "Availability zone removed when set to empty string" {
@@ -118,14 +108,8 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         assert {[string match "*zone-b*" $slots_str] == 0}
         assert {[string match "*zone-c*" $slots_str] == 0}
 
-        puts "CLUSTER SLOTS (after clearing availability zone):"
-        puts $slots_resp
-
         set shards_resp [R 0 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
         assert {[string match "*availability-zone*" $shards_str] == 0}
-
-        puts "CLUSTER SHARDS (after clearing availability zone):"
-        puts $shards_resp
     }
 }

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,3 +1,23 @@
+proc read_file {path} {
+    set fd [open $path r]
+    set data [read $fd]
+    close $fd
+    return $data
+}
+
+proc file_has_pattern {path pattern} {
+    if {![file exists $path]} {
+        return 0
+    }
+    return [regexp $pattern [read_file $path]]
+}
+
+proc cluster_nodes_conf_path {id} {
+    set dir [lindex [R $id config get dir] 1]
+    set conf [lindex [R $id config get cluster-config-file] 1]
+    return [file join $dir $conf]
+}
+
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
     test "Availability zone appears in SLOTS/SHARDS" {
         set slots_resp [R 0 CLUSTER SLOTS]
@@ -91,5 +111,42 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         set shards_resp [R 0 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
         assert_no_match "*availability-zone*" $shards_str
+    }
+
+    test "Load cluster az config on server start" {
+        R 0 config set availability-zone load-az0
+        R 1 config set availability-zone load-az1
+        R 0 config rewrite
+        R 1 config rewrite
+
+        set nodes_conf0 [cluster_nodes_conf_path 0]
+        set nodes_conf1 [cluster_nodes_conf_path 1]
+        wait_for_condition 50 100 {
+            [file exists $nodes_conf0] &&
+            [file exists $nodes_conf1] &&
+            [file_has_pattern $nodes_conf0 {availability-zone=load-az0}] &&
+            [file_has_pattern $nodes_conf0 {availability-zone=load-az1}] &&
+            [file_has_pattern $nodes_conf1 {availability-zone=load-az0}] &&
+            [file_has_pattern $nodes_conf1 {availability-zone=load-az1}]
+        } else {
+            fail "Availability zone was not persisted to nodes.conf"
+        }
+
+        restart_server 0 true false
+        wait_for_cluster_propagation
+
+        wait_for_condition 50 100 {
+            [string match "*load-az0*" [join [R 0 CLUSTER SLOTS] " "]] &&
+            [string match "*load-az1*" [join [R 0 CLUSTER SLOTS] " "]]
+        } else {
+            fail "Availability zone was not restored after restart in CLUSTER SLOTS"
+        }
+
+        wait_for_condition 50 100 {
+            [string match "*load-az0*" [join [R 0 CLUSTER SHARDS] " "]] &&
+            [string match "*load-az1*" [join [R 0 CLUSTER SHARDS] " "]]
+        } else {
+            fail "Availability zone was not restored after restart in CLUSTER SHARDS"
+        }
     }
 }

--- a/tests/unit/cluster/availability-zone.tcl
+++ b/tests/unit/cluster/availability-zone.tcl
@@ -1,29 +1,63 @@
+proc slots_map_has_az_last {slots_resp} {
+    foreach entry $slots_resp {
+        foreach node [lrange $entry 2 end] {
+            set extra_map [lindex $node 3]
+            if {[llength $extra_map] == 0} {
+                return 0
+            }
+            if {[lindex $extra_map end-1] ne "availability-zone"} {
+                return 0
+            }
+        }
+    }
+    return 1
+}
+
+proc shards_map_has_az_last {shards_resp} {
+    foreach shard $shards_resp {
+        set nodes_index [lsearch -exact $shard "nodes"]
+        if {$nodes_index < 0} {
+            return 0
+        }
+        set nodes [lindex $shard [expr {$nodes_index + 1}]]
+        foreach node $nodes {
+            if {[lindex $node end-1] ne "availability-zone"} {
+                return 0
+            }
+        }
+    }
+    return 1
+}
+
 start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval 100}} {
-    test "Availability zone appears in CLUSTER NODES/SLOTS/SHARDS" {
+    test "Availability zone appears in SLOTS/SHARDS" {
         R 0 CONFIG SET availability-zone zone-a
         R 1 CONFIG SET availability-zone zone-b
 
         wait_for_condition 50 100 {
-            [string match "* zone-a*" [R 1 CLUSTER NODES]] &&
-            [string match "* zone-b*" [R 0 CLUSTER NODES]]
+            [slots_map_has_az_last [R 0 CLUSTER SLOTS]]
         } else {
-            fail "Availability zone was not propagated in CLUSTER NODES"
+            fail "Availability zone was not propagated in CLUSTER SLOTS"
         }
-
-        puts "CLUSTER NODES (after initial set):"
-        puts [R 0 CLUSTER NODES]
 
         set slots_resp [R 0 CLUSTER SLOTS]
         set slots_str [join $slots_resp " "]
+        assert_match "*availability-zone*" $slots_str
         assert_match "*zone-a*" $slots_str
         assert_match "*zone-b*" $slots_str
 
         puts "CLUSTER SLOTS (after initial set):"
         puts $slots_resp
 
+        wait_for_condition 50 100 {
+            [shards_map_has_az_last [R 0 CLUSTER SHARDS]]
+        } else {
+            fail "Availability zone was not propagated in CLUSTER SHARDS"
+        }
+
         set shards_resp [R 0 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
-        assert_match "*availability_zone*" $shards_str
+        assert_match "*availability-zone*" $shards_str
         assert_match "*zone-a*" $shards_str
         assert_match "*zone-b*" $shards_str
 
@@ -33,32 +67,33 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
 
     test "Availability zone updates at runtime" {
         R 0 CONFIG SET availability-zone zone-a
-        wait_for_condition 50 100 {
-            [string match "* zone-a*" [R 1 CLUSTER NODES]]
-        } else {
-            fail "Initial availability zone not propagated in CLUSTER NODES"
-        }
-
         R 0 CONFIG SET availability-zone zone-c
-        wait_for_condition 50 100 {
-            [string match "* zone-c*" [R 1 CLUSTER NODES]]
-        } else {
-            fail "Updated availability zone not propagated in CLUSTER NODES"
-        }
 
-        puts "CLUSTER NODES (after update to zone-c):"
-        puts [R 1 CLUSTER NODES]
+        wait_for_condition 50 100 {
+            [slots_map_has_az_last [R 1 CLUSTER SLOTS]] &&
+            [string match "*zone-c*" [join [R 1 CLUSTER SLOTS] " "]]
+        } else {
+            fail "Availability zone was not propagated in CLUSTER SLOTS"
+        }
 
         set slots_resp [R 1 CLUSTER SLOTS]
         set slots_str [join $slots_resp " "]
+        assert_match "*availability-zone*" $slots_str
         assert_match "*zone-c*" $slots_str
 
         puts "CLUSTER SLOTS (after update to zone-c):"
         puts $slots_resp
 
+        wait_for_condition 50 100 {
+            [shards_map_has_az_last [R 1 CLUSTER SHARDS]] &&
+            [string match "*zone-c*" [join [R 1 CLUSTER SHARDS] " "]]
+        } else {
+            fail "Availability zone was not propagated in CLUSTER SHARDS"
+        }
+
         set shards_resp [R 1 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
-        assert_match "*availability_zone*" $shards_str
+        assert_match "*availability-zone*" $shards_str
         assert_match "*zone-c*" $shards_str
 
         puts "CLUSTER SHARDS (after update to zone-c):"
@@ -70,21 +105,15 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
         R 1 CONFIG SET availability-zone ""
 
         wait_for_condition 50 100 {
-            ![string match "* zone-a*" [R 0 CLUSTER NODES]] &&
-            ![string match "* zone-b*" [R 0 CLUSTER NODES]] &&
-            ![string match "* zone-c*" [R 0 CLUSTER NODES]] &&
-            ![string match "* zone-a*" [R 1 CLUSTER NODES]] &&
-            ![string match "* zone-b*" [R 1 CLUSTER NODES]] &&
-            ![string match "* zone-c*" [R 1 CLUSTER NODES]]
+            ![string match "*availability-zone*" [join [R 0 CLUSTER SLOTS] " "]] &&
+            ![string match "*availability-zone*" [join [R 0 CLUSTER SHARDS] " "]]
         } else {
-            fail "Availability zone was not cleared from CLUSTER NODES"
+            fail "Availability zone was not cleared from CLUSTER SLOTS/SHARDS"
         }
-
-        puts "CLUSTER NODES (after clearing availability zone):"
-        puts [R 0 CLUSTER NODES]
 
         set slots_resp [R 0 CLUSTER SLOTS]
         set slots_str [join $slots_resp " "]
+        assert {[string match "*availability-zone*" $slots_str] == 0}
         assert {[string match "*zone-a*" $slots_str] == 0}
         assert {[string match "*zone-b*" $slots_str] == 0}
         assert {[string match "*zone-c*" $slots_str] == 0}
@@ -94,7 +123,7 @@ start_cluster 2 0 {tags {external:skip cluster} overrides {cluster-ping-interval
 
         set shards_resp [R 0 CLUSTER SHARDS]
         set shards_str [join $shards_resp " "]
-        assert {[string match "*availability_zone*" $shards_str] == 0}
+        assert {[string match "*availability-zone*" $shards_str] == 0}
 
         puts "CLUSTER SHARDS (after clearing availability zone):"
         puts $shards_resp


### PR DESCRIPTION
Implemented a way to propagate az through gossip and obtain az information
through the CLUSTER SHARDS and CLUSTER SLOTS commands. It will only be
displayed if the node is configured with it.

Examples:
```
CLUSTER SLOTS 
{0 8191 {127.0.0.1 21112 xxx {availability-zone zone-a}}} {8192 16383 {127.0.0.1 21111 xxx {availability-zone zone-b}}}

CLUSTER SHARDS 
{slots {8192 16383} nodes {{id xxx port 21111 ip 127.0.0.1 endpoint 127.0.0.1 role master replication-offset 0 health online availability-zone zone-b}} id xxx} {slots {0 8191} nodes {{id xxx port 21112 ip 127.0.0.1 endpoint 127.0.0.1 role master replication-offset 0 health online availability-zone zone-a}} id xxx}
```

Closes #3110 