### PR TITLE
Fix server assert on ACL LOAD and resetchannels

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -488,22 +488,6 @@ static void ACLFreeUserVoid(void *u) {
     ACLFreeUser(u);
 }
 
-/* Helper function to free client.
- * We can't immediately free the current client because that would trigger assert
- * in prepareClientToWrite() when the server tries to write the response to the client.
- * So instead flag it for closure after the current command completes. */
-static inline void ACLFreeClientOrCloseLater(client *c, int async) {
-    if (c == server.current_client) {
-        c->flag.close_after_command = 1;
-    } else {
-        if (async) {
-            freeClientAsync(c);
-        } else {
-            freeClient(c);
-        }
-    }
-}
-
 /* When a user is deleted we need to cycle the active
  * connections in order to kill all the pending ones that
  * are authenticated with such user. */
@@ -523,7 +507,7 @@ void ACLFreeUserAndKillClients(user *u) {
             clientSetUser(c, DefaultUser, 0);
             /* We will write replies to this client later, so we can't
              * close it directly even if async. */
-            ACLFreeClientOrCloseLater(c, 1);
+            freeClientOrCloseLater(c, 1);
         }
     }
     ACLFreeUser(u);
@@ -2203,7 +2187,7 @@ static void ACLKillPubsubClientsIfNeeded(user *new, user *original) {
         client *c = listNodeValue(ln);
         if (c->user != original) continue;
         if (ACLShouldKillPubsubClient(c, channels)) {
-            ACLFreeClientOrCloseLater(c, 0);
+            freeClientOrCloseLater(c, 0);
         }
     }
 
@@ -2633,7 +2617,7 @@ static sds ACLLoadFromFile(const char *filename) {
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's
              * list. */
             if (!new_user || (channels && ACLShouldKillPubsubClient(c, channels))) {
-                ACLFreeClientOrCloseLater(c, 0);
+                freeClientOrCloseLater(c, 0);
                 continue;
             }
             c->user = new_user;

--- a/src/acl.c
+++ b/src/acl.c
@@ -2619,7 +2619,11 @@ static sds ACLLoadFromFile(const char *filename) {
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's
              * list. */
             if (!new_user || (channels && ACLShouldKillPubsubClient(c, channels))) {
-                freeClient(c);
+                if (c == server.current_client) {
+                    c->flag.close_after_command = 1;
+                } else {
+                    freeClient(c);
+                }
                 continue;
             }
             c->user = new_user;

--- a/src/acl.c
+++ b/src/acl.c
@@ -488,6 +488,22 @@ static void ACLFreeUserVoid(void *u) {
     ACLFreeUser(u);
 }
 
+/* Helper function to free client.
+ * We can't immediately free the current client because that would trigger assert
+ * in prepareClientToWrite() when the server tries to write the response to the client.
+ * So instead flag it for closure after the current command completes. */
+static inline void ACLFreeClientOrCloseLater(client *c, int async) {
+    if (c == server.current_client) {
+        c->flag.close_after_command = 1;
+    } else {
+        if (async) {
+            freeClientAsync(c);
+        } else {
+            freeClient(c);
+        }
+    }
+}
+
 /* When a user is deleted we need to cycle the active
  * connections in order to kill all the pending ones that
  * are authenticated with such user. */
@@ -507,11 +523,7 @@ void ACLFreeUserAndKillClients(user *u) {
             clientSetUser(c, DefaultUser, 0);
             /* We will write replies to this client later, so we can't
              * close it directly even if async. */
-            if (c == server.current_client) {
-                c->flag.close_after_command = 1;
-            } else {
-                freeClientAsync(c);
-            }
+            ACLFreeClientOrCloseLater(c, 1);
         }
     }
     ACLFreeUser(u);
@@ -2190,7 +2202,9 @@ static void ACLKillPubsubClientsIfNeeded(user *new, user *original) {
     while ((ln = listNext(&li)) != NULL) {
         client *c = listNodeValue(ln);
         if (c->user != original) continue;
-        if (ACLShouldKillPubsubClient(c, channels)) freeClient(c);
+        if (ACLShouldKillPubsubClient(c, channels)) {
+            ACLFreeClientOrCloseLater(c, 0);
+        }
     }
 
     listRelease(channels);
@@ -2619,11 +2633,7 @@ static sds ACLLoadFromFile(const char *filename) {
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's
              * list. */
             if (!new_user || (channels && ACLShouldKillPubsubClient(c, channels))) {
-                if (c == server.current_client) {
-                    c->flag.close_after_command = 1;
-                } else {
-                    freeClient(c);
-                }
+                ACLFreeClientOrCloseLater(c, 0);
                 continue;
             }
             c->user = new_user;

--- a/src/module.c
+++ b/src/module.c
@@ -10005,11 +10005,7 @@ void revokeClientAuthentication(client *c) {
     clientSetUser(c, DefaultUser, 0);
     /* We will write replies to this client later, so we can't close it
      * directly even if async. */
-    if (c == server.current_client) {
-        c->flag.close_after_command = 1;
-    } else {
-        freeClientAsync(c);
-    }
+    freeClientOrCloseLater(c, 1);
 }
 
 /* Cleanup all clients that have been authenticated with this module. This

--- a/src/networking.c
+++ b/src/networking.c
@@ -2168,6 +2168,22 @@ void freeClientAsync(client *c) {
     debugServerAssertWithInfo(c, NULL, listSearchKey(server.clients_to_close, c) == NULL);
     listAddNodeTail(server.clients_to_close, c);
 }
+/* Helper function to free a client or flag it for closure after current command.
+ * We can't free the current client right now because that would trigger an
+ * assert in prepareClientToWrite() when the server tries to write the response.
+ * So instead flag it for closure after the current command completes. */
+void freeClientOrCloseLater(client *c, int async) {
+    if (c == server.current_client) {
+        c->flag.close_after_command = 1;
+    } else {
+        if (async) {
+            freeClientAsync(c);
+        } else {
+            freeClient(c);
+        }
+    }
+}
+
 
 /* Log errors for invalid use and free the client in async way.
  * We will add additional information about the client to the message. */

--- a/src/server.h
+++ b/src/server.h
@@ -2877,6 +2877,7 @@ void dictVanillaFree(void *val);
 client *createClient(connection *conn);
 void freeClient(client *c);
 void freeClientAsync(client *c);
+void freeClientOrCloseLater(client *c, int async);
 void logInvalidUseAndFreeClientAsync(client *c, const char *fmt, ...);
 void beforeNextClient(client *c);
 void clearClientConnectionState(client *c);

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1177,10 +1177,6 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         
         # Verify server is still running
         assert_equal [r PING] "PONG"
-        
-        # Cleanup
-        r ACL setuser removed-user on >password +@all ~* &*
-        r ACL save
     }
 }
 

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1134,6 +1134,54 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         r ACL deluser harry
         set e
     } {*NOPERM*channel*}
