### PR TITLE
Fix compatibility for OpenSSL < 3.0 and Almalinux version mismatch for daily tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1241,7 +1241,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-jemalloc
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-jemalloc
             container: quay.io/centos/centos:stream9
@@ -1316,7 +1316,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-tls-module
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-tls-module
             container: quay.io/centos/centos:stream9
@@ -1392,7 +1392,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-tls-module-no-tls
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-tls-module-no-tls
             container: quay.io/centos/centos:stream9

--- a/src/tls.c
+++ b/src/tls.c
@@ -1861,12 +1861,19 @@ static sds connTLSGetPeerCert(connection *conn_) {
     tls_connection *conn = (tls_connection *)conn_;
     if ((conn_->type != connectionTypeTls()) || !conn->ssl) return NULL;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    X509 *cert = SSL_get0_peer_certificate(conn->ssl);
+#else
     X509 *cert = SSL_get_peer_certificate(conn->ssl);
+#endif
     if (!cert) return NULL;
 
     BIO *bio = BIO_new(BIO_s_mem());
     if (bio == NULL || !PEM_write_bio_X509(bio, cert)) {
         if (bio != NULL) BIO_free(bio);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+        X509_free(cert);
+#endif
         return NULL;
     }
 
@@ -1874,6 +1881,10 @@ static sds connTLSGetPeerCert(connection *conn_) {
     long long bio_len = BIO_get_mem_data(bio, &bio_ptr);
     sds cert_pem = sdsnewlen(bio_ptr, bio_len);
     BIO_free(bio);
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    X509_free(cert);
+#endif
 
     return cert_pem;
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -1350,7 +1350,11 @@ user *tlsGetPeerUser(connection *conn_, sds *cert_username) {
         return NULL;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     X509 *cert = SSL_get0_peer_certificate(conn->ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+#endif
     if (!cert) return NULL;
 
     user *result = NULL;
@@ -1381,6 +1385,10 @@ user *tlsGetPeerUser(connection *conn_, sds *cert_username) {
     default:
         break;
     }
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    X509_free(cert);
+#endif
 
     return result;
 }


### PR DESCRIPTION
`SSL_get0_peer_certificate()` was introduced in OpenSSL 3.0. The recent commit 7e110ae2b (Support TLS authentication using SAN URI) used it in `tlsGetPeerUser()` without a version guard, breaking builds against `OpenSSL 1.1.x.`

Use `SSL_get_peer_certificate()` on OpenSSL < 3.0 with the corresponding `X509_free()` since the older API increments the reference count.

Fixes build failure: implicit declaration of function `SSL_get0_peer_certificate [-Werror=implicit-function-declaration]`
https://github.com/valkey-io/valkey/actions/runs/22648954538/job/65643630947

Test run for this change: https://github.com/roshkhatri/valkey/actions/runs/22655187385
<img width="250" height="470" alt="Screenshot 2026-03-03 at 8 49 43 PM" src="https://github.com/user-attachments/assets/37795770-8c20-4eff-a30e-66dbb4336878" />
<img width="379" height="304" alt="Screenshot 2026-03-03 at 8 50 27 PM" src="https://github.com/user-attachments/assets/51f2b944-bf43-4a97-8e72-637323f2e0cc" />

Also fixes the version mismatch for almalinux 9 daily tests: https://github.com/valkey-io/valkey/issues/3304