### PR TITLE
Fix compatibility issue for death test with Valgrind

### DIFF
--- a/src/unit/example_tests.cpp
+++ b/src/unit/example_tests.cpp
@@ -29,7 +29,7 @@ using ExampleDeathTest = ExampleTest;
 TEST_F(ExampleDeathTest, TestSimpleDeath) {
     EXPECT_DEATH(
         {
-            *((volatile char *)0) = 'x'; // SEGV
+            serverAssert(false);
         },
         "");
 }

--- a/src/unit/main.cpp
+++ b/src/unit/main.cpp
@@ -80,6 +80,11 @@ int main(int argc, char **argv) {
     // The following line must be executed to initialize GoogleTest before running the tests.
     ::testing::InitGoogleMock(&argc, argv);
 
+    // Set death test style to threadsafe when running under Valgrind
+    if (valgrind) {
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+    }
+
     test_argc = argc;
     test_argv = argv;
     int result = RUN_ALL_TESTS();


### PR DESCRIPTION
This is for fixing the Valgrind errors when running GoogleTest death tests. By setting the death test style to "threadsafe" when the `--valgrind` flag is detected, allowing Valgrind to properly handle death tests using fork() instead
of clone().

Previous test failed link: https://github.com/valkey-io/valkey/actions/runs/22556317878

Valgrind tests are passing now: https://github.com/harrylin98/valkey_forked/actions/runs/22650420470