### PR TITLE
Deflake Restart target replica during migration (without save) causes success test

### DIFF
--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2117,7 +2117,7 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_countkeysinslot $not_owning_repl 16379 0
             wait_for_countkeysinslot $not_owning_repl 16381 0
             wait_for_countkeysinslot $not_owning_repl 16383 0
-            assert_equal "0" [R $not_owning_repl DBSIZE]
+            assert_equal "0" [R $not_owning_prim DBSIZE]
             wait_for_condition 50 1000 {
                 [R $not_owning_repl DBSIZE] == 0
             } else {

--- a/tests/unit/cluster/cluster-migrateslots.tcl
+++ b/tests/unit/cluster/cluster-migrateslots.tcl
@@ -2092,7 +2092,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 wait_for_countkeysinslot $owning_repl 16381 0
                 wait_for_countkeysinslot $owning_repl 16383 0
                 assert_equal "0" [R $owning_prim DBSIZE]
-                assert_equal "0" [R $owning_repl DBSIZE]
+                wait_for_condition 50 1000 {
+                    [R $owning_repl DBSIZE] == 0
+                } else {
+                    fail "owning_repl DBSIZE expected 0, got [R $owning_repl DBSIZE]"
+                }
             } else {
                 assert_match "333" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16379]
                 assert_match "333" [R $owning_prim CLUSTER COUNTKEYSINSLOT 16381]
@@ -2101,7 +2105,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
                 wait_for_countkeysinslot $owning_repl 16381 333
                 wait_for_countkeysinslot $owning_repl 16383 334
                 assert_equal "1000" [R $owning_prim DBSIZE]
-                assert_equal "1000" [R $owning_repl DBSIZE]
+                wait_for_condition 50 1000 {
+                    [R $owning_repl DBSIZE] == 1000
+                } else {
+                    fail "owning_repl DBSIZE expected 1000, got [R $owning_repl DBSIZE]"
+                }
             }
             assert_match "0" [R $not_owning_prim CLUSTER COUNTKEYSINSLOT 16379]
             assert_match "0" [R $not_owning_prim CLUSTER COUNTKEYSINSLOT 16381]
@@ -2110,7 +2118,11 @@ start_cluster 3 3 {tags {logreqres:skip external:skip cluster} overrides {cluste
             wait_for_countkeysinslot $not_owning_repl 16381 0
             wait_for_countkeysinslot $not_owning_repl 16383 0
             assert_equal "0" [R $not_owning_repl DBSIZE]
-            assert_equal "0" [R $not_owning_repl DBSIZE]
+            wait_for_condition 50 1000 {
+                [R $not_owning_repl DBSIZE] == 0
+            } else {
+                fail "not_owning_repl DBSIZE expected 0, got [R $not_owning_repl DBSIZE]"
+            }
 
             # Cleanup for the next test
             assert_match "OK" [R $owning_prim FLUSHDB SYNC]


### PR DESCRIPTION
Fix #3222

- Replace assert_equal with wait_for_condition for replica DBSIZE checks
- Fix a duplicate assert_equal line that checked $not_owning_repl twice instead of checking both $not_owning_prim and $not_owning_repl.

## Analysis

wait_for_countkeysinslot did work, the keys were there. The issue is that COUNTKEYSINSLOT and DBSIZE read from different sources.

COUNTKEYSINSLOT reads the actual hashtable size:
```
// countKeysInSlotForDb (cluster.c, line 831)
kvstoreHashtableSize(db->keys, hashslot)
    → hashtableSize(ht)    // actual keys in the slot
```
DBSIZE reads a cached counter:
```
// dbsizeCommand (db.c)
kvstoreSize(c->db->keys) // This can be found in line 358, kvstore.c)
    → kvs->key_count       // cached total
```
When a slot is marked as importing, keys are excluded from key_count:
```
// cumulativeKeyCountAdd (kvstore.c, line 157)
if (kvstoreIsImporting(kvs, didx)) {
    kvs->importing_key_count += delta;  // hidden from DBSIZE
    return;                              // key_count NOT updated
}
kvs->key_count += delta;                // visible to DBSIZE
```

key_count will be updated when:
```
finishSlotMigrationJob (cluster_migrateslots.c, line 2302)
-> call setSlotImportingStateInAllDbs(slots, 0) (cluster_migrateslots.c, line 2340)
  -> call setSlotImportingStateInDb() (cluster_migrateslots.c, line 249)
    -> call kvstoreSetIsImporting() (cluster_migrates.c, line 238)
      -> call cmulativeKeyCountAdd() (kvstore.c, line 955)
        -> kvs->key_count += delta;
```

When slots are marked as importing, the keys exist in the hashtables but are excluded from metrics like key_count. As documented in kvstoreSetIsImporting (kvstore.c):

"Importing hashtables are not included in hashtable metrics and are excluded from scanning and random key lookup."

After the replica restarts and resyncs, there is a brief window where the migrated slots are still marked as importing. During this window, COUNTKEYSINSLOT sees the keys (reads actual hashtable) but DBSIZE returns 0 (reads key_count which excludes importing keys). Once the importing flag is cleared, key_count is updated and DBSIZE returns the correct value.

wait_for_condition handles this by retrying until DBSIZE reflects the updated key_count.

## Test
ran the test for 1000 times: https://github.com/hanxizh9910/valkey/actions/runs/22116756480/job/63926756369