### PR TITLE
Pin workflow pip/go/npm dependencies for OpenSSF compliance

### DIFF
--- a/.github/workflows/benchmark-on-label.yml
+++ b/.github/workflows/benchmark-on-label.yml
@@ -66,7 +66,7 @@ jobs:
               openssl-devel \
               bzip2-devel \
               libffi-devel
-          pip install -r requirements.txt
+          pip install --require-hashes -r requirements.txt
 
       - name: Build latest valkey_latest
         working-directory: valkey_latest

--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -106,7 +106,7 @@ jobs:
               openssl-devel \
               bzip2-devel \
               libffi-devel
-          pip install -r requirements.txt
+          pip install --require-hashes -r requirements.txt
 
       - name: Build latest valkey_latest
         working-directory: valkey_latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
 
       - name: Setup YAML formatter
         run: |
-          go install github.com/google/yamlfmt/cmd/yamlfmt@latest
+          go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
 
       - name: Run yamlfmt
         id: yamlfmt

--- a/.github/workflows/reply-schemas-linter.yml
+++ b/.github/workflows/reply-schemas-linter.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       - name: Install packages
-        run: npm install ajv
+        working-directory: utils/reply-schema-linter
+        run: npm ci --ignore-scripts
       - name: linter
-        run: node ./utils/reply_schema_linter.js
+        run: NODE_PATH=utils/reply-schema-linter/node_modules node ./utils/reply_schema_linter.js
 

--- a/utils/reply-schema-linter/package-lock.json
+++ b/utils/reply-schema-linter/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "reply-schema-linter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reply-schema-linter",
+      "version": "1.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/utils/reply-schema-linter/package.json
+++ b/utils/reply-schema-linter/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "reply-schema-linter",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "ajv": "^8.17.1"
+  }
+}


### PR DESCRIPTION
Pin dependencies in CI workflows to improve the Pinned-Dependencies score in OpenSSF Scorecard (currently 8/10). The [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/valkey-io/valkey#:~:text=Warn%3A%20pipCommand%20not,linter.yml%3A27) currently scores `Pinned-Dependencies` at 8/10 due to 4  unpinned package manager commands in CI workflows:
```
Warn: pipCommand not pinned by hash: .github/workflows/benchmark-on-label.yml:69
Warn: pipCommand not pinned by hash: .github/workflows/benchmark-release.yml:109
Warn: goCommand not pinned by hash: .github/workflows/ci.yml:333
Warn: npmCommand not pinned by hash: .github/workflows/reply-schemas-linter.yml:27
```
Changes:
- benchmark-on-label.yml, benchmark-release.yml: add `--require-hashes` to `pip install` adding on valkey-perf-benchmark repo: https://github.com/valkey-io/valkey-perf-benchmark/pull/44
- ci.yml: pin `yamlfmt` to `v0.21.0` instead of `@latest`
- reply-schemas-linter.yml: use npm ci with `package-lock.json` instead of unpinned npm install, package files in `utils/reply-schema-linter/`