### PR TITLE
Big Endian: add daily workflow UT job and fix UTs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -247,7 +247,7 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt-get update
-            apt-get install -y build-essential
+            apt-get install -y build-essential pkg-config libgtest-dev libgmock-dev
             make all-with-unit-tests SERVER_CFLAGS='-Werror'
             ./src/unit/valkey-unit-gtests
   test-ubuntu-jemalloc-fortify:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -247,7 +247,7 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apt-get update
-            apt-get install -y build-essential pkg-config libgtest-dev libgmock-dev
+            apt-get install -y build-essential pkg-config libgtest-dev libgmock-dev python3
             make all-with-unit-tests SERVER_CFLAGS='-Werror'
             ./src/unit/valkey-unit-gtests
   test-ubuntu-jemalloc-fortify:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -243,7 +243,7 @@ jobs:
         uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         with:
           arch: s390x
-          distro: ubuntu22.04
+          distro: ubuntu_latest
           githubToken: ${{ github.token }}
           run: |
             apt-get update

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,7 +16,7 @@ on:
     inputs:
       skipjobs:
         description: "jobs to skip (delete the ones you wanna keep, do not leave empty)"
-        default: "valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,rpm-distros,malloc,specific,fortify,reply-schema,arm,lttng"
+        default: "valgrind,sanitizer,tls,freebsd,macos,alpine,32bit,iothreads,ubuntu,rpm-distros,malloc,specific,fortify,reply-schema,arm,s390x,lttng"
       skiptests:
         description: "tests to skip (delete the ones you wanna keep, do not leave empty)"
         default: "valkey,modules,sentinel,cluster,unittest,large-memory"
@@ -216,6 +216,40 @@ jobs:
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
+  test-s390x:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'unstable') ||
+        (github.event_name == 'pull_request_target' && github.event.label.name == 'run-extra-tests')) &&
+      !contains(github.event.inputs.skipjobs, 's390x')
+    timeout-minutes: 1440
+    steps:
+      - name: prep
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        run: |
+          echo "GITHUB_REPOSITORY=${{inputs.use_repo || github.event.inputs.use_repo}}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{inputs.use_git_ref || github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+          echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+          echo "skiptests: ${{github.event.inputs.skiptests}}"
+          echo "test_args: ${{github.event.inputs.test_args}}"
+          echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ ((github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.use_repo || github.event.inputs.use_repo)) || github.repository }}
+          ref: ${{ ((github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.use_git_ref || github.event.inputs.use_git_ref)) || github.ref }}
+      - name: Build and test on s390x (big endian)
+        uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+        with:
+          arch: s390x
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          run: |
+            apt-get update
+            apt-get install -y build-essential
+            make all-with-unit-tests SERVER_CFLAGS='-Werror'
+            ./src/unit/valkey-unit-gtests
   test-ubuntu-jemalloc-fortify:
     runs-on: ubuntu-latest
     if: |
@@ -1856,6 +1890,7 @@ jobs:
     needs:
       - test-ubuntu-jemalloc
       - test-ubuntu-arm
+      - test-s390x
       - test-ubuntu-jemalloc-fortify
       - test-ubuntu-libc-malloc
       - test-ubuntu-no-malloc-usable-size

--- a/src/server.h
+++ b/src/server.h
@@ -3878,6 +3878,8 @@ void blockedBeforeSleep(void);
 void addClientToTimeoutTable(client *c);
 void removeClientFromTimeoutTable(client *c);
 void handleBlockedClientsTimeout(void);
+void encodeTimeoutKey(client *c, uint64_t timeout, unsigned char *buf_out);
+void decodeTimeoutKey(unsigned char *buf, uint64_t *timeout_ptr, client **client_ptr);
 int clientsCronHandleTimeout(client *c, mstime_t now_ms);
 
 /* evict.c -- maxmemory handling and LRU eviction. */

