### PR TITLE
New command flag to indicate modification of first key only (forkless)

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -57,6 +57,7 @@ typedef enum {
 #define CMD_MODULE_GETCHANNELS (1ULL << 27) /* Use the modules getchannels interface. */
 #define CMD_TOUCHES_ARBITRARY_KEYS (1ULL << 28)
 #define CMD_ALL_DBS (1ULL << 29)
+#define CMD_WRITE_FIRSTKEY_ONLY (1ULL << 30)
 /* Command flags. Please don't forget to add command flag documentation in struct
  * serverCommand in server.h file. */
 

--- a/src/module.c
+++ b/src/module.c
@@ -2104,6 +2104,8 @@ int VM_SetCommandInfo(ValkeyModuleCommand *command, const ValkeyModuleCommandInf
         /* Update the legacy (first,last,step) spec and "movablekeys" flag used by the COMMAND command,
          * by trying to "glue" consecutive range key specs. */
         populateCommandLegacyRangeSpec(cmd);
+
+        detectWriteFirstkeyOnlyCommand(cmd);
     }
 
     if (info->args) {

--- a/src/server.c
+++ b/src/server.c
@@ -3340,6 +3340,27 @@ void commandAddSubcommand(struct serverCommand *parent, struct serverCommand *su
     serverAssert(hashtableAdd(parent->subcommands_ht, subcommand));
 }
 
+/* Automatically set CMD_WRITE_FIRSTKEY_ONLY for write commands where the first
+ * key is written, and other keys are read only. */
+void detectWriteFirstkeyOnlyCommand(struct serverCommand *c) {
+    c->flags &= ~CMD_WRITE_FIRSTKEY_ONLY; // Override if set elsewhere
+    if (!(c->flags & CMD_WRITE)) return;
+    if (c->key_specs_num < 2) return;
+    if (!(c->key_specs[0].flags & (CMD_KEY_OW | CMD_KEY_RW))) return;
+    if (c->key_specs[0].find_keys_type != KSPEC_FK_RANGE) return;
+    if (c->key_specs[0].fk.range.lastkey != 0) return;
+
+    bool write_first_key_only = true;
+    for (int i = 1; i < c->key_specs_num; i++) {
+        if (!(c->key_specs[i].flags & CMD_KEY_RO) || (c->key_specs[i].flags & (CMD_KEY_RW | CMD_KEY_OW | CMD_KEY_RM))) {
+            write_first_key_only = false;
+            break;
+        }
+    }
+
+    if (write_first_key_only) c->flags |= CMD_WRITE_FIRSTKEY_ONLY;
+}
+
 /* Recursively populate the command structure.
  *
  * On success, the function return C_OK. Otherwise C_ERR is returned and we won't
@@ -3362,6 +3383,8 @@ int populateCommandStructure(struct serverCommand *c) {
 
     /* Handle the legacy range spec and the "movablekeys" flag (must be done after populating all key specs). */
     populateCommandLegacyRangeSpec(c);
+
+    detectWriteFirstkeyOnlyCommand(c);
 
     /* Assign the ID used for ACL. */
     c->id = ACLGetCommandID(c->fullname);

--- a/src/server.h
+++ b/src/server.h
@@ -2631,6 +2631,9 @@ typedef int *commandDbIdArgs(robj **argv, int argc, int *count);
  *
  * CMD_ALL_DBS: The command works with all databases.
  *
+ * CMD_WRITE_FIRSTKEY_ONLY: The command must be CMD_WRITE.  It only modifies the first key.
+ *                          Other keys are read-only.  Example: SUNIONSTORE
+ *
  * The following additional flags are only used in order to put commands
  * in a specific ACL category. Commands can have multiple ACL categories.
  * See valkey.conf for the exact meaning of each.
@@ -2810,6 +2813,7 @@ extern dict *modules;
 
 /* Command metadata */
 void populateCommandLegacyRangeSpec(struct serverCommand *c);
+void detectWriteFirstkeyOnlyCommand(struct serverCommand *c);
 
 /* Utils */
 mstime_t commandTimeSnapshot(void);

--- a/src/unit/test_cmdflags.cpp
+++ b/src/unit/test_cmdflags.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+extern "C" {
+#include "server.h"
+}
+extern hashtableType commandSetType;
+extern hashtableType originalCommandSetType;
+
+
+class CmdFlagsTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        server.commands = hashtableCreate(&commandSetType);
+        server.orig_commands = hashtableCreate(&originalCommandSetType);
+        populateCommandTable();
+    }
+};
+
+
+TEST_F(CmdFlagsTest, TestWriteFirstkeyOnly) {
+    /* Each command with this flag is explicitly listed here to ensure:
+     *   - new commands are not mistakenly detected as write firstkey only
+     *   - commands which should be write firstkey only are detected. */
+    const char *const writeFirstkeyCommands[] = {
+        "bitop", "geosearchstore", "pfmerge", "sdiffstore", "sinterstore",
+        "sunionstore", "zdiffstore", "zinterstore", "zrangestore", "zunionstore"};
+    int expectedCount = sizeof(writeFirstkeyCommands) / sizeof(char *);
+
+    int count = 0;
+
+    hashtableIterator iter;
+    hashtableInitIterator(&iter, server.commands, 0);
+    struct serverCommand *c;
+    while (hashtableNext(&iter, (void **)&c)) {
+        if (c->flags & CMD_WRITE_FIRSTKEY_ONLY) {
+            count++;
+            bool found = false;
+            for (int i = 0; i < expectedCount; i++) {
+                if (strcmp(c->declared_name, writeFirstkeyCommands[i]) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+            EXPECT_TRUE(found);
+        }
+    }
+    hashtableCleanupIterator(&iter);
+
+    EXPECT_EQ(count, expectedCount);
+}


### PR DESCRIPTION
New command flag for first-key modification

During forkless save, when a write command is received, we must ensure that all keys are persisted as they exist before the write command executes.  This often involves blocking the write command while the keys are being persisted.

There is an optimization for write commands which only write to the first key.  For these commands, the remaining keys are read-only and don't require immediate persistence.

Example: **`SUNIONSTORE A B C D E`**

For this command, only key `A` is written and requires persistence.  Keys `B`, `C`, `D`, & `E` can be accessed for read, regardless of their current states of persistence.

This optimization applies to: `BITOP`, `PFMERGE`, `SDIFFSTORE`, `SINTERSTORE`, `SUNIONSTORE`, `ZDIFFSTORE`, `ZINTERSTORE`, & `ZUNIONSTORE`.