### PR TITLE
Add availability-zone to the reply schema for CLUSTER SHARDS/SLOTS

### DIFF
--- a/src/commands.def
+++ b/src/commands.def
@@ -1008,6 +1008,7 @@ struct COMMAND_ARG CLUSTER_SETSLOT_Args[] = {
 /* CLUSTER SHARDS history */
 commandHistory CLUSTER_SHARDS_History[] = {
 {"9.1.0","Added shard id field to CLUSTER SHARDS response"},
+{"9.1.0","Added `availability-zone` field."},
 };
 #endif
 
@@ -1104,6 +1105,7 @@ struct COMMAND_ARG CLUSTER_SLOT_STATS_Args[] = {
 commandHistory CLUSTER_SLOTS_History[] = {
 {"4.0.0","Added node IDs."},
 {"7.0.0","Added additional networking metadata field."},
+{"9.1.0","Added `availability-zone` field."},
 };
 #endif
 
@@ -1167,10 +1169,10 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("saveconfig","Forces a node to save the cluster configuration to disk.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SAVECONFIG_History,0,CLUSTER_SAVECONFIG_Tips,0,clusterCommand,2,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SAVECONFIG_Keyspecs,0,NULL,0)},
 {MAKE_CMD("set-config-epoch","Sets the configuration epoch for a new node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SET_CONFIG_EPOCH_History,0,CLUSTER_SET_CONFIG_EPOCH_Tips,0,clusterCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SET_CONFIG_EPOCH_Keyspecs,0,NULL,1),.args=CLUSTER_SET_CONFIG_EPOCH_Args},
 {MAKE_CMD("setslot","Binds a hash slot to a node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SETSLOT_History,1,CLUSTER_SETSLOT_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE|CMD_MAY_REPLICATE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SETSLOT_Keyspecs,0,NULL,3),.args=CLUSTER_SETSLOT_Args},
-{MAKE_CMD("shards","Returns the mapping of cluster slots to shards.","O(N) where N is the total number of cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SHARDS_History,1,CLUSTER_SHARDS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SHARDS_Keyspecs,0,NULL,0)},
+{MAKE_CMD("shards","Returns the mapping of cluster slots to shards.","O(N) where N is the total number of cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SHARDS_History,2,CLUSTER_SHARDS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SHARDS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("slaves","Lists the replica nodes of a primary node.","O(N) where N is the number of replicas.","3.0.0",CMD_DOC_DEPRECATED,"`CLUSTER REPLICAS`","5.0.0","cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLAVES_History,0,CLUSTER_SLAVES_Tips,1,clusterCommand,3,CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SLAVES_Keyspecs,0,NULL,1),.args=CLUSTER_SLAVES_Args},
 {MAKE_CMD("slot-stats","Return an array of slot usage statistics for slots assigned to the current node.","O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.","8.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOT_STATS_History,0,CLUSTER_SLOT_STATS_Tips,2,clusterSlotStatsCommand,-4,CMD_STALE|CMD_LOADING,ACL_CATEGORY_SLOW,NULL,CLUSTER_SLOT_STATS_Keyspecs,0,NULL,1),.args=CLUSTER_SLOT_STATS_Args},
-{MAKE_CMD("slots","Returns the mapping of cluster slots to nodes.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOTS_History,2,CLUSTER_SLOTS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SLOTS_Keyspecs,0,NULL,0)},
+{MAKE_CMD("slots","Returns the mapping of cluster slots to nodes.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOTS_History,3,CLUSTER_SLOTS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SLOTS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("syncslots","A container for internal slot migration commands.","Depends on subcommand.","9.0.0",CMD_DOC_SYSCMD,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SYNCSLOTS_History,0,CLUSTER_SYNCSLOTS_Tips,0,clusterCommand,-3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE|CMD_MAY_REPLICATE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SYNCSLOTS_Keyspecs,0,NULL,0)},
 {0}
 };

--- a/src/commands.def
+++ b/src/commands.def
@@ -1007,8 +1007,7 @@ struct COMMAND_ARG CLUSTER_SETSLOT_Args[] = {
 #ifndef SKIP_CMD_HISTORY_TABLE
 /* CLUSTER SHARDS history */
 commandHistory CLUSTER_SHARDS_History[] = {
-{"9.1.0","Added shard id field to CLUSTER SHARDS response"},
-{"9.1.0","Added `availability-zone` field."},
+{"9.1.0","Added shard level `id` field and node level `availability-zone` field."},
 };
 #endif
 
@@ -1105,7 +1104,7 @@ struct COMMAND_ARG CLUSTER_SLOT_STATS_Args[] = {
 commandHistory CLUSTER_SLOTS_History[] = {
 {"4.0.0","Added node IDs."},
 {"7.0.0","Added additional networking metadata field."},
-{"9.1.0","Added `availability-zone` field."},
+{"9.1.0","Added `availability-zone` field inside the networking metadata."},
 };
 #endif
 
@@ -1169,7 +1168,7 @@ struct COMMAND_STRUCT CLUSTER_Subcommands[] = {
 {MAKE_CMD("saveconfig","Forces a node to save the cluster configuration to disk.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SAVECONFIG_History,0,CLUSTER_SAVECONFIG_Tips,0,clusterCommand,2,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SAVECONFIG_Keyspecs,0,NULL,0)},
 {MAKE_CMD("set-config-epoch","Sets the configuration epoch for a new node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SET_CONFIG_EPOCH_History,0,CLUSTER_SET_CONFIG_EPOCH_Tips,0,clusterCommand,3,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SET_CONFIG_EPOCH_Keyspecs,0,NULL,1),.args=CLUSTER_SET_CONFIG_EPOCH_Args},
 {MAKE_CMD("setslot","Binds a hash slot to a node.","O(1)","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SETSLOT_History,1,CLUSTER_SETSLOT_Tips,0,clusterCommand,-4,CMD_NO_ASYNC_LOADING|CMD_ADMIN|CMD_STALE|CMD_MAY_REPLICATE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SETSLOT_Keyspecs,0,NULL,3),.args=CLUSTER_SETSLOT_Args},
-{MAKE_CMD("shards","Returns the mapping of cluster slots to shards.","O(N) where N is the total number of cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SHARDS_History,2,CLUSTER_SHARDS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SHARDS_Keyspecs,0,NULL,0)},
+{MAKE_CMD("shards","Returns the mapping of cluster slots to shards.","O(N) where N is the total number of cluster nodes","7.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SHARDS_History,1,CLUSTER_SHARDS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SHARDS_Keyspecs,0,NULL,0)},
 {MAKE_CMD("slaves","Lists the replica nodes of a primary node.","O(N) where N is the number of replicas.","3.0.0",CMD_DOC_DEPRECATED,"`CLUSTER REPLICAS`","5.0.0","cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLAVES_History,0,CLUSTER_SLAVES_Tips,1,clusterCommand,3,CMD_ADMIN|CMD_STALE,ACL_CATEGORY_ADMIN|ACL_CATEGORY_DANGEROUS|ACL_CATEGORY_SLOW,NULL,CLUSTER_SLAVES_Keyspecs,0,NULL,1),.args=CLUSTER_SLAVES_Args},
 {MAKE_CMD("slot-stats","Return an array of slot usage statistics for slots assigned to the current node.","O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.","8.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOT_STATS_History,0,CLUSTER_SLOT_STATS_Tips,2,clusterSlotStatsCommand,-4,CMD_STALE|CMD_LOADING,ACL_CATEGORY_SLOW,NULL,CLUSTER_SLOT_STATS_Keyspecs,0,NULL,1),.args=CLUSTER_SLOT_STATS_Args},
 {MAKE_CMD("slots","Returns the mapping of cluster slots to nodes.","O(N) where N is the total number of Cluster nodes","3.0.0",CMD_DOC_NONE,NULL,NULL,"cluster",COMMAND_GROUP_CLUSTER,CLUSTER_SLOTS_History,3,CLUSTER_SLOTS_Tips,1,clusterCommand,2,CMD_LOADING|CMD_STALE,ACL_CATEGORY_SLOW,NULL,CLUSTER_SLOTS_Keyspecs,0,NULL,0)},

--- a/src/commands/cluster-shards.json
+++ b/src/commands/cluster-shards.json
@@ -10,11 +10,7 @@
         "history": [
             [
                 "9.1.0",
-                "Added shard id field to CLUSTER SHARDS response"
-            ],
-            [
-                "9.1.0",
-                "Added `availability-zone` field."
+                "Added shard level `id` field and node level `availability-zone` field."
             ]
         ],
         "command_flags": [

--- a/src/commands/cluster-shards.json
+++ b/src/commands/cluster-shards.json
@@ -11,6 +11,10 @@
             [
                 "9.1.0",
                 "Added shard id field to CLUSTER SHARDS response"
+            ],
+            [
+                "9.1.0",
+                "Added `availability-zone` field."
             ]
         ],
         "command_flags": [
@@ -84,6 +88,9 @@
                                             "const": "online"
                                         }
                                     ]
+                                },
+                                "availability-zone": {
+                                    "type": "string"
                                 }
                             }
                         }

--- a/src/commands/cluster-slots.json
+++ b/src/commands/cluster-slots.json
@@ -15,6 +15,10 @@
             [
                 "7.0.0",
                 "Added additional networking metadata field."
+            ],
+            [
+                "9.1.0",
+                "Added `availability-zone` field."
             ]
         ],
         "command_flags": [
@@ -77,6 +81,9 @@
                                     },
                                     "ip": {
                                         "type": "string"
+                                    },
+                                    "availability-zone": {
+                                        "type": "string"
                                     }
                                 }
                             }
@@ -119,6 +126,9 @@
                                     "type": "string"
                                 },
                                 "ip": {
+                                    "type": "string"
+                                },
+                                "availability-zone": {
                                     "type": "string"
                                 }
                             }

--- a/src/commands/cluster-slots.json
+++ b/src/commands/cluster-slots.json
@@ -18,7 +18,7 @@
             ],
             [
                 "9.1.0",
-                "Added `availability-zone` field."
+                "Added `availability-zone` field inside the networking metadata."
             ]
         ],
         "command_flags": [
@@ -72,7 +72,7 @@
                                 "type": "string"
                             },
                             {
-                                "description": "Array of node descriptions.",
+                                "description": "Map of additional networking metadata fields.",
                                 "type": "object",
                                 "additionalProperties": false,
                                 "properties": {
@@ -118,7 +118,7 @@
                             "type": "string"
                         },
                         {
-                            "description": "Array of node descriptions.",
+                            "description": "Map of additional networking metadata fields.",
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {

--- a/src/commands/hello.json
+++ b/src/commands/hello.json
@@ -74,6 +74,9 @@
                             }
                         }
                     }
+                },
+                "availability_zone": {
+                    "type": "string"
                 }
             }
         },

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -325,18 +325,10 @@ start_server {tags {"protocol hello"}} {
         assert_equal [dict get $reply proto] 3
 
         set reply [r HELLO 2]
-        if {$::force_resp3} {
-            assert_equal [dict get $reply proto] 3
-        } else {
-            assert_equal [dict get $reply proto] 2
-        }
+        assert_equal [dict get $reply proto] [expr $::force_resp3 ? 3 : 2]
 
         set reply [r HELLO]
-        if {$::force_resp3} {
-            assert_equal [dict get $reply proto] 3
-        } else {
-            assert_equal [dict get $reply proto] 2
-        }
+        assert_equal [dict get $reply proto] [expr $::force_resp3 ? 3 : 2]
     }
 
     test {HELLO and availability-zone} {

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -316,7 +316,7 @@ start_server {tags {"protocol network"}} {
 
 }
 
-start_server {tags {"protocol hello logreqres:skip"}} {
+start_server {tags {"protocol hello"}} {
     test {HELLO without protover} {
         set reply [r HELLO 3]
         assert_equal [dict get $reply proto] 3

--- a/tests/unit/protocol.tcl
+++ b/tests/unit/protocol.tcl
@@ -325,10 +325,18 @@ start_server {tags {"protocol hello"}} {
         assert_equal [dict get $reply proto] 3
 
         set reply [r HELLO 2]
-        assert_equal [dict get $reply proto] 2
+        if {$::force_resp3} {
+            assert_equal [dict get $reply proto] 3
+        } else {
+            assert_equal [dict get $reply proto] 2
+        }
 
         set reply [r HELLO]
-        assert_equal [dict get $reply proto] 2
+        if {$::force_resp3} {
+            assert_equal [dict get $reply proto] 3
+        } else {
+            assert_equal [dict get $reply proto] 2
+        }
     }
 
     test {HELLO and availability-zone} {


### PR DESCRIPTION
`availability_zone` was added to the HELLO command in #1487, and
it was missing the reply schema and the test was wrongly marked
with `logreqres:skip`.

`availability-zone` was added to CLUSTER SHARDS and CLUSTER SLOTS
commands in #3156, and it was missing the reply schema.