### PR TITLE
`libvalkeylua` is now a dependency of `valkey-server`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -254,7 +254,12 @@ endif
 FINAL_CFLAGS+= -I../deps/libvalkey/include -I../deps/linenoise -I../deps/hdr_histogram -I../deps/fpconv
 
 # Lua scripting engine module
-LUA_MODULE_NAME:=modules/lua/libvalkeylua.so
+SO_EXT=so
+ifeq ($(uname_S),Darwin)
+	SO_EXT=dylib
+endif
+LUA_MODULE_NAME:=modules/lua/libvalkeylua.$(SO_EXT)
+
 ifeq ($(BUILD_LUA),no)
 	LUA_MODULE=
 	LUA_MODULE_INSTALL=
@@ -263,12 +268,12 @@ else
 	LUA_MODULE_INSTALL=install-lua-module
 
 	current_dir = $(shell pwd)
-	FINAL_CFLAGS+=-DLUA_ENABLED -DLUA_LIB=libvalkeylua.so
+	FINAL_CFLAGS+=-DLUA_ENABLED -DLUA_LIB=libvalkeylua.$(SO_EXT)
 ifeq ($(uname_S),Darwin)
 	FINAL_LDFLAGS+= -Wl,-rpath,$(PREFIX)/lib
 	FINAL_LDFLAGS+= -Wl,-rpath,$(current_dir)/modules/lua
 else
-	FINAL_LDFLAGS+= -Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua -Wl,--disable-new-dtags
+	FINAL_LDFLAGS+= -Wl,-rpath,'$$ORIGIN/../lib':$(current_dir)/modules/lua -Wl,--disable-new-dtags
 endif
 endif
 
@@ -637,7 +642,7 @@ endif
 
 DEPENDENCY_TARGETS+= gtest-parallel
 
-ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE) $(LUA_MODULE)
+ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE)
 
 all: $(ALL_BUILD_PREREQUISITES)
 	@echo ""
@@ -694,8 +699,8 @@ ifneq ($(strip $(PREV_FINAL_LDFLAGS)), $(strip $(FINAL_LDFLAGS)))
 endif
 
 # valkey-server
-$(SERVER_NAME): $(ENGINE_SERVER_OBJ)
-	$(SERVER_LD) -o $@ $^ ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
+$(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
+	$(SERVER_LD) -o $@ $(ENGINE_SERVER_OBJ) ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
@@ -722,7 +727,7 @@ $(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
 # engine_lua.so
-$(LUA_MODULE_NAME): $(SERVER_NAME)
+$(LUA_MODULE):
 	cd modules/lua && $(MAKE) OPTIMIZATION="$(OPTIMIZATION)"
 
 # valkey-cli

--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -2,10 +2,12 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 CLANG := $(findstring clang,$(shell sh -c '$(CC) --version | head -1'))
 
 DEPS_DIR=../../../deps
+SO_EXT=so
 
 ifeq ($(uname_S),Darwin)
 	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -dynamic -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
-	SHOBJ_LDFLAGS= -bundle -undefined dynamic_lookup $(LDFLAGS)
+	SHOBJ_LDFLAGS= -shared -undefined dynamic_lookup $(LDFLAGS)
+	SO_EXT=dylib
 else
 	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
 	SHOBJ_LDFLAGS= -shared $(LDFLAGS)
@@ -43,9 +45,9 @@ ifeq ("$(wildcard /usr/lib/libSystem.dylib)","")
 endif
 endif
 
-all: libvalkeylua.so
+all: libvalkeylua.$(SO_EXT)
 
-libvalkeylua.so: $(OBJS) $(LIBS)
+libvalkeylua.$(SO_EXT): $(OBJS) $(LIBS)
 	$(CC) -o $@ $(SHOBJ_LDFLAGS) $^
 
 sha1.o: ../../sha1.c
@@ -64,4 +66,4 @@ $(DEPS_DIR)/fpconv/libfpconv.a:
 	cd $(DEPS_DIR) && $(MAKE) fpconv
 
 clean:
-	rm -f *.so $(OBJS)
+	rm -f $(LUA_LIB) $(OBJS) $(LIBS)


### PR DESCRIPTION
Building `valkey-server` should now build `libvalkeylua.{so|dyblib}` unless disabled.

In addition, fixed MacOS Build By Using Correct Shared Library Extension.

This change updates the build system to properly handle platform-specific shared library extensions. On macOS, shared libraries use the `.dylib` extension instead of `.so`, which was causing build and runtime linking issues.

The Lua module Makefile now defines a `SO_EXT` variable that defaults to `so` but is set to `dylib` on Darwin systems. The linker flag was also changed from `-bundle` to `-shared` on macOS for consistency with standard shared library conventions.

In the main Makefile, the same extension logic is applied, and the Lua module is now built as an explicit dependency of the server binary to ensure correct build ordering. Additionally, the runtime library search path on Linux now uses `$ORIGIN` to enable relocatable binaries.

* Build system (Makefiles)
* Lua module compilation and linking
* Platform-specific shared library handling

**Generated by CodeLite**