### PR TITLE
valgrind test fix: example death without invalid dereference

### DIFF
--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -27,7 +27,7 @@ using ExampleDeathTest = ExampleTest;
 
 // Example of a DeathTest, which passes only if the code crashes.
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
-    EXPECT_DEATH({ abort(); }, "");
+    EXPECT_DEATH({ serverAssert(false); }, "");
 }
 
 // Simple assertions test

--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -27,7 +27,7 @@ using ExampleDeathTest = ExampleTest;
 
 // Example of a DeathTest, which passes only if the code crashes.
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
-    EXPECT_DEATH({ serverAssert(false); }, "");
+    EXPECT_DEATH({ abort(); }, "");
 }
 
 // Simple assertions test

--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -27,11 +27,7 @@ using ExampleDeathTest = ExampleTest;
 
 // Example of a DeathTest, which passes only if the code crashes.
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
-    EXPECT_DEATH(
-        {
-            *((volatile char *)0) = 'x'; // SEGV
-        },
-        "");
+    EXPECT_DEATH({ abort(); }, "");
 }
 
 // Simple assertions test

--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -4,6 +4,8 @@ extern "C" {
 #include "server.h"
 }
 
+extern bool valgrind;
+
 // Use a class name descriptive of your test unit
 class ExampleTest : public ::testing::Test {
     // standard boilerplate supporting mocked functions
@@ -27,7 +29,8 @@ using ExampleDeathTest = ExampleTest;
 
 // Example of a DeathTest, which passes only if the code crashes.
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
-    EXPECT_DEATH({ abort(); }, "");
+    if (valgrind) GTEST_SKIP() << "Death tests trigger Valgrind";
+    EXPECT_DEATH({ serverAssert(false); }, "");
 }
 
 // Simple assertions test


### PR DESCRIPTION
Fix for failure in daily (example: https://github.com/valkey-io/valkey/actions/runs/22532150784/job/65273105682)
```
==38722== Invalid write of size 1
==38722==    at 0x16BCC0: ExampleDeathTest_TestSimpleDeath_Test::TestBody() (example_tests.cpp:30)
==38722==    by 0x3DEE8E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3C67F5: testing::Test::Run() (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3C69B4: testing::TestInfo::Run() (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3C6B9E: testing::TestSuite::Run() (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3D4A0B: testing::internal::UnitTestImpl::RunAllTests() (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3DF566: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x3C6D97: testing::UnitTest::Run() (in /home/runner/work/valkey/valkey/src/unit/valkey-unit-gtests)
==38722==    by 0x172B00: RUN_ALL_TESTS() (gtest.h:2317)
==38722==    by 0x172AA7: main (main.cpp:85)
==38722==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```