### PR TITLE
Update the CodeQL action to resolve v3 deprecation warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,12 +40,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5


### PR DESCRIPTION
The CodeQL workflow is currently throwing a deprecation warning regarding use of v3. [[Recent example](https://github.com/valkey-io/valkey/actions/runs/22686353075/job/65770256659#annotation:3:11)]:

> CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

This PR introduces the following changes:

* References to CodeQL v3 have been updated to the SHA of the latest CodeQL release, [v4.32.5](https://github.com/github/codeql-action/releases/tag/v4.32.5).

----

> [!NOTE]
>
> I see that a Dependabot config file exists for this repo, and it appears to be valid. I also see that [the Dependabot workflow ran once a few days ago](https://github.com/valkey-io/valkey/actions/runs/22560065441/job/65344757439#step:3:1292)...but doesn't appear to have successfully opened any PRs that I can find.
>
> You might need to double-check that Dependabot is configured correctly for this repo.