--- a/src/stream.h
+++ b/src/stream.h
@@ -140,6 +140,7 @@ streamConsumer *streamLookupConsumer(streamCG *cg, sds name);
 streamConsumer *streamCreateConsumer(streamCG *cg, sds name, robj *key, int dbid, int flags);
 streamCG *streamCreateCG(stream *s, char *name, size_t namelen, streamID *id, long long entries_read);
 streamNACK *streamCreateNACK(streamConsumer *consumer);
+void streamEncodeID(void *buf, streamID *id);
 void streamDecodeID(void *buf, streamID *id);
 int streamCompareID(streamID *a, streamID *b);
 void streamFreeNACK(streamNACK *na);

--- a/src/unit/test_endianconv.cpp
+++ b/src/unit/test_endianconv.cpp
@@ -30,3 +30,57 @@ TEST_F(EndianconvTest, TestEndianconv) {
     memrev64(buf);
     ASSERT_STREQ(buf, "amoroaic");
 }
+
+TEST_F(EndianconvTest, TestBswap) {
+    ASSERT_EQ(bswap16(0x0102), 0x0201);
+    ASSERT_EQ(bswap32(0x01020304), 0x04030201);
+    ASSERT_EQ(bswap64(0x0102030405060708ULL), 0x0807060504030201ULL);
+}
+
+TEST_F(EndianconvTest, TestMemrevIfbeRoundtrip) {
+    uint16_t v16 = 0x0102;
+    uint32_t v32 = 0x01020304;
+    uint64_t v64 = 0x0102030405060708ULL;
+
+    uint16_t orig16 = v16;
+    uint32_t orig32 = v32;
+    uint64_t orig64 = v64;
+
+    /* Apply twice - should return to original on both LE and BE */
+    memrev16ifbe(&v16);
+    memrev16ifbe(&v16);
+    ASSERT_EQ(v16, orig16);
+
+    memrev32ifbe(&v32);
+    memrev32ifbe(&v32);
+    ASSERT_EQ(v32, orig32);
+
+    memrev64ifbe(&v64);
+    memrev64ifbe(&v64);
+    ASSERT_EQ(v64, orig64);
+}
+
+TEST_F(EndianconvTest, TestIntrevIfbeRoundtrip) {
+    ASSERT_EQ(intrev16ifbe(intrev16ifbe(0x0102)), 0x0102);
+    ASSERT_EQ(intrev32ifbe(intrev32ifbe(0x01020304)), 0x01020304);
+    ASSERT_EQ(intrev64ifbe(intrev64ifbe(0x0102030405060708ULL)), 0x0102030405060708ULL);
+}
+
+TEST_F(EndianconvTest, TestHtonuNtohu64) {
+    /* Round-trip must hold on any architecture */
+    ASSERT_EQ(ntohu64(htonu64(0x0102030405060708ULL)), 0x0102030405060708ULL);
+    ASSERT_EQ(ntohu64(htonu64(0ULL)), 0ULL);
+    ASSERT_EQ(ntohu64(htonu64(UINT64_MAX)), UINT64_MAX);
+
+    /* Verify network byte order (big-endian) output */
+    uint64_t net = htonu64(0x0102030405060708ULL);
+    unsigned char *p = (unsigned char *)&net;
+    ASSERT_EQ(p[0], 0x01);
+    ASSERT_EQ(p[1], 0x02);
+    ASSERT_EQ(p[2], 0x03);
+    ASSERT_EQ(p[3], 0x04);
+    ASSERT_EQ(p[4], 0x05);
+    ASSERT_EQ(p[5], 0x06);
+    ASSERT_EQ(p[6], 0x07);
+    ASSERT_EQ(p[7], 0x08);
+}

--- a/src/unit/test_endianconv.cpp
+++ b/src/unit/test_endianconv.cpp
@@ -32,8 +32,8 @@ TEST_F(EndianconvTest, TestEndianconv) {
 }
 
 TEST_F(EndianconvTest, TestBswap) {
-    ASSERT_EQ(bswap16(0x0102), 0x0201);
-    ASSERT_EQ(bswap32(0x01020304), 0x04030201);
+    ASSERT_EQ(bswap16(0x0102U), 0x0201U);
+    ASSERT_EQ(bswap32(0x01020304U), 0x04030201U);
     ASSERT_EQ(bswap64(0x0102030405060708ULL), 0x0807060504030201ULL);
 }
 

