### PR TITLE
[DEFLAKE] Fix flaky block_keyspace_notification pipelining test

### DIFF
--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -32,21 +32,21 @@ start_server {tags {"modules"}} {
         wait_for_blocked_clients_count 0
         assert_equal "1" [$rd1 read]
         pause_process [srv 0 pid]
-        # Queue up three commands
+        # Queue up three commands: hget (non-blocking), hset (blocking), hget (non-blocking)
         $rd1 hget key_10 field_10
         $rd1 hset key_10 value_10 ss
         $rd1 hget key_10 field_10
-        set start [clock milliseconds]; # Record time before unblocking
         resume_process [srv 0 pid]
+        # First hget should return immediately (non-blocking)
         assert_equal "value_10" [$rd1 read]
-        set first_hget [expr [clock milliseconds] - $start];
-        assert_equal "1" [$rd1 read]
-        set first_hset [expr [clock milliseconds] - $start];
-        assert_equal "value_10" [$rd1 read]
-        set second_hget [expr [clock milliseconds] - $start];
-        assert {[expr {$first_hget * 10 < $first_hset}]}
-        assert {[expr {$second_hget - $first_hset <= 50}]}
+        # hset triggers blocking keyspace notification - wait for it to block
+        wait_for_blocked_clients_count 1
+        # Now wait for hset to complete
         wait_for_blocked_clients_count 0
+        assert_equal "1" [$rd1 read]
+        # Second hget returns after hset completes
+        assert_equal "value_10" [$rd1 read]
+        $rd1 close
     }
     test {Blocking keyspace notification with pipelining hget after hset} {
         wait_for_blocked_clients_count 0


### PR DESCRIPTION
The test "Blocking keyspace notification with pipelining hset after hget" was recently failing intermittently with two different errors:

1. `Expected [expr {114 * 10 < 1114}]` - timing assertion failed under Valgrind https://github.com/valkey-io/valkey/actions/runs/22508917648/job/65213691473
2. `Timeout waiting for blocked clients` - race condition on normal runs https://github.com/valkey-io/valkey/actions/runs/22532150784/job/65273105736

The test used wall-clock timing to verify that hget (non-blocking) completed faster than hset (blocking). This is unreliable because:
- Valgrind slows execution 10-50x, making timing ratios meaningless
- Fast systems may complete both operations in <10ms, causing ratio failures

This fix replaces timing assertions with blocked client count checks, which directly verify the blocking mechanism rather than inferring it from timing. The test now confirms hget's response is available before hset blocks, then waits for the blocked client count to transition through the expected states.

Tested 100x in this workflow run: https://github.com/rainsupreme/valkey/actions/runs/22597356966/job/65470689123