### PR TITLE
Ignore stale readable callbacks after replica sync handoff

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2933,6 +2933,10 @@ void receiveRDBinBioThread(bool is_dual_channel) {
         conn = server.repl_transfer_s;
         server.repl_transfer_s = NULL;
     }
+    if (!conn) {
+        serverLog(LL_VERBOSE, "Ignoring stale RDB transfer callback without an active replication connection");
+        return;
+    }
     connSetReadHandler(conn, NULL);
     bioCreateSaveRDBToDiskJob(conn, is_dual_channel);
 }
@@ -4167,6 +4171,12 @@ void syncWithPrimary(connection *conn) {
             return;
         }
         server.repl_state = REPL_STATE_RECEIVE_PSYNC_REPLY;
+        return;
+    case REPL_STATE_TRANSFER:
+    case REPL_STATE_CONNECTED:
+        /* A readable event can be queued before we swap the read handler to the
+         * RDB transfer or steady-state handler. Ignore the stale callback and let
+         * the current handler process the connection. */
         return;
     /* If reached this point, we should be in REPL_STATE_RECEIVE_PSYNC_REPLY. */
     default:


### PR DESCRIPTION
I noticed this crash in yesterday's daily run: https://github.com/valkey-io/valkey/actions/runs/22880939835/job/66383301850#step:10:7530

```
30553:S 10 Mar 2026 01:02:11.216 - Error accepting cluster node connection: error:0A000126:SSL routines::unexpected eof while reading
30553:S 10 Mar 2026 01:02:11.233 # syncWithPrimary(): state machine error, state should be RECEIVE_PSYNC but is 13
30553:S 10 Mar 2026 01:02:11.233 - Accepting cluster node connection from 127.0.0.1:37896
30553:S 10 Mar 2026 01:02:11.241 - Error accepting cluster node connection: error:0A000126:SSL routines::unexpected eof while reading
30553:S 10 Mar 2026 01:02:11.241 * Replica main thread creating Bio thread to save RDB to disk


=== VALKEY BUG REPORT START: Cut & paste starting from here ===
30553:S 10 Mar 2026 01:02:11.241 # valkey 255.255.255 crashed by signal: 11, si_code: 1
30553:S 10 Mar 2026 01:02:11.241 # Accessing address: (nil)
30553:S 10 Mar 2026 01:02:11.241 # Crashed running the instruction at: 0x55579c

------ STACK TRACE ------
EIP:
/__w/valkey/valkey/src/valkey-server 127.0.0.1:21217 [cluster](receiveRDBinBioThreadSingleChannel+0x2c)[0x55579c]
```

During sync, the main connection starts with `syncWithPrimary()` as its read handler. After the PSYNC reply is processed, the code swaps that handler to the RDB transfer path and sets replication to `REPL_STATE_TRANSFER`.

The race could be that a readable event for the old handler can already be queued before the handler swap is completed. When that stale callback later fires, `syncWithPrimary()` runs one more time even though the replica is already in the
transfer phase.

The patch fixes two things - 

1. Ignore the late `syncWithPrimary()` callbacks once replication is already in`REPL_STATE_TRANSFER` or `REPL_STATE_CONNECTED`
2. Skip the BIO-thread RDB handoff if the transfer connection is already gone

Passing CI Run 200 times - https://github.com/sarthakaggarwal97/valkey/actions/runs/22888409606/job/66406230369 