### PR TITLE
Avoid crash in genClusterInfoString when myself is uninitialized

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7129,10 +7129,7 @@ void clusterCommandShards(client *c) {
 sds genClusterInfoString(sds info) {
     char *statestr[] = {"ok", "fail"};
     int slots_assigned = 0, slots_ok = 0, slots_pfail = 0, slots_fail = 0;
-    uint64_t my_epoch = 0;
-    if (myself != NULL) {
-        my_epoch = nodeEpoch(myself);
-    }
+    uint64_t my_epoch = myself ? nodeEpoch(myself) : 0;
 
     dictIterator *di = dictGetIterator(server.cluster->nodes);
     dictEntry *de;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7129,6 +7129,10 @@ void clusterCommandShards(client *c) {
 sds genClusterInfoString(sds info) {
     char *statestr[] = {"ok", "fail"};
     int slots_assigned = 0, slots_ok = 0, slots_pfail = 0, slots_fail = 0;
+    uint64_t my_epoch = 0;
+    if (myself != NULL) {
+        my_epoch = nodeEpoch(myself);
+    }
 
     dictIterator *di = dictGetIterator(server.cluster->nodes);
     dictEntry *de;
@@ -7178,7 +7182,7 @@ sds genClusterInfoString(sds info) {
                      statestr[server.cluster->state], slots_assigned, slots_ok, slots_pfail, slots_fail,
                      nodes_pfail, nodes_fail, voting_nodes_pfail, voting_nodes_fail,
                      (unsigned long long)dictSize(server.cluster->nodes), server.cluster->size,
-                     (unsigned long long)server.cluster->currentEpoch, (unsigned long long)nodeEpoch(myself));
+                     (unsigned long long)server.cluster->currentEpoch, (unsigned long long)my_epoch);
 
     /* Show stats about messages sent and received. */
     long long tot_msg_sent = 0;


### PR DESCRIPTION
Fixes a crash that occurs when `genClusterInfoString()` is called before the cluster node has fully initialized. The myself pointer may be `NULL` in these edge cases, causing a segfault when calling `nodeEpoch(myself)`.

Related to #3170 