### PR TITLE
Fix flake replicas different ranks test

### DIFF
--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -121,16 +121,18 @@ start_cluster 3 6 {tags {external:skip cluster}} {
     }
 
     test "Make sure the replicas always get the different ranks" {
-        set log3 [exec tail -n +1 < [srv -3 stdout]]
-        set log6 [exec tail -n +1 < [srv -6 stdout]]
-        
-        set srv3_has_rank0 [string match "*(rank #0,*" $log3]
-        set srv3_has_rank1 [string match "*(rank #1,*" $log3]
-        set srv6_has_rank0 [string match "*(rank #0,*" $log6]
-        set srv6_has_rank1 [string match "*(rank #1,*" $log6]
-        
-        assert {($srv3_has_rank0 && $srv6_has_rank1) || ($srv3_has_rank1 && $srv6_has_rank0)} \
-            "Replicas should have different ranks: srv3_rank0=$srv3_has_rank0, srv3_rank1=$srv3_has_rank1, srv6_rank0=$srv6_has_rank0, srv6_rank1=$srv6_has_rank1"
+        set log3 [exec cat [srv -3 stdout]]
+        set log6 [exec cat [srv -6 stdout]]
+    
+        set srv3_has_rank0 [string match "*Start of election*(rank #0*" $log3]
+        set srv3_has_rank1 [string match "*Start of election*(rank #1*" $log3]
+        set srv6_has_rank0 [string match "*Start of election*(rank #0*" $log6]
+        set srv6_has_rank1 [string match "*Start of election*(rank #1*" $log6]
+    
+        # One should have rank #0, other should have rank #1 (different ranks)
+        if {!(($srv3_has_rank0 && $srv6_has_rank1) || ($srv3_has_rank1 && $srv6_has_rank0))} {
+            fail "Replicas should have different ranks: srv3_rank0=$srv3_has_rank0, srv3_rank1=$srv3_has_rank1, srv6_rank0=$srv6_has_rank0, srv6_rank1=$srv6_has_rank1"
+        }
     }
 
 } ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -121,7 +121,45 @@ start_cluster 3 6 {tags {external:skip cluster}} {
     }
 
     test "Make sure the replicas always get the different ranks" {
-        if {[s -3 role] == "master"} {
+        # Get logs first
+        set log3 [exec cat [srv -3 stdout]]
+        set log6 [exec cat [srv -6 stdout]]
+        
+        # Extract rank information
+        set srv3_has_rank0 [string match "*Start of election*rank #0*" $log3]
+        set srv3_has_rank1 [string match "*Start of election*rank #1*" $log3]
+        set srv6_has_rank0 [string match "*Start of election*rank #0*" $log6]
+        set srv6_has_rank1 [string match "*Start of election*rank #1*" $log6]
+        
+        # Check if test will pass
+        set role3 [s -3 role]
+        set test_will_pass 0
+        
+        if {$role3 == "master"} {
+            if {$srv3_has_rank0 && $srv6_has_rank1} {
+                set test_will_pass 1
+            }
+        } else {
+            if {$srv3_has_rank1 && $srv6_has_rank0} {
+                set test_will_pass 1
+            }
+        }
+        
+        # If test will fail, print debug info
+        if {!$test_will_pass} {
+            puts "========== TEST FAILING - DEBUG INFO =========="
+            puts "Replica -3 role: $role3"
+            puts "Replica -6 role: [s -6 role]"
+            puts ""
+            puts "Replica -3 has rank #0: $srv3_has_rank0"
+            puts "Replica -3 has rank #1: $srv3_has_rank1"
+            puts "Replica -6 has rank #0: $srv6_has_rank0"
+            puts "Replica -6 has rank #1: $srv6_has_rank1"
+            puts "========== END DEBUG INFO =========="
+        }
+        
+        # Original test logic
+        if {$role3 == "master"} {
             verify_log_message -3 "*Start of election*rank #0*" 0
             verify_log_message -6 "*Start of election*rank #1*" 0
         } else {

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -121,6 +121,7 @@ start_cluster 3 6 {tags {external:skip cluster}} {
     }
 
     test "Make sure the replicas always get the different ranks" {
+        puts "========== MAKE SURE TEST STARTING =========="
         # Get logs first
         set log3 [exec cat [srv -3 stdout]]
         set log6 [exec cat [srv -6 stdout]]

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -121,8 +121,8 @@ start_cluster 3 6 {tags {external:skip cluster}} {
     }
 
     test "Make sure the replicas always get the different ranks" {
-        set log3 [exec cat [srv -3 stdout]]
-        set log6 [exec cat [srv -6 stdout]]
+        set log3 [exec tail -n +1 < [srv -3 stdout]]
+        set log6 [exec tail -n +1 < [srv -6 stdout]]
         
         set srv3_has_rank0 [string match "*(rank #0,*" $log3]
         set srv3_has_rank1 [string match "*(rank #1,*" $log3]

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -120,63 +120,29 @@ start_cluster 3 6 {tags {external:skip cluster}} {
         wait_for_cluster_propagation
     }
 
-    test "Make sure the replicas always get the different ranks" {
-        puts "========== MAKE SURE TEST STARTING =========="
-        # Get logs first
+    test "Make sure the replicas always get different ranks" {
         set log3 [exec cat [srv -3 stdout]]
         set log6 [exec cat [srv -6 stdout]]
         
-        # Extract rank information
-        set srv3_has_rank0 [string match "*Start of election*rank #0*" $log3]
-        set srv3_has_rank1 [string match "*Start of election*rank #1*" $log3]
-        set srv6_has_rank0 [string match "*Start of election*rank #0*" $log6]
-        set srv6_has_rank1 [string match "*Start of election*rank #1*" $log6]
+        # Get the LAST "Start of election" line for each replica
+        set election_lines3 [regexp -all -inline {Start of election delayed for \d+ milliseconds \(rank #\d+} $log3]
+        set election_lines6 [regexp -all -inline {Start of election delayed for \d+ milliseconds \(rank #\d+} $log6]
         
-        # Check if test will pass
-        set role3 [s -3 role]
-        set test_will_pass 0
+        # Get the last one (final rank)
+        set last_election3 [lindex $election_lines3 end]
+        set last_election6 [lindex $election_lines6 end]
         
-        if {$role3 == "master"} {
-            if {$srv3_has_rank0 && $srv6_has_rank1} {
-                set test_will_pass 1
-            }
-        } else {
-            if {$srv3_has_rank1 && $srv6_has_rank0} {
-                set test_will_pass 1
-            }
-        }
+        # Extract rank number from the last election line
+        regexp {rank #(\d+)} $last_election3 -> rank3
+        regexp {rank #(\d+)} $last_election6 -> rank6
         
-        # If test will fail, print debug info AND entire logs
-        if {!$test_will_pass} {
-            puts "========== TEST FAILING - DEBUG INFO =========="
-            puts "Replica -3 role: $role3"
-            puts "Replica -6 role: [s -6 role]"
-            puts ""
-            puts "Replica -3 has rank #0: $srv3_has_rank0"
-            puts "Replica -3 has rank #1: $srv3_has_rank1"
-            puts "Replica -6 has rank #0: $srv6_has_rank0"
-            puts "Replica -6 has rank #1: $srv6_has_rank1"
-            puts "========== END DEBUG INFO =========="
-            
-            puts ""
-            puts "========== REPLICA -3 FULL LOG =========="
-            puts $log3
-            puts "========== END REPLICA -3 LOG =========="
-            
-            puts ""
-            puts "========== REPLICA -6 FULL LOG =========="
-            puts $log6
-            puts "========== END REPLICA -6 LOG =========="
-        }
+        puts "========== DEBUG INFO =========="
+        puts "Replica -3 final rank: $rank3"
+        puts "Replica -6 final rank: $rank6"
+        puts "========== END DEBUG INFO =========="
         
-        # Original test logic
-        if {$role3 == "master"} {
-            verify_log_message -3 "*Start of election*rank #0*" 0
-            verify_log_message -6 "*Start of election*rank #1*" 0
-        } else {
-            verify_log_message -3 "*Start of election*rank #1*" 0
-            verify_log_message -6 "*Start of election*rank #0*" 0
-        }
+        # Verify they have different ranks
+        assert {$rank3 ne $rank6} "Both replicas have the same rank: $rank3"
     }
 
 } ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -146,7 +146,7 @@ start_cluster 3 6 {tags {external:skip cluster}} {
             }
         }
         
-        # If test will fail, print debug info
+        # If test will fail, print debug info AND entire logs
         if {!$test_will_pass} {
             puts "========== TEST FAILING - DEBUG INFO =========="
             puts "Replica -3 role: $role3"
@@ -157,6 +157,16 @@ start_cluster 3 6 {tags {external:skip cluster}} {
             puts "Replica -6 has rank #0: $srv6_has_rank0"
             puts "Replica -6 has rank #1: $srv6_has_rank1"
             puts "========== END DEBUG INFO =========="
+            
+            puts ""
+            puts "========== REPLICA -3 FULL LOG =========="
+            puts $log3
+            puts "========== END REPLICA -3 LOG =========="
+            
+            puts ""
+            puts "========== REPLICA -6 FULL LOG =========="
+            puts $log6
+            puts "========== END REPLICA -6 LOG =========="
         }
         
         # Original test logic

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -120,29 +120,17 @@ start_cluster 3 6 {tags {external:skip cluster}} {
         wait_for_cluster_propagation
     }
 
-    test "Make sure the replicas always get different ranks" {
+    test "Make sure the replicas always get the different ranks" {
         set log3 [exec cat [srv -3 stdout]]
         set log6 [exec cat [srv -6 stdout]]
         
-        # Get the LAST "Start of election" line for each replica
-        set election_lines3 [regexp -all -inline {Start of election delayed for \d+ milliseconds \(rank #\d+} $log3]
-        set election_lines6 [regexp -all -inline {Start of election delayed for \d+ milliseconds \(rank #\d+} $log6]
+        set srv3_has_rank0 [string match "*(rank #0,*" $log3]
+        set srv3_has_rank1 [string match "*(rank #1,*" $log3]
+        set srv6_has_rank0 [string match "*(rank #0,*" $log6]
+        set srv6_has_rank1 [string match "*(rank #1,*" $log6]
         
-        # Get the last one (final rank)
-        set last_election3 [lindex $election_lines3 end]
-        set last_election6 [lindex $election_lines6 end]
-        
-        # Extract rank number from the last election line
-        regexp {rank #(\d+)} $last_election3 -> rank3
-        regexp {rank #(\d+)} $last_election6 -> rank6
-        
-        puts "========== DEBUG INFO =========="
-        puts "Replica -3 final rank: $rank3"
-        puts "Replica -6 final rank: $rank6"
-        puts "========== END DEBUG INFO =========="
-        
-        # Verify they have different ranks
-        assert {$rank3 ne $rank6} "Both replicas have the same rank: $rank3"
+        assert {($srv3_has_rank0 && $srv6_has_rank1) || ($srv3_has_rank1 && $srv6_has_rank0)} \
+            "Replicas should have different ranks: srv3_rank0=$srv3_has_rank0, srv3_rank1=$srv3_has_rank1, srv6_rank0=$srv6_has_rank0, srv6_rank1=$srv6_has_rank1"
     }
 
 } ;# start_cluster


### PR DESCRIPTION
Closes #2683 

For the test, I found two problems.

### 1. Test Assumes Winner Has Rank #0
In my test run, in the failing case:
- Replica -3 (rank 0) won epoch 10 first
- Replica -6 (rank 1) won epoch 11 second
- Replica -3 saw higher epoch and stepped down
- Final result: rank 1 became master

Rank #0 doesn't guarantee being the final master.

### 2. Pattern Matching Bug
The pattern `*Start of election*rank #0*` incorrectly matches "primary rank #0":

Log: `Start of election delayed for 350 milliseconds (rank #1, primary rank #0, offset 2172)`

This line has rank `#1`, but the pattern matches because of "primary rank `#0`" at the end.

This is the [test example](https://github.com/hanxizh9910/valkey/actions/runs/21695392026/job/62564415150). I added some print statements in the [test](https://github.com/hanxizh9910/valkey/commit/eabbeb110dbf1bac7e089dfa129bfea84d9ba43b)

## Solution
- Fixed the format problem by checking if `(rank #0` or `(rank #1` so that we won't accidentally match the primary rank
- Only check to make sure replica 3 and replica 6 have different ranks without assuming the replica with rank 0 will become the master.

## Test
I ran it for 1000 times: https://github.com/hanxizh9910/valkey/actions/runs/21705632232