### PR TITLE
Convert LTTng tracepoints from duration to entry/exit pairs

### DIFF
--- a/docs/lttng_duration_filtering.md
+++ b/docs/lttng_duration_filtering.md
@@ -1,0 +1,220 @@
+# Filtering on Duration with LTTng Snapshots
+
+Exit events in Valkey's LTTng tracepoints carry a `duration` field marked
+as `nowrite`. This field is **not** written to the trace output, but it
+**is** available for real-time filtering. This is useful for snapshot-based
+tracing: the trace buffers keep rolling in flight mode, and a snapshot is
+captured only when a slow event is detected.
+
+## Quick Start
+
+### 1. Create a snapshot session
+
+```bash
+lttng create valkey-slow --snapshot
+```
+
+### 2. Enable events with a duration filter
+
+Capture only exit events where duration exceeds a threshold (in
+microseconds):
+
+```bash
+# Commands slower than 1ms
+lttng enable-event -u 'valkey_server:command' --filter 'duration > 1000'
+lttng enable-event -u 'valkey_server:fast_command' --filter 'duration > 1000'
+
+# Per-command detail slower than 1ms
+lttng enable-event -u 'valkey_commands:command_call' --filter 'duration > 1000'
+```
+
+### 3. Add context and start
+
+```bash
+lttng add-context -u -t vtid -t procname
+lttng start
+```
+
+### 4. Take a snapshot when needed
+
+```bash
+lttng snapshot record
+```
+
+### 5. View results
+
+```bash
+lttng stop
+lttng destroy valkey-slow
+babeltrace2 ~/lttng-traces/valkey-slow-*
+```
+
+## Filter Examples
+
+```bash
+# Event loop iterations longer than 10ms
+lttng enable-event -u 'valkey_server:eventloop' \
+    --filter 'duration > 10000'
+
+# AOF writes longer than 5ms
+lttng enable-event -u 'valkey_aof:aof_write' \
+    --filter 'duration > 5000'
+
+# AOF fsync longer than 1ms (always policy)
+lttng enable-event -u 'valkey_aof:aof_fsync_always' \
+    --filter 'duration > 1000'
+
+# Expire cycle longer than 2ms
+lttng enable-event -u 'valkey_db:expire_cycle' \
+    --filter 'duration > 2000'
+
+# Fork operations longer than 50ms
+lttng enable-event -u 'valkey_rdb:fork' \
+    --filter 'duration > 50000'
+lttng enable-event -u 'valkey_aof:fork' \
+    --filter 'duration > 50000'
+
+# Cluster config fsync longer than 1ms
+lttng enable-event -u 'valkey_cluster:cluster_config_fsync' \
+    --filter 'duration > 1000'
+
+# Combine filters: slow SET/GET commands from a specific connection type
+# (enum_field 0 = SOCKET)
+lttng enable-event -u 'valkey_commands:command_call' \
+    --filter 'duration > 1000 && enum_field == 0'
+```
+
+## Continuous Monitoring with Snapshots
+
+A typical production workflow: run in snapshot mode and trigger a snapshot
+from an external monitor when latency spikes are observed.
+
+```bash
+# Setup
+lttng create valkey-monitor --snapshot
+lttng enable-event -u 'valkey_server:command' --filter 'duration > 5000'
+lttng enable-event -u 'valkey_server:fast_command' --filter 'duration > 5000'
+lttng enable-event -u 'valkey_server:eventloop' --filter 'duration > 10000'
+lttng enable-event -u 'valkey_commands:command_call' --filter 'duration > 5000'
+lttng add-context -u -t vtid -t procname
+lttng start
+
+# From a monitoring script, when p99 latency spikes:
+lttng snapshot record
+
+# Cleanup
+lttng stop
+lttng destroy valkey-monitor
+```
+
+## Notes
+
+- The `duration` field is in microseconds.
+- Since `duration` is `nowrite`, it does not appear in the trace output.
+  Use entry/exit timestamps to compute duration in post-analysis tools.
+- Entry events (`*_entry`) have no duration field and cannot be filtered
+  on duration.
+- Snapshot mode uses flight recorder buffers — only the most recent data
+  is captured when `lttng snapshot record` is called.
+
+## Combining Kernel and Userspace Tracing
+
+LTTng can trace kernel events alongside Valkey's userspace tracepoints in
+the same session. This lets you correlate Valkey operations with system
+calls, scheduling, block I/O, and CPU migrations.
+
+### Setup
+
+```bash
+# Create a session (requires root for kernel tracing)
+sudo lttng create valkey-full
+
+# Enable Valkey userspace events
+sudo lttng enable-event -u 'valkey_server:*'
+sudo lttng enable-event -u 'valkey_commands:*'
+sudo lttng enable-event -u 'valkey_aof:*'
+sudo lttng enable-event -u 'valkey_db:*'
+sudo lttng enable-event -u 'valkey_rdb:*'
+sudo lttng enable-event -u 'valkey_cluster:*'
+
+# Enable kernel syscall tracing
+sudo lttng enable-event -k --syscall --all
+
+# Enable scheduler events (context switches, wakeups)
+sudo lttng enable-event -k sched_switch,sched_wakeup,sched_migrate_task
+
+# Enable block I/O events
+sudo lttng enable-event -k block_rq_issue,block_rq_complete
+
+# Add context: thread ID, CPU ID, process name
+sudo lttng add-context -u -t vtid -t procname
+sudo lttng add-context -k -t tid -t procname
+
+sudo lttng start
+```
+
+### Targeted Kernel Tracing
+
+To reduce overhead, filter kernel events to the Valkey process:
+
+```bash
+VALKEY_PID=$(pidof valkey-server)
+
+# Syscalls from Valkey only
+sudo lttng track -k --pid $VALKEY_PID
+
+# Only trace specific syscalls (fsync, write, read, epoll_wait)
+sudo lttng enable-event -k --syscall write,read,fsync,fdatasync,epoll_wait
+```
+
+### Analyzing System Call Cost
+
+With both kernel and userspace events, you can see exactly which system
+calls happen inside a Valkey operation:
+
+```
+valkey_aof:aof_write_entry          [cpu 2]  vtid=1234
+  syscall_entry_write               [cpu 2]  tid=1234  fd=7 count=4096
+  syscall_exit_write                [cpu 2]  tid=1234  ret=4096
+valkey_aof:aof_write                [cpu 2]  vtid=1234
+```
+
+### Critical Path Analysis
+
+Use Trace Compass or babeltrace2 to identify:
+
+- **CPU time per operation**: correlate `sched_switch` events with
+  entry/exit pairs to see how much wall time vs CPU time an operation
+  consumes.
+- **I/O latency**: match `block_rq_issue` / `block_rq_complete` pairs
+  inside AOF or RDB operations to measure actual disk latency.
+- **Scheduling delays**: `sched_wakeup` to `sched_switch` gaps show
+  how long Valkey waited in the run queue.
+- **CPU migrations**: `sched_migrate_task` events reveal when the
+  scheduler moves the Valkey thread between cores, which can cause
+  cache misses.
+
+### Example: Finding fsync Bottlenecks
+
+```bash
+sudo lttng create valkey-fsync --snapshot
+sudo lttng enable-event -u 'valkey_aof:aof_fsync_always' \
+    --filter 'duration > 1000'
+sudo lttng enable-event -k --syscall fsync,fdatasync
+sudo lttng enable-event -k block_rq_issue,block_rq_complete
+sudo lttng track -k --pid $(pidof valkey-server)
+sudo lttng add-context -u -t vtid
+sudo lttng add-context -k -t tid
+sudo lttng start
+
+# When latency spikes:
+sudo lttng snapshot record
+
+sudo lttng stop
+sudo lttng destroy valkey-fsync
+babeltrace2 ~/lttng-traces/valkey-fsync-*
+```
+
+This captures the full picture: the Valkey `aof_fsync_always` event
+filtered to slow occurrences, the underlying `fdatasync` syscall, and
+the block I/O requests that show actual disk latency.