+
+    test {ACL LOAD does not crash server if current user is removed from ACL file} {
+        # Setup
+        reconnect
+        r ACL setuser removed-user on >password +@all ~* &*
+        r ACL save
+        
+        set rd [valkey_deferring_client]
+        $rd AUTH removed-user password
+        assert_equal [$rd read] "OK"
+        
+        # Remove user from ACL file
+        set dir [lindex [r CONFIG GET dir] 1]
+        set aclfile [lindex [r CONFIG GET aclfile] 1]
+        set aclpath [file join $dir $aclfile]
+        
+        set fd [open $aclpath r]
+        set lines [split [read $fd] "\n"]
+        close $fd
+        
+        set filtered_lines [list]
+        foreach line $lines {
+            if {![string match "*removed-user*" $line]} {
+                lappend filtered_lines $line
+            }
+        }
+        
+        set fd [open $aclpath w]
+        puts $fd [join $filtered_lines "\n"]
+        close $fd
+        
+        # Execute ACL LOAD as the removed user, should return OK
+        $rd ACL LOAD
+        assert_equal [$rd read] "OK"
+        
+        # Client should be disconnected after the command completes
+        $rd PING
+        catch {$rd read} err
+        assert_match "*I/O error*" $err
+        $rd close
+        
+        # Verify server is still running
+        assert_equal [r PING] "PONG"
+        
+        # Cleanup
+        r ACL setuser removed-user on >password +@all ~* &*
+        r ACL save
+    }
 }
 
 set server_path [tmpdir "resetchannels.acl"]

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1135,9 +1135,21 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         set e
     } {*NOPERM*channel*}
 
+    test {Validate a user can remove their own channel permissions} {
+        reconnect
+        r ACL SETUSER removed_channels on nopass +@all &test
+        
+        # Create a RESP3 client will attempt to close itself by removing it's channel permissions
+        set resp3 [valkey_client]
+        $resp3 HELLO 3
+        $resp3 AUTH removed_channels blank
+        $resp3 SUBSCRIBE test
+        $resp3 ACL SETUSER removed_channels resetchannels
+        $resp3 close
+    }
+
     test {ACL LOAD does not crash server if current user is removed from ACL file} {
         # Setup
-        reconnect
         r ACL setuser removed-user on >password +@all ~* &*
         r ACL save
         


### PR DESCRIPTION
if the client executing `ACL LOAD` is a user that is removed from ACL file, it frees itself while still executing the command. Same happens for user while removing it's channel permissions. 
This causes `c->conn` pointer to become `null` and later `serverAssert(c->conn)` fails for that client on write in `prepareClientToWrite()`. 
Solution is to flag current client to be closed after command completes and reply is written, later this client is freed async.

Bug is present in 8.0, 8.1, 9.0.

Resolves #3181