### PR TITLE
Fix getKeysUsingKeySpecs keynum case ignoring keystep when calc the last key

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2352,7 +2352,7 @@ int getKeysUsingKeySpecs(struct serverCommand *cmd, robj **argv, int argc, int s
             }
 
             first += spec->fk.keynum.firstkey;
-            last = first + (int)numkeys - 1;
+            last = first + ((int)numkeys - 1) * step;
         } else {
             /* unknown spec */
             goto invalid_spec;


### PR DESCRIPTION
This issue was encountered while processing #3121. Currently in all our
commands with KSPEC_FK_KEYNUM, key step is 1. So this bug does not currently
affect any core commands.

If we have commands with different key step values, calculting the last key
in here will casue problems since we are not including step in the calculation.