### PR TITLE
Make macOS leaks check skippable

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1595,10 +1595,10 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --verbose --clients 1 --no-latency --dump-logs --leaks ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
-        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
+        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs --leaks ${{github.event.inputs.test_args}}
   test-macos-latest-sentinel:
     runs-on: macos-latest
     if: |
@@ -1637,7 +1637,7 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
-        run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
+        run: ./runtest-sentinel --leaks ${{github.event.inputs.cluster_test_args}}
   test-macos-latest-cluster:
     runs-on: macos-latest
     if: |
@@ -1676,7 +1676,7 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: cluster tests
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
-        run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
+        run: ./runtest-cluster --leaks ${{github.event.inputs.cluster_test_args}}
   build-old-macos-versions:
     strategy:
       fail-fast: false

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1595,10 +1595,10 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: test
         if: true && !contains(github.event.inputs.skiptests, 'valkey')
-        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --verbose --clients 1 --no-latency --dump-logs --leaks ${{github.event.inputs.test_args}}
+        run: ./runtest ${{ github.event_name != 'pull_request' && '--accurate' || '' }} --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
       - name: module api test
         if: true && !contains(github.event.inputs.skiptests, 'modules')
-        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs --leaks ${{github.event.inputs.test_args}}
+        run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --clients 1 --no-latency --dump-logs ${{github.event.inputs.test_args}}
   test-macos-latest-sentinel:
     runs-on: macos-latest
     if: |
@@ -1637,7 +1637,7 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: sentinel tests
         if: true && !contains(github.event.inputs.skiptests, 'sentinel')
-        run: ./runtest-sentinel --leaks ${{github.event.inputs.cluster_test_args}}
+        run: ./runtest-sentinel ${{github.event.inputs.cluster_test_args}}
   test-macos-latest-cluster:
     runs-on: macos-latest
     if: |
@@ -1676,7 +1676,7 @@ jobs:
         run: make SERVER_CFLAGS='-Werror' USE_LIBBACKTRACE=yes
       - name: cluster tests
         if: true && !contains(github.event.inputs.skiptests, 'cluster')
-        run: ./runtest-cluster --leaks ${{github.event.inputs.cluster_test_args}}
+        run: ./runtest-cluster ${{github.event.inputs.cluster_test_args}}
   build-old-macos-versions:
     strategy:
       fail-fast: false

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -19,6 +19,7 @@ set ::valgrind 0
 set ::tls 0
 set ::tls_module 0
 set ::io_threads 0
+set ::leaks 0
 set ::pause_on_error 0
 set ::dont_clean 0
 set ::simulate_error 0
