### PR TITLE
Suppress valgrind for BIO jobs

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -86,8 +86,6 @@ typedef struct {
     const char *const bio_worker_title;
     pthread_t bio_thread_id;
     mutexQueue *bio_jobs;
-    void *current_job; /* In-flight job pointer, kept here so it remains reachable from the
-                        * static bio_workers[] array for memcheck after thread cancellation. */
 } bio_worker_data;
 
 static bio_worker_data bio_workers[] = {
@@ -269,7 +267,6 @@ void *bioProcessBackgroundJobs(void *arg) {
 
     while (1) {
         bio_job *job = mutexQueuePop(bwd->bio_jobs, true);
-        bwd->current_job = job; /* Keep reachable from static bio_workers[] for memcheck. */
 
         /* Process the job accordingly to its type. */
         int job_type = job->header.type;
@@ -320,7 +317,6 @@ void *bioProcessBackgroundJobs(void *arg) {
         } else {
             serverPanic("Wrong job type in bioProcessBackgroundJobs().");
         }
-        bwd->current_job = NULL;
         zfree(job);
         atomic_fetch_sub(&bio_jobs_counter[job_type], 1);
     }

--- a/src/bio.c
+++ b/src/bio.c
@@ -146,6 +146,12 @@ typedef union bio_job {
 
 void *bioProcessBackgroundJobs(void *arg);
 
+/* Allocate a bio_job. Marked noinline so that it appears as a distinct frame in valgrind
+ * stack traces, allowing a targeted Valgrind suppression for BIO job leaks */
+__attribute__((noinline)) static bio_job *allocBioJob(size_t extra) {
+    return zmalloc(sizeof(bio_job) + extra);
+}
+
 /* Make sure we have enough stack to perform all the things we do in the
  * main thread. */
 #define VALKEY_THREAD_STACK_SIZE (1024 * 1024 * 4)
@@ -190,7 +196,7 @@ void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...) {
     va_list valist;
     /* Allocate memory for the job structure and all required
      * arguments */
-    bio_job *job = zmalloc(sizeof(*job) + sizeof(void *) * (arg_count));
+    bio_job *job = allocBioJob(sizeof(void *) * (arg_count));
     job->free_args.free_fn = free_fn;
 
     va_start(valist, arg_count);
@@ -202,7 +208,7 @@ void bioCreateLazyFreeJob(lazy_free_fn free_fn, int arg_count, ...) {
 }
 
 void bioCreateCloseJob(int fd, int need_fsync, int need_reclaim_cache) {
-    bio_job *job = zmalloc(sizeof(*job));
+    bio_job *job = allocBioJob(0);
     job->fd_args.fd = fd;
     job->fd_args.need_fsync = need_fsync;
     job->fd_args.need_reclaim_cache = need_reclaim_cache;
@@ -211,7 +217,7 @@ void bioCreateCloseJob(int fd, int need_fsync, int need_reclaim_cache) {
 }
 
 void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache) {
-    bio_job *job = zmalloc(sizeof(*job));
+    bio_job *job = allocBioJob(0);
     job->fd_args.fd = fd;
     job->fd_args.offset = offset;
     job->fd_args.need_fsync = 1;
@@ -221,7 +227,7 @@ void bioCreateCloseAofJob(int fd, long long offset, int need_reclaim_cache) {
 }
 
 void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache) {
-    bio_job *job = zmalloc(sizeof(*job));
+    bio_job *job = allocBioJob(0);
     job->fd_args.fd = fd;
     job->fd_args.offset = offset;
     job->fd_args.need_reclaim_cache = need_reclaim_cache;
@@ -230,14 +236,14 @@ void bioCreateFsyncJob(int fd, long long offset, int need_reclaim_cache) {
 }
 
 void bioCreateSaveRDBToDiskJob(connection *conn, int is_dual_channel) {
-    bio_job *job = zmalloc(sizeof(*job));
+    bio_job *job = allocBioJob(0);
     job->save_to_disk_args.conn = conn;
     job->save_to_disk_args.is_dual_channel = is_dual_channel;
     bioSubmitJob(BIO_RDB_SAVE, job);
 }
 
 void bioCreateTlsReloadJob(void) {
-    bio_job *job = zmalloc(sizeof(*job));
+    bio_job *job = allocBioJob(0);
     bioSubmitJob(BIO_TLS_RELOAD, job);
 }
 

--- a/src/valgrind.sup
+++ b/src/valgrind.sup
@@ -24,3 +24,12 @@
    fun:ztrymalloc_usable
    fun:ztrymalloc
 }
+
+{
+   <bio_job_in_flight_at_exit>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:allocBioJob
+}


### PR DESCRIPTION
Suppress valgrind for BIO jobs valgrind errors: https://github.com/valkey-io/valkey/actions/runs/21969557125/job/63467641572#step:6:8648

## Changes

- Add `allocBioJob()` with `__attribute__((noinline))` as a centralized allocation function for all BIO jobs. The `noinline` attribute ensures it appears as a distinct frame in valgrind stack traces.
- Replace all direct `zmalloc` calls in `bioCreate*Job` functions with`allocBioJob()`.
- Add a valgrind suppression in `src/valgrind.sup` matching definite leaks with `allocBioJob` in the call stack.
- Remove `current_job` introduced in #3256 