### PR TITLE
Fix ZDIFF algorithm 2 memory leak on early exit

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -2507,7 +2507,10 @@ static void zdiffAlgorithm2(zsetopsrc *src, long setnum, zset *dstzset, size_t *
 
             /* Exit if result set is empty as any additional removal
              * of elements will have no effect. */
-            if (cardinality == 0) break;
+            if (cardinality == 0) {
+                zuiDiscardDirtyValue(&zval);
+                break;
+            }
         }
         zuiClearIterator(&src[j]);
 

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1088,6 +1088,16 @@ start_server {tags {"zset"}} {
             assert_equal {a 1 e 5} [r zrange zsete{t} 0 -1 withscores]
         }
 
+        test "ZDIFF algorithm 2 empty result early - $encoding" {
+            r del zseta{t} zsetb{t} zsetc{t}
+            r zadd zseta{t} 1 a
+            r zadd zseta{t} 2 b
+            r zadd zsetb{t} 1 a
+            r zadd zsetb{t} 2 b
+            assert_equal 0 [r zdiffstore zsetc{t} 2 zseta{t} zsetb{t}]
+            assert_equal {} [r zrange zsetc{t} 0 -1 withscores]
+        }
+
         test "ZDIFF fuzzing - $encoding" {
             for {set j 0} {$j < 100} {incr j} {
                 unset -nocomplain s

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -1090,10 +1090,8 @@ start_server {tags {"zset"}} {
 
         test "ZDIFF algorithm 2 empty result early - $encoding" {
             r del zseta{t} zsetb{t} zsetc{t}
-            r zadd zseta{t} 1 a
-            r zadd zseta{t} 2 b
-            r zadd zsetb{t} 1 a
-            r zadd zsetb{t} 2 b
+            r zadd zseta{t} 1 a 2 b
+            r zadd zsetb{t} 1 a 2 b
             assert_equal 0 [r zdiffstore zsetc{t} 2 zseta{t} zsetb{t}]
             assert_equal {} [r zrange zsetc{t} 0 -1 withscores]
         }


### PR DESCRIPTION
`zdiffAlgorithm2()` can break out early once the destination cardinality reaches zero. In that path, a temporary SDS created by `zuiSdsFromValue()` was left dirty and never released, because that cleanup normally happens on the next
iterator step.

This patch explicitly discards the dirty value before the early `break`.

Failed Valgrind Test: https://github.com/valkey-io/valkey/actions/runs/22742928823/job/65960333327#step:8:10189

```

==11724== 11 bytes in 1 blocks are definitely lost in loss record 36 of 1,442
==11724==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==11724==    by 0x2FA974: ztrymalloc_usable_internal (zmalloc.c:156)
==11724==    by 0x2FAAEA: zmalloc_usable (zmalloc.c:200)
==11724==    by 0x282D25: _sdsnewlen (sds.c:102)
==11724==    by 0x2830B2: sdsnewlen (sds.c:169)
==11724==    by 0x2DB537: zuiSdsFromValue (t_zset.c:2290)
==11724==    by 0x2DBE00: zdiffAlgorithm2 (t_zset.c:2502)
==11724==    by 0x2DC085: zdiff (t_zset.c:2568)
==11724==    by 0x2DD01F: zunionInterDiffGenericCommand (t_zset.c:2817)
==11724==    by 0x2DD574: zdiffCommand (t_zset.c:2898)
==11724==    by 0x29F5AE: call (server.c:3883)
==11724==    by 0x2A1598: processCommand (server.c:4569)

```