### PR TITLE
Skip death test when running under valgrind

### DIFF
--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -4,6 +4,8 @@ extern "C" {
 #include "server.h"
 }
 
+extern bool valgrind;
+
 // Use a class name descriptive of your test unit
 class ExampleTest : public ::testing::Test {
     // standard boilerplate supporting mocked functions
@@ -27,6 +29,9 @@ using ExampleDeathTest = ExampleTest;
 
 // Example of a DeathTest, which passes only if the code crashes.
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
+    if (valgrind) {
+        GTEST_SKIP() << "Skipping death test under valgrind";
+    }
     EXPECT_DEATH(
         {
             *((volatile char *)0) = 'x'; // SEGV


### PR DESCRIPTION
The `ExampleDeathTest.TestSimpleDeath` test intentionally crashes by writing to a `NULL` pointer to verify death test functionality. However, when running under valgrind, this causes valgrind to report an invalid memory write error before the test framework can properly handle the expected crash, causing the test suite to fail.

This change skips the death test when the `--valgrind` flag is passed, preventing valgrind from intercepting the intentional crash.

Fixes [test-valgrind-misc](https://github.com/valkey-io/valkey/actions/runs/22556317878/job/65334230429#logs) and [test-valgrind-no-malloc-usable-size-misc](https://github.com/valkey-io/valkey/actions/runs/22556317878/job/65334230418#logs) failure in Daily workflow.

Verification WFs of my for:[test-valgrind-misc](https://github.com/roshkhatri/valkey/actions/runs/22593701034/job/65458046930#logs) and [test-valgrind-no-malloc-usable-size-misc](https://github.com/roshkhatri/valkey/actions/runs/22593701034/job/65458046968#logs)