--- a/src/aof.c
+++ b/src/aof.c
@@ -1119,9 +1119,20 @@ void flushAppendOnlyFile(int force) {
         usleep(server.aof_flush_sleep);
     }
 
+    /* Emit entry traces for write subcategories */
+    if (sync_in_progress) {
+        latencyTraceStart(aof, aof_write_pending_fsync);
+    } else if (hasActiveChildProcess()) {
+        latencyTraceStart(aof, aof_write_active_child);
+    } else {
+        latencyTraceStart(aof, aof_write_alone);
+    }
+
     latencyStartMonitor(latency);
+    latencyTraceStart(aof, aof_write);
     nwritten = aofWrite(server.aof_fd, server.aof_buf, sdslen(server.aof_buf));
     latencyEndMonitor(latency);
+    latencyTraceEnd(aof, aof_write, latency);
     /* We want to capture different events for delayed writes:
      * when the delay happens with a pending fsync, or with a saving child
      * active, and when the above two conditions are missing.
@@ -1129,16 +1140,15 @@ void flushAppendOnlyFile(int force) {
      * useful for graphing / monitoring purposes. */
     if (sync_in_progress) {
         latencyAddSampleIfNeeded("aof-write-pending-fsync", latency);
-        latencyTraceIfNeeded(aof, aof_write_pending_fsync, latency);
+        latencyTraceEnd(aof, aof_write_pending_fsync, latency);
     } else if (hasActiveChildProcess()) {
         latencyAddSampleIfNeeded("aof-write-active-child", latency);
-        latencyTraceIfNeeded(aof, aof_write_active_child, latency);
+        latencyTraceEnd(aof, aof_write_active_child, latency);
     } else {
         latencyAddSampleIfNeeded("aof-write-alone", latency);
-        latencyTraceIfNeeded(aof, aof_write_alone, latency);
+        latencyTraceEnd(aof, aof_write_alone, latency);
     }
     latencyAddSampleIfNeeded("aof-write", latency);
-    latencyTraceIfNeeded(aof, aof_write, latency);
 
     /* We performed the write so reset the postponed flush sentinel to zero. */
     server.aof_flush_postponed_start = 0;
@@ -1240,6 +1250,7 @@ try_fsync:
         /* valkey_fsync is defined as fdatasync() for Linux in order to avoid
          * flushing metadata. */
         latencyStartMonitor(latency);
+        latencyTraceStart(aof, aof_fsync_always);
         /* Let's try to get this data on the disk. To guarantee data safe when
          * the AOF fsync policy is 'always', we should exit if failed to fsync
          * AOF (see comment next to the exit(1) after write error above). */
@@ -1251,8 +1262,8 @@ try_fsync:
             exit(1);
         }
         latencyEndMonitor(latency);
+        latencyTraceEnd(aof, aof_fsync_always, latency);
         latencyAddSampleIfNeeded("aof-fsync-always", latency);
-        latencyTraceIfNeeded(aof, aof_fsync_always, latency);
 
         server.aof_last_incr_fsync_offset = server.aof_last_incr_size;
         server.aof_last_fsync = server.mstime;
