### PR TITLE
Optimize WATCH duplicate key check from O(N) to O(1) using per-db hashtable

### DIFF
--- a/src/multi.c
+++ b/src/multi.c
@@ -56,7 +56,7 @@ void freeClientMultiWatchedKeysByDB(client *c) {
 
     for (int i = 0; i < server.dbnum; i++) {
         if (c->mstate->watched_keys_by_db[i]) {
-            dictRelease(c->mstate->watched_keys_by_db[i]);
+            hashtableRelease(c->mstate->watched_keys_by_db[i]);
             c->mstate->watched_keys_by_db[i] = NULL;
         }
     }
@@ -319,6 +319,22 @@ typedef struct watchedKey {
     unsigned expired : 1; /* Flag that we're watching an already expired key. */
 } watchedKey;
 
+/* Callback used for watchedKeysHashtableType where the entries are watchedKey *
+ * and it already contains the key. */
+static const void *watchedKeyGetKey(const void *entry) {
+    const watchedKey *wk = entry;
+    return wk->key;
+}
+
+/* Hashtable type for client's per-db watched keys lookup.
+ * Entries are watchedKey* stored directly, no destructor needed since the
+ * actual memory is managed by the multiState->watched_keys list. */
+hashtableType watchedKeysHashtableType = {
+    .entryGetKey = watchedKeyGetKey,
+    .hashFunction = dictEncObjHash,
+    .keyCompare = hashtableEncObjKeyCompare,
+};
+
 /* Attach a watchedKey to the list of clients watching that key. */
 static inline void watchedKeyLinkToClients(list *clients, watchedKey *wk) {
     wk->node.value = clients;             /* Point the value back to the list */
@@ -343,18 +359,18 @@ void watchForKey(client *c, robj *key) {
 
     if (listLength(&c->mstate->watched_keys) == 0) server.watching_clients++;
 
-    /* Lazily allocate the per-db dict array. */
+    /* Lazily allocate the per-db hashtable array. */
     if (c->mstate->watched_keys_by_db == NULL) {
-        c->mstate->watched_keys_by_db = zcalloc(sizeof(dict *) * server.dbnum);
+        c->mstate->watched_keys_by_db = zcalloc(sizeof(hashtable *) * server.dbnum);
     }
 
-    /* Lazily allocate the dict for this specific db. */
+    /* Lazily allocate the hashtable for this specific db. */
     if (c->mstate->watched_keys_by_db[c->db->id] == NULL) {
-        c->mstate->watched_keys_by_db[c->db->id] = dictCreate(&watchedKeysDictType);
+        c->mstate->watched_keys_by_db[c->db->id] = hashtableCreate(&watchedKeysHashtableType);
     }
 
     /* Check if we are already watching for this key */
-    if (dictFind(c->mstate->watched_keys_by_db[c->db->id], key) != NULL) {
+    if (hashtableFind(c->mstate->watched_keys_by_db[c->db->id], key, NULL)) {
         return; /* Key already watched */
     }
 
@@ -376,8 +392,8 @@ void watchForKey(client *c, robj *key) {
     listAddNodeTail(&c->mstate->watched_keys, wk);
     watchedKeyLinkToClients(clients, wk);
 
-    /* Add to the per-db dict for O(1) lookup. Key is borrowed from wk->key. */
-    dictAdd(c->mstate->watched_keys_by_db[c->db->id], wk->key, wk);
+    /* Add the new key to the per-db hashtable for O(1) lookup. */
+    hashtableAdd(c->mstate->watched_keys_by_db[c->db->id], wk);
 }
 
 /* Unwatch all the keys watched by this client. To clean the EXEC dirty
@@ -405,11 +421,11 @@ void unwatchAllKeys(client *c) {
         zfree(wk);
     }
 
-    /* Empty the per-db dicts as we have unwatched all keys. */
+    /* Empty the per-db hashtables as we have unwatched all keys. */
     if (c->mstate->watched_keys_by_db) {
         for (int i = 0; i < server.dbnum; i++) {
             if (c->mstate->watched_keys_by_db[i]) {
-                dictEmpty(c->mstate->watched_keys_by_db[i], NULL);
+                hashtableEmpty(c->mstate->watched_keys_by_db[i], NULL);
             }
         }
     }
@@ -553,12 +569,12 @@ size_t multiStateMemOverhead(client *c) {
     /* Add watched keys overhead, Note: this doesn't take into account the watched keys themselves, because they aren't
      * managed per-client. */
     mem += listLength(&c->mstate->watched_keys) * (sizeof(listNode) + sizeof(c->mstate->watched_keys));
-    /* Add per-db watched keys dict overhead. */
+    /* Add per-db watched keys hashtable overhead. */
     if (c->mstate->watched_keys_by_db) {
-        mem += sizeof(dict *) * server.dbnum;
+        mem += sizeof(hashtable *) * server.dbnum;
         for (int i = 0; i < server.dbnum; i++) {
             if (c->mstate->watched_keys_by_db[i]) {
-                mem += dictMemUsage(c->mstate->watched_keys_by_db[i]);
+                mem += hashtableMemUsage(c->mstate->watched_keys_by_db[i]);
             }
         }
     }

--- a/src/multi.c
+++ b/src/multi.c
@@ -51,12 +51,26 @@ void freeClientMultiStateCmds(client *c) {
     c->mstate->commands = NULL;
 }
 
+void freeClientMultiWatchedKeysByDB(client *c) {
+    if (!c->mstate || !c->mstate->watched_keys_by_db) return;
+
+    for (int i = 0; i < server.dbnum; i++) {
+        if (c->mstate->watched_keys_by_db[i]) {
+            dictRelease(c->mstate->watched_keys_by_db[i]);
+            c->mstate->watched_keys_by_db[i] = NULL;
+        }
+    }
+    zfree(c->mstate->watched_keys_by_db);
+    c->mstate->watched_keys_by_db = NULL;
+}
+
 /* Release all the resources associated with MULTI/EXEC state */
 void freeClientMultiState(client *c) {
     if (!c->mstate) return;
 
     freeClientMultiStateCmds(c);
     unwatchAllKeys(c);
+    freeClientMultiWatchedKeysByDB(c);
     zfree(c->mstate);
     c->mstate = NULL;
 }
@@ -325,18 +339,25 @@ static inline listNode *watchedKeyGetClientNode(watchedKey *wk) {
 /* Watch for the specified key */
 void watchForKey(client *c, robj *key) {
     list *clients = NULL;
-    listIter li;
-    listNode *ln;
     watchedKey *wk;
 
     if (listLength(&c->mstate->watched_keys) == 0) server.watching_clients++;
 
-    /* Check if we are already watching for this key */
-    listRewind(&c->mstate->watched_keys, &li);
-    while ((ln = listNext(&li))) {
-        wk = listNodeValue(ln);
-        if (wk->db == c->db && equalStringObjects(key, wk->key)) return; /* Key already watched */
+    /* Lazily allocate the per-db dict array. */
+    if (c->mstate->watched_keys_by_db == NULL) {
+        c->mstate->watched_keys_by_db = zcalloc(sizeof(dict *) * server.dbnum);
     }
+
+    /* Lazily allocate the dict for this specific db. */
+    if (c->mstate->watched_keys_by_db[c->db->id] == NULL) {
+        c->mstate->watched_keys_by_db[c->db->id] = dictCreate(&watchedKeysDictType);
+    }
+
+    /* Check if we are already watching for this key */
+    if (dictFind(c->mstate->watched_keys_by_db[c->db->id], key) != NULL) {
+        return; /* Key already watched */
+    }
+
     /* This key is not already watched in this DB. Let's add it */
     clients = dictFetchValue(c->db->watched_keys, key);
     if (!clients) {
@@ -344,6 +365,7 @@ void watchForKey(client *c, robj *key) {
         dictAdd(c->db->watched_keys, key, clients);
         incrRefCount(key);
     }
+
     /* Add the new key to the list of keys watched by this client */
     wk = zmalloc(sizeof(*wk));
     wk->key = key;
@@ -353,6 +375,9 @@ void watchForKey(client *c, robj *key) {
     incrRefCount(key);
     listAddNodeTail(&c->mstate->watched_keys, wk);
     watchedKeyLinkToClients(clients, wk);
+
+    /* Add to the per-db dict for O(1) lookup. Key is borrowed from wk->key. */
+    dictAdd(c->mstate->watched_keys_by_db[c->db->id], wk->key, wk);
 }
 
 /* Unwatch all the keys watched by this client. To clean the EXEC dirty
@@ -379,6 +404,16 @@ void unwatchAllKeys(client *c) {
         decrRefCount(wk->key);
         zfree(wk);
     }
+
+    /* Empty the per-db dicts as we have unwatched all keys. */
+    if (c->mstate->watched_keys_by_db) {
+        for (int i = 0; i < server.dbnum; i++) {
+            if (c->mstate->watched_keys_by_db[i]) {
+                dictEmpty(c->mstate->watched_keys_by_db[i], NULL);
+            }
+        }
+    }
+
     server.watching_clients--;
 }
 
@@ -518,6 +553,15 @@ size_t multiStateMemOverhead(client *c) {
     /* Add watched keys overhead, Note: this doesn't take into account the watched keys themselves, because they aren't
      * managed per-client. */
     mem += listLength(&c->mstate->watched_keys) * (sizeof(listNode) + sizeof(c->mstate->watched_keys));
+    /* Add per-db watched keys dict overhead. */
+    if (c->mstate->watched_keys_by_db) {
+        mem += sizeof(dict *) * server.dbnum;
+        for (int i = 0; i < server.dbnum; i++) {
+            if (c->mstate->watched_keys_by_db[i]) {
+                mem += dictMemUsage(c->mstate->watched_keys_by_db[i]);
+            }
+        }
+    }
     /* Reserved memory for queued multi commands. */
     mem += c->mstate->alloc_count * sizeof(multiCmd);
     return mem;

--- a/src/server.c
+++ b/src/server.c
@@ -714,18 +714,6 @@ dictType objToHashtableDictType = {
     NULL                     /* allow to expand */
 };
 
-/* Dict type for client's per-db watched keys lookup.
- * Keys are robj* (borrowed, not owned), values are watchedKey* (also borrowed).
- * No destructors needed since the actual memory is managed by the watched_keys list. */
-dictType watchedKeysDictType = {
-    dictObjHash,       /* hash function */
-    NULL,              /* key dup */
-    dictObjKeyCompare, /* key compare */
-    NULL,              /* key destructor - key is borrowed from watchedKey->key */
-    NULL,              /* val destructor - val is borrowed watchedKey pointer */
-    NULL               /* allow to expand */
-};
-
 /* Callback used for hash tables where the entries are dicts and the key
  * (channel name) is stored in each dict's metadata. */
 const void *hashtableChannelsGetKey(const void *entry) {

--- a/src/server.c
+++ b/src/server.c
@@ -714,6 +714,18 @@ dictType objToHashtableDictType = {
     NULL                     /* allow to expand */
 };
 
+/* Dict type for client's per-db watched keys lookup.
+ * Keys are robj* (borrowed, not owned), values are watchedKey* (also borrowed).
+ * No destructors needed since the actual memory is managed by the watched_keys list. */
+dictType watchedKeysDictType = {
+    dictObjHash,       /* hash function */
+    NULL,              /* key dup */
+    dictObjKeyCompare, /* key compare */
+    NULL,              /* key destructor - key is borrowed from watchedKey->key */
+    NULL,              /* val destructor - val is borrowed watchedKey pointer */
+    NULL               /* allow to expand */
+};
+
 /* Callback used for hash tables where the entries are dicts and the key
  * (channel name) is stored in each dict's metadata. */
 const void *hashtableChannelsGetKey(const void *entry) {
@@ -728,7 +740,7 @@ void hashtableChannelsDestructor(void *entry) {
     hashtableRelease(ht);
 }
 
-/* Similar to objToDictDictType, but changed to hashtable and added some kvstore
+/* Similar to objToHashtableDictType, but changed to hashtable and added some kvstore
  * callbacks, it's used for PUBSUB command to track clients subscribing the
  * channels. The elements are dicts where the keys are clients. The metadata in
  * each dict stores a pointer to the channel name. */

--- a/src/server.h
+++ b/src/server.h
@@ -974,18 +974,21 @@ typedef struct multiCmd {
 } multiCmd;
 
 typedef struct multiState {
-    multiCmd *commands;   /* Array of MULTI commands */
-    int count;            /* Total number of MULTI commands */
-    int cmd_flags;        /* The accumulated command flags OR-ed together.
-                             So if at least a command has a given flag, it
-                             will be set in this field. */
-    int cmd_inv_flags;    /* Same as cmd_flags, OR-ing the ~flags. so that it
-                             is possible to know if all the commands have a
-                             certain flag. */
-    size_t argv_len_sums; /* mem used by all commands arguments */
-    int alloc_count;      /* total number of multiCmd struct memory reserved. */
-    list watched_keys;
-    int transaction_db_id; /* Currently SELECTed DB id in transaction context */
+    multiCmd *commands;        /* Array of MULTI commands */
+    int count;                 /* Total number of MULTI commands */
+    int cmd_flags;             /* The accumulated command flags OR-ed together.
+                                  So if at least a command has a given flag, it
+                                  will be set in this field. */
+    int cmd_inv_flags;         /* Same as cmd_flags, OR-ing the ~flags. so that it
+                                  is possible to know if all the commands have a
+                                  certain flag. */
+    size_t argv_len_sums;      /* mem used by all commands arguments */
+    int alloc_count;           /* total number of multiCmd struct memory reserved. */
+    list watched_keys;         /* List of watchedKey for iteration and cleanup. */
+    dict **watched_keys_by_db; /* Per-db dict for O(1) watched key lookup.
+                                  Array of size server.dbnum, lazily allocated.
+                                  Each dict maps key -> watchedKey*. */
+    int transaction_db_id;     /* Currently SELECTed DB id in transaction context */
 } multiState;
 
 /* This structure holds the blocking operation state for a client.
@@ -2802,7 +2805,6 @@ extern dictType objectKeyPointerValueDictType;
 extern hashtableType objectHashtableType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern hashtableType setHashtableType;
-extern dictType BenchmarkDictType;
 extern hashtableType zsetHashtableType;
 extern hashtableType kvstoreKeysHashtableType;
 extern hashtableType kvstoreExpiresHashtableType;
@@ -2813,11 +2815,11 @@ extern dictType stringSetDictType;
 extern dictType externalStringType;
 extern dictType sdsHashDictType;
 extern hashtableType clientHashtableType;
-extern dictType objToDictDictType;
 extern hashtableType kvstoreChannelHashtableType;
 extern dictType modulesDictType;
 extern hashtableType sdsReplyHashtableType;
 extern dictType keylistDictType;
+extern dictType watchedKeysDictType;
 extern dict *modules;
 
 /*-----------------------------------------------------------------------------

--- a/src/server.h
+++ b/src/server.h
@@ -974,21 +974,21 @@ typedef struct multiCmd {
 } multiCmd;
 
 typedef struct multiState {
-    multiCmd *commands;        /* Array of MULTI commands */
-    int count;                 /* Total number of MULTI commands */
-    int cmd_flags;             /* The accumulated command flags OR-ed together.
-                                  So if at least a command has a given flag, it
-                                  will be set in this field. */
-    int cmd_inv_flags;         /* Same as cmd_flags, OR-ing the ~flags. so that it
-                                  is possible to know if all the commands have a
-                                  certain flag. */
-    size_t argv_len_sums;      /* mem used by all commands arguments */
-    int alloc_count;           /* total number of multiCmd struct memory reserved. */
-    list watched_keys;         /* List of watchedKey for iteration and cleanup. */
-    dict **watched_keys_by_db; /* Per-db dict for O(1) watched key lookup.
-                                  Array of size server.dbnum, lazily allocated.
-                                  Each dict maps key -> watchedKey*. */
-    int transaction_db_id;     /* Currently SELECTed DB id in transaction context */
+    multiCmd *commands;             /* Array of MULTI commands */
+    int count;                      /* Total number of MULTI commands */
+    int cmd_flags;                  /* The accumulated command flags OR-ed together.
+                                       So if at least a command has a given flag, it
+                                       will be set in this field. */
+    int cmd_inv_flags;              /* Same as cmd_flags, OR-ing the ~flags. so that it
+                                       is possible to know if all the commands have a
+                                       certain flag. */
+    size_t argv_len_sums;           /* mem used by all commands arguments */
+    int alloc_count;                /* total number of multiCmd struct memory reserved. */
+    list watched_keys;              /* List of watchedKey for iteration and cleanup. */
+    hashtable **watched_keys_by_db; /* Per-db hashtable for O(1) watched key lookup.
+                                       Array of size server.dbnum, lazily allocated.
+                                       Each hashtable stores watchedKey* directly. */
+    int transaction_db_id;          /* Currently SELECTed DB id in transaction context */
 } multiState;
 
 /* This structure holds the blocking operation state for a client.
@@ -2819,7 +2819,6 @@ extern hashtableType kvstoreChannelHashtableType;
 extern dictType modulesDictType;
 extern hashtableType sdsReplyHashtableType;
 extern dictType keylistDictType;
-extern dictType watchedKeysDictType;
 extern dict *modules;
 
 /*-----------------------------------------------------------------------------
@@ -3886,8 +3885,10 @@ void startEvictionTimeProc(void);
 /* Keys hashing/comparison functions for dict.c and hashtable.c hash tables. */
 uint64_t dictSdsHash(const void *key);
 uint64_t dictSdsCaseHash(const void *key);
+uint64_t dictEncObjHash(const void *key);
 int dictSdsKeyCompare(const void *key1, const void *key2);
 int hashtableSdsKeyCompare(const void *key1, const void *key2);
+int hashtableEncObjKeyCompare(const void *key1, const void *key2);
 int dictSdsKeyCaseCompare(const void *key1, const void *key2);
 void dictSdsDestructor(void *val);
 void dictListDestructor(void *val);

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -420,7 +420,7 @@ start_server {tags {"multi"}} {
     test {WATCH with large number of keys} {
         set elements {}
         for {set i 0} {$i < 50000} {incr i} {
-            lappend elements key-$i
+            lappend elements key{t}-$i
         }
         r watch {*}$elements
         r watch {*}$elements

--- a/tests/unit/multi.tcl
+++ b/tests/unit/multi.tcl
@@ -370,6 +370,66 @@ start_server {tags {"multi"}} {
         r exec
     } {}
 
+    test {WATCH same key multiple times should be fine} {
+        r set x 10
+        r watch x
+        r watch x x
+        r watch x x x
+        assert_equal 1 [get_field_in_client_info [r client info] "watch"]
+        r multi
+        r incr x
+        r exec
+        assert_equal {11} [r get x]
+        assert_equal 0 [get_field_in_client_info [r client info] "watch"]
+    }
+
+    test {WATCH same key name in different DBs} {
+        set rd0 [valkey_client]
+        set rd1 [valkey_client]
+
+        # Set up two keys with the same name in different DBs
+        r select 0
+        r set key value
+        r select 1
+        r set key value
+
+        # rd0 and rd1 are watching the same key in different DBs
+        $rd0 select 0
+        $rd0 watch key
+        $rd0 multi
+        $rd1 select 1
+        $rd1 watch key
+        $rd1 multi
+
+        # Modify key in DB 0, should only affect DB 0's watch, that is, only affect rd0
+        r select 0
+        r set key modified
+
+        # Transaction should fail because key in DB 0 was touched
+        $rd0 set key new_value
+        assert_equal {} [$rd0 exec]
+
+        # Transaction should succeed because key in DB 1 was not touched
+        $rd1 set key new_value
+        assert_equal {OK} [$rd1 exec]
+
+        $rd0 close
+        $rd1 close
+    } {0} {singledb:skip}
+
+    test {WATCH with large number of keys} {
+        set elements {}
+        for {set i 0} {$i < 50000} {incr i} {
+            lappend elements key-$i
+        }
+        r watch {*}$elements
+        r watch {*}$elements
+        assert_equal 50000 [get_field_in_client_info [r client info] "watch"]
+
+        r unwatch
+        assert_equal 0 [get_field_in_client_info [r client info] "watch"]
+    }
+
     test {DISCARD should clear the WATCH dirty flag on the client} {
         r watch x
         r set x 10


### PR DESCRIPTION
Previously, watchForKey() checked for duplicate watched keys by iterating
through the client's entire watched_keys list with O(N) complexity, where
N is the total number of keys watched by the client. So the time complexity
for the WATCH command could be quite poor and become a slow command.

This commit introduces a per-db hashtable (watched_keys_by_db) in the
client's multiState structure to enable O(1) duplicate key detection.
The hashtable is lazily allocated only when the client starts watching
keys, minimizing memory overhead for clients that don't use WATCH.

The per-db hashtable stores watchedKey* directly as the hashtable entry
since it already contains the key, so no custom destructors are needed.
Memory management remains centralized in the watched_keys list.

This optimization is especially beneficial when a client watches many
keys across different databases, as the check no longer scales with
the total watched key count.

This might be a minor scenario, but there's no harm in optimizing it.

There is a test in multi.tcl, before this patch, it took 15s, and after
this patch, it only took 50ms.
```
        set elements {}
        for {set i 0} {$i < 50000} {incr i} {
            lappend elements key-$i
        }
        r watch {*}$elements
        r watch {*}$elements
```