### PR TITLE
Avoid compiler optimizations removing a call to `memset`

### DIFF
--- a/src/sha1.c
+++ b/src/sha1.c
@@ -24,6 +24,7 @@ A million repetitions of "a"
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include "solarisfixes.h"
 #include "sha1.h"
 #include "config.h"
@@ -107,7 +108,7 @@ void SHA1Transform(uint32_t state[5], const unsigned char buffer[64])
     /* Wipe variables */
     a = b = c = d = e = 0;
 #ifdef SHA1HANDSOFF
-    memset(block, '\0', sizeof(block));
+    memset_s(block, '\0', sizeof(block));
 #endif
 }
 


### PR DESCRIPTION
> [!NOTE]
>
> I'm closing this issue because I don't know how to get `memset_s` to exist as a defined name in the file. I apologize for the noise on your tracker!

This attempts to resolve a CodeQL security warning
which appeared in my fork when I enabled the workflows:

> Calling memset or bzero on a buffer to clear its contents
> may get optimized away by the compiler if the buffer is not
> subsequently used. This is not desirable behavior
> if the buffer contains sensitive data
> that could somehow be retrieved by an attacker.

The recommended solution from CodeQL is:

> Use `memset_s` (from C11) instead of `memset`,
> as `memset_s` will not get optimized away.

The CodeQL security warning provides these references:

* CERT C Coding Standard: MSC06-C. [Beware of compiler optimizations](https://wiki.sei.cmu.edu/confluence/display/c/MSC06-C.+Beware+of+compiler+optimizations).
* USENIX: The Advanced Computing Systems Association: [Dead Store Elimination (Still) Considered Harmfuls](https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-yang.pdf)
* Common Weakness Enumeration: [CWE-14](https://cwe.mitre.org/data/definitions/14.html).