### PR TITLE
Parallel crc16

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -50,28 +50,32 @@
 
 /* Extract the hash tag portion of a key. Returns pointer to the portion
  * to hash and sets *len to its length. */
-void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *hash_len) {
-    int s, e;
+const char *getKeyHashPortion(const char *key, int keylen, int *hash_len) {
+    int s, e; /* start-end indexes of { and } */
 
     for (s = 0; s < keylen; s++)
         if (key[s] == '{') break;
 
+    /* No '{' ? Hash the whole key. This is the base case. */
     if (s == keylen) {
-        *hash_ptr = key;
         *hash_len = keylen;
-        return;
+        return key;
     }
 
+    /* '{' found? Check if we have the corresponding '}'. */
     for (e = s + 1; e < keylen; e++)
         if (key[e] == '}') break;
 
+    /* No '}' or nothing between {} ? Hash the whole key. */
     if (e == keylen || e == s + 1) {
-        *hash_ptr = key;
         *hash_len = keylen;
-    } else {
-        *hash_ptr = key + s + 1;
-        *hash_len = e - s - 1;
+        return key;
     }
+
+    /* If we are here there is both a { and a } on its right. Hash
+     * what is in the middle between { and }. */
+    *hash_len = e - s - 1;
+    return key + s + 1;
 }
 
 /* We have 16384 hash slots. The hash slot of a given key is obtained
@@ -81,9 +85,8 @@ void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
 unsigned int keyHashSlot(const char *key, int keylen) {
-    const char *hash_ptr;
     int hash_len;
-    getKeyHashPortion(key, keylen, &hash_ptr, &hash_len);
+    const char *hash_ptr = getKeyHashPortion(key, keylen, &hash_len);
     return crc16(hash_ptr, hash_len) & 0x3FFF;
 }
 
@@ -1006,7 +1009,7 @@ int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *
         /* Extract hash tag portions for all keys */
         for (int i = 0; i < numkeys; i++) {
             sds key = objectGetVal(argv[result.keys[i].pos]);
-            getKeyHashPortion(key, sdslen(key), &key_bufs[i], &key_lens[i]);
+            key_bufs[i] = getKeyHashPortion(key, sdslen(key), &key_lens[i]);
         }
 
         /* Compute all CRC16 values in parallel */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -48,6 +48,32 @@
  * Key space handling
  * -------------------------------------------------------------------------- */
 
+/* Extract the hash tag portion of a key. Returns pointer to the portion
+ * to hash and sets *len to its length. */
+void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *hash_len) {
+    int s, e;
+    
+    for (s = 0; s < keylen; s++)
+        if (key[s] == '{') break;
+    
+    if (s == keylen) {
+        *hash_ptr = key;
+        *hash_len = keylen;
+        return;
+    }
+    
+    for (e = s + 1; e < keylen; e++)
+        if (key[e] == '}') break;
+    
+    if (e == keylen || e == s + 1) {
+        *hash_ptr = key;
+        *hash_len = keylen;
+    } else {
+        *hash_ptr = key + s + 1;
+        *hash_len = e - s - 1;
+    }
+}
+
 /* We have 16384 hash slots. The hash slot of a given key is obtained
  * as the least significant 14 bits of the crc16 of the key.
  *
@@ -55,24 +81,10 @@
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
 unsigned int keyHashSlot(const char *key, int keylen) {
-    int s, e; /* start-end indexes of { and } */
-
-    for (s = 0; s < keylen; s++)
-        if (key[s] == '{') break;
-
-    /* No '{' ? Hash the whole key. This is the base case. */
-    if (s == keylen) return crc16(key, keylen) & 0x3FFF;
-
-    /* '{' found? Check if we have the corresponding '}'. */
-    for (e = s + 1; e < keylen; e++)
-        if (key[e] == '}') break;
-
-    /* No '}' or nothing between {} ? Hash the whole key. */
-    if (e == keylen || e == s + 1) return crc16(key, keylen) & 0x3FFF;
-
-    /* If we are here there is both a { and a } on its right. Hash
-     * what is in the middle between { and }. */
-    return crc16(key + s + 1, e - s - 1) & 0x3FFF;
+    const char *hash_ptr;
+    int hash_len;
+    getKeyHashPortion(key, keylen, &hash_ptr, &hash_len);
+    return crc16(hash_ptr, hash_len) & 0x3FFF;
 }
 
 /* If it can be inferred that the given glob-style pattern, as implemented in
@@ -984,17 +996,33 @@ int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *
     int numkeys = getKeysFromCommand(cmd, argv, argc, &result);
     int slot = -1;
     if (numkeys == 0) *read_flags |= READ_FLAGS_NO_KEYS;
-    for (int i = 0; i < numkeys; i++) {
-        sds key = objectGetVal(argv[result.keys[i].pos]);
-        int keyslot = keyHashSlot(key, sdslen(key));
-        if (slot == -1) {
-            slot = keyslot;
-        } else if (keyslot != slot) {
-            slot = -1;
-            *read_flags |= READ_FLAGS_CROSSSLOT;
-            break;
+    
+    if (numkeys > 1) {
+        const char *key_bufs[numkeys];
+        int key_lens[numkeys];
+        uint16_t crcs[numkeys];
+        
+        for (int i = 0; i < numkeys; i++) {
+            sds key = objectGetVal(argv[result.keys[i].pos]);
+            getKeyHashPortion(key, sdslen(key), &key_bufs[i], &key_lens[i]);
         }
+        
+        crc16_parallel(key_bufs, key_lens, crcs, numkeys);
+        
+        slot = crcs[0] & 0x3FFF;
+        for (int i = 1; i < numkeys; i++) {
+            int keyslot = crcs[i] & 0x3FFF;
+            if (keyslot != slot) {
+                slot = -1;
+                *read_flags |= READ_FLAGS_CROSSSLOT;
+                break;
+            }
+        }
+    } else if (numkeys == 1) {
+        sds key = objectGetVal(argv[result.keys[0].pos]);
+        slot = keyHashSlot(key, sdslen(key));
     }
+    
     getKeysFreeResult(&result);
     return slot;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -52,19 +52,19 @@
  * to hash and sets *len to its length. */
 void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *hash_len) {
     int s, e;
-    
+
     for (s = 0; s < keylen; s++)
         if (key[s] == '{') break;
-    
+
     if (s == keylen) {
         *hash_ptr = key;
         *hash_len = keylen;
         return;
     }
-    
+
     for (e = s + 1; e < keylen; e++)
         if (key[e] == '}') break;
-    
+
     if (e == keylen || e == s + 1) {
         *hash_ptr = key;
         *hash_len = keylen;
@@ -996,19 +996,23 @@ int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *
     int numkeys = getKeysFromCommand(cmd, argv, argc, &result);
     int slot = -1;
     if (numkeys == 0) *read_flags |= READ_FLAGS_NO_KEYS;
-    
+
     if (numkeys > 1) {
+        /* Use parallel CRC16 computation for multiple keys */
         const char *key_bufs[numkeys];
         int key_lens[numkeys];
         uint16_t crcs[numkeys];
-        
+
+        /* Extract hash tag portions for all keys */
         for (int i = 0; i < numkeys; i++) {
             sds key = objectGetVal(argv[result.keys[i].pos]);
             getKeyHashPortion(key, sdslen(key), &key_bufs[i], &key_lens[i]);
         }
-        
+
+        /* Compute all CRC16 values in parallel */
         crc16_parallel(key_bufs, key_lens, crcs, numkeys);
-        
+
+        /* Check if all keys belong to same slot */
         slot = crcs[0] & 0x3FFF;
         for (int i = 1; i < numkeys; i++) {
             int keyslot = crcs[i] & 0x3FFF;
@@ -1022,7 +1026,7 @@ int clusterSlotByCommand(struct serverCommand *cmd, robj **argv, int argc, int *
         sds key = objectGetVal(argv[result.keys[0].pos]);
         slot = keyHashSlot(key, sdslen(key));
     }
-    
+
     getKeysFreeResult(&result);
     return slot;
 }

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -138,7 +138,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);
 unsigned int keyHashSlot(const char *key, int keylen);
-void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *hash_len);
+const char *getKeyHashPortion(const char *key, int keylen, int *hash_len);
 int patternHashSlot(char *pattern, int length);
 int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -138,6 +138,7 @@ int clusterRedirectBlockedClientIfNeeded(client *c);
 void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_code);
 void migrateCloseTimedoutSockets(void);
 unsigned int keyHashSlot(const char *key, int keylen);
