### PR TITLE
fix Codecov v5 input from file to files

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -44,4 +44,4 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./src/valkey.info
+          files: ./src/valkey.info


### PR DESCRIPTION
This PR fixes a Codecov workflow misconfiguration introduced when upgrading codecov/codecov-action from v4 to v5 (in #3185).
In v5, the action expects files (plural), but the workflow still used file.

The coverage shown is 0 right now: https://app.codecov.io/gh/valkey-io/valkey


Documentation from - https://github.com/codecov/codecov-action/tree/v5?tab=readme-ov-file#arguments

```
The following arguments have been changed

    file (this has been deprecated in favor of files)
    plugin (this has been deprecated in favor of plugins)

```