### PR TITLE
ci: include gtests in code coverage report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,6 +35,12 @@ jobs:
       - run: cd libbacktrace && ./configure && make && sudo make install
       - name: Checkout Valkey
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install gtest
+        run: |
+          git clone --depth 1 -b v1.17.x https://github.com/google/googletest.git
+          cmake -S googletest -B googletest/build
+          cmake --build googletest/build -- -j$(nproc)
+          sudo cmake --install googletest/build
       - name: Install lcov and run test
         run: |
           sudo apt-get install lcov tclx

--- a/src/Makefile
+++ b/src/Makefile
@@ -794,6 +794,7 @@ lcov:
 	@lcov --version
 	$(MAKE) gcov
 	@(set -e; cd ..; ./runtest)
+	$(MAKE) test-unit COVERAGE=1 COVERAGE_CFLAGS="-fprofile-arcs -ftest-coverage"
 	@geninfo -o valkey.info .
 	@genhtml --legend -o lcov-html valkey.info
 


### PR DESCRIPTION
The change includes running gtest unit tests in the code coverage report.