### PR TITLE
Let script continue if busy-reply-threshold is zero

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -83,7 +83,7 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
     if (server.busy_reply_threshold == 0) {
         return SCRIPT_CONTINUE;
     }
-    
+
     long long elapsed = elapsedMs(run_ctx->start_time);
     if (elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;

--- a/src/script.c
+++ b/src/script.c
@@ -81,7 +81,7 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
     }
 
     long long elapsed = elapsedMs(run_ctx->start_time);
-    if (elapsed < server.busy_reply_threshold) {
+    if (server.busy_reply_threshold == 0 || elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -80,8 +80,12 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
         return (run_ctx->flags & SCRIPT_KILLED) ? SCRIPT_KILL : SCRIPT_CONTINUE;
     }
 
+    if (server.busy_reply_threshold == 0) {
+        return SCRIPT_CONTINUE;
+    }
+    
     long long elapsed = elapsedMs(run_ctx->start_time);
-    if (server.busy_reply_threshold == 0 || elapsed < server.busy_reply_threshold) {
+    if (elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -81,7 +81,7 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
     }
 
     long long elapsed = elapsedMs(run_ctx->start_time);
-    if (server.busy_reply_threshold > 0 || elapsed < server.busy_reply_threshold) {
+    if (server.busy_reply_threshold == 0 || elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -81,7 +81,7 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
     }
 
     long long elapsed = elapsedMs(run_ctx->start_time);
-    if (server.busy_reply_threshold == 0 || elapsed < server.busy_reply_threshold) {
+    if (server.busy_reply_threshold > 0 || elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;
     }
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1790,9 +1790,9 @@ aof-timestamp-enabled no
 # the server in the case a write command was already issued by the script when
 # the user doesn't want to wait for the natural termination of the script.
 #
-# The default is 5 seconds. It is possible to set it to 0 or a negative value
-# to disable this mechanism (uninterrupted execution). Note that in the past
-# this config had a different name, which is now an alias, so both of these do
+# The default is 5 seconds. It is possible to set it to 0 to disable this 
+# mechanism (uninterrupted execution). Note that in the past this config had a 
+# different name, which is now an alias, so both of these do
 # the same:
 # lua-time-limit 5000
 # busy-reply-threshold 5000


### PR DESCRIPTION
Before we added LUA as a module we had a logic to NOT register the
luaHook when the value of `busy-reply-threshold` config is set to 0.

Now we ALWAYS register the hook and in order to keep aligned with
old behavior we will let the execution of the script continue from
the interrupt hook when `busy-reply-threshold` config is set == 0.

And in value.conf, we are saying the config can be negative, but in
fact the config is minimum at 0, fix the valkey.conf as well.
```
# The default is 5 seconds. It is possible to set it to 0 or a negative value
# to disable this mechanism (uninterrupted execution)
```

It was introduced in #2858.