### PR TITLE
Add `disable-auth` ACL user flag to prevent re-authentication

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -152,6 +152,7 @@ struct ACLUserFlag {
     {"nopass", USER_FLAG_NOPASS},
     {"skip-sanitize-payload", USER_FLAG_SANITIZE_PAYLOAD_SKIP},
     {"sanitize-payload", USER_FLAG_SANITIZE_PAYLOAD},
+    {"disable-auth", USER_FLAG_DISABLE_AUTH},
     {NULL, 0} /* Terminator. */
 };
 
@@ -1336,6 +1337,9 @@ static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen) {
  *              will still work.
  * skip-sanitize-payload    RESTORE dump-payload sanitization is skipped.
  * sanitize-payload         RESTORE dump-payload is sanitized (default).
+ * disable-auth  Prevent the user from using AUTH or HELLO AUTH to
+ *               re-authenticate as a different user.
+ * enable-auth   Allow the user to use AUTH (default).
  * ><password>  Add this password to the list of valid password for the user.
  *              For example >mypass will add "mypass" to the list.
  *              This directive clears the "nopass" flag (see later).
@@ -1418,6 +1422,10 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
     } else if (!strcasecmp(op, "sanitize-payload")) {
         u->flags &= ~USER_FLAG_SANITIZE_PAYLOAD_SKIP;
         u->flags |= USER_FLAG_SANITIZE_PAYLOAD;
+    } else if (!strcasecmp(op, "disable-auth")) {
+        u->flags |= USER_FLAG_DISABLE_AUTH;
+    } else if (!strcasecmp(op, "enable-auth")) {
+        u->flags &= ~USER_FLAG_DISABLE_AUTH;
     } else if (!strcasecmp(op, "nopass")) {
         u->flags |= USER_FLAG_NOPASS;
         listEmpty(u->passwords);
@@ -1490,6 +1498,7 @@ int ACLSetUser(user *u, const char *op, ssize_t oplen) {
         serverAssert(ACLSetUser(u, "alldbs", -1) == C_OK);
         serverAssert(ACLSetUser(u, "off", -1) == C_OK);
         serverAssert(ACLSetUser(u, "sanitize-payload", -1) == C_OK);
+        serverAssert(ACLSetUser(u, "enable-auth", -1) == C_OK);
         serverAssert(ACLSetUser(u, "clearselectors", -1) == C_OK);
         serverAssert(ACLSetUser(u, "-@all", -1) == C_OK);
     } else {
@@ -3456,6 +3465,12 @@ void authCommand(client *c) {
         addReplyErrorObject(c, shared.syntaxerr);
         return;
     }
+    /* If the user has the disable-auth flag, deny re-authentication. */
+    if (c->flag.authenticated && c->user && (c->user->flags & USER_FLAG_DISABLE_AUTH)) {
+        addReplyError(c, "-NOPERM AUTH command not allowed for this user");
+        return;
+    }
+
     /* Always redact the second argument */
     redactClientCommandArgument(c, 1);
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -5709,6 +5709,12 @@ void helloCommand(client *c) {
     }
 
     if (username && password) {
+        /* If the user has the disable-auth flag, deny re-authentication. */
+        if (c->flag.authenticated && c->user && (c->user->flags & USER_FLAG_DISABLE_AUTH)) {
+            addReplyError(c, "-NOPERM AUTH command not allowed for this user");
+            return;
+        }
+
         robj *err = NULL;
         int auth_result = ACLAuthenticateUser(c, username, password, &err);
         if (auth_result == AUTH_ERR) {

--- a/src/server.h
+++ b/src/server.h
@@ -1058,6 +1058,9 @@ typedef struct readyList {
 #define USER_FLAG_SANITIZE_PAYLOAD_SKIP (1 << 4) /* The user should skip the     \
                                                   * deep sanitization of RESTORE \
                                                   * payload. */
+#define USER_FLAG_DISABLE_AUTH (1 << 5)          /* The user is not allowed to \
+                                                  * use AUTH or HELLO AUTH to  \
+                                                  * re-authenticate. */
 
 #define SELECTOR_FLAG_ROOT (1 << 0)        /* This is the root user permission \
                                             * selector. */

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -889,6 +889,93 @@ start_server {tags {"acl external:skip"}} {
         assert {[r client getname] eq {client0}}
     }
 
+    test {disable-auth flag denies AUTH for authenticated user} {
+        r ACL setuser authdenied on >authpass disable-auth +@all ~* &*
+        r AUTH authdenied authpass
+        assert {[r ACL WHOAMI] eq {authdenied}}
+
+        # AUTH should be denied
+        catch {r AUTH default pwd} e
+        assert_match "*NOPERM*" $e
+
+        # User is still authdenied
+        assert {[r ACL WHOAMI] eq {authdenied}}
+        r RESET
+        r ACL deluser authdenied
+    }
+
+    test {disable-auth flag denies HELLO AUTH for authenticated user} {
+        r ACL setuser hellodenied on >hellopass disable-auth +@all ~* &*
+        r AUTH hellodenied hellopass
+        assert {[r ACL WHOAMI] eq {hellodenied}}
+
+        # HELLO with AUTH should be denied
+        catch {r HELLO 2 AUTH default pwd} e
+        assert_match "*NOPERM*" $e
+
+        # User is still hellodenied
+        assert {[r ACL WHOAMI] eq {hellodenied}}
+        r RESET
+        r ACL deluser hellodenied
+    }
+
+    test {disable-auth flag appears in ACL LIST and ACL GETUSER} {
+        r ACL setuser flaguser on >flagpass disable-auth +@all ~* &*
+
+        # Check ACL LIST
+        set users [r ACL LIST]
+        foreach user $users {
+            if {[string match "*flaguser*" $user]} {
+                assert_match "*disable-auth*" $user
+            }
+        }
+
+        # Check ACL GETUSER flags
+        set flags [dict get [r ACL GETUSER flaguser] flags]
+        assert {[lsearch -exact $flags disable-auth] >= 0}
+
+        r ACL deluser flaguser
+    }
+
+    test {enable-auth clears disable-auth flag} {
+        r ACL setuser toggleuser on >togglepass disable-auth +@all ~* &*
+        set flags [dict get [r ACL GETUSER toggleuser] flags]
+        assert {[lsearch -exact $flags disable-auth] >= 0}
+
+        r ACL setuser toggleuser enable-auth
+        set flags [dict get [r ACL GETUSER toggleuser] flags]
+        assert {[lsearch -exact $flags disable-auth] < 0}
+
+        r ACL deluser toggleuser
+    }
+
+    test {reset clears disable-auth flag} {
+        r ACL setuser resetuser on >resetpass disable-auth +@all ~* &*
+        set flags [dict get [r ACL GETUSER resetuser] flags]
+        assert {[lsearch -exact $flags disable-auth] >= 0}
+
+        r ACL setuser resetuser reset on >resetpass +@all ~* &*
+        set flags [dict get [r ACL GETUSER resetuser] flags]
+        assert {[lsearch -exact $flags disable-auth] < 0}
+
+        r ACL deluser resetuser
+    }
+
+    test {Unauthenticated client can AUTH to user with disable-auth} {
+        r ACL setuser dauser on >dapass disable-auth +@all ~* &*
+
+        # Initial login should succeed
+        r AUTH dauser dapass
+        assert {[r ACL WHOAMI] eq {dauser}}
+
+        # Re-auth should fail
+        catch {r AUTH default pwd} e
+        assert_match "*NOPERM*" $e
+
+        r RESET
+        r ACL deluser dauser
+    }
+
     test {ACL HELP should not have unexpected options} {
         catch {r ACL help xxx} e
         assert_match "*wrong number of arguments for 'acl|help' command" $e

--- a/valkey.conf
+++ b/valkey.conf
@@ -1090,6 +1090,8 @@ replica-priority 100
 #               will still work.
 #  skip-sanitize-payload    RESTORE dump-payload sanitization is skipped.
 #  sanitize-payload         RESTORE dump-payload is sanitized (default).
+#  disable-auth             Prevent the user from using AUTH or HELLO AUTH.
+#  enable-auth              Allow the user to use AUTH (default).
 #  +<command>   Allow the execution of that command.
 #               May be used with `|` for allowing subcommands (e.g "+config|get")
 #  -<command>   Disallow the execution of that command.


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/3286

### Summary

The ACL `-AUTH` rule currently has no effect because `CMD_NO_AUTH` commands bypass ACL checks entirely. Instead of changing the `-AUTH` behavior (https://github.com/valkey-io/valkey/pull/3287), which would be a breaking change, this PR adds a new user-level flag `disable-auth` that prevents authenticated users from running `AUTH` or `HELLO AUTH` to re-authenticate.

### Changes

1. Add new `USER_FLAG_DISABLE_AUTH` flag
   - `disable-auth` sets the flag, `enable-auth` clears it
   - Flag is cleared on `reset`
   - Appears in `ACL LIST` and `ACL GETUSER` output when set
2. Enforce the flag in `AUTH` and `HELLO AUTH` handling
   - Only checked for already-authenticated clients, so initial login is not affected

### Usage

```
ACL SETUSER restricted on >clientpass disable-auth ~* &* +@all
```

### Behavior after change

```
127.0.0.1:6379> AUTH restricted clientpass
OK
127.0.0.1:6379> ACL WHOAMI
"restricted"
127.0.0.1:6379> AUTH admin nopass
(error) NOPERM AUTH command not allowed for this user
127.0.0.1:6379> HELLO 2 AUTH admin nopass
(error) NOPERM AUTH command not allowed for this user
127.0.0.1:6379> ACL WHOAMI
"restricted"
```

### Backward compatibility

No breaking changes. The `disable-auth` flag is opt-in so existing ACL configurations are unaffected.

### Tests

```
[ok]: disable-auth flag denies AUTH for authenticated user (0 ms)
[ok]: disable-auth flag denies HELLO AUTH for authenticated user (0 ms)
[ok]: disable-auth flag appears in ACL LIST and ACL GETUSER (1 ms)
[ok]: enable-auth clears disable-auth flag (0 ms)
[ok]: reset clears disable-auth flag (0 ms)
[ok]: Unauthenticated client can AUTH to user with disable-auth (1 ms)
```
