### PR TITLE
Fix SIGTERM crash during Lua script execution

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1774,9 +1774,9 @@ void whileBlockedCron(void) {
     latencyAddSampleIfNeeded("while-blocked-cron", latency);
     latencyTraceIfNeeded(server, while_blocked_cron, latency);
 
-    /* We received a SIGTERM during loading, shutting down here in a safe way,
+    /* We received a SIGTERM during loading or script execution, shutting down here in a safe way,
      * as it isn't ok doing so inside the signal handler. */
-    if (server.shutdown_asap && server.loading) {
+    if (server.shutdown_asap && (server.loading || scriptIsRunning())) {
         if (prepareForShutdown(NULL, SHUTDOWN_NOSAVE) == C_OK) exit(0);
         serverLog(LL_WARNING,
                   "SIGTERM received but errors trying to shut down the server, check the logs for more information");

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2659,3 +2659,34 @@ start_server {tags {"scripting"}} {
        r config set maxmemory 0
     }
 }
+
+start_server {tags {"scripting"}} {
+    test {Script shutdown - server handles SIGTERM gracefully during busy script} {
+        set pid [s process_id]
+        # So that we don't wait for default 5 seconds
+        r config set lua-time-limit 10
+        
+        set rd [valkey_deferring_client]
+        
+        # Start the infinite loop script using deferring client
+        # We don't read the response since the script will be killed by SIGTERM
+        run_script_on_connection $rd {while true do end} 0
+        
+        wait_for_condition 50 100 {
+            [catch {r ping} e] == 1
+        } else {
+            fail "Can't wait for script to timeout"
+        }
+        
+        exec kill -TERM $pid
+        
+        # Wait for the server to shut down cleanly without crashing
+        wait_for_condition 100 100 {
+            [catch {exec ps -p $pid} e] == 1
+        } else {
+            fail "Server didn't shut down in time"
+        }
+        
+        $rd close
+    } {0} {external:skip}
+}


### PR DESCRIPTION
Now we handle SIGTERM immediately in `processEventsWhileBlocked()`. This way we `finishShutdown()` while still on the script's call stack.
Before fix when SIGTERM arrived during script execution, `whileBlockedCron()` only checked `server.loading`, returned to `serverCron()` which called `finishShutdown()` while Lua script was still executing and later Lua accessed corrupted memory.

Fixes #3238
This is reproducible on all versions, so looks like it should be backported to all versions