### PR TITLE
Fix remaining_repl_size should be in CLUSTER GETSLOTMIGRATIONS in conf

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -2036,7 +2036,7 @@ aof-timestamp-enabled no
 # received by the target).
 #
 # You can check the remaining buffer data size by examining the 'remaining_repl_size' field in the
-# 'CLUSTER MIGRATESLOTS' command output on the source node.
+# 'CLUSTER GETSLOTMIGRATIONS' command output on the source node.
 #
 # slot-migration-max-failover-repl-bytes 0
 


### PR DESCRIPTION
In #3135, it was incorrectly written as CLUSTER MIGRATESLOTS, it should
be CLUSTE GETSLOTMIGRATIONS.