### PR TITLE
Apply security fixes for CVEs

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -3629,17 +3629,38 @@ int clusterIsValidPacket(clusterLink *link) {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
         explen += (sizeof(clusterMsgDataGossip) * count);
 
+        /* Make sure that the number of gossip messages fit in the remaining
+         * space in the message. */
+        if (totlen < explen) {
+            serverLog(LL_WARNING,
+                      "Received invalid %s packet with gossip count %d that exceeds "
+                      "total packet length (%lld)",
+                      clusterGetMessageTypeString(type), count, (unsigned long long)totlen);
+            return 0;
+        }
+
         /* If there is extension data, which doesn't have a fixed length,
          * loop through them and validate the length of it now. */
         if (msg->mflags[0] & CLUSTERMSG_FLAG0_EXT_DATA) {
             clusterMsgPingExt *ext = getInitialPingExt(msg, count);
             while (extensions--) {
+                /* Make sure there is at least enough memory for the extension information so
+                 * we can parse it. */
+                if ((totlen - explen) < sizeof(clusterMsgPingExt)) {
+                    serverLog(LL_WARNING,
+                              "Received invalid %s packet with extension data that exceeds "
+                              "total packet length (%lld)",
+                              clusterGetMessageTypeString(type), (unsigned long long)totlen);
+                    return 0;
+                }
                 uint32_t extlen = getPingExtLength(ext);
                 if (extlen % 8 != 0) {
                     serverLog(LL_WARNING, "Received a %s packet without proper padding (%d bytes)",
                               clusterGetMessageTypeString(type), (int)extlen);
                     return 0;
                 }
+                /* Similar check to earlier, but we want to make sure the extension length is valid
+                 * this time. */
                 if ((totlen - explen) < extlen) {
                     serverLog(LL_WARNING,
                               "Received invalid %s packet with extension data that exceeds "

--- a/src/networking.c
+++ b/src/networking.c
@@ -973,6 +973,16 @@ void addReplyErrorSdsSafe(client *c, sds err) {
     addReplyErrorSdsEx(c, err, 0);
 }
 
+/* Add error reply to the given client.
+ * Supported flags:
+ * ERR_REPLY_FLAG_NO_STATS_UPDATE - indicate not to perform any error stats updates
+ * As a side effect the SDS string is freed. */
+void addReplyErrorSdsExSafe(client *c, sds err, int flags) {
+    err = sdstrim(err, "\r\n");
+    err = sdsmapchars(err, "\r\n", "  ", 2);
+    addReplyErrorSdsEx(c, err, flags);
+}
+
 /* Internal function used by addReplyErrorFormat, addReplyErrorFormatEx and RM_ReplyWithErrorFormat.
  * Refer to afterErrorReply for more information about the flags. */
 void addReplyErrorFormatInternal(client *c, int flags, const char *fmt, va_list ap) {

--- a/src/server.h
+++ b/src/server.h
@@ -2926,6 +2926,7 @@ void addReplyOrErrorObject(client *c, robj *reply);
 void afterErrorReply(client *c, const char *s, size_t len, int flags);
 void addReplyErrorFormatInternal(client *c, int flags, const char *fmt, va_list ap);
 void addReplyErrorSdsEx(client *c, sds err, int flags);
+void addReplyErrorSdsExSafe(client *c, sds err, int flags);
 void addReplyErrorSds(client *c, sds err);
 void addReplyErrorSdsSafe(client *c, sds err);
 void addReplyError(client *c, const char *err);

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -1,0 +1,113 @@
+# Test that cluster bus messages with certain invalid packets are rejected
+# and don't crash the system.
+proc create_cluster_meet_packet {sender_name sender_port sender_cport} {
+    # Constants
+    set CLUSTER_NAMELEN 40
+    set CLUSTER_SLOTS 16384
+    set NET_IP_STR_LEN 46
+    set CLUSTERMSG_TYPE_MEET 2
+    
+    # Build the packet
+    set packet ""
+    
+    # Signature "RCmb" (4 bytes)
+    append packet "RCmb"
+    
+    # totlen (uint32_t) - will be updated at the end
+    append packet [binary format I 0]
+    
+    # ver (uint16_t) - protocol version 1
+    append packet [binary format S 1]
+    
+    # port (uint16_t)
+    append packet [binary format S $sender_port]
+    
+    # type (uint16_t) - MEET
+    append packet [binary format S $CLUSTERMSG_TYPE_MEET]
+    
+    # count (uint16_t) - 100 gossip messages
+    # Value intentionally set to a high value, even though no gossip
+    # messages are included. 
+    append packet [binary format S 100]
+    
+    # currentEpoch (uint64_t)
+    append packet [binary format W 1]
+    
+    # configEpoch (uint64_t)
+    append packet [binary format W 1]
+    
+    # offset (uint64_t)
+    append packet [binary format W 0]
+    
+    # sender[40] - node name
+    set sender_padded [string range "${sender_name}[string repeat "\x00" $CLUSTER_NAMELEN]" 0 [expr {$CLUSTER_NAMELEN - 1}]]
+    append packet $sender_padded
+    
+    # myslots[2048] - all zeros
+    append packet [string repeat "\x00" [expr {$CLUSTER_SLOTS / 8}]]
+    
+    # replicaof[40] - all zeros
+    append packet [string repeat "\x00" $CLUSTER_NAMELEN]
+    
+    # myip[46] - all zeros
+    append packet [string repeat "\x00" $NET_IP_STR_LEN]
+    
+    # extensions (uint16_t) - Set to 2
+    append packet [binary format S 2000000000]
+    
+    # notused1[30] - reserved
+    append packet [string repeat "\x00" 30]
+    
+    # pport (uint16_t)
+    append packet [binary format S 0]
+    
+    # cport (uint16_t) - cluster bus port
+    append packet [binary format S $sender_cport]
+    
+    # flags (uint16_t) - CLUSTER_NODE_PRIMARY
+    append packet [binary format S 1]
+    
+    # state (unsigned char) - CLUSTER_OK
+    append packet [binary format c 0]
+    
+    # mflags[3] - message flags (WITH CLUSTERMSG_FLAG0_EXT_DATA flag set)
+    # CLUSTERMSG_FLAG0_EXT_DATA = (1 << 2) = 4
+    append packet [binary format ccc 4 0 0]
+
+    # Update totlen
+    set totlen [string length $packet]
+    set packet [string replace $packet 4 7 [binary format I $totlen]]
+    
+    return $packet
+}
+
+start_cluster 1 0 {tags {external:skip cluster tls:skip}} {
+    test "Packet with missing gossip messages don't cause invalid read" {
+        set base_port [srv 0 port]
+        set cluster_port [expr {$base_port + 10000}]
+        set fake_node_id "abcdef1234567890abcdef1234567890abcdef12"
+        
+        # Get initial total messages received
+        set info_before [R 0 cluster info]
+        regexp {cluster_stats_messages_received:(\d+)} $info_before -> initial_received
+        
+        # Create a packet with extensions=0 but CLUSTERMSG_FLAG0_EXT_DATA flag set
+        set packet [create_cluster_meet_packet $fake_node_id $base_port $cluster_port]
+        
+        # Verify packet length
+        set packet_len [string length $packet]
+        
+        # Send the packet after configuring the socket to accept binary data
+        set sock [socket 127.0.0.1 $cluster_port]
+        fconfigure $sock -translation binary -encoding binary -buffering none -blocking 1
+        puts -nonewline $sock $packet
+        flush $sock
+        close $sock
+
+        wait_for_condition 1000 10 {
+            [CI 0 cluster_stats_messages_received] == 1
+        } else {
+            fail "Packet was never received"
+        }
+    }
+}

--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -2527,6 +2527,24 @@ start_server {tags {"scripting"}} {
         assert_equal [errorrstat MY_ERR_CODE r] {} ;# error stats were not incremented
     }
 
+    test "LUA redis.error_reply API sanitation" {
+        r config resetstat
+        assert_error {ERR*} {
+            r eval {error(redis.error_reply("-ERR\r\n-ERR FAKE"))} 0
+        }
+        assert_equal PONG [r ping]
+        assert_equal [errorrstat ERR r] {count=1}
+    }
+
+    test "LUA error function API sanitation" {
+        r config resetstat
+        assert_error {ERR*} {
+            r eval {error("-ERR\r\n-ERR FAKE")} 0
+        }
+        assert_equal PONG [r ping]
+        assert_equal [errorrstat ERR r] {count=1}
+    }
+
     test "LUA test pcall" {
         assert_equal [
             r eval {local status, res = pcall(function() return 1 end); return 'status: ' .. tostring(status) .. ' result: ' .. res} 0


### PR DESCRIPTION
Apply the security fixes for unstable

[CVE-2025-67733] RESP Protocol Injectiton via Lua error_reply
[CVE-2026-21863] Remote DoS with malformed Valkey Cluster bus message

For [CVE-2025-67733] RESP Protocol Injectiton via Lua error_reply, 
src/lua/script_lua.c has been migrated to src/modules/lua/script_lua.c, and the code that used addReplyErrorSdsEx has been replaced with ValkeyModule_ReplyWithCustomErrorFormat, which
already calls addReplyErrorFormatInternal and that function already sanitizes newlines (trims \r\n at ends, replaces them in the middle with spaces). So the core fix from the patch
is already applied through the refactored code path.
We still want to backport these to older versions
