### PR TITLE
Deflake io-threads test by generating enough work

### DIFF
--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -1,16 +1,19 @@
 proc activate_io_threads_and_wait {} {
     set server_pid [s process_id]
-    # Create 16 clients
-    for {set i 0} {$i < 16} {incr i} {
+    set client_count 16
+    set requests_per_client 32
+    for {set i 0} {$i < $client_count} {incr i} {
         set rd($i) [valkey_deferring_client]
     }
     r set a 0
     # Create a batch of commands by suspending the server for a while
     # before responding to the first command
     pause_process $server_pid
-    # Send set commands for all clients except the first
-    for {set i 1} {$i < 16} {incr i} {
-        $rd($i) incr a
+    # Send a pipeline of INCR commands for all clients except the first.
+    for {set i 1} {$i < $client_count} {incr i} {
+        for {set j 0} {$j < $requests_per_client} {incr j} {
+            $rd($i) incr a
+        }
         $rd($i) flush
     }
     # Resume the server
@@ -18,9 +21,13 @@ proc activate_io_threads_and_wait {} {
 
     # Wait until all the client commands have executed
     wait_for_condition 1000 50 {
-        [r get a] eq 15
+        [r get a] eq [expr {($client_count - 1) * $requests_per_client}]
     } else {
         fail "Failed to apply the incr command for all clients"
+    }
+
+    for {set i 0} {$i < $client_count} {incr i} {
+        $rd($i) close
     }
 
     # Wait until active io_threads are no longer active
@@ -28,10 +35,6 @@ proc activate_io_threads_and_wait {} {
         [getInfoProperty [r info server] io_threads_active] eq 0
     } else {
         fail "Failed to wait until no io_threads are active"
-    }
-
-    for {set i 0} {$i < 16} {incr i} {
-        $rd($i) close
     }
 }
 


### PR DESCRIPTION
Fixes the failing run: https://github.com/valkey-io/valkey/actions/runs/22810251608/job/66165776196#step:7:8704

```
[err]: Force the use of IO threads and assert active IO thread usage in tests/unit/io-threads.tcl
Expected '0.000000' to be more than '0' (context: type source line 49 file /Users/runner/work/valkey/valkey/tests/unit/io-threads.tcl cmd {assert_morethan $used_active_time 0} proc ::test)
```

The change deflakes the test by generating enough I/O-thread work.

The test previously created 16 deferred clients but only sent 15 total `INCR` commands. On fast runners, that burst could be short enough that `used_active_time_io_thread_*` was still reported as `0.000000`, causing the test to fail even though I/O threads had run.

Passing Run 200 times: https://github.com/sarthakaggarwal97/valkey/actions/runs/22869618064
