### PR TITLE
Optimize ustime() with monotonic delta

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1608,7 +1608,7 @@ long long ustime(void) {
     if (getMonotonicUs != NULL && monotonicGetType() == MONOTONIC_CLOCK_HW) {
         monotime mono_now = getMonotonicUs();
         monotime mono_since_gettimeofday = mono_now - mono_at_last_timeofday;
-        if (mono_since_gettimeofday < 100000) return ust + mono_since_gettimeofday;
+        if (mono_since_gettimeofday < 1000) return ust + mono_since_gettimeofday;
 
         /* Use time of day. */
         mono_at_last_timeofday = mono_now;

--- a/src/util.c
+++ b/src/util.c
@@ -53,6 +53,7 @@
 #include "zmalloc.h"
 #include "serverassert.h"
 #include "valkey_strtod.h"
+#include "monotonic.h"
 
 #if HAVE_X86_SIMD
 #include <immintrin.h>
@@ -1599,9 +1600,21 @@ int snprintf_async_signal_safe(char *to, size_t n, const char *fmt, ...) {
 
 /* Return the UNIX time in microseconds */
 long long ustime(void) {
-    struct timeval tv;
-    long long ust;
+    static long long ust = 0;
+    static monotime mono_at_last_timeofday = 0;
 
+    /* Fast path. Only call gettimeofday() periodically and add monotonic delta.
+     * This avoids a syscall if we have a no-syscall monotonic clock. */
+    if (getMonotonicUs != NULL && monotonicGetType() == MONOTONIC_CLOCK_HW) {
+        monotime mono_now = getMonotonicUs();
+        monotime mono_since_gettimeofday = mono_now - mono_at_last_timeofday;
+        if (mono_since_gettimeofday < 100000) return ust + mono_since_gettimeofday;
+
+        /* Use time of day. */
+        mono_at_last_timeofday = mono_now;
+    }
+
+    struct timeval tv;
     gettimeofday(&tv, NULL);
     ust = ((long long)tv.tv_sec) * 1000000;
     ust += tv.tv_usec;


### PR DESCRIPTION
Only call gettimeofday() periodically and add monotonic delta. This avoids a syscall if we have a fast monotonic clock, which we have now by default on most platforms.

`ustime()` is called once per command execution. In a busy server running 1M RPS, `ustime()` is called every microsecond. By calling `gettimeofday()` only once every millisecond, we save 99.9% of these syscalls.