### PR TITLE
Minor cleanup in memtoull to also check ERANGE when calling strtoull

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -282,7 +282,7 @@ unsigned long long memtoull(const char *p, int *err) {
     char *endptr;
     errno = 0;
     val = strtoull(buf, &endptr, 10);
-    if ((val == 0 && errno == EINVAL) || *endptr != '\0') {
+    if ((errno == ERANGE) || (val == 0 && errno == EINVAL) || *endptr != '\0') {
         if (err) *err = 1;
         return 0;
     }


### PR DESCRIPTION
Code Quality Improvement

It might be a good idea to improve the code quality to carefully check for exceptions when converting strings to numbers by calling the strtoull function.
EINVAL checks if a number was converted incorrectly, and checks if the entire buf is a number, but requires ERANGE in addition.
It's safe to check for overflows, which can occur when a user enters an absurdly large value like 9999999999999999999999999gb.

Suggested fix: Check both EINVAL and ERANGE