### PR TITLE
Ensure the daily workflow uses gtest-parallel to run unit tests in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           if [[ ! -z "$dirty" ]]; then echo "$dirty"; exit 1; fi
       - name: unit tests
         run: |
-          ./src/unit/valkey-unit-gtests
+          make test-unit
 
   test-ubuntu-latest-compatibility:
     runs-on: ubuntu-latest
@@ -116,8 +116,7 @@ jobs:
           ./utils/gen-test-certs.sh
           ./build-release/runtest --verbose --tags -slow --dump-logs --tls
       - name: unit tests
-        run: |
-          ./build-release/bin/valkey-unit-gtests
+        run: make -C build-release test-unit
 
   test-sanitizer-address:
     runs-on: ubuntu-latest
@@ -144,7 +143,7 @@ jobs:
         run: CFLAGS='-Werror' ./runtest-moduleapi --verbose --dump-logs
       - name: unit tests
         run: |
-          ./src/unit/valkey-unit-gtests
+          make test-unit
 
   test-rdma:
     runs-on: ubuntu-latest
@@ -283,7 +282,9 @@ jobs:
             GTEST_LIBS="/usr/lib32/libgtest.a /usr/lib32/libgmock.a"
       - name: unit tests
         run: |
-          ./src/unit/valkey-unit-gtests
+          make test-unit \
+            GTEST_CFLAGS="-I/usr/src/googletest/googletest/include -I/usr/src/googletest/googlemock/include" \
+            GTEST_LIBS="/usr/lib32/libgtest.a /usr/lib32/libgmock.a"
 
   build-libc-malloc:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -132,7 +132,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate
+            make test-unit accurate=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
@@ -218,7 +218,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate
+            make test-unit accurate=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
@@ -283,7 +283,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate
+            make test-unit accurate=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
@@ -464,7 +464,9 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate
+            make test-unit accurate=1 \
+              GTEST_CFLAGS="-I/usr/src/googletest/googletest/include -I/usr/src/googletest/googlemock/include" \
+              GTEST_LIBS="/usr/lib32/libgtest.a /usr/lib32/libgmock.a"
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
@@ -843,8 +845,8 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/unit/valkey-unit-gtests --valgrind
-            if grep -q 0x err.txt; then cat err.txt; exit 1; fi
+            ./deps/gtest-parallel/gtest-parallel valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
+            if grep -qlE '0x[0-9A-Fa-f]+:' err.*.txt 2>/dev/null; then grep -lE '0x[0-9A-Fa-f]+:' err.*.txt | xargs cat; exit 1; fi
           elif [ -f ./src/valkey-unit-tests ]; then
             valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/valkey-unit-tests --valgrind
             if grep -q 0x err.txt; then cat err.txt; exit 1; fi
@@ -931,8 +933,8 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/unit/valkey-unit-gtests --valgrind
-            if grep -q 0x err.txt; then cat err.txt; exit 1; fi
+            ./deps/gtest-parallel/gtest-parallel valgrind -- --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.%p.txt ./src/unit/valkey-unit-gtests --valgrind
+            if grep -qlE '0x[0-9A-Fa-f]+:' err.*.txt 2>/dev/null; then grep -lE '0x[0-9A-Fa-f]+:' err.*.txt | xargs cat; exit 1; fi
           elif [ -f ./src/valkey-unit-tests ]; then
             valgrind --track-origins=yes --suppressions=./src/valgrind.sup --show-reachable=no --show-possibly-lost=no --leak-check=full --log-file=err.txt ./src/valkey-unit-tests --valgrind
             if grep -q 0x err.txt; then cat err.txt; exit 1; fi
@@ -996,7 +998,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests
+            make test-unit
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests
           fi
@@ -1055,7 +1057,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --large-memory
+            make test-unit large_memory=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --large-memory
           fi
@@ -1134,7 +1136,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate
+            make test-unit accurate=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate
           fi
@@ -1193,7 +1195,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests --accurate --large-memory
+            make test-unit accurate=1 large_memory=1
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests --accurate --large-memory
           fi
@@ -1268,7 +1270,7 @@ jobs:
         if: true && !contains(github.event.inputs.skiptests, 'unittest')
         run: |
           if [ -f ./src/unit/valkey-unit-gtests ]; then
