### PR TITLE
Upload all benchmark artifacts including server logs 

### DIFF
--- a/.github/workflows/benchmark-on-label.yml
+++ b/.github/workflows/benchmark-on-label.yml
@@ -132,8 +132,7 @@ jobs:
         with:
           name: ${{ github.event.label.name }}-results
           path: |
-            ./valkey-perf-benchmark/results/${{ github.event.pull_request.merge_commit_sha }}/metrics.json
-            ./valkey-perf-benchmark/results/${{ github.event.pull_request.base.ref }}/metrics.json
+            ./valkey-perf-benchmark/results/
             comparison.md
 
       - name: Comment PR with results


### PR DESCRIPTION
Upload the entire results directory instead of only metrics JSON files. This includes server logs which are useful for debugging benchmark failures.