--- a/src/unit/test_intset.cpp
+++ b/src/unit/test_intset.cpp
@@ -211,3 +211,26 @@ TEST_F(IntsetTest, TestIntsetStressAddDelete) {
     ASSERT_EQ(checkConsistency(is), 1);
     zfree(is);
 }
+
+TEST_F(IntsetTest, TestIntsetRawByteLayout) {
+    intset *is = intsetNew();
+    is = intsetAdd(is, 0x0102, nullptr);
+    ASSERT_EQ(intrev32ifbe(is->encoding), INTSET_ENC_INT16);
+
+    /* Verify raw contents are stored as little-endian */
+    unsigned char *raw = (unsigned char *)is->contents;
+    ASSERT_EQ(raw[0], 0x02); /* Low byte first (LE) */
+    ASSERT_EQ(raw[1], 0x01); /* High byte second */
+    zfree(is);
+
+    /* Test INT32 encoding */
+    is = intsetNew();
+    is = intsetAdd(is, 0x01020304, nullptr);
+    ASSERT_EQ(intrev32ifbe(is->encoding), INTSET_ENC_INT32);
+    raw = (unsigned char *)is->contents;
+    ASSERT_EQ(raw[0], 0x04);
+    ASSERT_EQ(raw[1], 0x03);
+    ASSERT_EQ(raw[2], 0x02);
+    ASSERT_EQ(raw[3], 0x01);
+    zfree(is);
+}

--- a/src/unit/test_intset.cpp
+++ b/src/unit/test_intset.cpp
@@ -48,27 +48,9 @@ static intset *createSet(int bits, int size) {
     return is;
 }
 
-/* Use memcpy to avoid strict aliasing violations and potential alignment issues. */
 static int checkConsistency(intset *is) {
     for (uint32_t i = 0; i < (intrev32ifbe(is->length) - 1); i++) {
-        uint32_t encoding = intrev32ifbe(is->encoding);
-
-        if (encoding == INTSET_ENC_INT16) {
-            int16_t v1, v2;
-            memcpy(&v1, is->contents + i * sizeof(int16_t), sizeof(int16_t));
-            memcpy(&v2, is->contents + (i + 1) * sizeof(int16_t), sizeof(int16_t));
-            if (v1 >= v2) return 0;
-        } else if (encoding == INTSET_ENC_INT32) {
-            int32_t v1, v2;
-            memcpy(&v1, is->contents + i * sizeof(int32_t), sizeof(int32_t));
-            memcpy(&v2, is->contents + (i + 1) * sizeof(int32_t), sizeof(int32_t));
-            if (v1 >= v2) return 0;
-        } else {
-            int64_t v1, v2;
-            memcpy(&v1, is->contents + i * sizeof(int64_t), sizeof(int64_t));
-            memcpy(&v2, is->contents + (i + 1) * sizeof(int64_t), sizeof(int64_t));
-            if (v1 >= v2) return 0;
-        }
+        if (testOnlyIntsetGet(is, i) >= testOnlyIntsetGet(is, i + 1)) return 0;
     }
     return 1;
 }

