### PR TITLE
Changed LUA module dependency

### DIFF
--- a/deps/lua/src/Makefile
+++ b/deps/lua/src/Makefile
@@ -18,9 +18,27 @@ MYCFLAGS=
 MYLDFLAGS=
 MYLIBS=
 
+# Pretty-printing setup
+CC_COLOR="\033[32m"
+LNK_COLOR="\033[36;1m"
+SCOPE_COLOR="\033[38:5:250m"
+SRC_COLOR="\033[33m"
+BIN_COLOR="\033[35m"
+RESET="\033[0m"
+
+ifndef V
+QUIET_CC = @printf '    %b %b(LUA Lib)%b %b\n' $(CC_COLOR)CC$(RESET) $(SCOPE_COLOR) $(RESET) $(SRC_COLOR)$<$(RESET) 1>&2;
+QUIET_LINK = @printf '    %b %b\n' $(LNK_COLOR)LINK$(RESET) $(BIN_COLOR)$@$(RESET) 1>&2;
+QUIET_AR = @printf '    %b %b\n' $(CC_COLOR)ARCHIVE$(RESET) $(BIN_COLOR)$@$(RESET) 1>&2;
+endif
+
 # == END OF USER SETTINGS. NO NEED TO CHANGE ANYTHING BELOW THIS LINE =========
 
 PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
+
+# Explicit pattern rule for building object files from C sources
+%.o: %.c
+	$(QUIET_CC)$(CC) $(CFLAGS) -c $< -o $@
 
 LUA_A=	liblua.a
 CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
@@ -49,14 +67,14 @@ o:	$(ALL_O)
 a:	$(ALL_A)
 
 $(LUA_A): $(CORE_O) $(LIB_O)
-	$(AR) $@ $(CORE_O) $(LIB_O)	# DLL needs all object files
-	$(RANLIB) $@
+	$(QUIET_AR)$(AR) $@ $(CORE_O) $(LIB_O)	# DLL needs all object files
+	$(QUIET_AR)$(RANLIB) $@
 
 $(LUA_T): $(LUA_O) $(LUA_A)
-	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+	$(QUIET_LINK)$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
 
 $(LUAC_T): $(LUAC_O) $(LUA_A)
-	$(CC) -o $@ $(MYLDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+	$(QUIET_LINK)$(CC) -o $@ $(MYLDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
 
 clean:
 	$(RM) $(ALL_T) $(ALL_O)

--- a/src/Makefile
+++ b/src/Makefile
@@ -637,7 +637,7 @@ endif
 
 DEPENDENCY_TARGETS+= gtest-parallel
 
-ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE) $(LUA_MODULE)
+ALL_BUILD_PREREQUISITES=$(SERVER_NAME) $(ENGINE_SENTINEL_NAME) $(ENGINE_CLI_NAME) $(ENGINE_BENCHMARK_NAME) $(ENGINE_CHECK_RDB_NAME) $(ENGINE_CHECK_AOF_NAME) $(TLS_MODULE) $(RDMA_MODULE)
 
 all: $(ALL_BUILD_PREREQUISITES)
 	@echo ""
@@ -694,8 +694,8 @@ ifneq ($(strip $(PREV_FINAL_LDFLAGS)), $(strip $(FINAL_LDFLAGS)))
 endif
 
 # valkey-server
-$(SERVER_NAME): $(ENGINE_SERVER_OBJ)
-	$(SERVER_LD) -o $@ $^ ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
+$(SERVER_NAME): $(ENGINE_SERVER_OBJ) $(LUA_MODULE)
+	$(SERVER_LD) -o $@ $(ENGINE_SERVER_OBJ) ../deps/libvalkey/lib/libvalkey.a ../deps/hdr_histogram/libhdrhistogram.a ../deps/fpconv/libfpconv.a $(FINAL_LIBS)
 
 # Valkey static library, used to compile against for unit testing
 $(ENGINE_LIB_NAME): $(ENGINE_SERVER_OBJ)
@@ -722,7 +722,7 @@ $(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
 # engine_lua.so
-$(LUA_MODULE_NAME): $(SERVER_NAME)
+$(LUA_MODULE_NAME): .make-prerequisites
 	cd modules/lua && $(MAKE) OPTIMIZATION="$(OPTIMIZATION)"
 
 # valkey-cli

--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -10,6 +10,18 @@ else
 	SHOBJ_CFLAGS= -I. -I$(DEPS_DIR)/lua/src -I$(DEPS_DIR)/fpconv -fPIC -W -Wall -fno-common $(OPTIMIZATION) -std=gnu11 -D_GNU_SOURCE $(CFLAGS)
 	SHOBJ_LDFLAGS= -shared $(LDFLAGS)
 
+# Pretty-printing setup for module build
+CC_COLOR="\033[32m"
+LINKCOLOR_MOD="\033[36;1m"
+SRC_COLOR="\033[33m"
+SCOPE_COLOR="\033[38:5:250m"
+BINCOLOR_MOD="\033[35m"
+RESET="\033[0m"
+
+ifndef V
+QUIET_CC_MOD = @printf '    %b %b(LUA Module)%b %b\n' $(CC_COLOR)CC$(RESET) $(SCOPE_COLOR) $(RESET) $(SRC_COLOR)$<$(RESET) 1>&2;
+QUIET_LINK_MOD = @printf '    %b %b\n' $(LINKCOLOR_MOD)LINK$(RESET) $(BINCOLOR_MOD)$@$(RESET) 1>&2;
+endif
 ifeq (clang,$(CLANG))
 	SHOBJ_LDFLAGS+= -fuse-ld=lld
 endif
@@ -46,16 +58,16 @@ endif
 all: libvalkeylua.so
 
 libvalkeylua.so: $(OBJS) $(LIBS)
-	$(CC) -o $@ $(SHOBJ_LDFLAGS) $^
+	$(QUIET_LINK_MOD)$(CC) -o $@ $(SHOBJ_LDFLAGS) $^
 
 sha1.o: ../../sha1.c
-	$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
+	$(QUIET_CC_MOD)$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
 
 rand.o: ../../rand.c
-	$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
+	$(QUIET_CC_MOD)$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
+	$(QUIET_CC_MOD)$(CC) $(SHOBJ_CFLAGS) -c $< -o $@
 
 $(DEPS_DIR)/lua/src/liblua.a:
 	cd $(DEPS_DIR) && $(MAKE) lua


### PR DESCRIPTION
Before this change, if you built `valkey-server` (e.g. `make valkey-server`) the LUA module was not built. With this change, the LUA module is now a direct a dependency of `valkey-server`
- (unless `BUILD_LUA=no` is passed)

Added some colors to the Lua module & Lua lib `Makefile`s to they blend nicely in the build output.