### PR TITLE
Fix use zfree in cli --eval path 

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -3566,7 +3566,7 @@ static int evalMode(int argc, char **argv) {
         for (j = 0; j < argc + 3 - got_comma; j++) {
             sdsfree(argv2[j]);
         }
-        free(argv2);
+        zfree(argv2);
 
         if (eval_ldb) {
             if (!config.eval_ldb) {

--- a/tests/integration/valkey-cli.tcl
+++ b/tests/integration/valkey-cli.tcl
@@ -354,6 +354,12 @@ start_server {tags {"cli logreqres:skip"}} {
         assert_equal "foo\nbar" [run_cli lrange list 0 -1]
     }
 
+    test_nontty_cli "--eval should not crash valkey-cli" {
+        set scriptfile [write_tmpfile "return { 1 }"]
+        assert_equal "1" [run_cli --eval $scriptfile]
+        file delete $scriptfile
+    }
+
 if {!$::tls} { ;# fake_redis_node doesn't support TLS
     test_nontty_cli "ASK redirect test" {
         # Set up two fake nodes.


### PR DESCRIPTION
In `evalMode()`, `argv2` is allocated with `zmalloc()` but freed with `free()`.
On builds using jemalloc/tcmalloc, this can cause `free(): invalid pointer`
Closes #3273 