+void getKeyHashPortion(const char *key, int keylen, const char **hash_ptr, int *hash_len);
 int patternHashSlot(char *pattern, int length);
 int isValidAuxString(char *s, unsigned int length);
 void migrateCommand(client *c);

--- a/src/crc16.c
+++ b/src/crc16.c
@@ -92,12 +92,12 @@ uint16_t crc16(const char *buf, int len) {
 void crc16_parallel(const char **bufs, int *lens, uint16_t *results, int count) {
     uint16_t crcs[count];
     int counters[count];
-    
+
     for (int i = 0; i < count; i++) {
         crcs[i] = 0;
         counters[i] = 0;
     }
-    
+
     int active = count;
     while (active > 0) {
         active = 0;
@@ -109,7 +109,7 @@ void crc16_parallel(const char **bufs, int *lens, uint16_t *results, int count) 
             }
         }
     }
-    
+
     for (int i = 0; i < count; i++) {
         results[i] = crcs[i];
     }

--- a/src/crc16.c
+++ b/src/crc16.c
@@ -86,3 +86,31 @@ uint16_t crc16(const char *buf, int len) {
             crc = (crc<<8) ^ crc16tab[((crc>>8) ^ *buf++)&0x00FF];
     return crc;
 }
+
+/* Compute CRC16 for multiple buffers in parallel to improve memory-level parallelism.
+ * This interleaves the computation across multiple keys to hide memory latency. */
+void crc16_parallel(const char **bufs, int *lens, uint16_t *results, int count) {
+    uint16_t crcs[count];
+    int counters[count];
+    
+    for (int i = 0; i < count; i++) {
+        crcs[i] = 0;
+        counters[i] = 0;
+    }
+    
+    int active = count;
+    while (active > 0) {
+        active = 0;
+        for (int i = 0; i < count; i++) {
+            if (counters[i] < lens[i]) {
+                crcs[i] = (crcs[i]<<8) ^ crc16tab[((crcs[i]>>8) ^ bufs[i][counters[i]])&0x00FF];
+                counters[i]++;
+                active++;
+            }
+        }
+    }
+    
+    for (int i = 0; i < count; i++) {
+        results[i] = crcs[i];
+    }
+}

