### PR TITLE
Fix database ACL check for alldbs commands

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1834,10 +1834,11 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
             zfree(dbids);
         }
     } else if ((cmd->flags & CMD_ALL_DBS) && !(selector->flags & SELECTOR_FLAG_ALLDBS)) {
-        /* Intset stores unique IDs, if the count doesn't equal dbnum,
-         * the selector doesn't have access to all databases. */
-        if (!selector->dbs || intsetLen(selector->dbs) != (uint32_t)server.dbnum) {
-            return ACL_DENIED_DB;
+        for (int i = 0; i < server.dbnum; i++) {
+            if (!ACLSelectorCanAccessDb(selector, i)) {
+                if (keyidxptr) *keyidxptr = 0;
+                return ACL_DENIED_DB;
+            }
         }
     } else if (shouldRestrictCmd(cmd) && !ACLSelectorCanAccessDb(selector, dbid)) {
         if (keyidxptr) *keyidxptr = 0;

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -762,6 +762,40 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "OK" [$r2 flushdb]
     }
 
+    test {Test alldbs command with dbnum databases but wrong range} {
+        set dbnum [lindex [r config get databases] 1]
+        
+        # Create a user with dbnum databases, but with database IDs
+        # out of valid range for this server, so that this user
+        # would not have access to alldbs commands
+        set db_list ""
+        for {set i 1} {$i <= $dbnum} {incr i} {
+            if {$db_list ne ""} {
+                append db_list ","
+            }
+            append db_list $i
+        }
+        
+        r ACL SETUSER wrong-range on nopass +@all ~* db=$db_list
+        $r2 auth wrong-range password
+        
+        assert_equal "OK" [$r2 select 1]
+        $r2 set testkey value
+        
+        # FLUSHALL should fail because user doesn't have access to DB 0
+        catch {$r2 flushall} e
+        assert_match "*NOPERM*database*" $e
+        
+        assert_equal "value" [$r2 get testkey]
+        
+        assert_equal "OK" [$r2 flushdb]
+        assert_equal {} [$r2 get testkey]
+        
+        # cleanup
+        $r2 auth default password
+        $r2 select 0
+    }
+
     test {Test SWAPDB with database permissions} {
         r ACL SETUSER swapdb-user on nopass +@all ~* db=0,1
         $r2 auth swapdb-user password


### PR DESCRIPTION
At one point in development there was assumption that intset of database IDs would have IDs only in `[0, server.dbnum-1]` range, but [here](https://github.com/valkey-io/valkey/pull/2309#issuecomment-3684557935) we decided to change upper bound to `INT32_MAX` for ACL compatibility reasons between nodes.
Because of that change, assumption is not true anymore and we should explicitly check each database list to contain access to full `[0, server.dbnum-1]` range.
Also added test for that.