### PR TITLE
Logging fix or improvement around new shard ID generation

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -101,7 +101,6 @@ const char *clusterGetMessageTypeString(int type);
 void removeChannelsInSlot(unsigned int slot);
 unsigned int countChannelsInSlot(unsigned int hashslot);
 void clusterAddNodeToShard(const char *shard_id, clusterNode *node);
-list *clusterLookupNodeListByShardId(const char *shard_id);
 void clusterRemoveNodeFromShard(clusterNode *node);
 int auxShardIdSetter(clusterNode *n, void *value, size_t length);
 sds auxShardIdGetter(clusterNode *n, sds s);
@@ -1613,18 +1612,13 @@ void clusterHandleServerShutdown(bool auto_failover) {
  * 4) Only for hard reset: a new Node ID is generated.
  * 5) Only for hard reset: currentEpoch and configEpoch are set to 0.
  * 6) The new configuration is saved and the cluster state updated.
- * 7) If the node was a replica, the whole data set is flushed away. */
+ * 7) If the node was a replica, the whole data set is flushed away.
+ * 8) If it is a hard reset or the node was a replica: a new Shard ID is generated. */
 void clusterReset(int hard) {
     dictIterator *di;
     dictEntry *de;
-    int j, was_replica = 0;
-
-    /* Turn into primary. */
-    if (nodeIsReplica(myself)) {
-        was_replica = 1;
-        clusterSetNodeAsPrimary(myself);
-        flushAllDataAndResetRDB(server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
-    }
+    int j;
+    bool new_shard = false;
 
     /* Close slots, reset manual failover state. */
     clusterCloseAllSlots();
@@ -1664,22 +1658,34 @@ void clusterReset(int hard) {
 
         /* To change the Node ID we need to remove the old name from the
          * nodes table, change the ID, and re-add back with new name. */
+        new_shard = true;
         oldname = sdsnewlen(myself->name, CLUSTER_NAMELEN);
         dictDelete(server.cluster->nodes, oldname);
         sdsfree(oldname);
         getRandomHexChars(myself->name, CLUSTER_NAMELEN);
-        getRandomHexChars(myself->shard_id, CLUSTER_NAMELEN);
         clusterAddNode(myself);
         serverLog(LL_NOTICE, "Node hard reset, now I'm %.40s", myself->name);
     } else {
         /* If we were a replica, this means our shard_id is the shard_id of
          * the primary node, and since now we become a new empty primary, we
          * need to have our own shard_id. */
-        if (was_replica) getRandomHexChars(myself->shard_id, CLUSTER_NAMELEN);
+        new_shard = true;
     }
 
     /* Re-populate shards */
-    clusterAddNodeToShard(myself->shard_id, myself);
+    if (new_shard) {
+        clusterRemoveNodeFromShard(myself);
+        getRandomHexChars(myself->shard_id, CLUSTER_NAMELEN);
+        clusterAddNodeToShard(myself->shard_id, myself);
+        serverLog(LL_NOTICE, "Moving myself to a new shard %.40s.", myself->shard_id);
+    }
+
+    /* Turn into primary. clusterSetNodeAsPrimary prints the shard ID to the
+     * server logs, so calling it here we can print the new correct shard ID. */
+    if (nodeIsReplica(myself)) {
+        clusterSetNodeAsPrimary(myself);
+        flushAllDataAndResetRDB(server.lazyfree_lazy_user_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
+    }
 
     /* Make sure to persist the new config and update the state. */
     clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_FSYNC_CONFIG);
@@ -7882,6 +7888,7 @@ int clusterCommandSpecial(client *c) {
             char new_shard_id[CLUSTER_NAMELEN];
             getRandomHexChars(new_shard_id, CLUSTER_NAMELEN);
             updateShardId(myself, new_shard_id);
+            serverLog(LL_NOTICE, "Moving myself to a new shard %.40s.", myself->shard_id);
 
             clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
             addReply(c, shared.ok);


### PR DESCRIPTION
When a cluster reset is performed on a replica node, a new shard ID is generated
because the node is about to become an empty primary node, see #2283.

However, the log added in #2510 caused some confusions. In clusterSetNodeAsPrimary
we will print:
```
serverLog(LL_NOTICE, "Reconfiguring node %.40s (%s) as primary for shard %.40s", n->name, humanNodename(n), n->shard_id);
```

In clusterReset, we first call clusterSetNodeAsPrimary and then generate a new
shard ID, which causes us to print an error shard ID log first.

There is an exmaple, when a replica node performs a cluster reset, we will print:
```
xxx * Cluster reset (user request from 'xxx').
xxx * Reconfiguring node af76a3e0ffcd77bd14fa47ce4d07ab2bdc78702f (xxx) as primary for shard ea528667634af8beed83adac2b9af8360769a1b4
```

But the node shard id is actually:
```
xxx> cluster myshardid
"52ede26d1554dd203161ba09011af14574b2cc84"
```

Now after a new shard ID is generated we will print a log, and we also move the
call to clusterSetNodeAsPrimary after the new shard id, so that we can have the
right one. After this PR:
```
xxx * Cluster reset (user request from 'xxx').
xxx * Moving myself to a new shard bd31870ce73f5977084e6a46e337a4a1ad38fc66.
xxx * Reconfiguring node 1d54b904efd30cd9d7d1abbfd63c8fafbb62e1c8 (xxx) as primary for shard bd31870ce73f5977084e6a46e337a4a1ad38fc66
```

This is part of #2989, but i guess we won't merge the extension fix in a short
time, so i am gonna extracting it separately as a log fix (or improvement).