### PR TITLE
Add server side KPI for proto-max-bulk-len violations

### DIFF
--- a/src/bitops.c
+++ b/src/bitops.c
@@ -591,6 +591,7 @@ int getBitOffsetFromArgument(client *c, robj *o, uint64_t *offset, int hash, int
 
     /* Limit offset to server.proto_max_bulk_len (512MB in bytes by default) */
     if (loffset < 0 || (!mustObeyClient(c) && (loffset >> 3) >= server.proto_max_bulk_len)) {
+        if (loffset >= 0) server.stat_proto_max_bulk_len_exceeded++;
         addReplyError(c, err);
         return C_ERR;
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -3627,7 +3627,11 @@ static int parseMultibulk(client *c,
 
             size_t bulklen_slen = newline - (c->querybuf + c->qb_pos + 1);
             ok = string2ll(c->querybuf + c->qb_pos + 1, bulklen_slen, &ll);
-            if (!ok || ll < 0 || (!(is_replicated) && ll > server.proto_max_bulk_len)) {
+            if (!ok || ll < 0) {
+                return READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN;
+            }
+            if (!(is_replicated) && ll > server.proto_max_bulk_len) {
+                server.stat_proto_max_bulk_len_exceeded++;
                 return READ_FLAGS_ERROR_MBULK_INVALID_BULK_LEN;
             } else if (ll > 16384 && auth_required) {
                 return READ_FLAGS_ERROR_UNAUTHENTICATED_BULK_LEN;

--- a/src/server.c
+++ b/src/server.c
@@ -2794,6 +2794,7 @@ void resetServerStats(void) {
     server.stat_total_writes_processed = 0;
     server.stat_client_qbuf_limit_disconnections = 0;
     server.stat_client_outbuf_limit_disconnections = 0;
+    server.stat_proto_max_bulk_len_exceeded = 0;
     for (j = 0; j < STATS_METRIC_COUNT; j++) {
         server.inst_metric[j].idx = 0;
         server.inst_metric[j].last_sample_base = 0;
@@ -6409,6 +6410,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "io_threaded_total_prefetch_entries:%lld\r\n", server.stat_total_prefetch_entries,
                 "client_query_buffer_limit_disconnections:%lld\r\n", server.stat_client_qbuf_limit_disconnections,
                 "client_output_buffer_limit_disconnections:%lld\r\n", server.stat_client_outbuf_limit_disconnections,
+                "proto_max_bulk_len_exceeded:%lld\r\n", server.stat_proto_max_bulk_len_exceeded,
                 "reply_buffer_shrinks:%lld\r\n", server.stat_reply_buffer_shrinks,
                 "reply_buffer_expands:%lld\r\n", server.stat_reply_buffer_expands,
                 "eventloop_cycles:%llu\r\n", server.duration_stats[EL_DURATION_TYPE_EL].cnt,

--- a/src/server.h
+++ b/src/server.h
@@ -1927,6 +1927,7 @@ struct valkeyServer {
     long long stat_total_writes_processed;             /* Total number of write events processed */
     long long stat_client_qbuf_limit_disconnections;   /* Total number of clients reached query buf length limit */
     long long stat_client_outbuf_limit_disconnections; /* Total number of clients reached output buf length limit */
+    long long stat_proto_max_bulk_len_exceeded;        /* Total number of proto-max-bulk-len violations */
     long long stat_total_prefetch_entries;             /* Total number of prefetched dict entries */
     long long stat_total_prefetch_batches;             /* Total number of prefetched batches */
     /* The following two are used to track instantaneous metrics, like

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -49,6 +49,7 @@ static int checkStringLength(client *c, long long size, long long append) {
     /* Test configured max-bulk-len represending a limit of the biggest string object,
      * and also test for overflow. */
     if (total > server.proto_max_bulk_len || total < size || total < append) {
+        server.stat_proto_max_bulk_len_exceeded++;
         addReplyError(c, "string exceeds maximum allowed size (proto-max-bulk-len)");
         return C_ERR;
     }
@@ -762,6 +763,7 @@ void lcsCommand(client *c) {
     uint32_t *lcs = NULL;
     if (lcsalloc < SIZE_MAX && lcsalloc / lcssize == sizeof(uint32_t)) {
         if (lcsalloc > (size_t)server.proto_max_bulk_len) {
+            server.stat_proto_max_bulk_len_exceeded++;
             addReplyError(c, "Insufficient memory, transient memory for LCS exceeds proto-max-bulk-len");
             goto cleanup;
         }


### PR DESCRIPTION
Re: https://github.com/valkey-io/valkey/issues/2958

Add a server-side counter that tracks how many times a command or operation was rejected for exceeding proto-max-bulk-len. This gives operators visibility into oversized payload violations without needing to parse client-side logs.

The new stat 'proto_max_bulk_len_exceeded' is incremented at all violation points:
- RESP parser (networking.c): bulk string length exceeds limit
- APPEND (t_string.c): resulting string would exceed limit
- LCS (t_string.c): transient memory would exceed limit
- SETBIT/BITFIELD (bitops.c): offset would create string exceeding limit

Exposed via INFO stats alongside existing counters like client_query_buffer_limit_disconnections.