### PR TITLE
Move CONFIG REWRITE disk I/O to background thread

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -79,7 +79,8 @@ static unsigned int bio_job_to_worker[] = {
     [BIO_CLOSE_AOF] = 1,
     [BIO_LAZY_FREE] = 2,
     [BIO_RDB_SAVE] = 3,
-    [BIO_TLS_RELOAD] = 4, /* only used when BUILD_TLS=yes */
+    [BIO_TLS_RELOAD] = 4,        /* only used when BUILD_TLS=yes */
+    [BIO_CONFIG_REWRITE] = 5,
 };
 
 typedef struct {
@@ -93,7 +94,8 @@ static bio_worker_data bio_workers[] = {
     {"bio_aof"},
     {"bio_lazy_free"},
     {"bio_rdb_save"},
-    {"bio_tls_reload"}, /* only used when BUILD_TLS=yes */
+    {"bio_tls_reload"},        /* only used when BUILD_TLS=yes */
+    {"bio_config_rewrite"},
 };
 static const bio_worker_data *const bio_worker_end = bio_workers + (sizeof bio_workers / sizeof *bio_workers);
 
@@ -140,6 +142,13 @@ typedef union bio_job {
     struct {
         int type;
     } tls_reload_args;
+
+    struct {
+        int type;
+        sds content;       /* Serialized config file content. */
+        char *configfile;  /* Path to write config to. */
+        mode_t perm;       /* File permissions for the config file. */
+    } config_rewrite_args;
 } bio_job;
 
 void *bioProcessBackgroundJobs(void *arg);
@@ -239,6 +248,14 @@ void bioCreateTlsReloadJob(void) {
     bioSubmitJob(BIO_TLS_RELOAD, job);
 }
 
+void bioCreateConfigRewriteJob(sds content, char *configfile, mode_t perm) {
+    bio_job *job = zmalloc(sizeof(*job));
+    job->config_rewrite_args.content = content;
+    job->config_rewrite_args.configfile = configfile;
+    job->config_rewrite_args.perm = perm;
+    bioSubmitJob(BIO_CONFIG_REWRITE, job);
+}
+
 void *bioProcessBackgroundJobs(void *arg) {
     bio_worker_data *const bwd = arg;
     sigset_t sigset;
@@ -309,6 +326,20 @@ void *bioProcessBackgroundJobs(void *arg) {
 #else
             serverPanic("BIO_TLS_RELOAD job type requires built-in TLS (BUILD_TLS=yes).");
 #endif
+        } else if (job_type == BIO_CONFIG_REWRITE) {
+            int retval = rewriteConfigOverwriteFile(
+                job->config_rewrite_args.configfile,
+                job->config_rewrite_args.content,
+                job->config_rewrite_args.perm);
+            if (retval == -1) {
+                atomic_store_explicit(&server.config_rewrite_bio_errno, errno, memory_order_relaxed);
+                atomic_store_explicit(&server.config_rewrite_bio_status, C_ERR, memory_order_release);
+            } else {
+                atomic_store_explicit(&server.config_rewrite_bio_status, C_OK, memory_order_relaxed);
+            }
+            atomic_fetch_add_explicit(&server.config_rewrite_bio_completed, 1, memory_order_release);
+            sdsfree(job->config_rewrite_args.content);
+            zfree(job->config_rewrite_args.configfile);
         } else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }

--- a/src/bio.h
+++ b/src/bio.h
@@ -43,6 +43,7 @@ void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache);
 void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...);
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel);
 void bioCreateTlsReloadJob(void);
+void bioCreateConfigRewriteJob(sds content, char *configfile, mode_t perm);
 int inBioThread(void);
 
 /* Background job opcodes */
@@ -52,7 +53,8 @@ enum {
     BIO_LAZY_FREE,      /* Deferred objects freeing. */
     BIO_CLOSE_AOF,      /* Deferred close for AOF files. */
     BIO_RDB_SAVE,       /* Deferred save RDB to disk on replica */
-    BIO_TLS_RELOAD,     /* Deferred TLS reload. */
+    BIO_TLS_RELOAD,        /* Deferred TLS reload. */
+    BIO_CONFIG_REWRITE,    /* Deferred config file rewrite. */
     BIO_NUM_OPS
 };
 

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -228,6 +228,11 @@ void unblockClient(client *c, int queue_for_reprocessing) {
         c->bstate->postponed_list_node = NULL;
     } else if (c->bstate->btype == BLOCKED_SHUTDOWN) {
         /* No special cleanup. */
+    } else if (c->bstate->btype == BLOCKED_CONFIG_REWRITE) {
+        if (c->bstate->generic_blocked_list_node) {
+            listDelNode(server.clients_pending_config_rewrite, c->bstate->generic_blocked_list_node);
+            c->bstate->generic_blocked_list_node = NULL;
+        }
     } else {
         serverPanic("Unknown btype in unblockClient().");
     }
