### PR TITLE
Enforce ACL rules for CMD_NO_AUTH commands on authenticated clients

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -189,6 +189,8 @@ typedef struct {
 
 static void ACLResetFirstArgsForCommand(aclSelector *selector, unsigned long id);
 static void ACLResetFirstArgs(aclSelector *selector);
+static void ACLChangeSelectorPerm(aclSelector *selector, struct serverCommand *cmd, int allow);
+static struct serverCommand *ACLLookupCommand(const char *name);
 static void ACLAddAllowedFirstArg(aclSelector *selector, unsigned long id, const char *sub);
 static void ACLFreeLogEntry(void *le);
 static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen);
@@ -370,6 +372,16 @@ static aclSelector *ACLCreateSelector(int flags) {
     listSetFreeMethod(selector->channels, sdsfreeVoid);
     listSetDupMethod(selector->channels, ACLListDupSds);
     memset(selector->allowed_commands, 0, sizeof(selector->allowed_commands));
+
+    /* Allow CMD_NO_AUTH commands (AUTH, HELLO, QUIT, RESET) by default.
+     * They can be explicitly denied with -auth, -hello, etc. */
+    if (server.orig_commands) {
+        const char *no_auth_cmds[] = {"AUTH", "HELLO", "QUIT", "RESET"};
+        for (int i = 0; i < 4; i++) {
+            struct serverCommand *cmd = ACLLookupCommand(no_auth_cmds[i]);
+            if (cmd) ACLChangeSelectorPerm(selector, cmd, 1);
+        }
+    }
 
     return selector;
 }
@@ -1179,6 +1191,13 @@ static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen) {
         selector->flags &= ~SELECTOR_FLAG_ALLCOMMANDS;
         sdsclear(selector->command_rules);
         ACLResetFirstArgs(selector);
+        /* Re-allow CMD_NO_AUTH commands by default. They can still be
+         * explicitly denied with -auth, -hello, etc. */
+        const char *no_auth_cmds[] = {"AUTH", "HELLO", "QUIT", "RESET"};
+        for (int i = 0; i < 4; i++) {
+            struct serverCommand *cmd = ACLLookupCommand(no_auth_cmds[i]);
+            if (cmd) ACLChangeSelectorPerm(selector, cmd, 1);
+        }
     } else if (op[0] == '~' || op[0] == '%') {
         if (selector->flags & SELECTOR_FLAG_ALLKEYS) {
             errno = EEXIST;
@@ -1897,7 +1916,7 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
         return ACL_DENIED_DB;
     }
 
-    if (!(selector->flags & SELECTOR_FLAG_ALLCOMMANDS) && !(cmd->flags & CMD_NO_AUTH)) {
+    if (!(selector->flags & SELECTOR_FLAG_ALLCOMMANDS)) {
         /* If the bit is not set we have to check further, in case the
          * command is allowed just with that specific first argument. */
         if (ACLGetSelectorCommandBit(selector, id) == 0) {

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -889,6 +889,53 @@ start_server {tags {"acl external:skip"}} {
         assert {[r client getname] eq {client0}}
     }
 
+    test {ACL -auth denies AUTH command for authenticated user} {
+        r ACL setuser authdenied on >authpass +@all -auth ~* &*
+        r AUTH authdenied authpass
+        assert {[r ACL WHOAMI] eq {authdenied}}
+
+        # AUTH should be denied
+        catch {r AUTH default pwd} e
+        assert_match "*NOPERM*auth*" $e
+
+        # User is still authdenied
+        assert {[r ACL WHOAMI] eq {authdenied}}
+        r RESET
+        r ACL deluser authdenied
+    }
+
+    test {CMD_NO_AUTH commands are allowed by default without explicit +auth} {
+        r ACL setuser noauthuser on >napass +@all ~* &*
+        r AUTH noauthuser napass
+        assert {[r ACL WHOAMI] eq {noauthuser}}
+
+        # AUTH should work by default even without explicit +auth
+        r AUTH default pwd
+        assert {[r ACL WHOAMI] eq {default}}
+        r ACL deluser noauthuser
+    }
+
+    test {CMD_NO_AUTH commands survive -@all and are allowed by default} {
+        r ACL setuser minuser on >minpass -@all +acl +ping ~* &*
+        r AUTH minuser minpass
+        assert {[r PING] eq {PONG}}
+        # AUTH should still work since -@all preserves CMD_NO_AUTH commands
+        r AUTH default pwd
+        assert {[r ACL WHOAMI] eq {default}}
+        r ACL deluser minuser
+    }
+
+    test {Explicit -auth after -@all denies AUTH} {
+        r ACL setuser noauthmin on >namp -@all +acl +ping -auth ~* &*
+        r AUTH noauthmin namp
+        assert {[r PING] eq {PONG}}
+        # AUTH should be denied
+        catch {r AUTH default pwd} e
+        assert_match "*NOPERM*auth*" $e
+        r RESET
+        r ACL deluser noauthmin
+    }
+
     test {ACL HELP should not have unexpected options} {
         catch {r ACL help xxx} e
         assert_match "*wrong number of arguments for 'acl|help' command" $e


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/3286

### Summary

`CMD_NO_AUTH` commands (`AUTH`, `HELLO`, `QUIT`, `RESET`) currently bypass ACL checks entirely, meaning rules like `-auth` have no effect. This PR makes ACL rules enforceable for these commands on authenticated clients, while preserving the ability for unauthenticated clients to use them for initial login.

### Root cause

`AUTH` is tagged with `CMD_NO_AUTH`, which allows unauthenticated clients to run it before logging in. However, the ACL check in `ACLSelectorCheckCmd()` treats `CMD_NO_AUTH` as a blanket bypass for all ACL checks, even for already-authenticated clients.
This conflates two separate concerns:
1. **Pre-authentication gate** (`server.c`): Unauthenticated clients need to run `AUTH`/`HELLO` to log in. This is correct and should remain.
2. **Post-authentication ACL check** (`acl.c`): Once a client is authenticated, their ACL rules should be respected. The `CMD_NO_AUTH` bypass here causes `-auth` to be silently ignored.



### Changes

1. Remove `CMD_NO_AUTH` bypass from ACL check 
2. Allow CMD_NO_AUTH commands by default in ACL selectors to maintain backward compatibility

### Backward compatibility

| ACL rule | Before | After | Behavior changed? |
|---|---|---|---|
| `+@all` | AUTH allowed | AUTH allowed | No |
| `-@all +get` | AUTH allowed (bypass) | AUTH allowed (default bit) | No |
| `+@all -auth` | AUTH allowed (bug) | **AUTH denied (fixed)** | Yes |
| `-@all -auth` | AUTH allowed (bug) | **AUTH denied (fixed)** | Yes |

### Behavior after fix

```
127.0.0.1:6379> auth restricted clientpass
OK
127.0.0.1:6379> acl whoami
"restricted"
127.0.0.1:6379> shutdown
(error) NOPERM User restricted has no permissions to run the 'shutdown' command
127.0.0.1:6379> auth admin nopass
(error) NOPERM User restricted has no permissions to run the 'auth' command
```

### Tests

```
[ok]: ACL -auth denies AUTH command for authenticated user (1 ms)
[ok]: CMD_NO_AUTH commands are allowed by default without explicit +auth (0 ms)
[ok]: CMD_NO_AUTH commands survive -@all and are allowed by default (0 ms)
[ok]: Explicit -auth after -@all denies AUTH (1 ms)
```
