### PR TITLE
`libvalkeylua` is now a dependency of `valkey-server`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -44,4 +44,4 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./src/valkey.info
+          files: ./src/valkey.info

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,12 +40,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3.32.2
+        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1241,7 +1241,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-jemalloc
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-jemalloc
             container: quay.io/centos/centos:stream9
@@ -1316,7 +1316,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-tls-module
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-tls-module
             container: quay.io/centos/centos:stream9
@@ -1392,7 +1392,7 @@ jobs:
             container: almalinux:8
             install_epel: true
           - name: test-almalinux9-tls-module-no-tls
-            container: almalinux:8
+            container: almalinux:9
             install_epel: true
           - name: test-centosstream9-tls-module-no-tls
             container: quay.io/centos/centos:stream9

--- a/src/Makefile
+++ b/src/Makefile
@@ -254,7 +254,12 @@ endif
 FINAL_CFLAGS+= -I../deps/libvalkey/include -I../deps/linenoise -I../deps/hdr_histogram -I../deps/fpconv
 
 # Lua scripting engine module
-LUA_MODULE_NAME:=modules/lua/libvalkeylua.so
+SO_EXT=so
+ifeq ($(uname_S),Darwin)
+	SO_EXT=dylib
+endif
+LUA_MODULE_NAME:=modules/lua/libvalkeylua.$(SO_EXT)
+
 ifeq ($(BUILD_LUA),no)
 	LUA_MODULE=
 	LUA_MODULE_INSTALL=
@@ -263,12 +268,12 @@ else
 	LUA_MODULE_INSTALL=install-lua-module
 
 	current_dir = $(shell pwd)
-	FINAL_CFLAGS+=-DLUA_ENABLED -DLUA_LIB=libvalkeylua.so
+	FINAL_CFLAGS+=-DLUA_ENABLED -DLUA_LIB=libvalkeylua.$(SO_EXT)
 ifeq ($(uname_S),Darwin)
 	FINAL_LDFLAGS+= -Wl,-rpath,$(PREFIX)/lib
 	FINAL_LDFLAGS+= -Wl,-rpath,$(current_dir)/modules/lua
 else
-	FINAL_LDFLAGS+= -Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua -Wl,--disable-new-dtags
+	FINAL_LDFLAGS+= -Wl,-rpath,'$ORIGIN/../lib':$(current_dir)/modules/lua -Wl,--disable-new-dtags
 endif
 endif
 
@@ -637,7 +642,7 @@ endif
 
 DEPENDENCY_TARGETS+= gtest-parallel
 
-ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE) $(LUA_MODULE)
+ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE)
 
 all: $(ALL_BUILD_PREREQUISITES)
 	@echo ""
@@ -694,8 +699,8 @@ ifneq ($(strip $(PREV_FINAL_LDFLAGS)), $(strip $(FINAL_LDFLAGS)))
 endif
 
 # valkey-server