@@ -285,6 +286,8 @@ proc parse_options {} {
             set ::dont_clean 1
         } elseif {$opt eq "--fail"} {
             set ::simulate_error 1
+        } elseif {$opt eq {--leaks}} {
+            set ::leaks 1
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
         } elseif {$opt eq {--host}} {
@@ -321,6 +324,7 @@ proc parse_options {} {
             puts "--dont-clean            Keep log files on exit."
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
+            puts "--leaks                 Enable macOS leaks verification."
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
             puts "--tls-module            Run tests in TLS mode with Valkey module."
@@ -444,7 +448,7 @@ proc test {descr code} {
 
 # Check memory leaks when running on macOS using the "leaks" utility.
 proc check_leaks instance_types {
-    if {[string match {*Darwin*} [exec uname -a]]} {
+    if {$::leaks && [string match {*Darwin*} [exec uname -a]]} {
         puts -nonewline "Testing for memory leaks..."; flush stdout
         foreach type $instance_types {
             foreach_instance_id [set ::${type}_instances] id {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -286,7 +286,7 @@ proc parse_options {} {
             set ::dont_clean 1
         } elseif {$opt eq "--fail"} {
             set ::simulate_error 1
-        } elseif {$opt eq {--no-leaks}} {
+        } elseif {$opt eq {--skip-leaks}} {
             set ::leaks 0
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
@@ -324,7 +324,7 @@ proc parse_options {} {
             puts "--dont-clean            Keep log files on exit."
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
-            puts "--no-leaks              Disable macOS leaks verification."
+            puts "--skip-leaks            Disable macOS leaks verification."
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
             puts "--tls-module            Run tests in TLS mode with Valkey module."

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -19,7 +19,7 @@ set ::valgrind 0
 set ::tls 0
 set ::tls_module 0
 set ::io_threads 0
-set ::leaks 0
+set ::leaks 1
 set ::pause_on_error 0
 set ::dont_clean 0
 set ::simulate_error 0
@@ -286,8 +286,8 @@ proc parse_options {} {
             set ::dont_clean 1
         } elseif {$opt eq "--fail"} {
             set ::simulate_error 1
-        } elseif {$opt eq {--leaks}} {
-            set ::leaks 1
+        } elseif {$opt eq {--no-leaks}} {
+            set ::leaks 0
         } elseif {$opt eq {--valgrind}} {
             set ::valgrind 1
         } elseif {$opt eq {--host}} {
@@ -324,7 +324,7 @@ proc parse_options {} {
             puts "--dont-clean            Keep log files on exit."
             puts "--pause-on-error        Pause for manual inspection on error."
             puts "--fail                  Simulate a test failure."
-            puts "--leaks                 Enable macOS leaks verification."
+            puts "--no-leaks              Disable macOS leaks verification."
             puts "--valgrind              Run with valgrind."
             puts "--tls                   Run tests in TLS mode."
             puts "--tls-module            Run tests in TLS mode with Valkey module."

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -77,7 +77,7 @@ proc kill_server config {
     }
 
     # check for leaks
-    if {![dict exists $config "skipleaks"]} {
+    if {$::leaks && ![dict exists $config "skipleaks"]} {
         catch {
             if {[string match {*Darwin*} [exec uname -a]]} {
                 tags {"leaks"} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -55,6 +55,7 @@ set ::durable 0
 set ::tls 0
 set ::io_threads 0
 set ::tls_module 0
+set ::leaks 0
 set ::stack_logging 0
 set ::verbose 0
 set ::quiet 0
@@ -664,9 +665,10 @@ proc print_help_screen {} {
         "                   with all tests."
         "--moduleapi        Run the module API tests, this option should only be used in"
         "                   runtest-moduleapi which will build the test module."
+        "--leaks            Enable macOS leaks verification."
         "--valgrind         Run the test over valgrind."
         "--durable          suppress test crashes and keep running"
-        "--stack-logging    Enable macOS leaks/malloc stack logging."
+        "--stack-logging    Enable macOS leaks/malloc stack logging (implies --leaks)."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
         "--single <unit>    Just execute the specified unit (see next option). This"
@@ -764,10 +766,13 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--skiptest}} {
         lappend ::skiptests $arg
         incr j
+    } elseif {$opt eq {--leaks}} {
+        set ::leaks 1
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
     } elseif {$opt eq {--stack-logging}} {
         if {[string match {*Darwin*} [exec uname -a]]} {
+            set ::leaks 1
             set ::stack_logging 1
         }
     } elseif {$opt eq {--quiet}} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -55,7 +55,7 @@ set ::durable 0
 set ::tls 0
 set ::io_threads 0
 set ::tls_module 0
-set ::leaks 0
+set ::leaks 1
 set ::stack_logging 0
 set ::verbose 0
 set ::quiet 0
@@ -665,10 +665,10 @@ proc print_help_screen {} {
         "                   with all tests."
         "--moduleapi        Run the module API tests, this option should only be used in"
         "                   runtest-moduleapi which will build the test module."
-        "--leaks            Enable macOS leaks verification."
+        "--no-leaks         Disable macOS leaks verification."
         "--valgrind         Run the test over valgrind."
         "--durable          suppress test crashes and keep running"
-        "--stack-logging    Enable macOS leaks/malloc stack logging (implies --leaks)."
+        "--stack-logging    Enable macOS leaks/malloc stack logging."
         "--accurate         Run slow randomized tests for more iterations."
         "--quiet            Don't show individual tests."
         "--single <unit>    Just execute the specified unit (see next option). This"
@@ -766,8 +766,8 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--skiptest}} {
         lappend ::skiptests $arg
         incr j
-    } elseif {$opt eq {--leaks}} {
-        set ::leaks 1
+    } elseif {$opt eq {--no-leaks}} {
+        set ::leaks 0
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1
     } elseif {$opt eq {--stack-logging}} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -665,7 +665,7 @@ proc print_help_screen {} {
         "                   with all tests."
         "--moduleapi        Run the module API tests, this option should only be used in"
         "                   runtest-moduleapi which will build the test module."
-        "--no-leaks         Disable macOS leaks verification."
+        "--skip-leaks       Disable macOS leaks verification."
         "--valgrind         Run the test over valgrind."
         "--durable          suppress test crashes and keep running"
         "--stack-logging    Enable macOS leaks/malloc stack logging."
@@ -766,7 +766,7 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     } elseif {$opt eq {--skiptest}} {
         lappend ::skiptests $arg
         incr j
-    } elseif {$opt eq {--no-leaks}} {
+    } elseif {$opt eq {--skip-leaks}} {
         set ::leaks 0
     } elseif {$opt eq {--valgrind}} {
         set ::valgrind 1


### PR DESCRIPTION
I've been recently developing on macOS and running the integration test takes a while due to the `leaks` check during the process teardown. I would like to have a mechanism to disable it.

This PR introduces a new config `--skip-leaks` for ./runtest* to skip memory leak checks during tear down of the process.

Without leaks check:
```
./runtest --single tests/unit/cluster/packet.tcl --skip-leaks
.
.
Execution time of different units:
  7 seconds - unit/cluster/packet
```

With leaks check:
```
./runtest --single tests/unit/cluster/packet.tcl
.
.
Execution time of different units:
  21 seconds - unit/cluster/packet
```