--- a/src/unit/test_t_stream.cpp
+++ b/src/unit/test_t_stream.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "stream.h"
+}
+
+class StreamIdTest : public ::testing::Test {};
+
+TEST_F(StreamIdTest, TestStreamEncodeDecodeRoundtrip) {
+    streamID id = {0x0102030405060708ULL, 0x090a0b0c0d0e0f10ULL};
+    unsigned char buf[16];
+
+    streamEncodeID(buf, &id);
+
+    streamID decoded;
+    streamDecodeID(buf, &decoded);
+
+    ASSERT_EQ(decoded.ms, id.ms);
+    ASSERT_EQ(decoded.seq, id.seq);
+}
+
+TEST_F(StreamIdTest, TestStreamEncodeIDBigEndian) {
+    streamID id = {0x0102030405060708ULL, 0x090a0b0c0d0e0f10ULL};
+    unsigned char buf[16];
+
+    streamEncodeID(buf, &id);
+
+    /* Verify big-endian byte order for ms (first 8 bytes) */
+    ASSERT_EQ(buf[0], 0x01);
+    ASSERT_EQ(buf[1], 0x02);
+    ASSERT_EQ(buf[2], 0x03);
+    ASSERT_EQ(buf[3], 0x04);
+    ASSERT_EQ(buf[4], 0x05);
+    ASSERT_EQ(buf[5], 0x06);
+    ASSERT_EQ(buf[6], 0x07);
+    ASSERT_EQ(buf[7], 0x08);
+
+    /* Verify big-endian byte order for seq (next 8 bytes) */
+    ASSERT_EQ(buf[8], 0x09);
+    ASSERT_EQ(buf[9], 0x0a);
+    ASSERT_EQ(buf[10], 0x0b);
+    ASSERT_EQ(buf[11], 0x0c);
+    ASSERT_EQ(buf[12], 0x0d);
+    ASSERT_EQ(buf[13], 0x0e);
+    ASSERT_EQ(buf[14], 0x0f);
+    ASSERT_EQ(buf[15], 0x10);
+}
+
+TEST_F(StreamIdTest, TestStreamIDLexicographicOrdering) {
+    /* Big-endian encoding ensures memcmp preserves numeric order */
+    streamID id_a = {100, 0};
+    streamID id_b = {200, 0};
+    unsigned char buf_a[16], buf_b[16];
+
+    streamEncodeID(buf_a, &id_a);
+    streamEncodeID(buf_b, &id_b);
+
+    ASSERT_LT(memcmp(buf_a, buf_b, 16), 0);
+
+    /* Test sequence ordering when ms is equal */
+    streamID id_c = {100, 1};
+    streamID id_d = {100, 2};
+    unsigned char buf_c[16], buf_d[16];
+
+    streamEncodeID(buf_c, &id_c);
+    streamEncodeID(buf_d, &id_d);
+
+    ASSERT_LT(memcmp(buf_c, buf_d, 16), 0);
+}

--- a/src/unit/test_timeout.cpp
+++ b/src/unit/test_timeout.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "server.h"
+}
+
+class TimeoutKeyTest : public ::testing::Test {};
+
+TEST_F(TimeoutKeyTest, TestEncodeDecodeRoundtrip) {
+    client dummy_client;
+    unsigned char buf[16];
+
+    uint64_t timeout = 0x0102030405060708ULL;
+    encodeTimeoutKey(&dummy_client, timeout, buf);
+
+    uint64_t decoded_timeout;
+    client *decoded_client;
+    decodeTimeoutKey(buf, &decoded_timeout, &decoded_client);
+
+    ASSERT_EQ(decoded_timeout, timeout);
+    ASSERT_EQ(decoded_client, &dummy_client);
+}
+
+TEST_F(TimeoutKeyTest, TestTimeoutBigEndianEncoding) {
+    client dummy_client;
+    unsigned char buf[16];
+
+    uint64_t timeout = 0x0102030405060708ULL;
+    encodeTimeoutKey(&dummy_client, timeout, buf);
+
+    /* Verify big-endian byte order for timeout (first 8 bytes) */
+    ASSERT_EQ(buf[0], 0x01);
+    ASSERT_EQ(buf[1], 0x02);
+    ASSERT_EQ(buf[2], 0x03);
+    ASSERT_EQ(buf[3], 0x04);
+    ASSERT_EQ(buf[4], 0x05);
+    ASSERT_EQ(buf[5], 0x06);
+    ASSERT_EQ(buf[6], 0x07);
+    ASSERT_EQ(buf[7], 0x08);
+}
+
+TEST_F(TimeoutKeyTest, TestTimeoutLexicographicOrdering) {
+    client dummy_client;
+    unsigned char buf_a[16], buf_b[16];
+
+    /* Big-endian encoding ensures memcmp preserves numeric order */
+    encodeTimeoutKey(&dummy_client, 100, buf_a);
+    encodeTimeoutKey(&dummy_client, 200, buf_b);
+
+    /* Earlier timeout should sort before later timeout */
+    ASSERT_LT(memcmp(buf_a, buf_b, 8), 0);
+}

