### PR TITLE
Fix `valkey-cli --cluster del-node` for unreachable nodes

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -7598,7 +7598,7 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
 
         /* Skip nodes without a valid connection. */
         if (!n->context) {
-            clusterManagerLogInfo(">>> Skipping %s:%d (not connected)\n", n->ip, n->port);
+            clusterManagerLogWarn(">>> Skipping %s:%d (not connected)\n", n->ip, n->port);
             continue;
         }
 
@@ -7625,6 +7625,7 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         valkeyReply *r = valkeyCommand(node->context, "CLUSTER RESET %s", "SOFT");
         success = clusterManagerCheckValkeyReply(node, r, NULL);
         if (r) freeReplyObject(r);
+        if (!success) return 0;
     } else {
         clusterManagerLogWarn(">>> WARNING: Could not connect to node %s:%d, "
                               "unable to send CLUSTER RESET.\n",

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -5766,11 +5766,11 @@ cleanup:
     return success;
 }
 
-/* Retrieves info about the cluster using argument 'node' as the starting
- * point. All nodes will be loaded inside the cluster_manager.nodes list.
- * Warning: if something goes wrong, it will free the starting node before
- * returning 0. */
-static int clusterManagerLoadInfoFromNode(clusterManagerNode *node) {
+/* Common helper function to load cluster info from the starting node.
+ * If include_unreachable is true, all nodes from gossip are added to the list.
+ * If include_unreachable is false, only healthy reachable nodes are added.
+ * Returns 1 on success, 0 on failure and frees the starting node. */
+static int clusterManagerLoadInfoCommon(clusterManagerNode *node, int include_unreachable) {
     if (node->context == NULL && !clusterManagerNodeConnect(node)) {
         freeClusterManagerNode(node);
         return 0;
@@ -5821,8 +5821,14 @@ static int clusterManagerLoadInfoFromNode(clusterManagerNode *node) {
             }
             continue;
         invalid_friend:
-            if (!(friend->flags & CLUSTER_MANAGER_FLAG_REPLICA)) cluster_manager.unreachable_primaries++;
-            freeClusterManagerNode(friend);
+            if (!(friend->flags & CLUSTER_MANAGER_FLAG_REPLICA)) {
+                cluster_manager.unreachable_primaries++;
+            }
+            if (include_unreachable) {
+                listAddNodeTail(cluster_manager.nodes, friend);
+            } else {
+                freeClusterManagerNode(friend);
+            }
         }
         listRelease(node->friends);
         node->friends = NULL;
@@ -5842,6 +5848,20 @@ static int clusterManagerLoadInfoFromNode(clusterManagerNode *node) {
         }
     }
     return 1;
+}
+
+/* Retrieves info about the cluster using argument 'node' as the starting
+ * point. Only reachable healthy nodes will be loaded.
+ * Returns 1 on success, 0 on failure. */
+static int clusterManagerLoadInfoFromNode(clusterManagerNode *node) {
+    return clusterManagerLoadInfoCommon(node, 0);
+}
+
+/* Retrieves info about the cluster using argument 'node' as the starting
+ * point. Loads all nodes from gossip regardless of their health status.
+ * Returns 1 on success, 0 on failure. */
+static int clusterManagerLoadAllInfoFromNode(clusterManagerNode *node) {
+    return clusterManagerLoadInfoCommon(node, 1);
 }
 
 /* Compare functions used by various sorting operations. */
@@ -7551,7 +7571,7 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
     clusterManagerNode *node = NULL;
 
     // Load cluster information
-    if (!clusterManagerLoadInfoFromNode(ref_node)) return 0;
+    if (!clusterManagerLoadAllInfoFromNode(ref_node)) return 0;
 
     // Check if the node exists and is not empty
     node = clusterManagerNodeByName(node_id);
@@ -7575,6 +7595,13 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
     while ((ln = listNext(&li)) != NULL) {
         clusterManagerNode *n = ln->value;
         if (n == node) continue;
+
+        /* Skip nodes without a valid connection. */
+        if (!n->context) {
+            clusterManagerLogInfo(">>> Skipping %s:%d (not connected)\n", n->ip, n->port);
+            continue;
+        }
+
         if (n->replicate && !strcasecmp(n->replicate, node_id)) {
             // Reconfigure the replica to replicate with some other node
             clusterManagerNode *primary = clusterManagerNodeWithLeastReplicas();
@@ -7591,12 +7618,19 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (!success) return 0;
     }
 
-    /* Finally send CLUSTER RESET to the node. */
-    clusterManagerLogInfo(">>> Sending CLUSTER RESET SOFT to the "
-                          "deleted node.\n");
-    valkeyReply *r = valkeyCommand(node->context, "CLUSTER RESET %s", "SOFT");
-    success = clusterManagerCheckValkeyReply(node, r, NULL);
-    if (r) freeReplyObject(r);
+    /* Finally send CLUSTER RESET to the node if we have a connection. */
+    if (node->context != NULL) {
+        clusterManagerLogInfo(">>> Sending CLUSTER RESET SOFT to the "
+                              "deleted node.\n");
+        valkeyReply *r = valkeyCommand(node->context, "CLUSTER RESET %s", "SOFT");
+        success = clusterManagerCheckValkeyReply(node, r, NULL);
+        if (r) freeReplyObject(r);
+    } else {
+        clusterManagerLogWarn(">>> WARNING: Could not connect to node %s:%d, "
+                              "unable to send CLUSTER RESET.\n",
+                              node->ip ? node->ip : "(null)", node->port);
+    }
+    clusterManagerLogOk("[OK] Node %s removed from the cluster.\n", node_id);
     return success;
 invalid_args:
     fprintf(stderr, CLUSTER_MANAGER_INVALID_HOST_ARG);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -5657,61 +5657,6 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
             node->flags |= CLUSTER_MANAGER_FLAG_MYSELF;
             currentNode = node;
             clusterManagerNodeResetSlots(node);
-            if (i == 8) {
-                int remaining = strlen(line);
-                while (remaining > 0) {
-                    p = strchr(line, ' ');
-                    if (p == NULL) p = line + remaining;
-                    remaining -= (p - line);
-
-                    char *slotsdef = line;
-                    *p = '\0';
-                    if (remaining) {
-                        line = p + 1;
-                        remaining--;
-                    } else
-                        line = p;
-                    char *dash = NULL;
-                    if (slotsdef[0] == '[') {
-                        slotsdef++;
-                        if ((p = strstr(slotsdef, "->-"))) { // Migrating
-                            *p = '\0';
-                            p += 3;
-                            char *closing_bracket = strchr(p, ']');
-                            if (closing_bracket) *closing_bracket = '\0';
-                            sds slot = sdsnew(slotsdef);
-                            sds dst = sdsnew(p);
-                            node->migrating_count += 2;
-                            node->migrating = zrealloc(node->migrating, (node->migrating_count * sizeof(sds)));
-                            node->migrating[node->migrating_count - 2] = slot;
-                            node->migrating[node->migrating_count - 1] = dst;
-                        } else if ((p = strstr(slotsdef, "-<-"))) { // Importing
-                            *p = '\0';
-                            p += 3;
-                            char *closing_bracket = strchr(p, ']');
-                            if (closing_bracket) *closing_bracket = '\0';
-                            sds slot = sdsnew(slotsdef);
-                            sds src = sdsnew(p);
-                            node->importing_count += 2;
-                            node->importing = zrealloc(node->importing, (node->importing_count * sizeof(sds)));
-                            node->importing[node->importing_count - 2] = slot;
-                            node->importing[node->importing_count - 1] = src;
-                        }
-                    } else if ((dash = strchr(slotsdef, '-')) != NULL) {
-                        p = dash;
-                        int start, stop;
-                        *p = '\0';
-                        start = atoi(slotsdef);
-                        stop = atoi(p + 1);
-                        node->slots_count += (stop - (start - 1));
-                        while (start <= stop) node->slots[start++] = 1;
-                    } else if (p > slotsdef) {
-                        node->slots[atoi(slotsdef)] = 1;
-                        node->slots_count++;
-                    }
-                }
-            }
-            node->dirty = 0;
         } else if (!getfriends) {
             if (!(node->flags & CLUSTER_MANAGER_FLAG_MYSELF))
                 continue;
@@ -5723,6 +5668,68 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
             if (node->friends == NULL) node->friends = listCreate();
             listAddNodeTail(node->friends, currentNode);
         }
+        /* Parse slot definitions for both myself and friend nodes.
+         * For unreachable friends, this gossip data is the only source
+         * of slot ownership info. For reachable friends, this will be
+         * overwritten when their own CLUSTER NODES is queried directly. */
+        if (i == 8) {
+            int remaining = strlen(line);
+            while (remaining > 0) {
+                p = strchr(line, ' ');
+                if (p == NULL) p = line + remaining;
+                remaining -= (p - line);
+
+                char *slotsdef = line;
+                *p = '\0';
+                if (remaining) {
+                    line = p + 1;
+                    remaining--;
+                } else
+                    line = p;
+                char *dash = NULL;
+                if (slotsdef[0] == '[') {
+                    /* Migrating/importing only applies to the local node. */
+                    if (myself) {
+                        slotsdef++;
+                        if ((p = strstr(slotsdef, "->-"))) {
+                            *p = '\0';
+                            p += 3;
+                            char *closing_bracket = strchr(p, ']');
+                            if (closing_bracket) *closing_bracket = '\0';
+                            sds slot = sdsnew(slotsdef);
+                            sds dst = sdsnew(p);
+                            node->migrating_count += 2;
+                            node->migrating = zrealloc(node->migrating, (node->migrating_count * sizeof(sds)));
+                            node->migrating[node->migrating_count - 2] = slot;
+                            node->migrating[node->migrating_count - 1] = dst;
+                        } else if ((p = strstr(slotsdef, "-<-"))) {
+                            *p = '\0';
+                            p += 3;
+                            char *closing_bracket = strchr(p, ']');
+                            if (closing_bracket) *closing_bracket = '\0';
+                            sds slot = sdsnew(slotsdef);
+                            sds src = sdsnew(p);
+                            node->importing_count += 2;
+                            node->importing = zrealloc(node->importing, (node->importing_count * sizeof(sds)));
+                            node->importing[node->importing_count - 2] = slot;
+                            node->importing[node->importing_count - 1] = src;
+                        }
+                    }
+                } else if ((dash = strchr(slotsdef, '-')) != NULL) {
+                    p = dash;
+                    int start, stop;
+                    *p = '\0';
+                    start = atoi(slotsdef);
+                    stop = atoi(p + 1);
+                    currentNode->slots_count += (stop - (start - 1));
+                    while (start <= stop) currentNode->slots[start++] = 1;
+                } else if (p > slotsdef) {
+                    currentNode->slots[atoi(slotsdef)] = 1;
+                    currentNode->slots_count++;
+                }
+            }
+        }
+        if (myself) node->dirty = 0;
         if (name != NULL) {
             if (currentNode->name) sdsfree(currentNode->name);
             currentNode->name = sdsnew(name);
@@ -6173,6 +6180,7 @@ static clusterManagerNode *clusterManagerNodeWithLeastReplicas(void) {
     while ((ln = listNext(&li)) != NULL) {
         clusterManagerNode *n = ln->value;
         if (n->flags & CLUSTER_MANAGER_FLAG_REPLICA) continue;
+        if (!n->context) continue; /* Skip unreachable primaries */
         if (node == NULL || n->replicas_count < lowest_count) {
             node = n;
             lowest_count = n->replicas_count;

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -7606,7 +7606,10 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
 
         /* Skip nodes without a valid connection. */
         if (!n->context) {
-            clusterManagerLogWarn(">>> Skipping %s:%d (not connected)\n", n->ip, n->port);
+            clusterManagerLogWarn(">>> Skipping unreachable node %s:%d. "
+                                  "It may need manual reconfiguration "
+                                  "when it comes back online.\n",
+                                  n->ip, n->port);
             continue;
         }
 

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -7444,7 +7444,10 @@ static int clusterManagerCommandAddNode(int argc, char **argv) {
             }
         } else {
             primary_node = clusterManagerNodeWithLeastReplicas();
-            assert(primary_node != NULL);
+            if (primary_node == NULL) {
+                clusterManagerLogErr("[ERR] Could not find a reachable primary node.\n");
+                return 0;
+            }
             printf("Automatically selected primary %s:%d\n", primary_node->ip, primary_node->port);
         }
     }
@@ -7616,7 +7619,11 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
         if (n->replicate && !strcasecmp(n->replicate, node_id)) {
             // Reconfigure the replica to replicate with some other node
             clusterManagerNode *primary = clusterManagerNodeWithLeastReplicas();
-            assert(primary != NULL);
+            if (primary == NULL) {
+                clusterManagerLogErr("[ERR] Could not find a reachable primary node "
+                                     "to reassign replica %s:%d.\n", n->ip, n->port);
+                return 0;
+            }
             clusterManagerLogInfo(">>> %s:%d as replica of %s:%d\n", n->ip, n->port, primary->ip, primary->port);
             valkeyReply *r = CLUSTER_MANAGER_COMMAND(n, "CLUSTER REPLICATE %s", primary->name);
             success = clusterManagerCheckValkeyReply(n, r, NULL);

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -5691,7 +5691,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
                     /* Migrating/importing only applies to the local node. */
                     if (myself) {
                         slotsdef++;
-                        if ((p = strstr(slotsdef, "->-"))) {
+                        if ((p = strstr(slotsdef, "->-"))) { // Migrating
                             *p = '\0';
                             p += 3;
                             char *closing_bracket = strchr(p, ']');
@@ -5702,7 +5702,7 @@ static int clusterManagerNodeLoadInfo(clusterManagerNode *node, int opts, char *
                             node->migrating = zrealloc(node->migrating, (node->migrating_count * sizeof(sds)));
                             node->migrating[node->migrating_count - 2] = slot;
                             node->migrating[node->migrating_count - 1] = dst;
-                        } else if ((p = strstr(slotsdef, "-<-"))) {
+                        } else if ((p = strstr(slotsdef, "-<-"))) { // Importing
                             *p = '\0';
                             p += 3;
                             char *closing_bracket = strchr(p, ']');

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -7621,7 +7621,8 @@ static int clusterManagerCommandDeleteNode(int argc, char **argv) {
             clusterManagerNode *primary = clusterManagerNodeWithLeastReplicas();
             if (primary == NULL) {
                 clusterManagerLogErr("[ERR] Could not find a reachable primary node "
-                                     "to reassign replica %s:%d.\n", n->ip, n->port);
+                                     "to reassign replica %s:%d.\n",
+                                     n->ip, n->port);
                 return 0;
             }
             clusterManagerLogInfo(">>> %s:%d as replica of %s:%d\n", n->ip, n->port, primary->ip, primary->port);

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -561,4 +561,99 @@ start_multiple_servers 3 [list overrides $base_conf] {
 
 } ;# foreach use_atomic_slot_migration
 
+# Test valkey-cli --cluster del-node
+set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
+start_multiple_servers 3 [list overrides $base_conf] {
+
+    # Create cluster with 1 primary and 2 replicas for del-node tests
+    exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
+                    127.0.0.1:[srv 0 port] \
+                    127.0.0.1:[srv -1 port] \
+                    127.0.0.1:[srv -2 port] \
+                    --cluster-replicas 2
+
+    # Wait for the cluster to be ready
+    wait_for_cluster_state ok
+
+    test "del-node: Cannot delete node with slots" {
+        set node1 [srv 0 client]
+        set node1_id [$node1 CLUSTER MYID]
+
+        # Try to delete node with slots - should fail
+        catch {
+            exec $::VALKEY_CLI_BIN --cluster-yes --cluster del-node \
+                         127.0.0.1:[srv -1 port] \
+                         $node1_id
+        } e
+        assert_match {*not empty*} $e
+        wait_for_cluster_size 3
+    }
+
+    test "del-node: Delete reachable node without slots" {
+        set node2 [srv -1 client]
+        set node2_id [$node2 CLUSTER MYID]
+
+        # Delete reachable node without slots
+        set result [catch {
+            exec $::VALKEY_CLI_BIN --cluster-yes --cluster del-node \
+                         127.0.0.1:[srv 0 port] \
+                         $node2_id
+        } output]
+
+        # Should succeed without stderr
+        assert_equal $result 0
+        assert_match {*Sending CLUSTER RESET SOFT*} $output
+        assert_match {*\[OK\] Node*removed from the cluster*} $output
+
+        # Verify cluster state after deletion:
+        # - Node0 (primary): still in cluster, knows 2 nodes
+        # - Node1 (deleted): reset to standalone, knows only itself
+        # - Node2 (replica): still in cluster, knows 2 nodes
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_known_nodes] == 2 &&
+            [CI 1 cluster_known_nodes] == 1 &&
+            [CI 2 cluster_known_nodes] == 2
+        } else {
+            fail "Nodes don't have expected cluster state"
+        }
+    }
+
+    test "del-node: Delete unreachable node without slots" {
+        set node3 [srv -2 client]
+        set node3_id [$node3 CLUSTER MYID]
+
+        # Shutdown node 3 to make it unreachable
+        catch {$node3 SHUTDOWN NOSAVE}
+
+        # Wait for cluster to detect node 3 as failed
+        wait_node_marked_fail 0 $node3_id
+
+        # Delete the unreachable empty replica
+        set result [catch {
+            exec $::VALKEY_CLI_BIN -t 1 --cluster-yes --cluster del-node \
+                         127.0.0.1:[srv 0 port] \
+                         $node3_id
+        } output]
+
+        # Result should be 1 due to stderr output
+        assert_equal $result 1
+        assert_match {*unable to send CLUSTER RESET*} $output
+        assert_match {*Connection refused*} $output
+
+        # Check for success message
+        assert_match {*\[OK\] Node*removed from the cluster*} $output
+
+        # Verify cluster state after deletion:
+        # - Node0 (primary): only node left, knows only itself
+        # - Node1 (deleted in test 2): still standalone
+        # - Node2 (deleted in test 3): shutdown, can't check
+        wait_for_condition 1000 50 {
+            [CI 0 cluster_known_nodes] == 1 &&
+            [CI 1 cluster_known_nodes] == 1
+        } else {
+            fail "Nodes don't have expected cluster state"
+        }
+    }
+} ;# stop servers
+
 }

--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -656,4 +656,36 @@ start_multiple_servers 3 [list overrides $base_conf] {
     }
 } ;# stop servers
 
+set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
+start_multiple_servers 3 [list overrides $base_conf] {
+
+    test "del-node: Cannot delete unreachable primary with slots" {
+        # Create cluster with 3 primaries, no replicas
+        exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
+                        127.0.0.1:[srv 0 port] \
+                        127.0.0.1:[srv -1 port] \
+                        127.0.0.1:[srv -2 port]
+
+        wait_for_cluster_state ok
+
+        set node3 [srv -2 client]
+        set node3_id [$node3 CLUSTER MYID]
+
+        # Shutdown node3 to make it unreachable
+        catch {$node3 SHUTDOWN NOSAVE}
+
+        # Wait for cluster to mark node3 as failed
+        wait_node_marked_fail 0 $node3_id
+
+        # Try to delete the unreachable primary that still owns slots
+        # This should fail with "not empty" error
+        catch {
+            exec $::VALKEY_CLI_BIN --cluster-yes --cluster del-node \
+                         127.0.0.1:[srv 0 port] \
+                         $node3_id
+        } e
+        assert_match {*not empty*} $e
+    }
+} ;# stop servers
+
 }


### PR DESCRIPTION
### Overview

The `valkey-cli --cluster del-node` command fails when attempting to delete unreachable or failed nodes, reporting `No such node ID` even though the node exists in the cluster topology.
The root cause is the command only loads information about reachable nodes, causing the lookup to fail. This PR added a new function for loading all nodes information to solve this.


### Implementation

1. Loading all nodes from gossip:
   - Added `clusterManagerLoadAllInfoFromNode()` that loads both reachable and unreachable nodes from cluster gossip
   - Extracts common logic into `clusterManagerLoadInfoCommon()` with an `include_unreachable` flag
   - Keeps the original `clusterManagerLoadInfoFromNode()` unchanged to avoid affecting existing callers
2. Added success message to be consistent with other cluster commands: `[OK] Node <id> removed from the cluster.`
3. Added test coverage for `del-node` which previously had none.
4. Load slot information from gossip for unreachable nodes in `clusterManagerNodeLoadInfo()`
5. Skip unreachable primaries in `clusterManagerNodeWithLeastReplicas()` 


### Testing
```
./runtest --single unit/cluster/cli

[ok]: del-node: Cannot delete node with slots (9 ms)
[ok]: del-node: Delete reachable node without slots (23 ms)
[ok]: del-node: Delete unreachable node without slots (1333 ms)
[ok]: del-node: Cannot delete unreachable primary with slots (3368 ms)
```
```
valkey-cli --cluster del-node 127.0.0.1:7000 eb837ea7c48908e5304eafd8b1b3ced57147c448

Could not connect to Valkey at 127.0.0.1:7002: Connection refused
>>> Removing node eb837ea7c48908e5304eafd8b1b3ced57147c448 from cluster 127.0.0.1:7000
>>> Sending CLUSTER FORGET messages to the cluster...
>>> WARNING: Could not connect to node 127.0.0.1:7002, unable to send CLUSTER RESET.
[OK] Node eb837ea7c48908e5304eafd8b1b3ced57147c448 removed from the cluster.
```

### Behavior change

Before
```
$ valkey-cli --cluster del-node <entry-node-ip>:<entry-node-port> <failed-node-id>
Could not connect to Valkey at <target-node-ip>:<target-node-port>: Connection refused
>>> Removing node <id> from cluster <entry-node-ip>:<entry-node-port>
[ERR] No such node ID <id>
```
After
```
$ valkey-cli --cluster del-node <entry-node-ip>:<entry-node-port> <failed-node-id>
Could not connect to Valkey at <target-node-ip>:<target-node-port>: Connection refused
>>> Removing node <id> from cluster <entry-node-ip>:<entry-node-port>
>>> Sending CLUSTER FORGET messages to the cluster...
>>> WARNING: Could not connect to node <target-node-ip>:<target-node-port>, unable to send CLUSTER RESET.
[OK] Node <id> removed from the cluster.
```

### Related Issue
Fixes https://github.com/valkey-io/valkey/issues/3208
