### PR TITLE
Deflake test 'LATENCY GRAPH can output the event graph'

### DIFF
--- a/tests/unit/latency-monitor.tcl
+++ b/tests/unit/latency-monitor.tcl
@@ -140,8 +140,8 @@ tags {"needs:debug"} {
         # These numbers are taken from the "Test latency events logging" test.
         # (debug sleep 0.3) and (debug sleep 0.5), using range to prevent timing issue.
         regexp "command - high (.*?) ms, low (.*?) ms" $res -> high low
-        assert_morethan_equal $high 500
-        assert_morethan_equal $low 300
+        assert_range $high 450 550
+        assert_range $low 250 350
     }
 
     r config set latency-monitor-threshold $old_threshold_value


### PR DESCRIPTION
The test was using `assert_morethan_equal` with fixed minimum thresholds (500ms for high, 300ms for low), which caused flaky failures when the actual latency values were slightly below these thresholds due to timing variations.

Example failure:

```
Expected '499' to be more than or equal to '500' (context: type eval line 12 cmd {assert_morethan_equal $high 500} proc ::test)
```

Changes:

- Replaced assert_morethan_equal $high 500 with assert_range $high 450 550
- Replaced assert_morethan_equal $low 300 with assert_range $low 250 350

The new ranges (450-550ms for high, 250-350ms for low) align with the expected latency values from the debug sleep commands (0.5s and 0.3s respectively) while providing tolerance for timing variations, consistent with the approach used elsewhere in the test file.