### PR TITLE
Fixed point arithmetic for x86 TSC

### DIFF
--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -25,7 +25,15 @@ static char monotonic_info_string[32];
 #endif
 
 
-#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
+/* x86_64 TSC-based monotonic clock implementation.
+ *
+ * Requirements for enabling this optimized path:
+ *   USE_PROCESSOR_CLOCK: processor clock usage not explicitly disabled
+ *   __x86_64__: requires 64-bit x86 architecture (for rdtsc instruction and 128-bit arithmetic)
+ *   __linux__: needed to access /proc/cpuinfo for verifying 'constant_tsc' CPU flag
+ *   __SIZEOF_INT128__: requires compiler support for 128-bit integers to prevent wraparound
+ */
+#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__) && defined(__SIZEOF_INT128__)
 #include <regex.h>
 #include <x86intrin.h>
 
@@ -35,7 +43,7 @@ static char monotonic_info_string[32];
 static uint64_t mono_ticks_speed = 0; /* Fixed-point: (1 << MONO_FPMULT_SHIFT) / ticks_per_us */
 
 static monotime getMonotonicUs_x86(void) {
-    return (__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
+    return ((__uint128_t)__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
 }
 
 static void monotonicInit_x86linux(void) {
@@ -165,7 +173,7 @@ static void monotonicInit_posix(void) {
 
 
 const char *monotonicInit(void) {
-#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__)
+#if defined(USE_PROCESSOR_CLOCK) && defined(__x86_64__) && defined(__linux__) && defined(__SIZEOF_INT128__)
     if (getMonotonicUs == NULL) monotonicInit_x86linux();
 #endif
 

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -30,11 +30,12 @@ static char monotonic_info_string[32];
 #include <x86intrin.h>
 
 #define TSC_CALIBRATION_ITERATIONS 3
+#define MONO_FPMULT_SHIFT 24
 
-static long mono_ticksPerMicrosecond = 0;
+static uint64_t mono_ticksPerMicrosecond = 0; /* Fixed-point: (2^MONO_FPMULT_SHIFT / ticksPerMicrosecond) */
 
 static monotime getMonotonicUs_x86(void) {
-    return __rdtsc() / mono_ticksPerMicrosecond;
+    return (__rdtsc() * mono_ticksPerMicrosecond) >> MONO_FPMULT_SHIFT;
 }
 
 static void monotonicInit_x86linux(void) {
@@ -62,11 +63,12 @@ static void monotonicInit_x86linux(void) {
 
         uint64_t elapsed_us = (end.tv_sec - start.tv_sec) * 1000000ULL + (end.tv_nsec - start.tv_nsec) / 1000;
         uint64_t tsc_elapsed = tsc_end - tsc_start;
-        long sample_ticksPerMicrosecond = tsc_elapsed / elapsed_us;
+        double sample_ticks_per_us = (double)tsc_elapsed / (double)elapsed_us;
+        uint64_t sample_mult = (uint64_t)((double)(1ULL << MONO_FPMULT_SHIFT) / sample_ticks_per_us);
 
         /* Use the maximum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy */
-        if (sample_ticksPerMicrosecond > mono_ticksPerMicrosecond) {
-            mono_ticksPerMicrosecond = sample_ticksPerMicrosecond;
+        if (sample_mult > mono_ticksPerMicrosecond) {
+            mono_ticksPerMicrosecond = sample_mult;
         }
     }
 
@@ -96,7 +98,9 @@ static void monotonicInit_x86linux(void) {
         return;
     }
 
-    snprintf(monotonic_info_string, sizeof(monotonic_info_string), "X86 TSC @ %ld ticks/us", mono_ticksPerMicrosecond);
+    /* Convert back to ticks/us for human-readable display */
+    double ticks_per_us = (double)(1ULL << MONO_FPMULT_SHIFT) / (double)mono_ticksPerMicrosecond;
+    snprintf(monotonic_info_string, sizeof(monotonic_info_string), "X86 TSC @ %.2f ticks/us", ticks_per_us);
     getMonotonicUs = getMonotonicUs_x86;
 }
 #endif

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -32,10 +32,10 @@ static char monotonic_info_string[32];
 #define TSC_CALIBRATION_ITERATIONS 3
 #define MONO_FPMULT_SHIFT 24
 
-static uint64_t mono_ticksPerMicrosecond = 0; /* Fixed-point: (2^MONO_FPMULT_SHIFT / ticksPerMicrosecond) */
+static uint64_t mono_ticks_speed = 0; /* Fixed-point: (1 << MONO_FPMULT_SHIFT) / ticks_per_us */
 
 static monotime getMonotonicUs_x86(void) {
-    return (__rdtsc() * mono_ticksPerMicrosecond) >> MONO_FPMULT_SHIFT;
+    return (__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
 }
 
 static void monotonicInit_x86linux(void) {
@@ -67,8 +67,8 @@ static void monotonicInit_x86linux(void) {
         uint64_t sample_mult = (uint64_t)((double)(1ULL << MONO_FPMULT_SHIFT) / sample_ticks_per_us);
 
         /* Use the maximum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy */
-        if (sample_mult > mono_ticksPerMicrosecond) {
-            mono_ticksPerMicrosecond = sample_mult;
+        if (sample_mult > mono_ticks_speed) {
+            mono_ticks_speed = sample_mult;
         }
     }
 
@@ -89,7 +89,7 @@ static void monotonicInit_x86linux(void) {
     }
     regfree(&constTscRegex);
 
-    if (mono_ticksPerMicrosecond == 0) {
+    if (mono_ticks_speed == 0) {
         fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate");
         return;
     }
@@ -99,7 +99,7 @@ static void monotonicInit_x86linux(void) {
     }
 
     /* Convert back to ticks/us for human-readable display */
-    double ticks_per_us = (double)(1ULL << MONO_FPMULT_SHIFT) / (double)mono_ticksPerMicrosecond;
+    double ticks_per_us = (double)(1ULL << MONO_FPMULT_SHIFT) / (double)mono_ticks_speed;
     snprintf(monotonic_info_string, sizeof(monotonic_info_string), "X86 TSC @ %.2f ticks/us", ticks_per_us);
     getMonotonicUs = getMonotonicUs_x86;
 }

--- a/src/monotonic.c
+++ b/src/monotonic.c
@@ -40,7 +40,7 @@ static char monotonic_info_string[32];
 #define TSC_CALIBRATION_ITERATIONS 3
 #define MONO_FPMULT_SHIFT 24
 
-static uint64_t mono_ticks_speed = 0; /* Fixed-point: (1 << MONO_FPMULT_SHIFT) / ticks_per_us */
+static uint64_t mono_ticks_speed = UINT64_MAX; /* Fixed-point: (1 << MONO_FPMULT_SHIFT) / ticks_per_us */
 
 static monotime getMonotonicUs_x86(void) {
     return ((__uint128_t)__rdtsc() * mono_ticks_speed) >> MONO_FPMULT_SHIFT;
@@ -74,8 +74,9 @@ static void monotonicInit_x86linux(void) {
         double sample_ticks_per_us = (double)tsc_elapsed / (double)elapsed_us;
         uint64_t sample_mult = (uint64_t)((double)(1ULL << MONO_FPMULT_SHIFT) / sample_ticks_per_us);
 
-        /* Use the maximum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy */
-        if (sample_mult > mono_ticks_speed) {
+        /* Use the minimum out of TSC_CALIBRATION_ITERATIONS iterations for accuracy
+         * because mono_ticks_speed represents an inverse relationship of ticks_per_us. */
+        if (sample_mult < mono_ticks_speed) {
             mono_ticks_speed = sample_mult;
         }
     }
@@ -97,7 +98,7 @@ static void monotonicInit_x86linux(void) {
     }
     regfree(&constTscRegex);
 
-    if (mono_ticks_speed == 0) {
+    if (mono_ticks_speed == UINT64_MAX) {
         fprintf(stderr, "monotonic: x86 linux, unable to determine clock rate");
         return;
     }


### PR DESCRIPTION
Replace integer mono_ticksPerMicrosecond with fixed-point arithmetic in x86 TSC monotonic clock for better accuracy (and performance because of multiplication + shift instead of division).
Calibration now uses double precision to compute multiplier.

**Comparison with TSC @ 2400.5 ticks/us**
**Old Method:**
Calibration: 2400 (truncated from 2400.5)
Converting 1 second of ticks: 2,400,500,000 / 2400 = 1,000,208 us
Error: +208 us per second

**New Method:**
Calibration: sample_ticks_per_us = 2400.5 (double stores exactly in this case)
Multiplier: 2^24 / 2400.5 = 6989.942 -> stored as 6989 in uint64_t
Converting 1 second: (2,400,500,000 * 6989) >> 24 = 999,992 us
Error: -8 us per second
