### PR TITLE
Enable USE_LIBBACKTRACE Across CI and Fix Alpine Builds

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1557,10 +1557,18 @@ jobs:
         with:
           repository: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name) || env.GITHUB_REPOSITORY || github.repository }}
           ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || env.GITHUB_HEAD_REF || github.ref }}
-      - name: make
+      - name: Install libbacktrace
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ianlancetaylor/libbacktrace
+          ref: b9e40069c0b47a722286b94eb5231f7f05c08713
+          path: libbacktrace
+      - name: Build libbacktrace
         run: |
-          apk add build-base libbacktrace-dev
-          make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
+          apk add build-base git
+          cd libbacktrace && ./configure && make && make install
+      - name: make
+        run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: testprep
         run: apk add tcl procps tclx
       - name: test
@@ -1598,10 +1606,18 @@ jobs:
         with:
           repository: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name) || env.GITHUB_REPOSITORY || github.repository }}
           ref: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.sha) || env.GITHUB_HEAD_REF || github.ref }}
-      - name: make
+      - name: Install libbacktrace
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ianlancetaylor/libbacktrace
+          ref: b9e40069c0b47a722286b94eb5231f7f05c08713
+          path: libbacktrace
+      - name: Build libbacktrace
         run: |
-          apk add build-base libbacktrace-dev
-          make SERVER_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE USE_LIBBACKTRACE=yes
+          apk add build-base git
+          cd libbacktrace && ./configure && make && make install
+      - name: make
+        run: make SERVER_CFLAGS='-Werror' USE_JEMALLOC=no CFLAGS=-DUSE_MALLOC_USABLE_SIZE USE_LIBBACKTRACE=yes
       - name: testprep
         run: apk add tcl procps tclx
       - name: test


### PR DESCRIPTION
This PR enables `USE_LIBBACKTRACE=yes` across all CI builds and builds upon the changes introduced in #3034. Alpine-based jobs previously attempted to install `libbacktrace-dev`, which does not exist in Alpine’s apk repositories.

This caused these two errors in the daily tests below:
- https://github.com/valkey-io/valkey/actions/runs/22045858351/job/63694456995
- https://github.com/valkey-io/valkey/actions/runs/22045858351/job/63694457018

To resolve this, Alpine jobs now build GNU libbacktrace from source inside the container before compiling Valkey. This aligns Alpine behavior with other environments (Ubuntu jobs) and now avoids utilizing non-existent Alpine packages. 

An alternative approach we can consider is to disable `USE_LIBBACKTRACE` for Alpine-based tests.