@@ -265,7 +270,8 @@ int blockedClientMayTimeout(client *c) {
     if (c->bstate->btype == BLOCKED_LIST ||
         c->bstate->btype == BLOCKED_ZSET ||
         c->bstate->btype == BLOCKED_STREAM ||
-        c->bstate->btype == BLOCKED_WAIT) {
+        c->bstate->btype == BLOCKED_WAIT ||
+        c->bstate->btype == BLOCKED_CONFIG_REWRITE) {
         return 1;
     }
     return 0;
@@ -292,6 +298,9 @@ void replyToBlockedClientTimedOut(client *c) {
         }
     } else if (c->bstate->btype == BLOCKED_MODULE) {
         moduleBlockedClientTimedOut(c, 0);
+    } else if (c->bstate->btype == BLOCKED_CONFIG_REWRITE) {
+        addReplyError(c, "CONFIG REWRITE timed out");
+        updateStatsOnUnblock(c, 0, 0, ERROR_COMMAND_FAILED);
     } else {
         serverPanic("Unknown btype in replyToBlockedClientTimedOut().");
     }
@@ -787,9 +796,42 @@ void unblockClientOnError(client *c, const char *err_str) {
     unblockClient(c, 1);
 }
 
+/* Check if any clients blocked on CONFIG REWRITE can be unblocked because
+ * the background I/O job has completed. */
+void processClientsWaitingConfigRewrite(void) {
+    unsigned long long completed =
+        atomic_load_explicit(&server.config_rewrite_bio_completed, memory_order_acquire);
+
+    listIter li;
+    listNode *ln;
+    listRewind(server.clients_pending_config_rewrite, &li);
+    while ((ln = listNext(&li))) {
+        client *c = ln->value;
+        unsigned long long wait_target = (unsigned long long)c->bstate->reploffset;
+
+        if (completed < wait_target) continue;
+
+        /* The BIO job for this client has finished. Reply based on status. */
+        int status = atomic_load_explicit(&server.config_rewrite_bio_status, memory_order_acquire);
+        if (status == C_OK) {
+            serverLog(LL_NOTICE, "CONFIG REWRITE executed with success.");
+            addReply(c, shared.ok);
+        } else {
+            int bio_errno = atomic_load_explicit(&server.config_rewrite_bio_errno, memory_order_relaxed);
+            serverLog(LL_WARNING, "CONFIG REWRITE failed: %s", strerror(bio_errno));
+            addReplyErrorFormat(c, "Rewriting config file: %s", strerror(bio_errno));
+        }
+        updateStatsOnUnblock(c, 0, 0, status == C_OK ? 0 : ERROR_COMMAND_FAILED);
+        unblockClient(c, 1);
+    }
+}
+
 void blockedBeforeSleep(void) {
     /* Handle precise timeouts of blocked clients. */
     handleBlockedClientsTimeout();
+
+    /* Unblock clients waiting for background CONFIG REWRITE to complete. */
+    if (listLength(server.clients_pending_config_rewrite)) processClientsWaitingConfigRewrite();
 
     /* Unblock all the clients blocked for synchronous replication
      * in WAIT or WAITAOF. */

--- a/src/config.c
+++ b/src/config.c
@@ -1696,7 +1696,7 @@ sds getConfigDebugInfo(void) {
  *
  * The function returns 0 on success, otherwise -1 is returned and errno
  * is set accordingly. */
-int rewriteConfigOverwriteFile(char *configfile, sds content) {
+int rewriteConfigOverwriteFile(char *configfile, sds content, mode_t perm) {
     int fd = -1;
     int retval = -1;
     char tmp_conffile[PATH_MAX];
@@ -1736,7 +1736,7 @@ int rewriteConfigOverwriteFile(char *configfile, sds content) {
 
     if (fsync(fd))
         serverLog(LL_WARNING, "Could not sync tmp config file to disk (%s)", strerror(errno));
-    else if (fchmod(fd, 0644 & ~server.umask) == -1)
+    else if (fchmod(fd, perm) == -1)
         serverLog(LL_WARNING, "Could not chmod config file (%s)", strerror(errno));
     else if (rename(tmp_conffile, configfile) == -1)
         serverLog(LL_WARNING, "Could not rename tmp config file (%s)", strerror(errno));
@@ -1755,23 +1755,18 @@ cleanup:
     return retval;
 }
 
-/* Rewrite the configuration file at "path".
- * If the configuration file already exists, we try at best to retain comments
- * and overall structure.
+/* Serialize the current server configuration to an sds string by reading
+ * the old config file (to preserve comments/structure) and updating all
+ * config values to match the current in-memory state.
  *
- * Configuration parameters that are at their default value, unless already
- * explicitly included in the old configuration file, are not rewritten.
- * The force_write flag overrides this behavior and forces everything to be
- * written. This is currently only used for testing purposes.
- *
- * On error -1 is returned and errno is set accordingly, otherwise 0. */
-int rewriteConfig(char *path, int force_write) {
+ * Returns the serialized config string on success, or NULL on error
+ * (errno is set accordingly). The caller takes ownership of the returned sds. */
+sds rewriteConfigSerialize(char *path, int force_write) {
     struct rewriteConfigState *state;
     sds newcontent;
-    int retval;
 
     /* Step 1: read the old config into our rewrite state. */
-    if ((state = rewriteConfigReadOldFile(path)) == NULL) return -1;
+    if ((state = rewriteConfigReadOldFile(path)) == NULL) return NULL;
     if (force_write) state->force_write = 1;
 
     /* Step 2: rewrite every single option, replacing or appending it inside
@@ -1799,13 +1794,29 @@ int rewriteConfig(char *path, int force_write) {
      * of multiple "save" options or duplicated options. */
     rewriteConfigRemoveOrphaned(state);
 
-    /* Step 4: generate a new configuration file from the modified state
-     * and write it into the original file. */
+    /* Step 4: generate a new configuration file from the modified state. */
     newcontent = rewriteConfigGetContentFromState(state);
-    retval = rewriteConfigOverwriteFile(server.configfile, newcontent);
-
-    sdsfree(newcontent);
     rewriteConfigReleaseState(state);
+    return newcontent;
+}
+
+/* Rewrite the configuration file at "path".
+ * If the configuration file already exists, we try at best to retain comments
+ * and overall structure.
+ *
+ * Configuration parameters that are at their default value, unless already
+ * explicitly included in the old configuration file, are not rewritten.
+ * The force_write flag overrides this behavior and forces everything to be
+ * written. This is currently only used for testing purposes.
+ *
+ * On error -1 is returned and errno is set accordingly, otherwise 0. */
+int rewriteConfig(char *path, int force_write) {
+    sds newcontent = rewriteConfigSerialize(path, force_write);
+    if (newcontent == NULL) return -1;
+
+    int retval = rewriteConfigOverwriteFile(server.configfile, newcontent,
+                                            0644 & ~server.umask);
+    sdsfree(newcontent);
     return retval;
 }
 
@@ -3610,13 +3621,36 @@ void configRewriteCommand(client *c) {
         addReplyError(c, "The server is running without a config file");
         return;
     }
-    if (rewriteConfig(server.configfile, 0) == -1) {
-        /* save errno in case of being tainted. */
+
+    /* Serialize config on the main thread (fast, in-memory). */
+    sds content = rewriteConfigSerialize(server.configfile, 0);
+    if (content == NULL) {
         int err = errno;
-        serverLog(LL_WARNING, "CONFIG REWRITE failed: %s", strerror(err));
+        serverLog(LL_WARNING, "CONFIG REWRITE serialization failed: %s", strerror(err));
         addReplyErrorFormat(c, "Rewriting config file: %s", strerror(err));
-    } else {
-        serverLog(LL_NOTICE, "CONFIG REWRITE executed with success.");
-        addReply(c, shared.ok);
+        return;
     }
+
+    /* Snapshot values needed by the BIO thread. */
+    char *configfile = zstrdup(server.configfile);
+    mode_t perm = 0644 & ~server.umask;
+
+    /* Record the completion target for this client before submitting the job.
+     * The BIO thread increments config_rewrite_bio_completed after each write,
+     * so we wait for it to exceed our snapshot of the counter + 1. */
+    unsigned long long wait_target =
+        atomic_load_explicit(&server.config_rewrite_bio_completed, memory_order_acquire) + 1;
+
+    /* Submit the disk I/O to the background thread. The BIO thread takes
+     * ownership of both 'content' and 'configfile'. */
+    bioCreateConfigRewriteJob(content, configfile, perm);
+
+    /* Block this client until the BIO thread signals completion. */
+    initClientBlockingState(c);
+    c->bstate->timeout = mstime() + 30000; /* 30 second timeout */
+    c->bstate->reploffset = (long long)wait_target; /* Reuse field as wait target */
+    blockClient(c, BLOCKED_CONFIG_REWRITE);
+    listAddNodeTail(server.clients_pending_config_rewrite, c);
+    serverAssert(c->bstate->generic_blocked_list_node == NULL);
+    c->bstate->generic_blocked_list_node = listLast(server.clients_pending_config_rewrite);
 }

--- a/src/server.c
+++ b/src/server.c
@@ -2917,6 +2917,10 @@ void initServer(void) {
     server.pending_push_messages = listCreate();
     server.clients_waiting_acks = listCreate();
     server.get_ack_from_replicas = 0;
+    server.config_rewrite_bio_status = C_OK;
+    server.config_rewrite_bio_errno = 0;
+    server.config_rewrite_bio_completed = 0;
+    server.clients_pending_config_rewrite = listCreate();
     server.paused_actions = 0;
     memset(server.client_pause_per_purpose, 0, sizeof(server.client_pause_per_purpose));
     server.postponed_clients = listCreate();
@@ -6061,6 +6065,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "lru_clock:%u\r\n", server.unixtime & ((1 << LRULFU_BITS) - 1),
                 "executable:%s\r\n", server.executable ? server.executable : "",
                 "config_file:%s\r\n", server.configfile ? server.configfile : "",
+                "config_rewrite_last_status:%s\r\n",
+                    atomic_load_explicit(&server.config_rewrite_bio_status, memory_order_relaxed) == C_OK ? "ok" : "err",
                 "io_threads_active:%i\r\n", server.active_io_threads_num > 1,
                 "availability_zone:%s\r\n", server.availability_zone));
 

--- a/src/server.h
+++ b/src/server.h
@@ -379,9 +379,10 @@ typedef enum blocking_type {
     BLOCKED_STREAM,   /* XREAD. */
     BLOCKED_ZSET,     /* BZPOP et al. */
     BLOCKED_POSTPONE, /* Blocked by processCommand, re-try processing later. */
-    BLOCKED_SHUTDOWN, /* SHUTDOWN. */
-    BLOCKED_NUM,      /* Number of blocked states. */
-    BLOCKED_END       /* End of enumeration */
+    BLOCKED_SHUTDOWN,        /* SHUTDOWN. */
+    BLOCKED_CONFIG_REWRITE,  /* CONFIG REWRITE waiting for BIO completion. */
+    BLOCKED_NUM,             /* Number of blocked states. */
+    BLOCKED_END              /* End of enumeration */
 } blocking_type;
 
 /* Client request types */
@@ -1745,6 +1746,11 @@ struct valkeyServer {
     char *executable;                                 /* Absolute executable file path. */
     char **exec_argv;                                 /* Executable argv vector (copy). */
     mode_t umask;                                     /* The umask value of the process on startup */
+    /* Background config rewrite state */
+    _Atomic int config_rewrite_bio_status;            /* C_OK or C_ERR from last BIO config rewrite. */
+    _Atomic int config_rewrite_bio_errno;             /* errno from last failed BIO config rewrite. */
+    _Atomic unsigned long long config_rewrite_bio_completed; /* Monotonic counter of completed BIO config rewrites. */
+    list *clients_pending_config_rewrite;             /* Clients blocked on CONFIG REWRITE. */
     int hz;                                           /* serverCron() calls frequency in hertz */
     int clients_hz;                                   /* clientsTimeProc() frequency in hertz */
     int in_fork_child;                                /* indication that this is a fork child */
@@ -3632,6 +3638,9 @@ struct rewriteConfigState; /* Forward declaration to export API. */
 int rewriteConfigRewriteLine(struct rewriteConfigState *state, const char *option, sds line, int force);
 void rewriteConfigMarkAsProcessed(struct rewriteConfigState *state, const char *option);
 int rewriteConfig(char *path, int force_write);
+sds rewriteConfigSerialize(char *path, int force_write);
+int rewriteConfigOverwriteFile(char *configfile, sds content, mode_t perm);
+void processClientsWaitingConfigRewrite(void);
 void initConfigValues(void);
 void removeConfig(sds name);
 sds getConfigDebugInfo(void);

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1964,6 +1964,192 @@ test {CONFIG REWRITE handles alias config properly} {
     }
 } {} {external:skip}
 
+test {CONFIG REWRITE async basic - set value and rewrite persists} {
+    start_server {tags {"introspection"}} {
+        r config set maxmemory 10mb
+        assert_equal [r config rewrite] {OK}
+
+        # Verify config survives restart
+        restart_server 0 true false
+        wait_done_loading r
+        assert_equal [lindex [r config get maxmemory] 1] {10485760}
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async concurrent - multiple clients all get replies} {
+    start_server {tags {"introspection"}} {
+        set num_clients 5
+        set clients {}
+
+        # Create deferring clients and send CONFIG REWRITE from each
+        for {set i 0} {$i < $num_clients} {incr i} {
+            set rd [valkey_deferring_client]
+            lappend clients $rd
+            r config set maxmemory [expr {10 + $i}]mb
+            $rd config rewrite
+        }
+
+        # All clients should get +OK replies
+        for {set i 0} {$i < $num_clients} {incr i} {
+            set rd [lindex $clients $i]
+            set reply [$rd read]
+            assert_equal $reply {OK}
+        }
+
+        # Cleanup
+        foreach rd $clients {
+            $rd close
+        }
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async non-blocking - other clients not blocked} {
+    start_server {tags {"introspection"}} {
+        set rd [valkey_deferring_client]
+
+        # Issue CONFIG REWRITE on a deferring client
+        $rd config rewrite
+
+        # Meanwhile, other commands should still work on the main client
+        assert_equal [r ping] {PONG}
+        assert_equal [r set testkey testvalue] {OK}
+        assert_equal [r get testkey] {testvalue}
+
+        # The deferred client should eventually get OK
+        set reply [$rd read]
+        assert_equal $reply {OK}
+
+        $rd close
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async error path - unwritable directory} {
+    start_server {tags {"introspection"}} {
+        set config_path [srv 0 config_file]
+        set config_dir [file dirname $config_path]
+
+        # Make the directory unwritable so mkstemp fails in the BIO thread.
+        # The config file itself is still readable for serialization.
+        file attributes $config_dir -permissions 00555
+
+        catch {r config rewrite} err
+
+        # Should get an error, not hang or crash
+        assert_match {*ERR*} $err
+
+        # Restore permissions
+        file attributes $config_dir -permissions 00755
+
+        # Verify server is still healthy
+        assert_equal [r ping] {PONG}
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async pipelined - 20 rapid rewrites from one client} {
+    start_server {tags {"introspection"}} {
+        set rd [valkey_deferring_client]
+        set num_cmds 20
+
+        # Pipeline 20 CONFIG REWRITE commands
+        for {set i 0} {$i < $num_cmds} {incr i} {
+            $rd config rewrite
+        }
+
+        # All 20 should return OK
+        for {set i 0} {$i < $num_cmds} {incr i} {
+            set reply [$rd read]
+            assert_equal $reply {OK}
+        }
+
+        $rd close
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async point-in-time snapshot semantics} {
+    start_server {tags {"introspection"}} {
+        # Set initial value and rewrite
+        r config set hz 15
+        assert_equal [r config rewrite] {OK}
+
+        # Set new value and rewrite again
+        r config set hz 20
+        assert_equal [r config rewrite] {OK}
+
+        # Read the config file - should contain the second rewrite's value
+        set config_path [srv 0 config_file]
+        set content [exec cat $config_path]
+        assert_match {*hz 20*} $content
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async - server restart after rewrite} {
+    start_server {tags {"introspection"}} {
+        # Set a known value
+        r config set maxmemory 42mb
+
+        # Rewrite config
+        assert_equal [r config rewrite] {OK}
+
+        # Restart the server
+        restart_server 0 true false
+        wait_done_loading r
+
+        # Verify the value persisted
+        assert_equal [lindex [r config get maxmemory] 1] {44040192}
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async - shutdown during pending rewrite no crash} {
+    start_server {tags {"introspection"}} {
+        # Issue a CONFIG REWRITE followed by immediate restart.
+        # This exercises bioDrainWorker() during shutdown.
+        r config set maxmemory 99mb
+        r config rewrite
+
+        # Restart (this invokes shutdown internally). If the server
+        # deadlocks or crashes, the test framework will catch it.
+        restart_server 0 true false
+        wait_done_loading r
+
+        # Server came back up — no crash/deadlock
+        assert_equal [r ping] {PONG}
+    }
+} {} {external:skip}
+
+test {CONFIG REWRITE async - INFO reflects rewrite status} {
+    start_server {tags {"introspection"}} {
+        # Successful rewrite
+        r config set maxmemory 10mb
+        assert_equal [r config rewrite] {OK}
+
+        # INFO should show ok
+        wait_for_condition 50 100 {
+            [string match {*config_rewrite_last_status:ok*} [r info server]]
+        } else {
+            fail "INFO config_rewrite_last_status not ok after successful rewrite"
+        }
+
+        # Trigger a failed rewrite by making directory unwritable
+        # so the BIO thread's mkstemp fails
+        set config_path [srv 0 config_file]
+        set config_dir [file dirname $config_path]
+        file attributes $config_dir -permissions 00555
+
+        catch {r config rewrite} err
+        assert_match {*ERR*} $err
+
+        # INFO should now show err
+        wait_for_condition 50 100 {
+            [string match {*config_rewrite_last_status:err*} [r info server]]
+        } else {
+            fail "INFO config_rewrite_last_status not err after failed rewrite"
+        }
+
+        # Restore permissions
+        file attributes $config_dir -permissions 00755
+    }
+} {} {external:skip}
+
 test {CONFIG hash-seed is immutable and settable at startup} {
     start_server {tags {"introspection"} overrides {hash-seed aabbccddeeffgghh}} {
         assert_error "ERR CONFIG SET failed (possibly related to argument 'hash-seed') - can't set immutable config*" {


### PR DESCRIPTION
CONFIG REWRITE runs synchronously on the main thread, blocking all command execution during the disk write and fsync. On slow disks this causes seconds of unavailability or even failovers.

This moves the disk write to a dedicated BIO worker thread. The config is serialized on the main thread (safe to read server globals), then the serialized content is handed off to the BIO thread for the actual write/fsync/rename. Only the issuing client is blocked until completion; all other connections continue serving.

- Add BIO_CONFIG_REWRITE job type with dedicated worker
- Extract rewriteConfigSerialize() from rewriteConfig()
- Add BLOCKED_CONFIG_REWRITE client blocking type with 30s timeout
- Track per-client completion via monotonic counter for concurrent rewrites
- Preserve synchronous rewriteConfig() for sentinel/debug/shutdown paths
- Add config_rewrite_last_status to INFO server output

Follows the same architecture as #2555 (async cluster config save).

## Testing

Added 9 new tests in `tests/unit/introspection.tcl`:

- Basic async CONFIG REWRITE persists config changes to disk
- Concurrent CONFIG REWRITE from 5 simultaneous clients all receive replies
- Non-blocking: other clients serve commands while CONFIG REWRITE is in flight
- Error path: CONFIG REWRITE returns -ERR when config directory is unwritable
- Rapid-fire: 20 pipelined CONFIG REWRITE commands all complete successfully
- Point-in-time snapshot: CONFIG SET between two rewrites produces correct final config
- Server restart after async rewrite loads persisted values correctly
- Shutdown during pending rewrite completes without crash or deadlock
- INFO server reports config_rewrite_last_status as ok/err after success/failure

Test stability verified across 10 consecutive runs (151 tests, 0 failures each run).

Full suite results (no regressions):
- `make test`: 5852 passed, 2 failed (pre-existing: HINCRBYFLOAT float precision, logging.tcl timeout)
- `make test-unit`: 25/26 suites passed (pre-existing test_entry.c failure)

Fixes #2860