--- a/src/server.c
+++ b/src/server.c
@@ -4258,7 +4258,7 @@ void prepareCommandQueue(client *c) {
     /* Current command keys */
     for (int j = 0; j < results[0].numkeys; j++) {
         sds key = objectGetVal(c->argv[results[0].keys[j].pos]);
-        getKeyHashPortion(key, sdslen(key), &key_bufs[key_idx], &key_lens[key_idx]);
+        key_bufs[key_idx] = getKeyHashPortion(key, sdslen(key), &key_lens[key_idx]);
         key_idx++;
     }
 
@@ -4267,7 +4267,7 @@ void prepareCommandQueue(client *c) {
         parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
         for (int j = 0; j < results[i].numkeys; j++) {
             sds key = objectGetVal(p->argv[results[i].keys[j].pos]);
-            getKeyHashPortion(key, sdslen(key), &key_bufs[key_idx], &key_lens[key_idx]);
+            key_bufs[key_idx] = getKeyHashPortion(key, sdslen(key), &key_lens[key_idx]);
             key_idx++;
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -4185,6 +4185,18 @@ static void prepareCommandGeneric(robj **argv, int argc, int *read_flags, struct
     }
 }
 
+/* Like prepareCommandGeneric but skips cluster slot calculation. */
+static void prepareCommandGenericNoSlot(robj **argv, int argc, int *read_flags, struct serverCommand **cmd) {
+    if (!(*read_flags & READ_FLAGS_PARSING_COMPLETED) || argc == 0) return;
+    debugServerAssert(*cmd == NULL && !(*read_flags & READ_FLAGS_COMMAND_NOT_FOUND));
+    *cmd = lookupCommand(argv, argc);
+    if (!*cmd) {
+        *read_flags |= READ_FLAGS_COMMAND_NOT_FOUND;
+    } else if (!commandCheckArity(*cmd, argc, NULL)) {
+        *read_flags |= READ_FLAGS_BAD_ARITY;
+    }
+}
+
 /* Prepare the client's current command. See prepareCommandGeneric(). */
 void prepareCommand(client *c) {
     prepareCommandGeneric(c->argv, c->argc, &c->read_flags, &c->parsed_cmd, &c->slot);
@@ -4192,13 +4204,117 @@ void prepareCommand(client *c) {
 
 /* Prepare all parsed commands in the client's queue. See prepareCommand(). */
 void prepareCommandQueue(client *c) {
-    /* First AKA current command (c->argv). */
-    prepareCommand(c);
+    if (!server.cluster_enabled) {
+        prepareCommand(c);
+        for (int i = c->cmd_queue.off; i < c->cmd_queue.len; i++) {
+            parsedCommand *p = &c->cmd_queue.cmds[i];
+            prepareCommandGeneric(p->argv, p->argc, &p->read_flags, &p->cmd, &p->slot);
+        }
+        return;
+    }
 
-    /* Commands in client's command queue. */
-    for (int i = c->cmd_queue.off; i < c->cmd_queue.len; i++) {
-        parsedCommand *p = &c->cmd_queue.cmds[i];
-        prepareCommandGeneric(p->argv, p->argc, &p->read_flags, &p->cmd, &p->slot);
+    /* In cluster mode, collect all keys from current command and queue, compute CRC16 in parallel */
+    int num_cmds = 1 + (c->cmd_queue.len - c->cmd_queue.off);
+    
+    /* First pass: lookup commands and get keys */
+    getKeysResult results[num_cmds];
+    int total_keys = 0;
+    
+    /* Current command */
+    initGetKeysResult(&results[0]);
+    prepareCommandGenericNoSlot(c->argv, c->argc, &c->read_flags, &c->parsed_cmd);
+    if (c->parsed_cmd && !(c->read_flags & (READ_FLAGS_COMMAND_NOT_FOUND | READ_FLAGS_BAD_ARITY))) {
+        total_keys += getKeysFromCommand(c->parsed_cmd, c->argv, c->argc, &results[0]);
+    }
+    
+    /* Queue commands */
+    for (int i = 1; i < num_cmds; i++) {
+        parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
+        initGetKeysResult(&results[i]);
+        prepareCommandGenericNoSlot(p->argv, p->argc, &p->read_flags, &p->cmd);
+        
+        if (p->cmd && !(p->read_flags & (READ_FLAGS_COMMAND_NOT_FOUND | READ_FLAGS_BAD_ARITY))) {
+            total_keys += getKeysFromCommand(p->cmd, p->argv, p->argc, &results[i]);
+        }
+    }
+
+    if (total_keys == 0) {
+        if (results[0].numkeys == 0 && c->parsed_cmd) c->read_flags |= READ_FLAGS_NO_KEYS;
+        getKeysFreeResult(&results[0]);
+        for (int i = 1; i < num_cmds; i++) {
+            parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
+            if (results[i].numkeys == 0 && p->cmd) p->read_flags |= READ_FLAGS_NO_KEYS;
+            getKeysFreeResult(&results[i]);
+        }
+        return;
+    }
+
+    /* Collect all key hash portions */
+    const char *key_bufs[total_keys];
+    int key_lens[total_keys];
+    uint16_t crcs[total_keys];
+    int key_idx = 0;
+
+    /* Current command keys */
+    for (int j = 0; j < results[0].numkeys; j++) {
+        sds key = objectGetVal(c->argv[results[0].keys[j].pos]);
+        getKeyHashPortion(key, sdslen(key), &key_bufs[key_idx], &key_lens[key_idx]);
+        key_idx++;
+    }
+    
+    /* Queue command keys */
+    for (int i = 1; i < num_cmds; i++) {
+        parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
+        for (int j = 0; j < results[i].numkeys; j++) {
+            sds key = objectGetVal(p->argv[results[i].keys[j].pos]);
+            getKeyHashPortion(key, sdslen(key), &key_bufs[key_idx], &key_lens[key_idx]);
+            key_idx++;
+        }
+    }
+
+    /* Compute all CRC16 values in parallel */
+    crc16_parallel(key_bufs, key_lens, crcs, total_keys);
+
+    /* Second pass: assign slots and check for cross-slot */
+    key_idx = 0;
+    
+    /* Current command */
+    if (results[0].numkeys == 0) {
+        if (c->parsed_cmd) c->read_flags |= READ_FLAGS_NO_KEYS;
+    } else {
+        c->slot = crcs[key_idx] & 0x3FFF;
+        for (int j = 1; j < results[0].numkeys; j++) {
+            int keyslot = crcs[key_idx + j] & 0x3FFF;
+            if (keyslot != c->slot) {
+                c->slot = -1;
+                c->read_flags |= READ_FLAGS_CROSSSLOT;
+                break;
+            }
+        }
+        key_idx += results[0].numkeys;
+    }
+    getKeysFreeResult(&results[0]);
+    
+    /* Queue commands */
+    for (int i = 1; i < num_cmds; i++) {
+        parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
+        
+        if (results[i].numkeys == 0) {
+            if (p->cmd) p->read_flags |= READ_FLAGS_NO_KEYS;
+        } else {
+            p->slot = crcs[key_idx] & 0x3FFF;
+            for (int j = 1; j < results[i].numkeys; j++) {
+                int keyslot = crcs[key_idx + j] & 0x3FFF;
+                if (keyslot != p->slot) {
+                    p->slot = -1;
+                    p->read_flags |= READ_FLAGS_CROSSSLOT;
+                    break;
+                }
+            }
+            key_idx += results[i].numkeys;
+        }
+        
+        getKeysFreeResult(&results[i]);
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -4215,24 +4215,24 @@ void prepareCommandQueue(client *c) {
 
     /* In cluster mode, collect all keys from current command and queue, compute CRC16 in parallel */
     int num_cmds = 1 + (c->cmd_queue.len - c->cmd_queue.off);
-    
+
     /* First pass: lookup commands and get keys */
     getKeysResult results[num_cmds];
     int total_keys = 0;
-    
+
     /* Current command */
     initGetKeysResult(&results[0]);
     prepareCommandGenericNoSlot(c->argv, c->argc, &c->read_flags, &c->parsed_cmd);
     if (c->parsed_cmd && !(c->read_flags & (READ_FLAGS_COMMAND_NOT_FOUND | READ_FLAGS_BAD_ARITY))) {
         total_keys += getKeysFromCommand(c->parsed_cmd, c->argv, c->argc, &results[0]);
     }
-    
+
     /* Queue commands */
     for (int i = 1; i < num_cmds; i++) {
         parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
         initGetKeysResult(&results[i]);
         prepareCommandGenericNoSlot(p->argv, p->argc, &p->read_flags, &p->cmd);
-        
+
         if (p->cmd && !(p->read_flags & (READ_FLAGS_COMMAND_NOT_FOUND | READ_FLAGS_BAD_ARITY))) {
             total_keys += getKeysFromCommand(p->cmd, p->argv, p->argc, &results[i]);
         }
@@ -4261,7 +4261,7 @@ void prepareCommandQueue(client *c) {
         getKeyHashPortion(key, sdslen(key), &key_bufs[key_idx], &key_lens[key_idx]);
         key_idx++;
     }
-    
+
     /* Queue command keys */
     for (int i = 1; i < num_cmds; i++) {
         parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
@@ -4277,7 +4277,7 @@ void prepareCommandQueue(client *c) {
 
     /* Second pass: assign slots and check for cross-slot */
     key_idx = 0;
-    
+
     /* Current command */
     if (results[0].numkeys == 0) {
         if (c->parsed_cmd) c->read_flags |= READ_FLAGS_NO_KEYS;
@@ -4294,11 +4294,11 @@ void prepareCommandQueue(client *c) {
         key_idx += results[0].numkeys;
     }
     getKeysFreeResult(&results[0]);
-    
+
     /* Queue commands */
     for (int i = 1; i < num_cmds; i++) {
         parsedCommand *p = &c->cmd_queue.cmds[c->cmd_queue.off + i - 1];
-        
+
         if (results[i].numkeys == 0) {
             if (p->cmd) p->read_flags |= READ_FLAGS_NO_KEYS;
         } else {
@@ -4313,7 +4313,7 @@ void prepareCommandQueue(client *c) {
             }
             key_idx += results[i].numkeys;
         }
-        
+
         getKeysFreeResult(&results[i]);
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -3788,6 +3788,7 @@ int setGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *
 int bitfieldGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *result);
 
 unsigned short crc16(const char *buf, int len);
+void crc16_parallel(const char **bufs, int *lens, uint16_t *results, int count);
 
 /* Sentinel */
 void initSentinelConfig(void);


### PR DESCRIPTION
Make use of memory parallelism by computing the crc16 for multiple keys in parallel.

In prepareCommandQueue, all the keys of all the parsed commands are crc16'ed in parallel using a new function `crc16_parallel()`.