--- a/src/unit/test_ziplist.cpp
+++ b/src/unit/test_ziplist.cpp
@@ -209,6 +209,30 @@ TEST_F(ZiplistTest, ziplistCreateIntList) {
     zfree(zl);
 }
 
+TEST_F(ZiplistTest, ziplistHeaderRawByteLayout) {
+    unsigned char *zl = ziplistNew();
+    zl = ziplistPush(zl, (unsigned char *)("test"), 4, ZIPLIST_TAIL);
+
+    /* Verify header fields are stored as little-endian */
+    uint32_t zlbytes, zltail;
+    uint16_t zllen;
+    memcpy(&zlbytes, zl, sizeof(uint32_t));
+    memcpy(&zltail, zl + 4, sizeof(uint32_t));
+    memcpy(&zllen, zl + 8, sizeof(uint16_t));
+
+    /* On any architecture, raw bytes should be LE - use intrev to get host value */
+    ASSERT_EQ(intrev32ifbe(zlbytes), ziplistBlobLen(zl));
+    ASSERT_EQ(intrev16ifbe(zllen), 1u);
+
+    /* Verify raw byte order is LE by checking low byte is at offset 0 */
+    unsigned char *raw = zl;
+    uint32_t expected_len = ziplistBlobLen(zl);
+    ASSERT_EQ(raw[0], (expected_len & 0xFF));
+    ASSERT_EQ(raw[1], ((expected_len >> 8) & 0xFF));
+
+    zfree(zl);
+}
+
 TEST_F(ZiplistTest, ziplistPop) {
     unsigned char *zl, *p;
 

--- a/src/unit/test_zipmap.cpp
+++ b/src/unit/test_zipmap.cpp
@@ -66,6 +66,31 @@ TEST_F(ZipmapTest, zipmapIterateWithLargeKey) {
     }
 }
 
+TEST_F(ZipmapTest, zipmapLargeKeyLengthDecoding) {
+    /* The 4-byte LE length field \xfe\x00\x02\x00\x00 should decode to 512 */
+    char zm[] = "\x01"
+                "\xfe\x00\x02\x00\x00"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "\x01\x00"
+                "v"
+                "\xff";
+    ASSERT_TRUE(zipmapValidateIntegrity((unsigned char *)zm, sizeof zm - 1, 1));
+
+    unsigned char *p = zipmapRewind((unsigned char *)zm);
+    unsigned char *key, *value;
+    unsigned int klen, vlen;
+    p = zipmapNext(p, &key, &klen, &value, &vlen);
+    ASSERT_NE(p, nullptr);
+    ASSERT_EQ(klen, 512u); /* Verify LE decoding of 4-byte length */
+}
+
 TEST_F(ZipmapTest, zipmapIterateThroughElements) {
     char zm[] = "\x06"
                 "\x04"


### PR DESCRIPTION
Big endian support on Valkey is "best effort" and not guaranteed, but we haven't been doing any regular testing at all afaik. This PR adds a job to the daily workflow to run UTs on an emulated big endian platform. Integration tests failed excessively because of how slow emulation is.

I fixed several problems with tests and improved UT coverage of key points where endian byte order matters - and fwiw I didn't find any bugs. I think the main coverage gap remaining after this is RDB serialization (maybe little endian <-> big endian round trips?)

And why did I do this? I wrote a couple lines of endian-specific code for #3166 and wanted to test it.