@@ -2592,6 +2603,7 @@ off_t getAppendOnlyFileSize(sds filename, int *status) {
 
     sds aof_filepath = makePath(server.aof_dirname, filename);
     latencyStartMonitor(latency);
+    latencyTraceStart(aof, aof_fstat);
     if (valkey_stat(aof_filepath, &sb) == -1) {
         if (status) *status = errno == ENOENT ? AOF_NOT_EXIST : AOF_OPEN_ERR;
         serverLog(LL_WARNING, "Unable to obtain the AOF file %s length. stat: %s", filename, strerror(errno));
@@ -2601,8 +2613,8 @@ off_t getAppendOnlyFileSize(sds filename, int *status) {
         size = sb.st_size;
     }
     latencyEndMonitor(latency);
+    latencyTraceEnd(aof, aof_fstat, latency);
     latencyAddSampleIfNeeded("aof-fstat", latency);
-    latencyTraceIfNeeded(aof, aof_fstat, latency);
     sdsfree(aof_filepath);
     return size;
 }
@@ -2668,6 +2680,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
 
         /* Rename the temporary aof file to 'new_base_filename'. */
         latencyStartMonitor(latency);
+        latencyTraceStart(aof, aof_rename);
         if (rename(tmpfile, new_base_filepath) == -1) {
             serverLog(LL_WARNING, "Error trying to rename the temporary AOF base file %s into %s: %s", tmpfile,
                       new_base_filepath, strerror(errno));
@@ -2678,8 +2691,8 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
             goto cleanup;
         }
         latencyEndMonitor(latency);
+        latencyTraceEnd(aof, aof_rename, latency);
         latencyAddSampleIfNeeded("aof-rename", latency);
-        latencyTraceIfNeeded(aof, aof_rename, latency);
         serverLog(LL_NOTICE, "Successfully renamed the temporary AOF base file %s into %s", tmpfile, new_base_filename);
 
         /* Rename the temporary incr aof file to 'new_incr_filename'. */
@@ -2691,6 +2704,7 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
             sds new_incr_filename = getNewIncrAofName(temp_am);
             new_incr_filepath = makePath(server.aof_dirname, new_incr_filename);
             latencyStartMonitor(latency);
+            latencyTraceStart(aof, aof_rename);
             if (rename(temp_incr_filepath, new_incr_filepath) == -1) {
                 serverLog(LL_WARNING, "Error trying to rename the temporary AOF incr file %s into %s: %s",
                           temp_incr_filepath, new_incr_filepath, strerror(errno));
@@ -2705,8 +2719,8 @@ void backgroundRewriteDoneHandler(int exitcode, int bysignal) {
                 goto cleanup;
             }
             latencyEndMonitor(latency);
+            latencyTraceEnd(aof, aof_rename, latency);
             latencyAddSampleIfNeeded("aof-rename", latency);
-            latencyTraceIfNeeded(aof, aof_rename, latency);
             serverLog(LL_NOTICE, "Successfully renamed the temporary AOF incr file %s into %s", temp_incr_aof_name,
                       new_incr_filename);
             sdsfree(temp_incr_filepath);

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -127,6 +127,7 @@ void blockClient(client *c, int btype) {
  * In case the command failed internally, ERROR_COMMAND_FAILED should be passed.
  * A value of zero indicate no error was reported after the command was unblocked  */
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_or_rejected) {
+    latencyTraceStart(server, command_unblocking);
     c->duration += blocked_us + reply_us;
     c->lastcmd->microseconds += c->duration;
     clusterSlotStatsAddCpuDuration(c, c->duration);
@@ -149,7 +150,7 @@ void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_
     c->duration = 0;
     /* Log the reply duration event. */
     latencyAddSampleIfNeeded("command-unblocking", reply_us);
-    latencyTraceIfNeeded(server, command_unblocking, reply_us);
+    latencyTraceEnd(server, command_unblocking, reply_us);
 }
 
 /* This function is called in the beforeSleep() function of the event loop

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1044,14 +1044,16 @@ int clusterSaveConfig(int do_fsync) {
     /* Create a temp file with the new content. */
     tmpfilename = sdscatfmt(sdsempty(), "%s.tmp-%i-%I", server.cluster_configfile, (int)getpid(), mstime());
     latencyStartMonitor(latency);
+    latencyTraceStart(cluster, cluster_config_open);
     if ((fd = open(tmpfilename, O_WRONLY | O_CREAT, 0644)) == -1) {
         serverLog(LL_WARNING, "Could not open temp cluster config file: %s", strerror(errno));
         goto cleanup;
     }
     latencyEndMonitor(latency);
+    latencyTraceEnd(cluster, cluster_config_open, latency);
     latencyAddSampleIfNeeded("cluster-config-open", latency);
-    latencyTraceIfNeeded(cluster, cluster_config_open, latency);
     latencyStartMonitor(latency);
+    latencyTraceStart(cluster, cluster_config_write);
     while (offset < content_size) {
         written_bytes = write(fd, ci + offset, content_size - offset);
         if (written_bytes <= 0) {
@@ -1063,54 +1065,59 @@ int clusterSaveConfig(int do_fsync) {
         offset += written_bytes;
     }
     latencyEndMonitor(latency);
+    latencyTraceEnd(cluster, cluster_config_write, latency);
     latencyAddSampleIfNeeded("cluster-config-write", latency);
-    latencyTraceIfNeeded(cluster, cluster_config_write, latency);
     if (do_fsync) {
         latencyStartMonitor(latency);
+        latencyTraceStart(cluster, cluster_config_fsync);
         server.cluster->todo_before_sleep &= ~CLUSTER_TODO_FSYNC_CONFIG;
         if (valkey_fsync(fd) == -1) {
             serverLog(LL_WARNING, "Could not sync tmp cluster config file: %s", strerror(errno));
             goto cleanup;
         }
         latencyEndMonitor(latency);
+        latencyTraceEnd(cluster, cluster_config_fsync, latency);
         latencyAddSampleIfNeeded("cluster-config-fsync", latency);
-        latencyTraceIfNeeded(cluster, cluster_config_fsync, latency);
     }
 
     latencyStartMonitor(latency);
+    latencyTraceStart(cluster, cluster_config_rename);
     if (rename(tmpfilename, server.cluster_configfile) == -1) {
         serverLog(LL_WARNING, "Could not rename tmp cluster config file: %s", strerror(errno));
         goto cleanup;
     }
     latencyEndMonitor(latency);
+    latencyTraceEnd(cluster, cluster_config_rename, latency);
     latencyAddSampleIfNeeded("cluster-config-rename", latency);
-    latencyTraceIfNeeded(cluster, cluster_config_rename, latency);
     if (do_fsync) {
         latencyStartMonitor(latency);
+        latencyTraceStart(cluster, cluster_config_dir_fsync);
         if (fsyncFileDir(server.cluster_configfile) == -1) {
             serverLog(LL_WARNING, "Could not sync cluster config file dir: %s", strerror(errno));
             goto cleanup;
         }
         latencyEndMonitor(latency);
+        latencyTraceEnd(cluster, cluster_config_dir_fsync, latency);
         latencyAddSampleIfNeeded("cluster-config-dir-fsync", latency);
-        latencyTraceIfNeeded(cluster, cluster_config_dir_fsync, latency);
     }
     retval = C_OK; /* If we reached this point, everything is fine. */
 
 cleanup:
     if (fd != -1) {
         latencyStartMonitor(latency);
+        latencyTraceStart(cluster, cluster_config_close);
         close(fd);
         latencyEndMonitor(latency);
+        latencyTraceEnd(cluster, cluster_config_close, latency);
         latencyAddSampleIfNeeded("cluster-config-close", latency);
-        latencyTraceIfNeeded(cluster, cluster_config_close, latency);
     }
     if (retval == C_ERR) {
         latencyStartMonitor(latency);
+        latencyTraceStart(cluster, cluster_config_unlink);
         unlink(tmpfilename);
         latencyEndMonitor(latency);
+        latencyTraceEnd(cluster, cluster_config_unlink, latency);
         latencyAddSampleIfNeeded("cluster-config-unlink", latency);
-        latencyTraceIfNeeded(cluster, cluster_config_unlink, latency);
     }
     sdsfree(tmpfilename);
     sdsfree(ci);

--- a/src/db.c
+++ b/src/db.c
@@ -1917,10 +1917,11 @@ long long getExpire(serverDb *db, robj *key) {
 void deleteExpiredKeyAndPropagateWithDictIndex(serverDb *db, robj *keyobj, int dict_index) {
     mstime_t expire_latency;
     latencyStartMonitor(expire_latency);
+    latencyTraceStart(db, expire_del);
     dbGenericDeleteWithDictIndex(db, keyobj, server.lazyfree_lazy_expire, DB_FLAG_KEY_EXPIRED, dict_index);
     latencyEndMonitor(expire_latency);
+    latencyTraceEnd(db, expire_del, expire_latency);
     latencyAddSampleIfNeeded("expire-del", expire_latency);
-    latencyTraceIfNeeded(db, expire_del, expire_latency);
     notifyKeyspaceEvent(NOTIFY_EXPIRED, "expired", keyobj, db->id);
     signalModifiedKey(NULL, db, keyobj);
     propagateDeletion(db, keyobj, server.lazyfree_lazy_expire, dict_index);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1162,6 +1162,7 @@ static long long activeDefragTimeProc(struct aeEventLoop *eventLoop, long long i
 
     mstime_t latency;
     latencyStartMonitor(latency);
+    latencyTraceStart(db, active_defrag_cycle);
 
     do {
         if (!defrag.current_stage) {
@@ -1185,8 +1186,8 @@ static long long activeDefragTimeProc(struct aeEventLoop *eventLoop, long long i
     } while (haveMoreWork && getMonotonicUs() <= endtime - server.active_defrag_cycle_us);
 
     latencyEndMonitor(latency);
+    latencyTraceEnd(db, active_defrag_cycle, latency);
     latencyAddSampleIfNeeded("active-defrag-cycle", latency);
-    latencyTraceIfNeeded(db, active_defrag_cycle, latency);
     if (haveMoreWork) {
         return computeDelayMs(endtime);
     } else {

--- a/src/evict.c
+++ b/src/evict.c
@@ -427,6 +427,7 @@ int performEvictions(void) {
     unsigned long eviction_time_limit_us = evictionTimeLimitUs();
 
     latencyStartMonitor(latency);
+    latencyTraceStart(db, eviction_cycle);
 
     monotime evictionTimer;
     elapsedStart(&evictionTimer);
@@ -560,10 +561,11 @@ int performEvictions(void) {
             enterExecutionUnit(1, 0);
             delta = (long long)zmalloc_used_memory();
             latencyStartMonitor(eviction_latency);
+            latencyTraceStart(db, eviction_del);
             dbGenericDelete(db, keyobj, server.lazyfree_lazy_eviction, DB_FLAG_KEY_EVICTED);
             latencyEndMonitor(eviction_latency);
+            latencyTraceEnd(db, eviction_del, eviction_latency);
             latencyAddSampleIfNeeded("eviction-del", eviction_latency);
-            latencyTraceIfNeeded(db, eviction_del, eviction_latency);
             delta -= (long long)zmalloc_used_memory();
             mem_freed += delta;
             server.stat_evictedkeys++;
@@ -618,6 +620,7 @@ cant_free:
          * short wait here if such jobs exist, but don't wait long.  */
         mstime_t lazyfree_latency;
         latencyStartMonitor(lazyfree_latency);
+        latencyTraceStart(db, eviction_lazyfree);
         while (bioPendingJobsOfType(BIO_LAZY_FREE) && elapsedUs(evictionTimer) < eviction_time_limit_us) {
             if (getMaxmemoryState(NULL, NULL, NULL, NULL) == C_OK) {
                 result = EVICT_OK;
@@ -626,13 +629,13 @@ cant_free:
             usleep(eviction_time_limit_us < 1000 ? eviction_time_limit_us : 1000);
         }
         latencyEndMonitor(lazyfree_latency);
+        latencyTraceEnd(db, eviction_lazyfree, lazyfree_latency);
         latencyAddSampleIfNeeded("eviction-lazyfree", lazyfree_latency);
-        latencyTraceIfNeeded(db, eviction_lazyfree, lazyfree_latency);
     }
 
     latencyEndMonitor(latency);
+    latencyTraceEnd(db, eviction_cycle, latency);
     latencyAddSampleIfNeeded("eviction-cycle", latency);
-    latencyTraceIfNeeded(db, eviction_cycle, latency);
 
 update_metrics:
     if (result == EVICT_RUNNING || result == EVICT_FAIL) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -221,6 +221,12 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
     int time_check_mask; /* Check time limit when (i & mask) == 0, i.e. every (X+1)th of the loop. */
     monotime start = getMonotonicUs();
 
+    if (jobType == KEYS) {
+        latencyTraceStart(db, expire_cycle_keys);
+    } else if (jobType == FIELDS) {
+        latencyTraceStart(db, expire_cycle_fields);
+    }
+
     if (cycleType == ACTIVE_EXPIRE_CYCLE_FAST) {
         /* Don't start a fast cycle if the previous cycle did not exit
          * for time limit, unless the percentage of estimated stale keys is
@@ -410,9 +416,9 @@ static long long activeExpireCycleJob(enum activeExpiryType jobType, int cycleTy
 
     long long elapsed = (long long)elapsedUs(start);
     if (jobType == KEYS) {
-        latencyTraceIfNeeded(db, expire_cycle_keys, elapsed);
+        latencyTraceEnd(db, expire_cycle_keys, elapsed);
     } else if (jobType == FIELDS) {
-        latencyTraceIfNeeded(db, expire_cycle_fields, elapsed);
+        latencyTraceEnd(db, expire_cycle_fields, elapsed);
     }
 
     /* Update our estimate of keys existing but yet to be expired.
@@ -491,6 +497,7 @@ long long activeExpireCycle(int type) {
     /* Try to smoke-out bugs (server.also_propagate should be empty here) */
     serverAssert(server.also_propagate.numops == 0);
 
+    latencyTraceStart(db, expire_cycle);
     if (expireCycleStartWithFields) {
         elapsed += activeExpireCycleJob(FIELDS, type, timelimit_us - elapsed);
         elapsed += activeExpireCycleJob(KEYS, type, timelimit_us - elapsed);
@@ -498,9 +505,9 @@ long long activeExpireCycle(int type) {
         elapsed += activeExpireCycleJob(KEYS, type, timelimit_us - elapsed);
         elapsed += activeExpireCycleJob(FIELDS, type, timelimit_us - elapsed);
     }
+    latencyTraceEnd(db, expire_cycle, elapsed);
     server.stat_expire_cycle_time_used += elapsed;
     latencyAddSampleIfNeeded("expire-cycle", elapsed);
-    latencyTraceIfNeeded(db, expire_cycle, elapsed);
     expireCycleStartWithFields = !expireCycleStartWithFields;
     return elapsed;
 }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3642,10 +3642,11 @@ static void backgroundSaveDoneHandlerDisk(int exitcode, int bysignal, time_t sav
 
         serverLog(LL_WARNING, "Background saving terminated by signal %d", bysignal);
         latencyStartMonitor(latency);
+        latencyTraceStart(rdb, rdb_unlink_temp_file);
         rdbRemoveTempFile(server.child_pid, 0);
         latencyEndMonitor(latency);
+        latencyTraceEnd(rdb, rdb_unlink_temp_file, latency);
         latencyAddSampleIfNeeded("rdb-unlink-temp-file", latency);
-        latencyTraceIfNeeded(rdb, rdb_unlink_temp_file, latency);
         /* SIGUSR1 is whitelisted, so we have a way to kill a child without
          * triggering an error condition. */
         if (bysignal != SIGUSR1) server.lastbgsave_status = C_ERR;

--- a/src/server.c
+++ b/src/server.c
@@ -1764,6 +1764,7 @@ void whileBlockedCron(void) {
 
     mstime_t latency;
     latencyStartMonitor(latency);
+    latencyTraceStart(server, while_blocked_cron);
 
     defragWhileBlocked();
 
@@ -1771,8 +1772,8 @@ void whileBlockedCron(void) {
     if (server.loading) cronUpdateMemoryStats();
 
     latencyEndMonitor(latency);
+    latencyTraceEnd(server, while_blocked_cron, latency);
     latencyAddSampleIfNeeded("while-blocked-cron", latency);
-    latencyTraceIfNeeded(server, while_blocked_cron, latency);
 
     /* We received a SIGTERM during loading, shutting down here in a safe way,
      * as it isn't ok doing so inside the signal handler. */
@@ -1866,6 +1867,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
      * tasks done by cron and beforeSleep, but excluding read, write and AOF, that are counted by other
      * sets of metrics. */
     monotime cron_start_time_before_aof = getMonotonicUs();
+    latencyTraceStart(server, eventloop_cron);
 
     /* Run a fast expire cycle (the called function will return
      * ASAP if a fast cycle is not needed). */
@@ -1914,6 +1916,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     /* Record the fsync'd offset before flushAppendOnly */
     long long prev_fsynced_reploff = server.fsynced_reploff;
 
+    latencyTraceStart(aof, aof_flush);
     /* Write the AOF buffer on disk,
      * must be done before handleClientsWithPendingWrites,
      * in case of appendfsync=always. */
@@ -1921,8 +1924,8 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     /* Record time consumption of AOF writing. */
     monotime aof_duration = getMonotonicUs() - aof_start_time;
+    latencyTraceEnd(aof, aof_flush, aof_duration);
     durationAddSample(EL_DURATION_TYPE_AOF, aof_duration);
-    latencyTraceIfNeeded(aof, aof_flush, aof_duration);
 
     /* Update the fsynced replica offset.
      * If an initial rewrite is in progress then not all data is guaranteed to have actually been
@@ -1974,7 +1977,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     if (server.el_start > 0) {
         monotime el_duration = getMonotonicUs() - server.el_start;
         durationAddSample(EL_DURATION_TYPE_EL, el_duration);
-        latencyTraceIfNeeded(server, eventloop, el_duration);
+        latencyTraceEnd(server, eventloop, el_duration);
 
         /* Accumulate time only for active cycles */
         if (server.el_iteration_active) {
@@ -1986,7 +1989,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     }
     server.el_cron_duration += duration_before_aof + duration_after_write;
     durationAddSample(EL_DURATION_TYPE_CRON, server.el_cron_duration);
-    latencyTraceIfNeeded(server, eventloop_cron, server.el_cron_duration);
+    latencyTraceEnd(server, eventloop_cron, server.el_cron_duration);
     server.el_cron_duration = 0;
     /* Record max command count per cycle. */
     if (server.stat_numcommands > server.el_cmd_cnt_start) {
@@ -2022,16 +2025,18 @@ void afterSleep(struct aeEventLoop *eventLoop, int numevents) {
         if (moduleCount()) {
             mstime_t latency;
             latencyStartMonitor(latency);
+            latencyTraceStart(server, module_acquire_gil);
             atomic_store_explicit(&server.module_gil_acquiring, 1, memory_order_relaxed);
             moduleAcquireGIL();
             atomic_store_explicit(&server.module_gil_acquiring, 0, memory_order_relaxed);
             moduleFireServerEvent(VALKEYMODULE_EVENT_EVENTLOOP, VALKEYMODULE_SUBEVENT_EVENTLOOP_AFTER_SLEEP, NULL);
             latencyEndMonitor(latency);
+            latencyTraceEnd(server, module_acquire_gil, latency);
             latencyAddSampleIfNeeded("module-acquire-GIL", latency);
-            latencyTraceIfNeeded(server, module_acquire_gil, latency);
         }
         /* Set the eventloop start time. */
         server.el_start = getMonotonicUs();
+        latencyTraceStart(server, eventloop);
         /* Reset iteration work flag */
         server.el_iteration_active = (numevents > 0);
         /* Set the eventloop command count at start. */
@@ -3880,6 +3885,13 @@ void call(client *c, int flags) {
     monotime monotonic_start = 0;
     if (monotonicGetType() == MONOTONIC_CLOCK_HW) monotonic_start = getMonotonicUs();
 
+    valkey_commands_trace(valkey_commands, command_call_entry, connGetType(c->conn), getClientPeerId(c), getClientSockname(c), real_cmd->declared_name);
+    if (real_cmd->flags & CMD_FAST) {
+        latencyTraceStart(server, fast_command);
+    } else {
+        latencyTraceStart(server, command);
+    }
+
     c->cmd->proc(c);
 
     exitExecutionUnit();
@@ -3896,7 +3908,13 @@ void call(client *c, int flags) {
     else
         duration = ustime() - call_timer;
 
+    if (real_cmd->flags & CMD_FAST) {
+        latencyTraceEnd(server, fast_command, duration);
+    } else {
+        latencyTraceEnd(server, command, duration);
+    }
     valkey_commands_trace(valkey_commands, command_call, connGetType(c->conn), getClientPeerId(c), getClientSockname(c), real_cmd->declared_name, duration);
+
     c->duration += duration;
     dirty = server.dirty - dirty;
     if (dirty < 0) dirty = 0;
@@ -3928,11 +3946,6 @@ void call(client *c, int flags) {
     if (update_command_stats) {
         char *latency_event = (real_cmd->flags & CMD_FAST) ? "fast-command" : "command";
         latencyAddSampleIfNeeded(latency_event, duration);
-        if (real_cmd->flags & CMD_FAST) {
-            latencyTraceIfNeeded(server, fast_command, duration);
-        } else {
-            latencyTraceIfNeeded(server, command, duration);
-        }
         if (server.execution_nesting == 0) durationAddSample(EL_DURATION_TYPE_CMD, duration);
     }
 
@@ -6999,6 +7012,13 @@ int serverFork(int purpose) {
 
     int childpid;
     long long start = ustime();
+    if (purpose == CHILD_TYPE_RDB) {
+        latencyTraceStart(rdb, fork);
+    } else if (purpose == CHILD_TYPE_AOF) {
+        latencyTraceStart(aof, fork);
+    } else if (purpose == CHILD_TYPE_SLOT_MIGRATION) {
+        latencyTraceStart(cluster, fork);
+    }
     if ((childpid = valkey_fork()) == 0) {
         /* Child.
          *
@@ -7031,11 +7051,11 @@ int serverFork(int purpose) {
             (double)zmalloc_used_memory() * 1000000 / server.stat_fork_time / (1024 * 1024 * 1024); /* GB per second. */
         latencyAddSampleIfNeeded("fork", server.stat_fork_time);
         if (purpose == CHILD_TYPE_RDB) {
-            latencyTraceIfNeeded(rdb, fork, server.stat_fork_time);
+            latencyTraceEnd(rdb, fork, server.stat_fork_time);
         } else if (purpose == CHILD_TYPE_AOF) {
-            latencyTraceIfNeeded(aof, fork, server.stat_fork_time);
+            latencyTraceEnd(aof, fork, server.stat_fork_time);
         } else if (purpose == CHILD_TYPE_SLOT_MIGRATION) {
-            latencyTraceIfNeeded(cluster, fork, server.stat_fork_time);
+            latencyTraceEnd(cluster, fork, server.stat_fork_time);
         }
 
         /* The child_pid and child_type are only for mutually exclusive children.

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -30,14 +30,22 @@
 #define LATENCY_TRACE_SWITCH 1
 pid_t do_fork(void);
 
-#define latencyTraceIfNeeded(type, event, var) \
-    valkey_##type##_trace(valkey_##type, event, (var));
+#define latencyTraceStart(type, event) \
+    valkey_##type##_trace(valkey_##type, event##_entry)
+
+#define latencyTraceEnd(type, event, dur) \
+    valkey_##type##_trace(valkey_##type, event, (dur))
 
 #else
 
-#define latencyTraceIfNeeded(type, event, var) \
-    do {                                       \
+#define latencyTraceStart(type, event) \
+    do {                               \
     } while (0)
+
+#define latencyTraceEnd(type, event, dur) \
+    do {                                  \
+    } while (0)
+
 #endif
 
 #endif /* __VALKEY_TRACE_H__ */

--- a/src/trace/trace_aof.h
+++ b/src/trace/trace_aof.h
@@ -28,110 +28,128 @@
 #include <lttng/tracepoint.h>
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    /* Tracepoint class provider name */
     valkey_aof,
+    valkey_aof_entry_class,
+    LTTNG_UST_TP_ARGS(),
+    LTTNG_UST_TP_FIELDS()
+)
 
-    /* Tracepoint class name */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    valkey_aof,
     valkey_aof_class,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     ),
-
-    /* List of fields of eventual event (output) */
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint64_t, duration, duration)
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, fork_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, fork,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_write_pending_fsync_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_write_pending_fsync,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_write_active_child_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_write_active_child,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_write_alone_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_write_alone,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_write_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_write,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_fsync_always_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_fsync_always,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_fstat_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_fstat,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_rename_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_aof, valkey_aof_class, valkey_aof, aof_rename,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_aof, valkey_aof_class, valkey_aof, aof_flush,
+    valkey_aof, valkey_aof_entry_class, valkey_aof, aof_flush_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_aof, valkey_aof_class, valkey_aof, aof_flush,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 

--- a/src/trace/trace_aof.h
+++ b/src/trace/trace_aof.h
@@ -41,7 +41,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
         uint64_t, duration
     ),
     LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer(uint64_t, duration, duration)
+        lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
     )
 )
 

--- a/src/trace/trace_cluster.h
+++ b/src/trace/trace_cluster.h
@@ -28,100 +28,116 @@
 #include <lttng/tracepoint.h>
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    /* Tracepoint class provider name */
     valkey_cluster,
+    valkey_cluster_entry_class,
+    LTTNG_UST_TP_ARGS(),
+    LTTNG_UST_TP_FIELDS()
+)
 
-    /* Tracepoint class name */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    valkey_cluster,
     valkey_cluster_class,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     ),
-
-    /* List of fields of eventual event (output) */
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint64_t, duration, duration)
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_open_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_open,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_write_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_write,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_fsync_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_fsync,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_rename_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_rename,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_dir_fsync_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_dir_fsync,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_close_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_close,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, cluster_config_unlink_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_cluster, valkey_cluster_class, valkey_cluster, cluster_config_unlink,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_cluster, valkey_cluster_class, valkey_cluster, fork,
+    valkey_cluster, valkey_cluster_entry_class, valkey_cluster, fork_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_cluster, valkey_cluster_class, valkey_cluster, fork,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 

--- a/src/trace/trace_cluster.h
+++ b/src/trace/trace_cluster.h
@@ -41,7 +41,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
         uint64_t, duration
     ),
     LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer(uint64_t, duration, duration)
+        lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
     )
 )
 

--- a/src/trace/trace_commands.h
+++ b/src/trace/trace_commands.h
@@ -44,13 +44,25 @@ LTTNG_UST_TRACEPOINT_ENUM(
 )
 
 LTTNG_UST_TRACEPOINT_EVENT(
-	/* Tracepoint provider name */
 	valkey_commands,
+	command_call_entry,
+	LTTNG_UST_TP_ARGS(
+		int, prot,
+		const char *, addr,
+		const char *, laddr,
+		const char *, name
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_enum(valkey_commands, valkey_conn_type_enum, int, enum_field, prot)
+		lttng_ust_field_string(addr, addr)
+		lttng_ust_field_string(laddr, laddr)
+		lttng_ust_field_string(name, name)
+	)
+)
 
-	/* Tracepoint name */
+LTTNG_UST_TRACEPOINT_EVENT(
+	valkey_commands,
 	command_call,
-
-	/* Input arguments */
 	LTTNG_UST_TP_ARGS(
 		int, prot,
 		const char *, addr,
@@ -58,8 +70,6 @@ LTTNG_UST_TRACEPOINT_EVENT(
 		const char *, name,
 		uint64_t, duration
 	),
-
-	/* Output event fields */
 	LTTNG_UST_TP_FIELDS(
 		lttng_ust_field_enum(valkey_commands, valkey_conn_type_enum, int, enum_field, prot)
 		lttng_ust_field_string(addr, addr)

--- a/src/trace/trace_commands.h
+++ b/src/trace/trace_commands.h
@@ -75,7 +75,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
 		lttng_ust_field_string(addr, addr)
 		lttng_ust_field_string(laddr, laddr)
 		lttng_ust_field_string(name, name)
-		lttng_ust_field_integer(uint64_t, duration, duration)
+		lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
 	)
 )
 

--- a/src/trace/trace_db.h
+++ b/src/trace/trace_db.h
@@ -28,100 +28,116 @@
 #include <lttng/tracepoint.h>
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    /* Tracepoint class provider name */
     valkey_db,
+    valkey_db_entry_class,
+    LTTNG_UST_TP_ARGS(),
+    LTTNG_UST_TP_FIELDS()
+)
 
-    /* Tracepoint class name */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    valkey_db,
     valkey_db_class,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     ),
-
-    /* List of fields of eventual event (output) */
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint64_t, duration, duration)
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, expire_del_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, expire_del,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, active_defrag_cycle_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, active_defrag_cycle,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, eviction_del_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, eviction_del,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, eviction_lazyfree_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, eviction_lazyfree,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, eviction_cycle_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, eviction_cycle,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, expire_cycle_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, expire_cycle,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_db, valkey_db_entry_class, valkey_db, expire_cycle_keys_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_db, valkey_db_class, valkey_db, expire_cycle_keys,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_db, valkey_db_class, valkey_db, expire_cycle_fields,
+    valkey_db, valkey_db_entry_class, valkey_db, expire_cycle_fields_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_db, valkey_db_class, valkey_db, expire_cycle_fields,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 

--- a/src/trace/trace_db.h
+++ b/src/trace/trace_db.h
@@ -41,7 +41,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
         uint64_t, duration
     ),
     LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer(uint64_t, duration, duration)
+        lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
     )
 )
 

--- a/src/trace/trace_rdb.h
+++ b/src/trace/trace_rdb.h
@@ -28,40 +28,44 @@
 #include <lttng/tracepoint.h>
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    /* Tracepoint class provider name */
     valkey_rdb,
+    valkey_rdb_entry_class,
+    LTTNG_UST_TP_ARGS(),
+    LTTNG_UST_TP_FIELDS()
+)
 
-    /* Tracepoint class name */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    valkey_rdb,
     valkey_rdb_class,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     ),
-
-    /* List of fields of eventual event (output) */
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint64_t, duration, duration)
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_rdb, valkey_rdb_class, valkey_rdb, fork,
+    valkey_rdb, valkey_rdb_entry_class, valkey_rdb, fork_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_rdb, valkey_rdb_class, valkey_rdb, fork,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_rdb, valkey_rdb_class, valkey_rdb, rdb_unlink_temp_file,
+    valkey_rdb, valkey_rdb_entry_class, valkey_rdb, rdb_unlink_temp_file_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_rdb, valkey_rdb_class, valkey_rdb, rdb_unlink_temp_file,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 

--- a/src/trace/trace_rdb.h
+++ b/src/trace/trace_rdb.h
@@ -41,7 +41,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
         uint64_t, duration
     ),
     LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer(uint64_t, duration, duration)
+        lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
     )
 )
 

