### PR TITLE
Fix large-memory tests by reducing allocation size

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1235,7 +1235,9 @@ start_server {tags {"scripting external:skip large-memory"}} {
             return #cjson.encode(s..s..s)
         } 0
     } {3221225474} ;# length includes two double quotes at both ends
+}
 
+start_server {tags {"scripting external:skip large-memory"}} {
     test {EVAL - Test long escape sequences for strings} {
         r eval {
             -- Generate 1gb '==...==' separator
@@ -1254,7 +1256,9 @@ start_server {tags {"scripting external:skip large-memory"}} {
             return #func()
         } 0
     } {1}
+}
 
+start_server {tags {"scripting external:skip large-memory"}} {
     test {EVAL - Lua can parse string with too many new lines} {
         # Create a long string consisting only of newline characters. When Lua
         # fails to parse a string, it typically includes a snippet like

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -1227,14 +1227,13 @@ start_server {tags {"scripting"}} {
     } {*Script attempted to access nonexistent global variable 'print'*}
 }
 
-# start a new server to test the large-memory tests
 start_server {tags {"scripting external:skip large-memory"}} {
     test {EVAL - JSON string encoding a string larger than 2GB} {
         run_script {
-            local s = string.rep("a", 1024 * 1024 * 1024)
+            local s = string.rep("a", 750 * 1024 * 1024)
             return #cjson.encode(s..s..s)
         } 0
-    } {3221225474} ;# length includes two double quotes at both ends
+    } {2359296002} ;# length includes two double quotes at both ends
 }
 
 start_server {tags {"scripting external:skip large-memory"}} {


### PR DESCRIPTION
Large-memory tests were failing with "I/O error reading reply" after the first test `EVAL - JSON string encoding a string larger than 2GB`. Three tests that shared a single server instance led to cascading failures when the first test's 3GB allocation left the server in a memory-stressed state.

This PR isolates each test by starting its own server. Additionally, I've reduced the JSON encoding test size from 3GB to 2.25GB. This included changing the allocated 1GB string (concatenated 3x) to a 750MB string to avoid memory exhaustion while still testing strings greater than 2GB like we intended.