### PR TITLE
Fix current_job method for BIO memcheck fix

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -315,9 +315,8 @@ void *bioProcessBackgroundJobs(void *arg) {
         } else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
+        zfree(job);
         bwd->current_job = NULL;
-zfree(job);
-bwd->current_job = NULL;
         atomic_fetch_sub(&bio_jobs_counter[job_type], 1);
     }
 }

--- a/src/bio.c
+++ b/src/bio.c
@@ -263,8 +263,8 @@ void *bioProcessBackgroundJobs(void *arg) {
     bio_worker_num = bioWorkerNum(bwd);
 
     while (1) {
-        bio_job *job = mutexQueuePop(bwd->bio_jobs, true);
-        bwd->current_job = job; /* Keep reachable from bio_workers[] for memcheck. */
+        bwd->current_job = mutexQueuePop(bwd->bio_jobs, true);
+        bio_job *job = bwd->current_job; /* Keep reachable from bio_workers[] for memcheck. */
 
         /* Process the job accordingly to its type. */
         int job_type = job->header.type;
@@ -315,7 +315,8 @@ void *bioProcessBackgroundJobs(void *arg) {
         } else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
-        zfree(job);
+        zfree(bwd->current_job);
+        bwd->current_job = NULL;
         atomic_fetch_sub(&bio_jobs_counter[job_type], 1);
     }
 }

--- a/src/bio.c
+++ b/src/bio.c
@@ -316,7 +316,6 @@ void *bioProcessBackgroundJobs(void *arg) {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
         zfree(job);
-        bwd->current_job = NULL;
         atomic_fetch_sub(&bio_jobs_counter[job_type], 1);
     }
 }

--- a/src/bio.c
+++ b/src/bio.c
@@ -86,11 +86,12 @@ typedef struct {
     const char *const bio_worker_title;
     pthread_t bio_thread_id;
     mutexQueue *bio_jobs;
-    void *current_job; /* In-flight job pointer, kept here so it remains reachable from the
-                        * static bio_workers[] array for memcheck after thread cancellation. */
+    void *volatile current_job; /* In-flight job pointer, kept here so it remains reachable from the
+                                 * bio_workers[] array for memcheck after thread cancellation.
+                                 * Volatile ensures the compiler doesn't optimize out the store. */
 } bio_worker_data;
 
-static bio_worker_data bio_workers[] = {
+bio_worker_data bio_workers[] = {
     {"bio_close_file"},
     {"bio_aof"},
     {"bio_lazy_free"},
@@ -263,7 +264,7 @@ void *bioProcessBackgroundJobs(void *arg) {
 
     while (1) {
         bio_job *job = mutexQueuePop(bwd->bio_jobs, true);
-        bwd->current_job = job; /* Keep reachable from static bio_workers[] for memcheck. */
+        bwd->current_job = job; /* Keep reachable from bio_workers[] for memcheck. */
 
         /* Process the job accordingly to its type. */
         int job_type = job->header.type;

--- a/src/bio.c
+++ b/src/bio.c
@@ -316,7 +316,8 @@ void *bioProcessBackgroundJobs(void *arg) {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
         bwd->current_job = NULL;
-        zfree(job);
+zfree(job);
+bwd->current_job = NULL;
         atomic_fetch_sub(&bio_jobs_counter[job_type], 1);
     }
 }


### PR DESCRIPTION
Two changes to the global's declaration for previous BIO memcheck fix: #3256 

1. Removed `static` for `bio_worker_data` to prevent the compiler from optimizing out stores to `current_job` field
2. Added a `volatile` qualifier to tell the compiler that the value may be accessed from another thread, and not to cache the value temporarily in functions, ensures the compiler doesn't optimize out the store.