### PR TITLE
fix benchmark queue and reduce the total duration

### DIFF
--- a/.github/workflows/benchmark-on-label.yml
+++ b/.github/workflows/benchmark-on-label.yml
@@ -5,8 +5,8 @@ on:
     types: [labeled]
 
 concurrency:
-  group: ec2-al-2023-pr-benchmarking-arm64
-  cancel-in-progress: false
+  group: benchmark-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
 
 defaults:
   run:
@@ -110,7 +110,7 @@ jobs:
             --target-ip ${{ secrets.EC2_ARM64_IP }}
             --valkey-path "../valkey"
             --results-dir "results"
-            --runs 5
+            --runs 3
           )
 
           # Run benchmark


### PR DESCRIPTION
Previously, our workflow used a global concurrency group, which effectively limited execution to one running job and one pending job. Any additional requests were automatically canceled, preventing a true queue from forming.

We are now shifting to a model where we remove the concurrency restriction and allow jobs to queue directly on the self-hosted runner. This enables multiple workflow runs to be accepted and queued instead of being dropped.

While GitHub can accept workflow triggers at a high rate (e.g., hundreds per minute), the actual execution is still constrained by runner capacity, in our case, a single runner processing one job at a time.

However, queued jobs are subject to GitHub’s 24-hour timeout policy. This means any job that waits in the queue for more than 24 hours before starting will be automatically canceled (timedout).

In practical terms, this approach improves reliability by eliminating premature cancellations, but the effective queue size is still bounded by how many jobs the runner can process within a 24-hour window. we could increase the number of runners to run these in parallel.