-            ./src/unit/valkey-unit-gtests
+            make test-unit
           elif [ -f ./src/valkey-unit-tests ]; then
             ./src/valkey-unit-tests
           fi

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -157,8 +157,14 @@ gtest_discover_tests(valkey-unit-gtests)
 
 # Add custom test target using gtest-parallel
 add_custom_target(test-unit
-    COMMAND python3 ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py $<TARGET_FILE:valkey-unit-gtests>
+    COMMAND sh -c "TEST_ARGS=''; \
+        [ -n \"$accurate\" ] && TEST_ARGS=\"$TEST_ARGS --accurate\"; \
+        [ -n \"$large_memory\" ] && TEST_ARGS=\"$TEST_ARGS --large-memory\"; \
+        [ -n \"$valgrind\" ] && TEST_ARGS=\"$TEST_ARGS --valgrind\"; \
+        [ -n \"$seed\" ] && TEST_ARGS=\"$TEST_ARGS --seed $seed\"; \
+        python3 ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest_parallel.py $<TARGET_FILE:valkey-unit-gtests> --gtest_filter=\"$UNIT_TEST_PATTERN\"* -- $TEST_ARGS"
     DEPENDS valkey-unit-gtests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running tests with gtest-parallel"
+    VERBATIM
 )

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -217,8 +217,9 @@ endif
 all: valkey-unit-gtests
 
 .PHONY: test-unit
+TEST_ARGS = $(if $(accurate),--accurate) $(if $(large_memory),--large-memory) $(if $(valgrind),--valgrind) $(if $(seed),--seed $(seed))
 test-unit: valkey-unit-gtests
-	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests
+	python3 ../../deps/gtest-parallel/gtest_parallel.py ./valkey-unit-gtests --gtest_filter=$(UNIT_TEST_PATTERN)* -- $(TEST_ARGS)
 	@printf '\033[32mAll UNIT TESTS PASSED!\033[0m\n'
 
 .PHONY: valgrind

--- a/src/unit/README.md
+++ b/src/unit/README.md
@@ -62,8 +62,7 @@ gtest unit tests that you can filter/play with:
    expected test class name
 
    ```bash
-   make valkey-unit-gtests
-   ./src/unit/valkey-unit-gtests --gtest_filter='TEST_CLASS_NAME.*'
+   make test-unit UNIT_TEST_PATTERN='TEST_CLASS_NAME.*'
    ```
 
 4. Running a subset of gtest unit tests in the test class, replace
@@ -71,8 +70,7 @@ gtest unit tests that you can filter/play with:
    with test name
 
    ```bash
-   make valkey-unit-gtests
-   ./src/unit/valkey-unit-gtests --gtest_filter='TEST_CLASS_NAME.TEST_NAME_PREFIX*'
+   make test-unit UNIT_TEST_PATTERN='TEST_CLASS_NAME.TEST_NAME_PREFIX*'
    ```
 
 5. Building and running with CMake
@@ -80,8 +78,7 @@ gtest unit tests that you can filter/play with:
    ```bash
    mkdir build-release && cd $_
    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/valkey -DBUILD_UNIT_GTESTS=yes
-   make valkey-unit-gtests
-   ./bin/valkey-unit-gtests
+   make test-unit
    ```
 
 6. Running disabled tests
@@ -99,13 +96,13 @@ gtest unit tests that you can filter/play with:
 
 The gtest framework supports several command-line flags to control test behavior:
 
-* `--accurate`: Indicates the test should use extra computation to more accurately validate the tests.
-* `--large-memory`: Indicates whether tests should use more than 100mb of memory.
-* `--valgrind`: A hint passed to tests to indicate that we are running under valgrind.
-* `--seed <number>`: Sets a specific random seed for reproducible test runs. All `rand()` calls will produce the same sequence with the same seed.
+* `accurate=1`: Indicates the test should use extra computation to more accurately validate the tests.
+* `large_memory=1`: Indicates whether tests should use more than 100mb of memory.
+* `valgrind=1`: A hint passed to tests to indicate that we are running under valgrind.
+* `seed=<number>`: Sets a specific random seed for reproducible test runs. All `rand()` calls will produce the same sequence with the same seed.
 
 Example usage:
 
 ```bash
-./src/unit/valkey-unit-gtests --accurate --large-memory --seed 12345
+make test-unit accurate=1 large_memory=1 seed=12345
 ```


### PR DESCRIPTION
The daily workflow was directly invoking the `valkey-unit-gtests` executable.  This results in sequential execution where one test can impact stability of other tests.  The intended invocation is to use gtest-parallel to ensure that the tests are executed in isolation.

Replace direct invocation of `valkey-unit-gtests` binary with `make test-unit`.

The `test-unit` target uses `gtest-parallel` for parallel test execution, gtest-parallel runs each test in a separate process, ensuring test isolation and preventing shared state between tests.

Daily workflow: https://github.com/harrylin98/valkey_forked/actions/runs/23270536943
