### PR TITLE
Reset request type after handling empty requests

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -3097,12 +3097,14 @@ parseResult handleParseResults(client *c) {
         /* in case the client's query was an empty line we will ignore it and proceed to process the rest of the buffer
          * if any */
         resetClient(c);
+        c->reqtype = 0;
         return PARSE_OK;
     }
 
     if (c->read_flags & READ_FLAGS_PARSING_NEGATIVE_MBULK_LEN) {
         /* Multibulk processing could see a <= 0 length. */
         resetClient(c);
+        c->reqtype = 0;
         return PARSE_OK;
     }
 

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -351,6 +351,13 @@ start_server {tags {"protocol hello logreqres:skip"}} {
 }
 
 start_server {tags {"regression"}} {
+    test "Regression for a crash on zero-length multibulk" {
+        reconnect
+        r write "*0\r\nPING\r\n"
+        r flush
+        assert_equal "PONG" [r ping]
+    }
+
     test "Regression for a crash with blocking ops and pipelining" {
         set rd [valkey_deferring_client]
         set fd [r channel]


### PR DESCRIPTION
Fix for CVE-2026-27623

If an empty request is sent, the parsing code doesn't completely reset the state, which can result in assertions being triggered since the code assumes the request type. Right now this is only a problem for multi-bulk, but also fixing this for inline since it seems more defensive.