--- a/src/trace/trace_server.h
+++ b/src/trace/trace_server.h
@@ -28,90 +28,104 @@
 #include <lttng/tracepoint.h>
 
 LTTNG_UST_TRACEPOINT_EVENT_CLASS(
-    /* Tracepoint class provider name */
     valkey_server,
+    valkey_server_entry_class,
+    LTTNG_UST_TP_ARGS(),
+    LTTNG_UST_TP_FIELDS()
+)
 
-    /* Tracepoint class name */
+LTTNG_UST_TRACEPOINT_EVENT_CLASS(
+    valkey_server,
     valkey_server_class,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     ),
-
-    /* List of fields of eventual event (output) */
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint64_t, duration, duration)
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, command_unblocking_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, command_unblocking,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, while_blocked_cron_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, while_blocked_cron,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, eventloop_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, eventloop,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, eventloop_cron_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, eventloop_cron,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, module_acquire_gil_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, module_acquire_gil,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
+    valkey_server, valkey_server_entry_class, valkey_server, command_entry,
+    LTTNG_UST_TP_ARGS()
+)
+
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
     valkey_server, valkey_server_class, valkey_server, command,
-
-    /* List of tracepoint arguments (input) */
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 
 LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
-    /* Name of the tracepoint class provider */
-    valkey_server, valkey_server_class, valkey_server, fast_command,
+    valkey_server, valkey_server_entry_class, valkey_server, fast_command_entry,
+    LTTNG_UST_TP_ARGS()
+)
 
