### PR TITLE
Fix PFADD corrupted sparse HLL handling by restoring hllSparseSet return type

### DIFF
--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -696,7 +696,7 @@ int hllSparseToDense(robj *o) {
  * sparse to dense: this happens when a register requires to be set to a value
  * not representable with the sparse representation, or when the resulting
  * size would be greater than server.hll_sparse_max_bytes. */
-static bool hllSparseSet(robj *o, long index, uint8_t count) {
+static int hllSparseSet(robj *o, long index, uint8_t count) {
     struct hllhdr *hdr;
     uint8_t oldcount, *sparse, *end, *p, *prev, *next;
     long first, span;


### PR DESCRIPTION
This fixes a regression where PFADD returned 1 instead of INVALIDOBJ for corrupted sparse HLL payloads. In small strings refactor (#2516) we incorrectly changed the datatype from int to bool. That function still uses -1 as its error signal. 

I have been looking into fixing large memory tests with ASan, and this is another error.

Failed Test: https://github.com/sarthakaggarwal97/valkey/actions/runs/21871589440/job/63130770208#step:7:696

Validation:

```
./runtest --single unit/hyperloglog --large-memory
```