### PR TITLE
cluster: fix use-after-free in generateSyncSlotsEstablishCommand

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -1410,9 +1410,9 @@ sds generateSyncSlotsEstablishCommand(slotMigrationJob *job) {
     listRewind(job->slot_ranges, &li);
     while ((ln = listNext(&li))) {
         slotRange *range = (slotRange *)ln->value;
-        sdscatfmt(result, "$%i\r\n%i\r\n$%i\r\n%i\r\n",
-                  digits10(range->start_slot), range->start_slot,
-                  digits10(range->end_slot), range->end_slot);
+        result = sdscatfmt(result, "$%i\r\n%i\r\n$%i\r\n%i\r\n",
+                           digits10(range->start_slot), range->start_slot,
+                           digits10(range->end_slot), range->end_slot);
     }
     return result;
 }


### PR DESCRIPTION
Noticed a use-after-free/double-free bug while load-testing manual slot migrations. Was able to reliably trigger a process crash.

Original trace:

```
Backtrace:
0   libsystem_platform.dylib            0x00000001917496a4 _sigtramp + 56
1   libsystem_pthread.dylib             0x000000019170f848 pthread_kill + 296
2   libsystem_c.dylib                   0x00000001916189e4 abort + 124
3   libsystem_malloc.dylib              0x000000019151c174 malloc_vreport + 892
4   libsystem_malloc.dylib              0x000000019151fc90 malloc_report + 64
5   libsystem_malloc.dylib              0x000000019152421c ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED + 32
6   valkey-server                       0x0000000104fc2174 _sdsMakeRoomFor + 780
7   valkey-server                       0x0000000104fc30a0 sdscatfmt + 168
8   valkey-server                       0x00000001050318b8 generateSyncSlotsEstablishCommand + 176
9   valkey-server                       0x000000010503156c createSlotImportJob + 324
10  valkey-server                       0x0000000105034fd4 clusterCommandSyncSlots + 1572
11  valkey-server                       0x000000010502f370 clusterCommandSpecial + 2432
12  valkey-server                       0x0000000105021e80 clusterCommand + 2992
13  valkey-server                       0x0000000104fb59a8 call + 320
14  valkey-server                       0x0000000104fcc708 processCommandAndResetClient + 3088
15  valkey-server                       0x0000000104fc9c3c processInputBuffer + 440
16  valkey-server                       0x0000000104fc9198 readQueryFromClient + 108
17  valkey-server                       0x000000010508073c connSocketEventHandler + 136
18  valkey-server                       0x0000000104fa49b4 aeProcessEvents + 316
19  valkey-server                       0x0000000104fc081c main + 18408
20  dyld                                0x000000019136eb98 start + 6076
```

The bug seems to be that the result of `sdscatfmt` is being ignored. Since `sdscatfmt` potentially reallocs a new buffer when it needs to, and deallocs the old one, this can cause a use-after-free/double-free if the loop triggers a buffer-size increase.

This PR fixes the bug.