-    /* List of tracepoint arguments (input) */
+LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
+    valkey_server, valkey_server_class, valkey_server, fast_command,
     LTTNG_UST_TP_ARGS(
-      uint64_t, duration
+        uint64_t, duration
     )
 )
 

--- a/src/trace/trace_server.h
+++ b/src/trace/trace_server.h
@@ -41,7 +41,7 @@ LTTNG_UST_TRACEPOINT_EVENT_CLASS(
         uint64_t, duration
     ),
     LTTNG_UST_TP_FIELDS(
-        lttng_ust_field_integer(uint64_t, duration, duration)
+        lttng_ust_field_integer_nowrite(uint64_t, duration, duration)
     )
 )
 


### PR DESCRIPTION
- Remove duration parameter from all tracepoint definitions (saves 64 bit per event)
- Replace latencyTraceIfNeeded with latencyTraceStart/End macros
- Update all trace call sites to emit entry/exit events
- CPU ID and timestamps automatically captured by LTTng context
- Duration calculated by trace analysis tools from timestamps

On my old laptop: (1145gs) with thermal and power throttling, I get with benchmark 
| Configuration | SET (req/s) | GET (req/s) |
|---|---:|---:|
| Before - No Trace | 40,700.04 | 42,984.87 |
| Before - With Trace | 37,001.41 | 36,002.30 |
| After - No Trace | 37,592.57 | 43,001.51 |
| After - With Trace | 39,111.39 | 40,708.32 |

This code is friendlier to trace viewers like trace compass which could then display the data as a chart. 
<img width="1868" height="1005" alt="Screenshot from 2026-02-26 14-52-32" src="https://github.com/user-attachments/assets/534dd955-63bc-41e8-9124-68b68a8eb383" />

note: this code was made with the assistance of Claude Sonnet 4.5