### PR TITLE
Skip large-memory unit test with ASan that go OOM

### DIFF
--- a/src/unit/test_quicklist.c
+++ b/src/unit/test_quicklist.c
@@ -2226,8 +2226,8 @@ int test_quicklistCompressAndDecompressQuicklistListpackNode(int argc, char **ar
     unsigned char *s = zmalloc(sz);
     randstring(s, sz);
 
-    /* Keep filling the node, until it reaches 1GB */
-    for (int i = 0; i < 32; i++) {
+    /* Keep filling the node, until it reaches 256MB */
+    for (int i = 0; i < 8; i++) {
         node->entry = lpAppend(node->entry, s, sz);
         node->sz = lpBytes((node)->entry);
 

--- a/src/unit/test_quicklist.c
+++ b/src/unit/test_quicklist.c
@@ -2213,6 +2213,11 @@ int test_quicklistCompressAndDecompressQuicklistListpackNode(int argc, char **ar
 
     if (!(flags & UNIT_TEST_LARGE_MEMORY)) return 0;
 
+#ifdef VALKEY_ADDRESS_SANITIZER
+    /* Skip this test under sanitizers */
+    return 0;
+#endif
+
     quicklistNode *node = quicklistCreateNode();
     node->entry = lpNew(0);
 
@@ -2226,8 +2231,8 @@ int test_quicklistCompressAndDecompressQuicklistListpackNode(int argc, char **ar
     unsigned char *s = zmalloc(sz);
     randstring(s, sz);
 
-    /* Keep filling the node, until it reaches 256MB */
-    for (int i = 0; i < 8; i++) {
+    /* Keep filling the node, until it reaches 1GB */
+    for (int i = 0; i < 32; i++) {
         node->entry = lpAppend(node->entry, s, sz);
         node->sz = lpBytes((node)->entry);
 

--- a/src/unit/test_quicklist.c
+++ b/src/unit/test_quicklist.c
@@ -2214,7 +2214,7 @@ int test_quicklistCompressAndDecompressQuicklistListpackNode(int argc, char **ar
     if (!(flags & UNIT_TEST_LARGE_MEMORY)) return 0;
 
 #ifdef VALKEY_ADDRESS_SANITIZER
-    /* Skip this test under sanitizers */
+    /* Skip this test under sanitizers to avoid OOM in github actions */
     return 0;
 #endif
 


### PR DESCRIPTION
The `test_quicklistCompressAndDecompressQuicklistListpackNode` unit test was failing with ASan in CI with OOM errors. The test was allocating and compressing up to 1GB of data (32 iterations × 32MB), which exceeded available memory in CI environments. The test is skipped for ASan builds.

This PR addressed the unit test failures in `test-sanitizer-address-large-memory` for both GCC and CLANG

Test Run: https://github.com/Nikhil-Manglore/valkey/actions/runs/22159517734/job/64072360332

Resolves #3221