### PR TITLE
fix alignment different between c and c++ in gtest

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -293,6 +293,24 @@ void setproctitle(const char *fmt, ...);
 #endif /* __aarch64__ && __APPLE__ */
 #endif /* CACHE_LINE_SIZE */
 
+/* Macro to declare atomic variables with consistent alignment across C and C++.
+ *
+ * On 32-bit platforms, C's _Atomic qualifier increases alignment of 64-bit types
+ * (e.g., _Atomic uint64_t gets 8-byte alignment for lock-free atomic operations).
+ * When server.h is included in C++ unit tests, _Atomic is stripped (wrappers.h
+ * defines it as empty), reducing alignment to the type's natural alignment (4 bytes
+ * for uint64_t on 32-bit). This causes struct layout mismatches between C-compiled
+ * code and C++ test code, leading to field offset differences and crashes.
+ *
+ * VALKEY_ATOMIC(type) resolves this by:
+ * - In C: expanding to _Atomic type (standard C11 atomic)
+ * - In C++: expanding to alignas(sizeof(type)) type (preserves alignment) */
+#ifdef __cplusplus
+#define VALKEY_ATOMIC(type) alignas(sizeof(type)) type
+#else
+#define VALKEY_ATOMIC(type) _Atomic type
+#endif
+
 #if (defined(__i386) || defined(__amd64) || defined(__powerpc__)) && defined(__GNUC__)
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if defined(__clang__)

--- a/src/config.h
+++ b/src/config.h
@@ -293,24 +293,6 @@ void setproctitle(const char *fmt, ...);
 #endif /* __aarch64__ && __APPLE__ */
 #endif /* CACHE_LINE_SIZE */
 
-/* Macro to declare atomic variables with consistent alignment across C and C++.
- *
- * On 32-bit platforms, C's _Atomic qualifier increases alignment of 64-bit types
- * (e.g., _Atomic uint64_t gets 8-byte alignment for lock-free atomic operations).
- * When server.h is included in C++ unit tests, _Atomic is stripped (wrappers.h
- * defines it as empty), reducing alignment to the type's natural alignment (4 bytes
- * for uint64_t on 32-bit). This causes struct layout mismatches between C-compiled
- * code and C++ test code, leading to field offset differences and crashes.
- *
- * VALKEY_ATOMIC(type) resolves this by:
- * - In C: expanding to _Atomic type (standard C11 atomic)
- * - In C++: expanding to alignas(sizeof(type)) type (preserves alignment) */
-#ifdef __cplusplus
-#define VALKEY_ATOMIC(type) alignas(sizeof(type)) type
-#else
-#define VALKEY_ATOMIC(type) _Atomic type
-#endif
-
 #if (defined(__i386) || defined(__amd64) || defined(__powerpc__)) && defined(__GNUC__)
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if defined(__clang__)

