### PR TITLE
Always untrack initialized safe iterator

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2146,11 +2146,12 @@ void hashtableCleanupIterator(hashtableIterator *iterator) {
     if (!(iter->index == -1 && iter->table == 0)) {
         if (isSafe(iter)) {
             hashtableResumeRehashing(iter->hashtable);
-            untrackSafeIterator(iter);
         } else {
             assert(iter->fingerprint == hashtableFingerprint(iter->hashtable));
         }
     }
+    if (isSafe(iter))
+        untrackSafeIterator(iter);
 }
 
 /* Allocates and initializes an iterator. */

--- a/src/unit/test_hashtable.c
+++ b/src/unit/test_hashtable.c
@@ -1015,10 +1015,11 @@ int test_safe_iterator_invalidation(int argc, char **argv, int flags) {
     }
 
     /* Create safe and non-safe iterators */
-    hashtableIterator safe_iter1, safe_iter2, unsafe_iter;
+    hashtableIterator safe_iter1, safe_iter2, unsafe_iter, *dyn_safe_iter;
     hashtableInitIterator(&safe_iter1, ht, HASHTABLE_ITER_SAFE);
     hashtableInitIterator(&safe_iter2, ht, HASHTABLE_ITER_SAFE);
     hashtableInitIterator(&unsafe_iter, ht, 0);
+    dyn_safe_iter = hashtableCreateIterator(ht, HASHTABLE_ITER_SAFE);
 
     /* Verify iterators work before invalidation */
     void *entry;
@@ -1028,6 +1029,7 @@ int test_safe_iterator_invalidation(int argc, char **argv, int flags) {
     /* Reset iterators to test state */
     hashtableCleanupIterator(&safe_iter1);
     hashtableCleanupIterator(&safe_iter2);
+    hashtableReleaseIterator(dyn_safe_iter);
     hashtableInitIterator(&safe_iter1, ht, HASHTABLE_ITER_SAFE);
     hashtableInitIterator(&safe_iter2, ht, HASHTABLE_ITER_SAFE);
 


### PR DESCRIPTION
in #2807 we added safe-iterator invalidation when a hashtable is deleted.
When we create a safeIterator we initialize it to it->table=0 and it-index=-1.
HOWEVER say someone creates a safe iterator never progress it and later on just delete the iterator using `hashtableReleaseIterator`. 
the iterator will NOT be untracked since, `hashtableCleanupIterator` will skip the untrack:

```c
    if (!(iter->index == -1 && iter->table == 0)) {
        if (isSafe(iter)) {
            hashtableResumeRehashing(iter->hashtable);
            untrackSafeIterator(iter);
        } else {
            assert(iter->fingerprint == hashtableFingerprint(iter->hashtable));
        }
    }
```

and then when the hashtable is freed the iterator will be referenced leading to a use-after-free.

For example:

```c
    it = hashtableCreateIterator(ht, HASHTABLE_ITER_SAFE);
    hashtableReleaseIterator(it);
    hashtableRelease(ht);
```

This PR fix it by ALWAYS untrack safe iterators which have a valid hashtable when they are being cleaned up.