-$(SERVER_NAME): $(ENGINE_SERVER_OBJ)
-	$(SERVER_LD) -o $@ $^ ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
+$(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
+	$(SERVER_LD) -o $@ $(ENGINE_SERVER_OBJ) ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
@@ -722,7 +727,7 @@ $(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
 # engine_lua.so
-$(LUA_MODULE_NAME): $(SERVER_NAME)
+$(LUA_MODULE):
 	cd modules/lua && $(MAKE) OPTIMIZATION="$(OPTIMIZATION)"
 
 # valkey-cli

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -268,15 +268,18 @@ static void activeDefragZsetNode(void *privdata, void *entry_ref) {
 
     /* find skiplist pointers that need to be updated if we end up moving the
      * skiplist node. */
+    sds ele = zslGetNodeElement(node);
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
     zskiplistNode *x = zslGetHeader(zsl);
     for (int i = zslGetHeight(zsl) - 1; i >= 0; i--) {
         /* stop when we've reached the end of this level or the next node comes
-         * after our target in sorted order */
+         * after our target in sorted order. Even though defrag replacements does not impact the skip list order,
+         * when scores are equal, we MUST compare elements lexicographically to maintain correct skip list ordering.
+         * Otherwise we might miss locating the entry. */
         zskiplistNode *next = x->level[i].forward;
         while (next &&
                (next->score < score ||
-                (next->score == score && next != node))) {
+                (next->score == score && sdscmp(zslGetNodeElement(next), ele) < 0))) {
             x = next;
             next = x->level[i].forward;
         }

--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -2,10 +2,12 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 
 DEPS_DIR=../../../deps
+SO_EXT=so
 
 ifeq ($(uname_S),Darwin)
 	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -dynamic -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
-	SHOBJ_LDFLAGS= -bundle -undefined dynamic_lookup $(LDFLAGS)
+	SHOBJ_LDFLAGS= -shared -undefined dynamic_lookup $(LDFLAGS)
+	SO_EXT=dylib
 else
 	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
 	SHOBJ_LDFLAGS= -shared $(LDFLAGS)
@@ -43,9 +45,10 @@ ifeq ("$(wildcard /usr/lib/libSystem.dylib)","")
 endif
 endif
 
-all: libvalkeylua.so
+LUA_LIB=libvalkeylua.$(SO_EXT)
+all: $(LUA_LIB)
 
-libvalkeylua.so: $(OBJS) $(LIBS)
+$(LUA_LIB): $(OBJS) $(LIBS)
 	$(CC) -o $@ $(SHOBJ_LDFLAGS) $^
 
 sha1.o: ../../sha1.c
@@ -64,4 +67,4 @@ $(DEPS_DIR)/fpconv/libfpconv.a:
 	cd $(DEPS_DIR) && $(MAKE) fpconv
 
 clean:
-	rm -f *.so $(OBJS)
+	rm -f $(LUA_LIB) $(OBJS)

--- a/src/script.c
+++ b/src/script.c
@@ -80,6 +80,10 @@ int scriptInterrupt(scriptRunCtx *run_ctx) {
         return (run_ctx->flags & SCRIPT_KILLED) ? SCRIPT_KILL : SCRIPT_CONTINUE;
     }
 
+    if (server.busy_reply_threshold == 0) {
+        return SCRIPT_CONTINUE;
+    }
+
     long long elapsed = elapsedMs(run_ctx->start_time);
     if (elapsed < server.busy_reply_threshold) {
         return SCRIPT_CONTINUE;

--- a/src/tls.c
+++ b/src/tls.c
@@ -1350,7 +1350,11 @@ user *tlsGetPeerUser(connection *conn_, sds *cert_username) {
         return NULL;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
     X509 *cert = SSL_get0_peer_certificate(conn->ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(conn->ssl);
+#endif
     if (!cert) return NULL;
 
     user *result = NULL;
@@ -1381,6 +1385,10 @@ user *tlsGetPeerUser(connection *conn_, sds *cert_username) {
     default:
         break;
     }
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    X509_free(cert);
+#endif
 
     return result;
 }
@@ -1853,12 +1861,19 @@ static sds connTLSGetPeerCert(connection *conn_) {
     tls_connection *conn = (tls_connection *)conn_;
     if ((conn_->type != connectionTypeTls()) || !conn->ssl) return NULL;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    X509 *cert = SSL_get0_peer_certificate(conn->ssl);
+#else
     X509 *cert = SSL_get_peer_certificate(conn->ssl);
+#endif
     if (!cert) return NULL;
 
     BIO *bio = BIO_new(BIO_s_mem());
     if (bio == NULL || !PEM_write_bio_X509(bio, cert)) {
         if (bio != NULL) BIO_free(bio);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+        X509_free(cert);
+#endif
         return NULL;
     }
 
@@ -1866,6 +1881,10 @@ static sds connTLSGetPeerCert(connection *conn_) {
     long long bio_len = BIO_get_mem_data(bio, &bio_ptr);
     sds cert_pem = sdsnewlen(bio_ptr, bio_len);
     BIO_free(bio);
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+    X509_free(cert);
+#endif
 
     return cert_pem;
 }

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -439,8 +439,8 @@ run_solo {defrag} {
         }
     }
 
-    proc test_big_zset {type} {
-        set title "Active Defrag big zset: $type"
+    proc test_big_zset {type score} {
+        set title "Active Defrag big zset: $type $score-score"
         test $title {
             # number of total fields.  zsets are progressively increasing sizes.
             set n 200000
@@ -452,7 +452,8 @@ run_solo {defrag} {
                 set k 0
                 set f 0
                 for {set j 0} {$j < $n} {incr j} {
-                    $rd zadd k$k [expr rand()] $val$f
+                    set s [expr {$score eq "fixed" ? 0 : rand()}]
+                    $rd zadd k$k $s $val$f
                     lassign [next_exp_kf $k $f] k f
                     if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
@@ -467,6 +468,14 @@ run_solo {defrag} {
                 $rd close
             }
         }
+    }
+
+    proc test_big_zset_random_score {type} {
+        test_big_zset $type random
+    }
+
+    proc test_big_zset_fixed_score {type} {
+        test_big_zset $type fixed
     }
 
     proc test_stream {type} {
@@ -579,7 +588,8 @@ run_solo {defrag} {
     lappend tests [list test_big_hash standalone $std_overrides]
     lappend tests [list test_big_list standalone $std_overrides]
     lappend tests [list test_big_set standalone $std_overrides]
-    lappend tests [list test_big_zset standalone $std_overrides]
+    lappend tests [list test_big_zset_random_score standalone $std_overrides]
+    lappend tests [list test_big_zset_fixed_score standalone $std_overrides]
     lappend tests [list test_stream standalone $std_overrides]
     lappend tests [list test_pubsub standalone $std_overrides]
 
@@ -588,7 +598,8 @@ run_solo {defrag} {
     lappend tests [list test_big_hash cluster $std_overrides]
     lappend tests [list test_big_list cluster $std_overrides]
     lappend tests [list test_big_set cluster $std_overrides]
-    lappend tests [list test_big_zset cluster $std_overrides]
+    lappend tests [list test_big_zset_random_score cluster $std_overrides]
+    lappend tests [list test_big_zset_fixed_score cluster $std_overrides]
     lappend tests [list test_stream cluster $std_overrides]
     lappend tests [list test_pubsub cluster $std_overrides]
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -1790,9 +1790,9 @@ aof-timestamp-enabled no
 # the server in the case a write command was already issued by the script when
 # the user doesn't want to wait for the natural termination of the script.
 #
-# The default is 5 seconds. It is possible to set it to 0 or a negative value
-# to disable this mechanism (uninterrupted execution). Note that in the past
-# this config had a different name, which is now an alias, so both of these do
+# The default is 5 seconds. It is possible to set it to 0 to disable this 
+# mechanism (uninterrupted execution). Note that in the past this config had a 
+# different name, which is now an alias, so both of these do
 # the same:
 # lua-time-limit 5000
 # busy-reply-threshold 5000


### PR DESCRIPTION
Building `valkey-server` should now build `libvalkeylua.{so|dyblib}` unless disabled.

In addition, fixed MacOS Build By Using Correct Shared Library Extension.

This change updates the build system to properly handle platform-specific shared library extensions. On macOS, shared libraries use the `.dylib` extension instead of `.so`, which was causing build and runtime linking issues.

The Lua module Makefile now defines a `SO_EXT` variable that defaults to `so` but is set to `dylib` on Darwin systems. The linker flag was also changed from `-bundle` to `-shared` on macOS for consistency with standard shared library conventions.

In the main Makefile, the same extension logic is applied, and the Lua module is now built as an explicit dependency of the server binary to ensure correct build ordering. Additionally, the runtime library search path on Linux now uses `$ORIGIN` to enable relocatable binaries.

* Build system (Makefiles)
* Lua module compilation and linking
* Platform-specific shared library handling

**Generated by CodeLite**