--- a/src/server.h
+++ b/src/server.h
@@ -1760,7 +1760,8 @@ struct valkeyServer {
     hashtable *orig_commands;                         /* Command table before command renaming. */
     sds command_response_cache[RESP_CACHE_INDEX_MAX]; /* Cached COMMAND response: [0]=RESP2, [1]=RESP3 */
     aeEventLoop *el;
-    _Atomic AeIoState io_poll_state;     /* Indicates the state of the IO polling. */
+    VALKEY_ATOMIC(AeIoState)
+    io_poll_state;                       /* Indicates the state of the IO polling. */
     int io_ae_fired_events;              /* Number of poll events received by the IO thread. */
     rax *errors;                         /* Errors table */
     volatile sig_atomic_t shutdown_asap; /* Shutdown ordered by signal handler. */
@@ -1785,16 +1786,17 @@ struct valkeyServer {
     int thp_enabled;                     /* If true, THP is enabled. */
     size_t page_size;                    /* The page size of OS. */
     /* Modules */
-    dict *moduleapi;                  /* Exported core APIs dictionary for modules. */
-    dict *sharedapi;                  /* Like moduleapi but containing the APIs that
-                                         modules share with each other. */
-    dict *module_configs_queue;       /* Dict that stores module configurations from .conf file until after modules are loaded
-                                         during startup or arguments to loadex. */
-    list *loadmodule_queue;           /* List of modules to load at startup. */
-    int module_pipe[2];               /* Pipe used to awake the event loop by module threads. */
-    pid_t child_pid;                  /* PID of current child */
-    int child_type;                   /* Type of current child */
-    _Atomic int module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
+    dict *moduleapi;            /* Exported core APIs dictionary for modules. */
+    dict *sharedapi;            /* Like moduleapi but containing the APIs that
+                                   modules share with each other. */
+    dict *module_configs_queue; /* Dict that stores module configurations from .conf file until after modules are loaded
+                                   during startup or arguments to loadex. */
+    list *loadmodule_queue;     /* List of modules to load at startup. */
+    int module_pipe[2];         /* Pipe used to awake the event loop by module threads. */
+    pid_t child_pid;            /* PID of current child */
+    int child_type;             /* Type of current child */
+    VALKEY_ATOMIC(int)
+    module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                              /* TCP listening port */
     int tls_port;                          /* TLS listening port */
@@ -1838,9 +1840,10 @@ struct valkeyServer {
     uint32_t paused_actions;    /* Bitmask of actions that are currently paused */
     list *postponed_clients;    /* List of postponed clients */
     pause_event client_pause_per_purpose[NUM_PAUSE_PURPOSES];
-    char neterr[ANET_ERR_LEN];                /* Error buffer for anet.c */
-    dict *migrate_cached_sockets;             /* MIGRATE cached sockets */
-    _Atomic uint64_t next_client_id;          /* Next client unique ID. Incremental. */
+    char neterr[ANET_ERR_LEN];    /* Error buffer for anet.c */
+    dict *migrate_cached_sockets; /* MIGRATE cached sockets */
+    VALKEY_ATOMIC(uint64_t)
+    next_client_id;                           /* Next client unique ID. Incremental. */
     int protected_mode;                       /* Don't accept external connections. */
     int io_threads_num;                       /* Number of IO threads to use. */
     int active_io_threads_num;                /* Current number of active IO threads, includes main thread. */
@@ -2035,11 +2038,13 @@ struct valkeyServer {
     int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
     int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
     int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
-    _Atomic int aof_bio_fsync_status;   /* Status of AOF fsync in bio job. */
-    _Atomic int aof_bio_fsync_errno;    /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest;          /* Used to track AOFs. */
-    int aof_disable_auto_gc;            /* If disable automatically deleting HISTORY type AOFs?
-                                           default no. (for testings). */
+    VALKEY_ATOMIC(int)
+    aof_bio_fsync_status; /* Status of AOF fsync in bio job. */
+    VALKEY_ATOMIC(int)
+    aof_bio_fsync_errno;       /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest; /* Used to track AOFs. */
+    int aof_disable_auto_gc;   /* If disable automatically deleting HISTORY type AOFs?
+                                  default no. (for testings). */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -2101,52 +2106,55 @@ struct valkeyServer {
     int shutdown_on_sigterm; /* Shutdown flags configured for SIGTERM. */
 
     /* Replication (primary) */
-    char replid[CONFIG_RUN_ID_SIZE + 1];       /* My current replication ID. */
-    char replid2[CONFIG_RUN_ID_SIZE + 1];      /* replid inherited from primary*/
-    long long primary_repl_offset;             /* My current replication offset */
-    long long second_replid_offset;            /* Accept offsets up to this for replid2. */
-    _Atomic long long fsynced_reploff_pending; /* Largest replication offset to
-                                      * potentially have been fsynced, applied to
-                                        fsynced_reploff only when AOF state is AOF_ON
-                                        (not during the initial rewrite) */
-    long long fsynced_reploff;                 /* Largest replication offset that has been confirmed to be fsynced */
-    int replicas_eldb;                         /* Last SELECTed DB in replication output */
-    int repl_ping_replica_period;              /* Primary pings the replica every N seconds */
-    replBacklog *repl_backlog;                 /* Replication backlog for partial syncs */
-    long long repl_backlog_size;               /* Backlog circular buffer size */
-    replDataBuf pending_repl_data;             /* Replication data buffer for dual-channel-replication */
-    time_t repl_backlog_time_limit;            /* Time without replicas after the backlog
-                                                  gets released. */
-    time_t repl_no_replicas_since;             /* We have no replicas since that time.
-                                                Only valid if server.replicas len is 0. */
-    int repl_min_replicas_to_write;            /* Min number of replicas to write. */
-    int repl_min_replicas_max_lag;             /* Max lag of <count> replicas to write. */
-    int repl_good_replicas_count;              /* Number of replicas with lag <= max_lag. */
-    int repl_diskless_sync;                    /* Primary send RDB to replicas sockets directly. */
-    int repl_diskless_load;                    /* Replica parse RDB directly from the socket.
-                                                * see REPL_DISKLESS_LOAD_* enum */
-    int repl_diskless_sync_delay;              /* Delay to start a diskless repl BGSAVE. */
-    int repl_diskless_sync_max_replicas;       /* Max replicas for diskless repl BGSAVE
-                                                * delay (start sooner if they all connect). */
-    int dual_channel_replication;              /* Config used to determine if the replica should
-                                                * use dual channel replication for full syncs. */
-    _Atomic int replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
-                                                * RDB save to disk has completed, or failed */
-    _Atomic bool replica_bio_abort_save;       /* Flag set by main thread, used to signal to replica's
-                                                * disk-saving bio thread to abort the save */
-    long long bio_stat_net_repl_input_bytes;   /* Used to calculate stat_net_repl_input_bytes on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_size;              /* Used to calculate bio_repl_transfer_size on the
-                                                * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_read;              /* Used to calculate bio_repl_transfer_read on the
-                                                * replica's bio thread without touching main thread vars */
-    int wait_before_rdb_client_free;           /* Grace period in seconds for replica main channel
-                                                * to establish psync. */
-    int debug_pause_after_fork;                /* Debug param that pauses the main process
-                                                * after a replication fork() (for bgsave). */
-    size_t repl_buffer_mem;                    /* The memory of replication buffer. */
-    list *repl_buffer_blocks;                  /* Replication buffers blocks list
-                                                * (serving replica clients and repl backlog) */
+    char replid[CONFIG_RUN_ID_SIZE + 1];  /* My current replication ID. */
+    char replid2[CONFIG_RUN_ID_SIZE + 1]; /* replid inherited from primary*/
+    long long primary_repl_offset;        /* My current replication offset */
+    long long second_replid_offset;       /* Accept offsets up to this for replid2. */
+    VALKEY_ATOMIC(long long)
+    fsynced_reploff_pending;             /* Largest replication offset to
+                         * potentially have been fsynced, applied to
+                           fsynced_reploff only when AOF state is AOF_ON
+                           (not during the initial rewrite) */
+    long long fsynced_reploff;           /* Largest replication offset that has been confirmed to be fsynced */
+    int replicas_eldb;                   /* Last SELECTed DB in replication output */
+    int repl_ping_replica_period;        /* Primary pings the replica every N seconds */
+    replBacklog *repl_backlog;           /* Replication backlog for partial syncs */
+    long long repl_backlog_size;         /* Backlog circular buffer size */
+    replDataBuf pending_repl_data;       /* Replication data buffer for dual-channel-replication */
+    time_t repl_backlog_time_limit;      /* Time without replicas after the backlog
+                                            gets released. */
+    time_t repl_no_replicas_since;       /* We have no replicas since that time.
+                                          Only valid if server.replicas len is 0. */
+    int repl_min_replicas_to_write;      /* Min number of replicas to write. */
+    int repl_min_replicas_max_lag;       /* Max lag of <count> replicas to write. */
+    int repl_good_replicas_count;        /* Number of replicas with lag <= max_lag. */
+    int repl_diskless_sync;              /* Primary send RDB to replicas sockets directly. */
+    int repl_diskless_load;              /* Replica parse RDB directly from the socket.
+                                          * see REPL_DISKLESS_LOAD_* enum */
+    int repl_diskless_sync_delay;        /* Delay to start a diskless repl BGSAVE. */
+    int repl_diskless_sync_max_replicas; /* Max replicas for diskless repl BGSAVE
+                                          * delay (start sooner if they all connect). */
+    int dual_channel_replication;        /* Config used to determine if the replica should
+                                          * use dual channel replication for full syncs. */
+    VALKEY_ATOMIC(int)
+    replica_bio_disk_save_state; /* Flag set by the bio thread to indicate that the
+                                  * RDB save to disk has completed, or failed */
+    VALKEY_ATOMIC(bool)
+    replica_bio_abort_save;                  /* Flag set by main thread, used to signal to replica's
+                                              * disk-saving bio thread to abort the save */
+    long long bio_stat_net_repl_input_bytes; /* Used to calculate stat_net_repl_input_bytes on the
+                                              * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_size;            /* Used to calculate bio_repl_transfer_size on the
+                                              * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_read;            /* Used to calculate bio_repl_transfer_read on the
+                                              * replica's bio thread without touching main thread vars */
+    int wait_before_rdb_client_free;         /* Grace period in seconds for replica main channel
+                                              * to establish psync. */
+    int debug_pause_after_fork;              /* Debug param that pauses the main process
+                                              * after a replication fork() (for bgsave). */
+    size_t repl_buffer_mem;                  /* The memory of replication buffer. */
+    list *repl_buffer_blocks;                /* Replication buffers blocks list
+                                              * (serving replica clients and repl backlog) */
     /* Replication (replica) */
     char *primary_user;     /* AUTH with this user and primary_auth with primary */
     sds primary_auth;       /* AUTH with this password with primary */
@@ -2162,33 +2170,34 @@ struct valkeyServer {
         long long read_reploff;
         int dbid;
     } repl_provisional_primary;
-    client *cached_primary;              /* Cached primary to be reused for PSYNC. */
-    rio *loading_rio;                    /* Pointer to the rio object currently used for loading data. */
-    int repl_syncio_timeout;             /* Timeout for synchronous I/O calls */
-    int repl_state;                      /* Replication status if the instance is a replica */
-    int repl_rdb_channel_state;          /* State of the replica's rdb channel during dual-channel-replication */
-    off_t repl_transfer_size;            /* Size of RDB to read from primary during sync. */
-    off_t repl_transfer_read;            /* Amount of RDB read from primary during sync. */
-    off_t repl_transfer_last_fsync_off;  /* Offset when we fsync-ed last time. */
-    connection *repl_transfer_s;         /* Replica -> Primary SYNC connection */
-    connection *repl_rdb_transfer_s;     /* Primary FULL SYNC connection (RDB download) */
-    int repl_transfer_fd;                /* Replica -> Primary SYNC temp file descriptor */
-    char *repl_transfer_tmpfile;         /* Replica-> Primary SYNC temp file name */
-    _Atomic time_t repl_transfer_lastio; /* Unix time of the latest read, for timeout */
-    int repl_serve_stale_data;           /* Serve stale data when link is down? */
-    int repl_replica_ro;                 /* Replica is read only? */
-    int repl_replica_ignore_maxmemory;   /* If true replicas do not evict. */
-    time_t repl_down_since;              /* Unix time at which link with primary went down */
-    int repl_disable_tcp_nodelay;        /* Disable TCP_NODELAY after SYNC? */
-    int repl_mptcp;                      /* Use Multipath TCP for replica on client side */
-    int replica_priority;                /* Reported in INFO and used by Sentinel. */
-    int replica_announced;               /* If true, replica is announced by Sentinel */
-    int replica_announce_port;           /* Give the primary this listening port. */
-    char *replica_announce_ip;           /* Give the primary this ip address. */
-    int propagation_error_behavior;      /* Configures the behavior of the replica
-                                          * when it receives an error on the replication stream */
-    int repl_ignore_disk_write_error;    /* Configures whether replicas panic when unable to
-                                          * persist writes to AOF. */
+    client *cached_primary;             /* Cached primary to be reused for PSYNC. */
+    rio *loading_rio;                   /* Pointer to the rio object currently used for loading data. */
+    int repl_syncio_timeout;            /* Timeout for synchronous I/O calls */
+    int repl_state;                     /* Replication status if the instance is a replica */
+    int repl_rdb_channel_state;         /* State of the replica's rdb channel during dual-channel-replication */
+    off_t repl_transfer_size;           /* Size of RDB to read from primary during sync. */
+    off_t repl_transfer_read;           /* Amount of RDB read from primary during sync. */
+    off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
+    connection *repl_transfer_s;        /* Replica -> Primary SYNC connection */
+    connection *repl_rdb_transfer_s;    /* Primary FULL SYNC connection (RDB download) */
+    int repl_transfer_fd;               /* Replica -> Primary SYNC temp file descriptor */
+    char *repl_transfer_tmpfile;        /* Replica-> Primary SYNC temp file name */
+    VALKEY_ATOMIC(time_t)
+    repl_transfer_lastio;              /* Unix time of the latest read, for timeout */
+    int repl_serve_stale_data;         /* Serve stale data when link is down? */
+    int repl_replica_ro;               /* Replica is read only? */
+    int repl_replica_ignore_maxmemory; /* If true replicas do not evict. */
+    time_t repl_down_since;            /* Unix time at which link with primary went down */
+    int repl_disable_tcp_nodelay;      /* Disable TCP_NODELAY after SYNC? */
+    int repl_mptcp;                    /* Use Multipath TCP for replica on client side */
+    int replica_priority;              /* Reported in INFO and used by Sentinel. */
+    int replica_announced;             /* If true, replica is announced by Sentinel */
+    int replica_announce_port;         /* Give the primary this listening port. */
+    char *replica_announce_ip;         /* Give the primary this ip address. */
+    int propagation_error_behavior;    /* Configures the behavior of the replica
+                                        * when it receives an error on the replication stream */
+    int repl_ignore_disk_write_error;  /* Configures whether replicas panic when unable to
+                                        * persist writes to AOF. */
 
     /* The following two fields is where we store primary PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
@@ -2243,9 +2252,11 @@ struct valkeyServer {
     int list_max_listpack_size;
     int list_compress_depth;
     /* time cache */
-    _Atomic time_t unixtime;     /* Unix time sampled every cron cycle. */
-    time_t timezone;             /* Cached timezone. As set by tzset(). */
-    _Atomic int daylight_active; /* Currently in daylight saving time. */
+    VALKEY_ATOMIC(time_t)
+    unixtime;        /* Unix time sampled every cron cycle. */
+    time_t timezone; /* Cached timezone. As set by tzset(). */
+    VALKEY_ATOMIC(int)
+    daylight_active;             /* Currently in daylight saving time. */
     mstime_t mstime;             /* 'unixtime' in milliseconds. */
     ustime_t ustime;             /* 'unixtime' in microseconds. */
     mstime_t cmd_time_snapshot;  /* Time snapshot of the root execution nesting. */

--- a/src/server.h
+++ b/src/server.h
@@ -1760,8 +1760,7 @@ struct valkeyServer {
     hashtable *orig_commands;                         /* Command table before command renaming. */
     sds command_response_cache[RESP_CACHE_INDEX_MAX]; /* Cached COMMAND response: [0]=RESP2, [1]=RESP3 */
     aeEventLoop *el;
-    VALKEY_ATOMIC(AeIoState)
-    io_poll_state;                       /* Indicates the state of the IO polling. */
+    _Atomic(AeIoState) io_poll_state;    /* Indicates the state of the IO polling. */
     int io_ae_fired_events;              /* Number of poll events received by the IO thread. */
     rax *errors;                         /* Errors table */
     volatile sig_atomic_t shutdown_asap; /* Shutdown ordered by signal handler. */
@@ -1786,17 +1785,16 @@ struct valkeyServer {
     int thp_enabled;                     /* If true, THP is enabled. */
     size_t page_size;                    /* The page size of OS. */
     /* Modules */
-    dict *moduleapi;            /* Exported core APIs dictionary for modules. */
-    dict *sharedapi;            /* Like moduleapi but containing the APIs that
-                                   modules share with each other. */
-    dict *module_configs_queue; /* Dict that stores module configurations from .conf file until after modules are loaded
-                                   during startup or arguments to loadex. */
-    list *loadmodule_queue;     /* List of modules to load at startup. */
-    int module_pipe[2];         /* Pipe used to awake the event loop by module threads. */
-    pid_t child_pid;            /* PID of current child */
-    int child_type;             /* Type of current child */
-    VALKEY_ATOMIC(int)
-    module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
+    dict *moduleapi;                   /* Exported core APIs dictionary for modules. */
+    dict *sharedapi;                   /* Like moduleapi but containing the APIs that
+                                          modules share with each other. */
+    dict *module_configs_queue;        /* Dict that stores module configurations from .conf file until after modules are loaded
+                                          during startup or arguments to loadex. */
+    list *loadmodule_queue;            /* List of modules to load at startup. */
+    int module_pipe[2];                /* Pipe used to awake the event loop by module threads. */
+    pid_t child_pid;                   /* PID of current child */
+    int child_type;                    /* Type of current child */
+    _Atomic(int) module_gil_acquiring; /* Indicates whether the GIL is being acquiring by the main thread. */
     /* Networking */
     int port;                              /* TCP listening port */
     int tls_port;                          /* TLS listening port */
@@ -1840,10 +1838,9 @@ struct valkeyServer {
     uint32_t paused_actions;    /* Bitmask of actions that are currently paused */
     list *postponed_clients;    /* List of postponed clients */
     pause_event client_pause_per_purpose[NUM_PAUSE_PURPOSES];
-    char neterr[ANET_ERR_LEN];    /* Error buffer for anet.c */
-    dict *migrate_cached_sockets; /* MIGRATE cached sockets */
-    VALKEY_ATOMIC(uint64_t)
-    next_client_id;                           /* Next client unique ID. Incremental. */
+    char neterr[ANET_ERR_LEN];                /* Error buffer for anet.c */
+    dict *migrate_cached_sockets;             /* MIGRATE cached sockets */
+    _Atomic(uint64_t) next_client_id;         /* Next client unique ID. Incremental. */
     int protected_mode;                       /* Don't accept external connections. */
     int io_threads_num;                       /* Number of IO threads to use. */
     int active_io_threads_num;                /* Current number of active IO threads, includes main thread. */
@@ -2038,13 +2035,11 @@ struct valkeyServer {
     int aof_load_truncated;             /* Don't stop on unexpected AOF EOF. */
     int aof_use_rdb_preamble;           /* Specify base AOF to use RDB encoding on AOF rewrites. */
     int aof_rewrite_use_rdb_preamble;   /* Base AOF to use RDB encoding on AOF rewrites start. */
-    VALKEY_ATOMIC(int)
-    aof_bio_fsync_status; /* Status of AOF fsync in bio job. */
-    VALKEY_ATOMIC(int)
-    aof_bio_fsync_errno;       /* Errno of AOF fsync in bio job. */
-    aofManifest *aof_manifest; /* Used to track AOFs. */
-    int aof_disable_auto_gc;   /* If disable automatically deleting HISTORY type AOFs?
-                                  default no. (for testings). */
+    _Atomic(int) aof_bio_fsync_status;  /* Status of AOF fsync in bio job. */
+    _Atomic(int) aof_bio_fsync_errno;   /* Errno of AOF fsync in bio job. */
+    aofManifest *aof_manifest;          /* Used to track AOFs. */
+    int aof_disable_auto_gc;            /* If disable automatically deleting HISTORY type AOFs?
+                                           default no. (for testings). */
 
     /* RDB persistence */
     long long dirty;                      /* Changes to DB from the last save */
@@ -2106,55 +2101,52 @@ struct valkeyServer {
     int shutdown_on_sigterm; /* Shutdown flags configured for SIGTERM. */
 
     /* Replication (primary) */
-    char replid[CONFIG_RUN_ID_SIZE + 1];  /* My current replication ID. */
-    char replid2[CONFIG_RUN_ID_SIZE + 1]; /* replid inherited from primary*/
-    long long primary_repl_offset;        /* My current replication offset */
-    long long second_replid_offset;       /* Accept offsets up to this for replid2. */
-    VALKEY_ATOMIC(long long)
-    fsynced_reploff_pending;             /* Largest replication offset to
+    char replid[CONFIG_RUN_ID_SIZE + 1];        /* My current replication ID. */
+    char replid2[CONFIG_RUN_ID_SIZE + 1];       /* replid inherited from primary*/
+    long long primary_repl_offset;              /* My current replication offset */
+    long long second_replid_offset;             /* Accept offsets up to this for replid2. */
+    _Atomic(long long) fsynced_reploff_pending; /* Largest replication offset to
                          * potentially have been fsynced, applied to
                            fsynced_reploff only when AOF state is AOF_ON
                            (not during the initial rewrite) */
-    long long fsynced_reploff;           /* Largest replication offset that has been confirmed to be fsynced */
-    int replicas_eldb;                   /* Last SELECTed DB in replication output */
-    int repl_ping_replica_period;        /* Primary pings the replica every N seconds */
-    replBacklog *repl_backlog;           /* Replication backlog for partial syncs */
-    long long repl_backlog_size;         /* Backlog circular buffer size */
-    replDataBuf pending_repl_data;       /* Replication data buffer for dual-channel-replication */
-    time_t repl_backlog_time_limit;      /* Time without replicas after the backlog
-                                            gets released. */
-    time_t repl_no_replicas_since;       /* We have no replicas since that time.
-                                          Only valid if server.replicas len is 0. */
-    int repl_min_replicas_to_write;      /* Min number of replicas to write. */
-    int repl_min_replicas_max_lag;       /* Max lag of <count> replicas to write. */
-    int repl_good_replicas_count;        /* Number of replicas with lag <= max_lag. */
-    int repl_diskless_sync;              /* Primary send RDB to replicas sockets directly. */
-    int repl_diskless_load;              /* Replica parse RDB directly from the socket.
-                                          * see REPL_DISKLESS_LOAD_* enum */
-    int repl_diskless_sync_delay;        /* Delay to start a diskless repl BGSAVE. */
-    int repl_diskless_sync_max_replicas; /* Max replicas for diskless repl BGSAVE
-                                          * delay (start sooner if they all connect). */
-    int dual_channel_replication;        /* Config used to determine if the replica should
-                                          * use dual channel replication for full syncs. */
-    VALKEY_ATOMIC(int)
-    replica_bio_disk_save_state; /* Flag set by the bio thread to indicate that the
-                                  * RDB save to disk has completed, or failed */
-    VALKEY_ATOMIC(bool)
-    replica_bio_abort_save;                  /* Flag set by main thread, used to signal to replica's
-                                              * disk-saving bio thread to abort the save */
-    long long bio_stat_net_repl_input_bytes; /* Used to calculate stat_net_repl_input_bytes on the
-                                              * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_size;            /* Used to calculate bio_repl_transfer_size on the
-                                              * replica's bio thread without touching main thread vars */
-    off_t bio_repl_transfer_read;            /* Used to calculate bio_repl_transfer_read on the
-                                              * replica's bio thread without touching main thread vars */
-    int wait_before_rdb_client_free;         /* Grace period in seconds for replica main channel
-                                              * to establish psync. */
-    int debug_pause_after_fork;              /* Debug param that pauses the main process
-                                              * after a replication fork() (for bgsave). */
-    size_t repl_buffer_mem;                  /* The memory of replication buffer. */
-    list *repl_buffer_blocks;                /* Replication buffers blocks list
-                                              * (serving replica clients and repl backlog) */
+    long long fsynced_reploff;                  /* Largest replication offset that has been confirmed to be fsynced */
+    int replicas_eldb;                          /* Last SELECTed DB in replication output */
+    int repl_ping_replica_period;               /* Primary pings the replica every N seconds */
+    replBacklog *repl_backlog;                  /* Replication backlog for partial syncs */
+    long long repl_backlog_size;                /* Backlog circular buffer size */
+    replDataBuf pending_repl_data;              /* Replication data buffer for dual-channel-replication */
+    time_t repl_backlog_time_limit;             /* Time without replicas after the backlog
+                                                   gets released. */
+    time_t repl_no_replicas_since;              /* We have no replicas since that time.
+                                                 Only valid if server.replicas len is 0. */
+    int repl_min_replicas_to_write;             /* Min number of replicas to write. */
+    int repl_min_replicas_max_lag;              /* Max lag of <count> replicas to write. */
+    int repl_good_replicas_count;               /* Number of replicas with lag <= max_lag. */
+    int repl_diskless_sync;                     /* Primary send RDB to replicas sockets directly. */
+    int repl_diskless_load;                     /* Replica parse RDB directly from the socket.
+                                                 * see REPL_DISKLESS_LOAD_* enum */
+    int repl_diskless_sync_delay;               /* Delay to start a diskless repl BGSAVE. */
+    int repl_diskless_sync_max_replicas;        /* Max replicas for diskless repl BGSAVE
+                                                 * delay (start sooner if they all connect). */
+    int dual_channel_replication;               /* Config used to determine if the replica should
+                                                 * use dual channel replication for full syncs. */
+    _Atomic(int) replica_bio_disk_save_state;   /* Flag set by the bio thread to indicate that the
+                                                 * RDB save to disk has completed, or failed */
+    _Atomic(bool) replica_bio_abort_save;       /* Flag set by main thread, used to signal to replica's
+                                                 * disk-saving bio thread to abort the save */
+    long long bio_stat_net_repl_input_bytes;    /* Used to calculate stat_net_repl_input_bytes on the
+                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_size;               /* Used to calculate bio_repl_transfer_size on the
+                                                 * replica's bio thread without touching main thread vars */
+    off_t bio_repl_transfer_read;               /* Used to calculate bio_repl_transfer_read on the
+                                                 * replica's bio thread without touching main thread vars */
+    int wait_before_rdb_client_free;            /* Grace period in seconds for replica main channel
+                                                 * to establish psync. */
+    int debug_pause_after_fork;                 /* Debug param that pauses the main process
+                                                 * after a replication fork() (for bgsave). */
+    size_t repl_buffer_mem;                     /* The memory of replication buffer. */
+    list *repl_buffer_blocks;                   /* Replication buffers blocks list
+                                                 * (serving replica clients and repl backlog) */
     /* Replication (replica) */
     char *primary_user;     /* AUTH with this user and primary_auth with primary */
     sds primary_auth;       /* AUTH with this password with primary */
@@ -2170,34 +2162,33 @@ struct valkeyServer {
         long long read_reploff;
         int dbid;
     } repl_provisional_primary;
-    client *cached_primary;             /* Cached primary to be reused for PSYNC. */
-    rio *loading_rio;                   /* Pointer to the rio object currently used for loading data. */
-    int repl_syncio_timeout;            /* Timeout for synchronous I/O calls */
-    int repl_state;                     /* Replication status if the instance is a replica */
-    int repl_rdb_channel_state;         /* State of the replica's rdb channel during dual-channel-replication */
-    off_t repl_transfer_size;           /* Size of RDB to read from primary during sync. */
-    off_t repl_transfer_read;           /* Amount of RDB read from primary during sync. */
-    off_t repl_transfer_last_fsync_off; /* Offset when we fsync-ed last time. */
-    connection *repl_transfer_s;        /* Replica -> Primary SYNC connection */
-    connection *repl_rdb_transfer_s;    /* Primary FULL SYNC connection (RDB download) */
-    int repl_transfer_fd;               /* Replica -> Primary SYNC temp file descriptor */
-    char *repl_transfer_tmpfile;        /* Replica-> Primary SYNC temp file name */
-    VALKEY_ATOMIC(time_t)
-    repl_transfer_lastio;              /* Unix time of the latest read, for timeout */
-    int repl_serve_stale_data;         /* Serve stale data when link is down? */
-    int repl_replica_ro;               /* Replica is read only? */
-    int repl_replica_ignore_maxmemory; /* If true replicas do not evict. */
-    time_t repl_down_since;            /* Unix time at which link with primary went down */
-    int repl_disable_tcp_nodelay;      /* Disable TCP_NODELAY after SYNC? */
-    int repl_mptcp;                    /* Use Multipath TCP for replica on client side */
-    int replica_priority;              /* Reported in INFO and used by Sentinel. */
-    int replica_announced;             /* If true, replica is announced by Sentinel */
-    int replica_announce_port;         /* Give the primary this listening port. */
-    char *replica_announce_ip;         /* Give the primary this ip address. */
-    int propagation_error_behavior;    /* Configures the behavior of the replica
-                                        * when it receives an error on the replication stream */
-    int repl_ignore_disk_write_error;  /* Configures whether replicas panic when unable to
-                                        * persist writes to AOF. */
+    client *cached_primary;               /* Cached primary to be reused for PSYNC. */
+    rio *loading_rio;                     /* Pointer to the rio object currently used for loading data. */
+    int repl_syncio_timeout;              /* Timeout for synchronous I/O calls */
+    int repl_state;                       /* Replication status if the instance is a replica */
+    int repl_rdb_channel_state;           /* State of the replica's rdb channel during dual-channel-replication */
+    off_t repl_transfer_size;             /* Size of RDB to read from primary during sync. */
+    off_t repl_transfer_read;             /* Amount of RDB read from primary during sync. */
+    off_t repl_transfer_last_fsync_off;   /* Offset when we fsync-ed last time. */
+    connection *repl_transfer_s;          /* Replica -> Primary SYNC connection */
+    connection *repl_rdb_transfer_s;      /* Primary FULL SYNC connection (RDB download) */
+    int repl_transfer_fd;                 /* Replica -> Primary SYNC temp file descriptor */
+    char *repl_transfer_tmpfile;          /* Replica-> Primary SYNC temp file name */
+    _Atomic(time_t) repl_transfer_lastio; /* Unix time of the latest read, for timeout */
+    int repl_serve_stale_data;            /* Serve stale data when link is down? */
+    int repl_replica_ro;                  /* Replica is read only? */
+    int repl_replica_ignore_maxmemory;    /* If true replicas do not evict. */
+    time_t repl_down_since;               /* Unix time at which link with primary went down */
+    int repl_disable_tcp_nodelay;         /* Disable TCP_NODELAY after SYNC? */
+    int repl_mptcp;                       /* Use Multipath TCP for replica on client side */
+    int replica_priority;                 /* Reported in INFO and used by Sentinel. */
+    int replica_announced;                /* If true, replica is announced by Sentinel */
+    int replica_announce_port;            /* Give the primary this listening port. */
+    char *replica_announce_ip;            /* Give the primary this ip address. */
+    int propagation_error_behavior;       /* Configures the behavior of the replica
+                                           * when it receives an error on the replication stream */
+    int repl_ignore_disk_write_error;     /* Configures whether replicas panic when unable to
+                                           * persist writes to AOF. */
 
     /* The following two fields is where we store primary PSYNC replid/offset
      * while the PSYNC is in progress. At the end we'll copy the fields into
@@ -2252,16 +2243,14 @@ struct valkeyServer {
     int list_max_listpack_size;
     int list_compress_depth;
     /* time cache */
-    VALKEY_ATOMIC(time_t)
-    unixtime;        /* Unix time sampled every cron cycle. */
-    time_t timezone; /* Cached timezone. As set by tzset(). */
-    VALKEY_ATOMIC(int)
-    daylight_active;             /* Currently in daylight saving time. */
-    mstime_t mstime;             /* 'unixtime' in milliseconds. */
-    ustime_t ustime;             /* 'unixtime' in microseconds. */
-    mstime_t cmd_time_snapshot;  /* Time snapshot of the root execution nesting. */
-    size_t blocking_op_nesting;  /* Nesting level of blocking operation, used to reset blocked_last_cron. */
-    long long blocked_last_cron; /* Indicate the mstime of the last time we did cron jobs from a blocking operation */
+    _Atomic(time_t) unixtime;     /* Unix time sampled every cron cycle. */
+    time_t timezone;              /* Cached timezone. As set by tzset(). */
+    _Atomic(int) daylight_active; /* Currently in daylight saving time. */
+    mstime_t mstime;              /* 'unixtime' in milliseconds. */
+    ustime_t ustime;              /* 'unixtime' in microseconds. */
+    mstime_t cmd_time_snapshot;   /* Time snapshot of the root execution nesting. */
+    size_t blocking_op_nesting;   /* Nesting level of blocking operation, used to reset blocked_last_cron. */
+    long long blocked_last_cron;  /* Indicate the mstime of the last time we did cron jobs from a blocking operation */
     /* Pubsub */
     kvstore *pubsub_channels;      /* Map channels to list of subscribed clients */
     dict *pubsub_patterns;         /* A dict of pubsub_patterns */

--- a/src/server.h
+++ b/src/server.h
@@ -2106,9 +2106,9 @@ struct valkeyServer {
     long long primary_repl_offset;              /* My current replication offset */
     long long second_replid_offset;             /* Accept offsets up to this for replid2. */
     _Atomic(long long) fsynced_reploff_pending; /* Largest replication offset to
-                         * potentially have been fsynced, applied to
-                           fsynced_reploff only when AOF state is AOF_ON
-                           (not during the initial rewrite) */
+                                                 * potentially have been fsynced, applied to
+                                                   fsynced_reploff only when AOF state is AOF_ON
+                                                   (not during the initial rewrite) */
     long long fsynced_reploff;                  /* Largest replication offset that has been confirmed to be fsynced */
     int replicas_eldb;                          /* Last SELECTed DB in replication output */
     int repl_ping_replica_period;               /* Primary pings the replica every N seconds */

--- a/src/unit/wrappers.h
+++ b/src/unit/wrappers.h
@@ -37,10 +37,10 @@ extern "C" {
 // Some C keywords or built-in types (e.g., _Atomic, _Bool) are not
 // recognized or have different meanings in C++. To allow C headers
 // to be included in C++ code without errors, we redefine them appropriately.
-#define _Atomic              /* _Atomic is not a C++ keyword; define empty */
-#define _Bool bool           /* Replace C _Bool with C++ bool */
-#define typename _typename   /* Avoid conflict with C++ 'typename' keyword */
-#define protected protected_ /* Avoid conflict with C++ 'protected' keyword */
+#define _Atomic(type) alignas(sizeof(type)) type /* Preserve alignment in C++ builds */
+#define _Bool bool                               /* Replace C _Bool with C++ bool */
+#define typename _typename                       /* Avoid conflict with C++ 'typename' keyword */
+#define protected protected_                     /* Avoid conflict with C++ 'protected' keyword */
 
 #include "ae.h"
 #include "server.h"


### PR DESCRIPTION
I found that on 32-bit platforms, the gtest fails if I add a declaration `int aof_rewrite_for_replication;` between two atomic 64-bit fields in the valkeyServer struct.

In C, the _Atomic modifier makes the type aligned to its own size, but for the C++ unit tests, we're stripping the _Atomic qualifier in src/unit/wrappers.h by defining it to empty. This makes struct valkeyServer have different alignment/field offsets in C-compiled code (libvalkey.a) vs C++-compiled tests (gtest). As a result, fields after these atomics are accessed at different offsets, leading to corrupted reads/writes and a segfault.

This commit changes `_Atomic` to always use parentheses, as in `_Atomic(int)` instead of `_Atomic int`, and for C++ defines it to be aligned in the same way as in C:

    #define _Atomic(type) alignas(sizeof(type)) type