### PR TITLE
CLUSTERSCAN range bounded scanning across contiguous slots

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1824,24 +1824,18 @@ void clusterscanCommand(client *c) {
         }
     }
 
-    /* Scan the slot using scanGenericCommand */
-    sds cursor_prefix = sdscatfmt(sdsempty(), "%s-{%s}-", clusterscanFingerprint(), crc16_slot_table[slot]);
-    sds finished_cursor_prefix = NULL;
-
     /* If SLOT argument was provided or implied by MATCH, don't advance to next slot then return 0 cursor.
-     * Else, advance to next slot for full cluster scan */
+     * Else, scan continuous range of slots owned by this node */
+    int final_slot;
     if (input_slot != -1 || match_slot != -1) {
-        finished_cursor_prefix = sdsnew("");
+        final_slot = -1; /* Single slot scan */
     } else {
-        int next_slot = slot + 1;
-        if (next_slot >= CLUSTER_SLOTS) {
-            finished_cursor_prefix = sdsnew("");
-        } else {
-            finished_cursor_prefix = sdscatfmt(sdsempty(), "0-{%s}-", crc16_slot_table[next_slot]);
+        clusterNode *owner = getNodeBySlot(slot);
+        final_slot = slot;
+        while (final_slot + 1 < CLUSTER_SLOTS && getNodeBySlot(final_slot + 1) == owner) {
+            final_slot++;
         }
     }
 
-    scanGenericCommand(c, NULL, cursor, slot, cursor_prefix, finished_cursor_prefix);
-    sdsfree(cursor_prefix);
-    sdsfree(finished_cursor_prefix);
+    scanGenericCommand(c, NULL, cursor, slot, final_slot, clusterscanFingerprint());
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1768,8 +1768,21 @@ void clusterscanCommand(client *c) {
             int patlen = sdslen(pat);
             match_slot = (patlen == 1 && pat[0] == '*') ? -1 : patternHashSlot(pat, patlen);
             i++;
-        } else if ((!strcasecmp(opt, "count") || !strcasecmp(opt, "type")) && remaining >= 2) {
-            i++; /* Let scanGenericCommand parse this */
+        } else if (!strcasecmp(opt, "count") && remaining >= 2) {
+            long count;
+            if (getLongFromObjectOrReply(c, c->argv[i + 1], &count, NULL) != C_OK) return;
+            if (count < 1) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return;
+            }
+            i++;
+        } else if (!strcasecmp(opt, "type") && remaining >= 2) {
+            char *typename = objectGetVal(c->argv[i + 1]);
+            if (getObjectTypeByName(typename) == LLONG_MAX) {
+                addReplyErrorFormat(c, "unknown type name '%s'", typename);
+                return;
+            }
+            i++;
         } else {
             addReplyErrorObject(c, shared.syntaxerr);
             return;
@@ -1824,19 +1837,24 @@ void clusterscanCommand(client *c) {
         }
     }
 
-    /* If SLOT argument was provided or implied by MATCH, don't advance to next slot then return 0 cursor.
-     * Else, scan continuous range of slots owned by this node */
-    int final_slot;
-    if (input_slot != -1 || match_slot != -1) {
-        final_slot = -1; /* Single slot scan */
-    } else {
+    /* If SLOT argument was provided or implied by MATCH, scan only that slot.
+     * Otherwise, scan the continuous range of slots owned by this node. */
+    int final_slot = slot;
+    bool advance_to_next_slot = false;
+    if (input_slot == -1 && match_slot == -1) {
         clusterNode *owner = getNodeBySlot(slot);
-        final_slot = slot;
         while (final_slot + 1 < CLUSTER_SLOTS && getNodeBySlot(final_slot + 1) == owner) {
             final_slot++;
         }
+        advance_to_next_slot = true;
     }
 
     serverAssert(slot >= 0 && slot < CLUSTER_SLOTS);
-    scanGenericCommand(c, NULL, cursor, slot, final_slot, clusterscanFingerprint());
+    clusterScanCtx cluster_ctx = {
+        .slot = slot,
+        .final_slot = final_slot,
+        .advance_to_next_slot = advance_to_next_slot,
+        .fp = clusterscanFingerprint(),
+    };
+    scanGenericCommand(c, NULL, cursor, &cluster_ctx);
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1837,5 +1837,6 @@ void clusterscanCommand(client *c) {
         }
     }
 
+    serverAssert(slot >= 0 && slot < CLUSTER_SLOTS);
     scanGenericCommand(c, NULL, cursor, slot, final_slot, clusterscanFingerprint());
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1746,59 +1746,21 @@ void clusterscanCommand(client *c) {
 
     int slot;
     unsigned long long cursor;
-    int input_slot = -1;
-    int match_slot = -1;
+    scanOptions opts;
     int skip_scan = 0;
 
-    /* Parse all arguments together so that values of MATCH/COUNT/SLOT/TYPE are
-     * not mistaken for the option names.*/
-    for (int i = 2; i < c->argc; i++) {
-        int remaining = c->argc - i;
-        char *opt = objectGetVal(c->argv[i]);
-
-        if (!strcasecmp(opt, "slot") && remaining >= 2) {
-            if (input_slot != -1) {
-                addReplyError(c, "SLOT option can only be specified once");
-                return;
-            }
-            if ((input_slot = getSlotOrReply(c, c->argv[i + 1])) == -1) return;
-            i++;
-        } else if (!strcasecmp(opt, "match") && remaining >= 2) {
-            sds pat = objectGetVal(c->argv[i + 1]);
-            int patlen = sdslen(pat);
-            match_slot = (patlen == 1 && pat[0] == '*') ? -1 : patternHashSlot(pat, patlen);
-            i++;
-        } else if (!strcasecmp(opt, "count") && remaining >= 2) {
-            long count;
-            if (getLongFromObjectOrReply(c, c->argv[i + 1], &count, NULL) != C_OK) return;
-            if (count < 1) {
-                addReplyErrorObject(c, shared.syntaxerr);
-                return;
-            }
-            i++;
-        } else if (!strcasecmp(opt, "type") && remaining >= 2) {
-            char *typename = objectGetVal(c->argv[i + 1]);
-            if (getObjectTypeByName(typename) == LLONG_MAX) {
-                addReplyErrorFormat(c, "unknown type name '%s'", typename);
-                return;
-            }
-            i++;
-        } else {
-            addReplyErrorObject(c, shared.syntaxerr);
-            return;
-        }
-    }
+    if (parseScanOptionsOrReply(c, NULL, 2, true, &opts) != C_OK) return;
 
     /* SLOT and single slot MATCH target different slots hence conclude the scan */
-    skip_scan = input_slot != -1 && match_slot != -1 && input_slot != match_slot;
+    skip_scan = opts.input_slot != -1 && opts.match_slot != -1 && opts.input_slot != opts.match_slot;
 
     /* Handle cursor "0" case. If slot information is provided we return
      * the updated cursor to scan input slot, else scan from slot 0. */
     if (strcmp(objectGetVal(c->argv[1]), "0") == 0) {
-        if (input_slot != -1) {
-            slot = input_slot;
-        } else if (match_slot != -1) {
-            slot = match_slot; /* If match maps to a particular slot, start scan from there */
+        if (opts.input_slot != -1) {
+            slot = opts.input_slot;
+        } else if (opts.match_slot != -1) {
+            slot = opts.match_slot; /* If match maps to a particular slot, start scan from there */
         } else {
             slot = 0;
         }
@@ -1818,16 +1780,16 @@ void clusterscanCommand(client *c) {
             return;
         }
 
-        if (input_slot != -1 && slot != input_slot) {
+        if (opts.input_slot != -1 && slot != opts.input_slot) {
             addReplyError(c, "Cursor slot mismatch with SLOT argument");
             return;
         }
 
-        if (match_slot != -1 && slot != match_slot) {
+        if (opts.match_slot != -1 && slot != opts.match_slot) {
             /* Advance cursor to the slot matched by MATCH if required but do not go back. */
             addReplyArrayLen(c, 2);
-            if (!skip_scan && match_slot > slot) {
-                sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[match_slot]);
+            if (!skip_scan && opts.match_slot > slot) {
+                sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[opts.match_slot]);
                 addReplyBulkSds(c, new_cursor);
             } else {
                 addReplyBulkCString(c, "0");
@@ -1841,7 +1803,7 @@ void clusterscanCommand(client *c) {
      * Otherwise, scan the continuous range of slots owned by this node. */
     int final_slot = slot;
     bool advance_to_next_slot = false;
-    if (input_slot == -1 && match_slot == -1) {
+    if (opts.input_slot == -1 && opts.match_slot == -1) {
         clusterNode *owner = getNodeBySlot(slot);
         while (final_slot + 1 < CLUSTER_SLOTS && getNodeBySlot(final_slot + 1) == owner) {
             final_slot++;
@@ -1856,5 +1818,5 @@ void clusterscanCommand(client *c) {
         .advance_to_next_slot = advance_to_next_slot,
         .fp = clusterscanFingerprint(),
     };
-    scanGenericCommand(c, NULL, cursor, &cluster_ctx);
+    scanGenericCommandWithOptions(c, NULL, cursor, &opts, &cluster_ctx);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -1159,16 +1159,18 @@ char *getObjectTypeName(robj *o) {
  * In the case of a Hash object the function returns both the field and value
  * of every element on the Hash.
  *
- * slot, final_slot and fingerprint 'fp' are used during CLUSTERSCAN to scan
- * a specific slot or range of slots and to return the valid cursor to advance the scan.
+ * cluster_ctx is used during CLUSTERSCAN to scan a specific slot or range of
+ * slots and to return the valid cursor to advance the scan.
  */
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, int final_slot, const char *fp) {
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clusterScanCtx *cluster_ctx) {
     int i, j;
     long count = DEFAULT_SCAN_COMMAND_COUNT;
     sds pat = NULL;
     sds typename = NULL;
     long long type = LLONG_MAX;
     int patlen = 0, use_pattern = 0, only_keys = 0;
+    int slot = cluster_ctx ? cluster_ctx->slot : -1;
+    int final_slot = cluster_ctx ? cluster_ctx->final_slot : -1;
     vector result;
 
     /* Object must be NULL (to iterate keys names), or the type of the object
@@ -1297,12 +1299,18 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
         /* For regular SCAN in cluster mode, derive the slot from the pattern's hashtag. */
         if (slot == -1 && o == NULL && use_pattern && server.cluster_enabled) {
             slot = patternHashSlot(pat, patlen);
+            final_slot = slot;
+        }
+        if (slot >= 0) {
+            serverAssert(final_slot >= slot && final_slot < CLUSTER_SLOTS);
+        } else {
+            serverAssert(final_slot == -1);
         }
         do {
             /* In cluster mode there is a separate dictionary for each slot.
              * If cursor is empty, we should try exploring next non-empty slot. */
             if (o == NULL) {
-                cursor = kvstoreScan(c->db->keys, cursor, slot, final_slot >= 0 ? final_slot : slot, keysScanCallback, NULL, &data);
+                cursor = kvstoreScan(c->db->keys, cursor, slot, final_slot, keysScanCallback, NULL, &data);
             } else {
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
@@ -1360,19 +1368,16 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
     /* Step 3: Reply to the client. */
     addReplyArrayLen(c, 2);
 
-    /* Handle CLUSTERSCAN prefixing.
-     * final_slot < 0 means single-slot mode (user passed SLOT or single-slot MATCH);
-     * we return cursor "0" without advancing. final_slot >= 0 means range mode,
-     * where we advance to final_slot+1 so iteration moves to the next node. */
-    if (cursor == 0 && fp && final_slot >= 0 && final_slot + 1 < CLUSTER_SLOTS) {
+    /* Handle CLUSTERSCAN prefixing. */
+    if (cursor == 0 && cluster_ctx && cluster_ctx->advance_to_next_slot && final_slot + 1 < CLUSTER_SLOTS) {
         /* Range mode: advance to next slot outside the current node's range. */
         sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[final_slot + 1]);
         addReplyBulkSds(c, new_cursor);
-    } else if (fp && cursor != 0) {
+    } else if (cluster_ctx && cursor != 0) {
         /* Derive hashtag from the cursor's actual slot for resharding safety.
          * Works for single slot mode as well. */
         int actual_slot = (int)(cursor & (CLUSTER_SLOTS - 1));
-        sds new_cursor = sdscatfmt(sdsempty(), "%s-{%s}-%U", fp, crc16_slot_table[actual_slot], cursor);
+        sds new_cursor = sdscatfmt(sdsempty(), "%s-{%s}-%U", cluster_ctx->fp, crc16_slot_table[actual_slot], cursor);
         addReplyBulkSds(c, new_cursor);
     } else {
         addReplyBulkLongLong(c, cursor);
@@ -1394,7 +1399,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
 void scanCommand(client *c) {
     unsigned long long cursor;
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[1]), &cursor) == C_ERR) return;
-    scanGenericCommand(c, NULL, cursor, -1, -1, NULL);
+    scanGenericCommand(c, NULL, cursor, NULL);
 }
 
 void dbsizeCommand(client *c) {

--- a/src/db.c
+++ b/src/db.c
@@ -37,6 +37,7 @@
 #include "module.h"
 #include "vector.h"
 #include "expire.h"
+#include "crc16_slottable.h"
 
 /*-----------------------------------------------------------------------------
  * C-level DB API
@@ -1158,10 +1159,10 @@ char *getObjectTypeName(robj *o) {
  * In the case of a Hash object the function returns both the field and value
  * of every element on the Hash.
  *
- * slot, cursor_prefix and finished_cursor_prefix are used during CLUSTERSCAN to scan
- * a specific slot and to return the valid cursor to advance the scan.
+ * slot, final_slot and fingerprint 'fp' are used during CLUSTERSCAN to scan
+ * a specific slot or range of slots and to return the valid cursor to advance the scan.
  */
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, sds cursor_prefix, sds finished_cursor_prefix) {
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, int final_slot, const char *fp) {
     int i, j;
     long count = DEFAULT_SCAN_COMMAND_COUNT;
     sds pat = NULL;
@@ -1304,7 +1305,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
             /* In cluster mode there is a separate dictionary for each slot.
              * If cursor is empty, we should try exploring next non-empty slot. */
             if (o == NULL) {
-                cursor = kvstoreScan(c->db->keys, cursor, onlydidx, keysScanCallback, NULL, &data);
+                cursor = kvstoreScan(c->db->keys, cursor, onlydidx, final_slot, keysScanCallback, NULL, &data);
             } else {
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
@@ -1363,11 +1364,15 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
     addReplyArrayLen(c, 2);
 
     /* Handle CLUSTERSCAN prefixing */
-    if (cursor == 0 && finished_cursor_prefix) {
-        sds new_cursor = sdscatfmt(sdsempty(), "%S%U", finished_cursor_prefix, cursor);
+    if (cursor == 0 && fp && final_slot >= 0 && final_slot + 1 < CLUSTER_SLOTS) {
+        /* Range mode: advance to next slot outside the current node's range. */
+        sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[final_slot + 1]);
         addReplyBulkSds(c, new_cursor);
-    } else if (cursor_prefix) {
-        sds new_cursor = sdscatfmt(sdsempty(), "%S%U", cursor_prefix, cursor);
+    } else if (fp && cursor != 0) {
+        /* Derive hashtag from the cursor's actual slot for resharding safety.
+         * Works for single slot mode as well. */
+        int actual_slot = (int)(cursor & (CLUSTER_SLOTS - 1));
+        sds new_cursor = sdscatfmt(sdsempty(), "%s-{%s}-%U", fp, crc16_slot_table[actual_slot], cursor);
         addReplyBulkSds(c, new_cursor);
     } else {
         addReplyBulkLongLong(c, cursor);
@@ -1389,7 +1394,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
 void scanCommand(client *c) {
     unsigned long long cursor;
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[1]), &cursor) == C_ERR) return;
-    scanGenericCommand(c, NULL, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, NULL, cursor, -1, -1, NULL);
 }
 
 void dbsizeCommand(client *c) {
@@ -2259,7 +2264,7 @@ unsigned long long dbSize(serverDb *db) {
 }
 
 unsigned long long dbScan(serverDb *db, unsigned long long cursor, kvstoreScanFunction scan_cb, void *privdata) {
-    return kvstoreScan(db->keys, cursor, -1, scan_cb, NULL, privdata);
+    return kvstoreScan(db->keys, cursor, -1, -1, scan_cb, NULL, privdata);
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/db.c
+++ b/src/db.c
@@ -1171,7 +1171,7 @@ int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, 
             opts->pat = objectGetVal(c->argv[i + 1]);
             opts->patlen = sdslen(opts->pat);
             opts->use_pattern = !(opts->patlen == 1 && opts->pat[0] == '*');
-            opts->match_slot = opts->use_pattern ? patternHashSlot(opts->pat, opts->patlen) : -1;
+            opts->match_slot = opts->use_pattern && server.cluster_enabled ? patternHashSlot(opts->pat, opts->patlen) : -1;
             i += 2;
         } else if (!strcasecmp(opt, "type") && o == NULL && j >= 2) {
             /* TYPE filter applies to key names only, not to object fields. */

--- a/src/db.c
+++ b/src/db.c
@@ -1294,18 +1294,15 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
             .only_keys = only_keys,
         };
 
-        /* Determine which slot to scan:
-         * - If slot >= 0, scan the specific slot (CLUSTERSCAN)
-         * - If slot == -1 try to derive from pattern; otherwise scan all */
-        int onlydidx = slot;
-        if (onlydidx == -1 && o == NULL && use_pattern && server.cluster_enabled) {
-            onlydidx = patternHashSlot(pat, patlen);
+        /* For regular SCAN in cluster mode, derive the slot from the pattern's hashtag. */
+        if (slot == -1 && o == NULL && use_pattern && server.cluster_enabled) {
+            slot = patternHashSlot(pat, patlen);
         }
         do {
             /* In cluster mode there is a separate dictionary for each slot.
              * If cursor is empty, we should try exploring next non-empty slot. */
             if (o == NULL) {
-                cursor = kvstoreScan(c->db->keys, cursor, onlydidx, final_slot, keysScanCallback, NULL, &data);
+                cursor = kvstoreScan(c->db->keys, cursor, slot, final_slot >= 0 ? final_slot : slot, keysScanCallback, NULL, &data);
             } else {
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
@@ -1363,7 +1360,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
     /* Step 3: Reply to the client. */
     addReplyArrayLen(c, 2);
 
-    /* Handle CLUSTERSCAN prefixing */
+    /* Handle CLUSTERSCAN prefixing.
+     * final_slot < 0 means single-slot mode (user passed SLOT or single-slot MATCH);
+     * we return cursor "0" without advancing. final_slot >= 0 means range mode,
+     * where we advance to final_slot+1 so iteration moves to the next node. */
     if (cursor == 0 && fp && final_slot >= 0 && final_slot + 1 < CLUSTER_SLOTS) {
         /* Range mode: advance to next slot outside the current node's range. */
         sds new_cursor = sdscatfmt(sdsempty(), "0-{%s}-0", crc16_slot_table[final_slot + 1]);

--- a/src/db.c
+++ b/src/db.c
@@ -1147,14 +1147,74 @@ char *getObjectTypeName(robj *o) {
     }
 }
 
+/* Parse options for SCAN, HSCAN, SSCAN, ZSCAN and CLUSTERSCAN commands,
+ * replying with an error on invalid input. */
+int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, scanOptions *opts) {
+    *opts = (scanOptions){
+        .count = DEFAULT_SCAN_COMMAND_COUNT,
+        .type = LLONG_MAX,
+        .input_slot = -1,
+        .match_slot = -1,
+    };
+
+    for (int i = start_idx; i < c->argc;) {
+        int j = c->argc - i;
+        char *opt = objectGetVal(c->argv[i]);
+        if (!strcasecmp(opt, "count") && j >= 2) {
+            if (getLongFromObjectOrReply(c, c->argv[i + 1], &opts->count, NULL) != C_OK) return C_ERR;
+            if (opts->count < 1) {
+                addReplyErrorObject(c, shared.syntaxerr);
+                return C_ERR;
+            }
+            i += 2;
+        } else if (!strcasecmp(opt, "match") && j >= 2) {
+            opts->pat = objectGetVal(c->argv[i + 1]);
+            opts->patlen = sdslen(opts->pat);
+            opts->use_pattern = !(opts->patlen == 1 && opts->pat[0] == '*');
+            opts->match_slot = opts->use_pattern ? patternHashSlot(opts->pat, opts->patlen) : -1;
+            i += 2;
+        } else if (!strcasecmp(opt, "type") && o == NULL && j >= 2) {
+            /* TYPE filter applies to key names only, not to object fields. */
+            char *typename = objectGetVal(c->argv[i + 1]);
+            opts->type = getObjectTypeByName(typename);
+            if (opts->type == LLONG_MAX) {
+                addReplyErrorFormat(c, "unknown type name '%s'", typename);
+                return C_ERR;
+            }
+            i += 2;
+        } else if (!strcasecmp(opt, "novalues")) {
+            if (!o || o->type != OBJ_HASH) {
+                addReplyError(c, "NOVALUES option can only be used in HSCAN");
+                return C_ERR;
+            }
+            opts->only_keys = 1;
+            i++;
+        } else if (!strcasecmp(opt, "noscores")) {
+            if (!o || o->type != OBJ_ZSET) {
+                addReplyError(c, "NOSCORES option can only be used in ZSCAN");
+                return C_ERR;
+            }
+            opts->only_keys = 1;
+            i++;
+        } else if (allow_slot && !strcasecmp(opt, "slot") && j >= 2) {
+            if (opts->input_slot != -1) {
+                addReplyError(c, "SLOT option can only be specified once");
+                return C_ERR;
+            }
+            if ((opts->input_slot = getSlotOrReply(c, c->argv[i + 1])) == -1) return C_ERR;
+            i += 2;
+        } else {
+            addReplyErrorObject(c, shared.syntaxerr);
+            return C_ERR;
+        }
+    }
+    return C_OK;
+}
+
 /* This command implements SCAN, HSCAN, SSCAN and CLUSTERSCAN commands.
  * If object 'o' is passed, then it must be a Hash, Set or Zset object, otherwise
  * if 'o' is NULL the command will operate on the dictionary associated with
  * the current database.
- *
- * When 'o' is not NULL the function assumes that the first argument in
- * the client arguments vector is a key so it skips it before iterating
- * in order to parse options.
  *
  * In the case of a Hash object the function returns both the field and value
  * of every element on the Hash.
@@ -1162,13 +1222,7 @@ char *getObjectTypeName(robj *o) {
  * cluster_ctx is used during CLUSTERSCAN to scan a specific slot or range of
  * slots and to return the valid cursor to advance the scan.
  */
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clusterScanCtx *cluster_ctx) {
-    int i, j;
-    long count = DEFAULT_SCAN_COMMAND_COUNT;
-    sds pat = NULL;
-    sds typename = NULL;
-    long long type = LLONG_MAX;
-    int patlen = 0, use_pattern = 0, only_keys = 0;
+void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor, const scanOptions *opts, const clusterScanCtx *cluster_ctx) {
     int slot = cluster_ctx ? cluster_ctx->slot : -1;
     int final_slot = cluster_ctx ? cluster_ctx->final_slot : -1;
     vector result;
@@ -1177,65 +1231,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
      * must be Set, Sorted Set, or Hash. */
     serverAssert(o == NULL || o->type == OBJ_SET || o->type == OBJ_HASH || o->type == OBJ_ZSET);
 
-    /* Set i to the first option argument. The previous one is the cursor. */
-    i = (o == NULL) ? 2 : 3; /* Skip the key argument if needed. */
-
-    /* Step 1: Parse options. */
-    while (i < c->argc) {
-        j = c->argc - i;
-        if (!strcasecmp(objectGetVal(c->argv[i]), "count") && j >= 2) {
-            if (getLongFromObjectOrReply(c, c->argv[i + 1], &count, NULL) != C_OK) {
-                return;
-            }
-
-            if (count < 1) {
-                addReplyErrorObject(c, shared.syntaxerr);
-                return;
-            }
-
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "match") && j >= 2) {
-            pat = objectGetVal(c->argv[i + 1]);
-            patlen = sdslen(pat);
-
-            /* The pattern always matches if it is exactly "*", so it is
-             * equivalent to disabling it. */
-            use_pattern = !(patlen == 1 && pat[0] == '*');
-
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "type") && o == NULL && j >= 2) {
-            /* SCAN for a particular type only applies to the db dict */
-            typename = objectGetVal(c->argv[i + 1]);
-            type = getObjectTypeByName(typename);
-            if (type == LLONG_MAX) {
-                addReplyErrorFormat(c, "unknown type name '%s'", typename);
-                return;
-            }
-            i += 2;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "novalues")) {
-            if (!o || o->type != OBJ_HASH) {
-                addReplyError(c, "NOVALUES option can only be used in HSCAN");
-                return;
-            }
-            only_keys = 1;
-            i++;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "noscores")) {
-            if (!o || o->type != OBJ_ZSET) {
-                addReplyError(c, "NOSCORES option can only be used in ZSCAN");
-                return;
-            }
-            only_keys = 1;
-            i++;
-        } else if (!strcasecmp(objectGetVal(c->argv[i]), "slot") && j >= 2 && slot >= 0) {
-            /* SLOT is already parsed by clusterscanCommand, we can skip it here. */
-            i += 2;
-        } else {
-            addReplyErrorObject(c, shared.syntaxerr);
-            return;
-        }
-    }
-
-    /* Step 2: Iterate the collection.
+    /* Iterate the collection.
      *
      * Note that if the object is encoded with a listpack, intset, or any other
      * representation that is not a hash table, we are sure that it is also
@@ -1271,7 +1267,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
          * COUNT, so if the hash table is in a pathological state (very
          * sparsely populated) we avoid to block too much time at the cost
          * of returning no or very few elements. */
-        unsigned long maxiterations = (unsigned long)count * 10UL;
+        unsigned long maxiterations = (unsigned long)opts->count * 10UL;
 
         /* We pass scanData which have three pointers to the callback:
          * 1. data.keys: the list to which it will add new elements;
@@ -1290,15 +1286,15 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
             .result = &result,
             .db = c->db,
             .o = o,
-            .type = type,
-            .pattern = use_pattern ? pat : NULL,
+            .type = opts->type,
+            .pattern = opts->use_pattern ? opts->pat : NULL,
             .sampled = 0,
-            .only_keys = only_keys,
+            .only_keys = opts->only_keys,
         };
 
         /* For regular SCAN in cluster mode, derive the slot from the pattern's hashtag. */
-        if (slot == -1 && o == NULL && use_pattern && server.cluster_enabled) {
-            slot = patternHashSlot(pat, patlen);
+        if (slot == -1 && o == NULL && opts->use_pattern && server.cluster_enabled) {
+            slot = opts->match_slot;
             final_slot = slot;
         }
         if (slot >= 0) {
@@ -1314,7 +1310,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
             } else {
                 cursor = hashtableScan(ht, cursor, hashtableScanCallback, &data);
             }
-        } while (cursor && maxiterations-- && data.sampled < count);
+        } while (cursor && maxiterations-- && data.sampled < opts->count);
     } else if (o->type == OBJ_SET) {
         char *str;
         char buf[LONG_STR_SIZE];
@@ -1326,7 +1322,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
                 len = ll2string(buf, sizeof(buf), llele);
             }
             char *key = str ? str : buf;
-            if (use_pattern && !stringmatchlen(pat, sdslen(pat), key, len, 0)) {
+            if (opts->use_pattern && !stringmatchlen(opts->pat, opts->patlen, key, len, 0)) {
                 continue;
             }
             sds item = sdsnewlen(key, len);
@@ -1344,7 +1340,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
             str = lpGet(p, &len, intbuf);
             /* point to the value */
             p = lpNext(objectGetVal(o), p);
-            if (use_pattern && !stringmatchlen(pat, sdslen(pat), (char *)str, len, 0)) {
+            if (opts->use_pattern && !stringmatchlen(opts->pat, opts->patlen, (char *)str, len, 0)) {
                 /* jump to the next key/val pair */
                 p = lpNext(objectGetVal(o), p);
                 continue;
@@ -1353,7 +1349,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
             sds item = sdsnewlen(str, len);
             addScanDataItem(&result, (const char *)item, sdslen(item));
             /* add value object */
-            if (!only_keys) {
+            if (!opts->only_keys) {
                 str = lpGet(p, &len, intbuf);
                 item = sdsnewlen(str, len);
                 addScanDataItem(&result, (const char *)item, sdslen(item));
@@ -1365,7 +1361,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
         serverPanic("Not handled encoding in SCAN.");
     }
 
-    /* Step 3: Reply to the client. */
+    /* Reply to the client. */
     addReplyArrayLen(c, 2);
 
     /* Handle CLUSTERSCAN prefixing. */
@@ -1395,11 +1391,18 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clu
     vectorCleanup(&result);
 }
 
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor) {
+    scanOptions opts;
+    int start_idx = (o == NULL) ? 2 : 3; /* Skip the key argument if needed. */
+    if (parseScanOptionsOrReply(c, o, start_idx, false, &opts) != C_OK) return;
+    scanGenericCommandWithOptions(c, o, cursor, &opts, NULL);
+}
+
 /* The SCAN command completely relies on scanGenericCommand. */
 void scanCommand(client *c) {
     unsigned long long cursor;
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[1]), &cursor) == C_ERR) return;
-    scanGenericCommand(c, NULL, cursor, NULL);
+    scanGenericCommand(c, NULL, cursor);
 }
 
 void dbsizeCommand(client *c) {

--- a/src/expire.c
+++ b/src/expire.c
@@ -338,7 +338,7 @@ static ustime_t activeExpireCycleJob(enum activeExpiryType jobType, int cycleTyp
 
             while (data.sampled < num && checked_buckets < max_buckets) {
                 unsigned long cursor = db->expiry[jobType].cursor;
-                cursor = kvstoreScan(kvs, cursor, -1, scan_cb,
+                cursor = kvstoreScan(kvs, cursor, -1, -1, scan_cb,
                                      expireShouldSkipTableForSamplingCb, &data);
                 if (!data.has_more_expired_entries) db->expiry[jobType].cursor = cursor;
                 if (db->expiry[jobType].cursor == 0 && !data.has_more_expired_entries) {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -408,12 +408,15 @@ void hashtableScanToKvstoreScanCallback(void *privdata, void *entry) {
  * 3. If the hashtable is entirely scanned i.e. the cursor has reached 0, the next non empty hashtable is discovered.
  *    The hashtable information is embedded into the cursor and returned.
  *
- * To restrict the scan to a single hashtable, pass a valid hashtable index as
- * 'onlydidx', otherwise pass -1.
+ * Scanning modes controlled by onlydidx and finaldidx:
+ * 1. onlydidx == -1 and finaldidx == -1: scan all hashtables.
+ * 2. onlydidx >= 0 and finaldidx == -1: scan only onlydidx.
+ * 3. onlydidx >= 0 and finaldidx >= 0: scan range [onlydidx, finaldidx].
  */
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
                                int onlydidx,
+                               int finaldidx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata) {
@@ -429,8 +432,11 @@ unsigned long long kvstoreScan(kvstore *kvs,
             assert(onlydidx < kvs->num_hashtables);
             didx = onlydidx;
             cursor = 0;
-        } else if (didx > onlydidx) {
-            /* The cursor is already past onlydidx. */
+        } else if (finaldidx < 0 && didx > onlydidx) {
+            /* The cursor is already past onlydidx in single slot mode. */
+            return 0;
+        } else if (finaldidx >= 0 && didx > finaldidx) {
+            /* The cursor is already past finaldidx in range slot mode. */
             return 0;
         }
     }
@@ -446,8 +452,18 @@ unsigned long long kvstoreScan(kvstore *kvs,
     }
     /* scanning done for the current hash table or if the scanning wasn't possible, move to the next hashtable index. */
     if (next_cursor == 0 || skip) {
-        if (onlydidx >= 0) return 0;
-        didx = kvstoreGetNextNonEmptyHashtableIndex(kvs, didx);
+        if (onlydidx >= 0 && finaldidx < 0) {
+            /* Single slot scan mode. */
+            return 0;
+        }
+        int nextdidx = kvstoreGetNextNonEmptyHashtableIndex(kvs, didx);
+        if (onlydidx >= 0 && finaldidx >= 0) {
+            if (nextdidx == KVSTORE_INDEX_NOT_FOUND || nextdidx > finaldidx) {
+                /* Range exhausted. */
+                return 0;
+            }
+        }
+        didx = nextdidx;
     }
     if (didx == KVSTORE_INDEX_NOT_FOUND) {
         return 0;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -408,15 +408,14 @@ void hashtableScanToKvstoreScanCallback(void *privdata, void *entry) {
  * 3. If the hashtable is entirely scanned i.e. the cursor has reached 0, the next non empty hashtable is discovered.
  *    The hashtable information is embedded into the cursor and returned.
  *
- * Scanning modes controlled by onlydidx and finaldidx:
- * 1. onlydidx == -1 and finaldidx == -1: scan all hashtables.
- * 2. onlydidx >= 0 and finaldidx == -1: scan only onlydidx.
- * 3. onlydidx >= 0 and finaldidx >= 0: scan range [onlydidx, finaldidx].
+ * Scanning modes controlled by first_idx and last_idx:
+ * 1. first_idx == -1 and last_idx == -1: scan all hashtables.
+ * 2. first_idx >= 0 and last_idx >= 0: scan range [first_idx, last_idx].
  */
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
-                               int onlydidx,
-                               int finaldidx,
+                               int first_idx,
+                               int last_idx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata) {
@@ -426,17 +425,15 @@ unsigned long long kvstoreScan(kvstore *kvs,
      * Hashtable index is always 0 at the start of iteration and can be incremented only if there are
      * multiple hashtables. */
     int didx = getAndClearHashtableIndexFromCursor(kvs, &cursor);
-    if (onlydidx >= 0) {
-        if (didx < onlydidx) {
-            /* Fast-forward to onlydidx. */
-            assert(onlydidx < kvs->num_hashtables);
-            didx = onlydidx;
+    if (first_idx >= 0) {
+        assert(last_idx >= first_idx);
+        assert(last_idx < kvs->num_hashtables);
+        if (didx < first_idx) {
+            /* Fast-forward to first_idx. */
+            didx = first_idx;
             cursor = 0;
-        } else if (finaldidx < 0 && didx > onlydidx) {
-            /* The cursor is already past onlydidx in single slot mode. */
-            return 0;
-        } else if (finaldidx >= 0 && didx > finaldidx) {
-            /* The cursor is already past finaldidx in range slot mode. */
+        } else if (didx > last_idx) {
+            /* The cursor is already past last_idx. */
             return 0;
         }
     }
@@ -452,16 +449,14 @@ unsigned long long kvstoreScan(kvstore *kvs,
     }
     /* scanning done for the current hash table or if the scanning wasn't possible, move to the next hashtable index. */
     if (next_cursor == 0 || skip) {
-        if (onlydidx >= 0 && finaldidx < 0) {
-            /* Single slot scan mode. */
+        if (first_idx >= 0 && didx >= last_idx) {
+            /* Range exhausted; no need to look up the next hashtable. */
             return 0;
         }
         int nextdidx = kvstoreGetNextNonEmptyHashtableIndex(kvs, didx);
-        if (onlydidx >= 0 && finaldidx >= 0) {
-            if (nextdidx == KVSTORE_INDEX_NOT_FOUND || nextdidx > finaldidx) {
-                /* Range exhausted. */
-                return 0;
-            }
+        if (first_idx >= 0 && nextdidx > last_idx) {
+            /* Range exhausted. */
+            return 0;
         }
         didx = nextdidx;
     }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -29,6 +29,7 @@ size_t kvstoreMemUsage(kvstore *kvs);
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
                                int onlydidx,
+                               int finaldidx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata);

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -28,8 +28,8 @@ unsigned long kvstoreBuckets(kvstore *kvs);
 size_t kvstoreMemUsage(kvstore *kvs);
 unsigned long long kvstoreScan(kvstore *kvs,
                                unsigned long long cursor,
-                               int onlydidx,
-                               int finaldidx,
+                               int first_idx,
+                               int last_idx,
                                kvstoreScanFunction scan_cb,
                                kvstoreScanShouldSkipHashtable *skip_cb,
                                void *privdata);

--- a/src/server.h
+++ b/src/server.h
@@ -831,6 +831,7 @@ struct serverObject {
 };
 static_assert(sizeof(struct serverObject) <= 8 + sizeof(void *), "unexpected size - verify struct is packed correctly");
 
+long long getObjectTypeByName(char *name);
 /* The string name for an object's type as listed above
  * Native types are checked against the OBJ_STRING, OBJ_LIST, OBJ_* defines,
  * and Module types have their registered name returned. */
@@ -3761,7 +3762,13 @@ void discardTempDb(serverDb **tempDb);
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, serverDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, int final_slot, const char *fp);
+typedef struct clusterScanCtx {
+    int slot;
+    int final_slot;
+    bool advance_to_next_slot;
+    const char *fp;
+} clusterScanCtx;
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clusterScanCtx *cluster_ctx);
 int parseScanCursorOrReply(client *c, sds buf, unsigned long long *cursor);
 int dbAsyncDelete(serverDb *db, robj *key);
 void emptyDbAsync(serverDb *db);

--- a/src/server.h
+++ b/src/server.h
@@ -3761,7 +3761,7 @@ void discardTempDb(serverDb **tempDb);
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, serverDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, sds cursor_prefix, sds finished_cursor_prefix);
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot, int final_slot, const char *fp);
 int parseScanCursorOrReply(client *c, sds buf, unsigned long long *cursor);
 int dbAsyncDelete(serverDb *db, robj *key);
 void emptyDbAsync(serverDb *db);

--- a/src/server.h
+++ b/src/server.h
@@ -831,7 +831,6 @@ struct serverObject {
 };
 static_assert(sizeof(struct serverObject) <= 8 + sizeof(void *), "unexpected size - verify struct is packed correctly");
 
-long long getObjectTypeByName(char *name);
 /* The string name for an object's type as listed above
  * Native types are checked against the OBJ_STRING, OBJ_LIST, OBJ_* defines,
  * and Module types have their registered name returned. */
@@ -2792,6 +2791,17 @@ typedef struct {
 
 } hashTypeIterator;
 
+typedef struct scanOptions {
+    long count;      /* COUNT option. */
+    sds pat;         /* MATCH pattern. */
+    long long type;  /* TYPE filter. */
+    int patlen;      /* MATCH pattern length. */
+    int use_pattern; /* MATCH is active. */
+    int only_keys;   /* NOVALUES/NOSCORES option. */
+    int input_slot;  /* SLOT option, or -1. */
+    int match_slot;  /* MATCH hashtag slot, or -1. */
+} scanOptions;
+
 typedef struct clusterScanCtx {
     int slot;
     int final_slot;
@@ -3769,7 +3779,9 @@ void discardTempDb(serverDb **tempDb);
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, serverDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clusterScanCtx *cluster_ctx);
+int parseScanOptionsOrReply(client *c, robj *o, int start_idx, bool allow_slot, scanOptions *opts);
+void scanGenericCommand(client *c, robj *o, unsigned long long cursor);
+void scanGenericCommandWithOptions(client *c, robj *o, unsigned long long cursor, const scanOptions *opts, const clusterScanCtx *cluster_ctx);
 int parseScanCursorOrReply(client *c, sds buf, unsigned long long *cursor);
 int dbAsyncDelete(serverDb *db, robj *key);
 void emptyDbAsync(serverDb *db);

--- a/src/server.h
+++ b/src/server.h
@@ -2792,6 +2792,13 @@ typedef struct {
 
 } hashTypeIterator;
 
+typedef struct clusterScanCtx {
+    int slot;
+    int final_slot;
+    bool advance_to_next_slot;
+    const char *fp;
+} clusterScanCtx;
+
 #include "stream.h" /* Stream data type header file. */
 
 #define OBJ_HASH_FIELD 1
@@ -3762,12 +3769,6 @@ void discardTempDb(serverDb **tempDb);
 int selectDb(client *c, int id);
 void signalModifiedKey(client *c, serverDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
-typedef struct clusterScanCtx {
-    int slot;
-    int final_slot;
-    bool advance_to_next_slot;
-    const char *fp;
-} clusterScanCtx;
 void scanGenericCommand(client *c, robj *o, unsigned long long cursor, const clusterScanCtx *cluster_ctx);
 int parseScanCursorOrReply(client *c, sds buf, unsigned long long *cursor);
 int dbAsyncDelete(serverDb *db, robj *key);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1822,7 +1822,7 @@ void hscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_HASH)) return;
-    scanGenericCommand(c, o, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, o, cursor, -1, -1, NULL);
 }
 
 static void hrandfieldReplyWithListpack(writePreparedClient *wpc, unsigned int count, listpackEntry *fields, listpackEntry *vals) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1822,7 +1822,7 @@ void hscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_HASH)) return;
-    scanGenericCommand(c, o, cursor, NULL);
+    scanGenericCommand(c, o, cursor);
 }
 
 static void hrandfieldReplyWithListpack(writePreparedClient *wpc, unsigned int count, listpackEntry *fields, listpackEntry *vals) {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1822,7 +1822,7 @@ void hscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_HASH)) return;
-    scanGenericCommand(c, o, cursor, -1, -1, NULL);
+    scanGenericCommand(c, o, cursor, NULL);
 }
 
 static void hrandfieldReplyWithListpack(writePreparedClient *wpc, unsigned int count, listpackEntry *fields, listpackEntry *vals) {

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1655,5 +1655,5 @@ void sscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, set, OBJ_SET)) return;
-    scanGenericCommand(c, set, cursor, -1, -1, NULL);
+    scanGenericCommand(c, set, cursor, NULL);
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1655,5 +1655,5 @@ void sscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, set, OBJ_SET)) return;
-    scanGenericCommand(c, set, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, set, cursor, -1, -1, NULL);
 }

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -1655,5 +1655,5 @@ void sscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, set, OBJ_SET)) return;
-    scanGenericCommand(c, set, cursor, NULL);
+    scanGenericCommand(c, set, cursor);
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3831,7 +3831,7 @@ void zscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_ZSET)) return;
-    scanGenericCommand(c, o, cursor, -1, -1, NULL);
+    scanGenericCommand(c, o, cursor, NULL);
 }
 
 void addZpopInitialReply(client *c, int emitkey, int use_nested_array, long rangelen, robj *key) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3831,7 +3831,7 @@ void zscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_ZSET)) return;
-    scanGenericCommand(c, o, cursor, NULL);
+    scanGenericCommand(c, o, cursor);
 }
 
 void addZpopInitialReply(client *c, int emitkey, int use_nested_array, long rangelen, robj *key) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -3831,7 +3831,7 @@ void zscanCommand(client *c) {
 
     if (parseScanCursorOrReply(c, objectGetVal(c->argv[2]), &cursor) == C_ERR) return;
     if ((o = lookupKeyReadOrReply(c, c->argv[1], shared.emptyscan)) == NULL || checkType(c, o, OBJ_ZSET)) return;
-    scanGenericCommand(c, o, cursor, -1, NULL, NULL);
+    scanGenericCommand(c, o, cursor, -1, -1, NULL);
 }
 
 void addZpopInitialReply(client *c, int emitkey, int use_nested_array, long rangelen, robj *key) {

--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -346,51 +346,61 @@ start_cluster 3 0 {tags {external:skip cluster}} {
 
     test "CLUSTERSCAN fingerprint validation" {
         set cluster [valkey_cluster 127.0.0.1:[srv 0 port]]
-        
-        set 0_slot_tag "{06S}"
-        set 1_slot_tag "{Qi}"
 
-
-        # Load keys into slot 0
+        # slot 0, 8192, 16000 are the three slots we will use for this test
         for {set i 0} {$i < 50} {incr i} {
-            $cluster set "$0_slot_tag:$i" "value:$i"
-            $cluster set "$1_slot_tag:$i" "value:$i" 
+            $cluster set "fingerprint:{06S}:$i" "value:$i"
+            $cluster set "fingerprint:{8YG}:$i" "value:$i"
+            $cluster set "fingerprint:{he}:$i" "value:$i"
         }
 
-        set res [$cluster clusterscan 0]
-        set cursor [lindex $res 0]
-
-        # Assert that fp is 0
-        assert_match "0-*-*" $cursor
-
-        # Assert to scan slot 0 only and assert that fp reset upon slot 1
-        set max_loops 10000
-        set iterations 0
-        while {$cursor ne "0-{Qi}-0" && $iterations < $max_loops} {
-            set res [$cluster clusterscan $cursor]
-            set cursor [lindex $res 0]
-            incr iterations
-        }
-        assert {$iterations < $max_loops} 
-
-         # Ensure that local cursor is ignored when fp is 0
-        set cursor "0-{Qi}-09393399393"
+        set max_loops 1000
+        set cursor "0"
         set keys {}
-        set max_loops 10000
+        set fps {}
         set iterations 0
-        while {$cursor ne "0" && $iterations < $max_loops} {
-            set res [$cluster clusterscan $cursor slot 1]
+        while {$iterations < $max_loops} {
+            set res [$cluster clusterscan $cursor match "fingerprint:*" ]
             set cursor [lindex $res 0]
             foreach k [lindex $res 1] {
                lappend keys $k
             }
             incr iterations
+            set fp [string range $cursor 0 [expr {[string first "-" $cursor] - 1}]]
+            if {$fp ne "0"} {
+                lappend fps $fp
+            }
+
+            if {$cursor eq "0"} {
+                break
+            }
         }
         assert {$iterations < $max_loops}
 
-        assert {[llength $keys] > 1}
-        assert {[llength $keys] < 300}
+        # Assert all keys are returned
+        assert_equal [llength $keys] 150
 
+        # Assert different finger print for different slots
+        set fps [lsort -unique $fps]
+        assert {[llength $fps] >= 3}
+
+        # Assert that the local cursor is ignored when finger print is 0
+        set cursor "0-{he}-09393399393"
+        set res [$cluster clusterscan $cursor match "fingerprint:*" count 100]
+        set keys [lindex $res 1]
+        assert_equal [llength $keys] 50
+
+        $cluster close
+    }
+
+    # Verify CLUSTERSCAN range end at non 64-bit aligned slot boundary.
+    # With 3 shards slot ownership is 0-5461, 5462-10922, 10923-16383.
+    test "CLUSTERSCAN cursor advances to next shard at non 64 bit aligned boundary" {
+        set cluster [valkey_cluster 127.0.0.1:[srv 0 port]]
+
+        set res [$cluster clusterscan 0-{06S}-0 COUNT 20000]
+        set cur [lindex $res 0]
+        assert_equal [$cluster cluster keyslot $cur] 5462
         $cluster close
     }
 }
@@ -502,6 +512,69 @@ start_cluster 2 0 {tags {external:skip cluster}} {
 
         # CLUSTERSCAN with two SLOT option should result in error
         assert_error "*SLOT option can only be specified once*" {R $slot0_node clusterscan 0-{06S}-0 SLOT 0 SLOT 0}
+    }
+
+    test "CLUSTERSCAN range scanning and cursor hashtag correctness" {
+        # slot 50 = {4ZG}, slot 100 = {0or} — both on node 0.
+        R 0 set "{4ZG}:key" "value"
+        R 0 set "{0or}:key" "value"
+
+        # Both slots scanned in single call (range scan, default count > 2 keys)
+        set res [R 0 clusterscan "0-{4ZG}-0"]
+        set keys [lsort [lindex $res 1]]
+        set cursor [lindex $res 0]
+
+        # Both keys from slot 50 and 100 returned in one call
+        assert_equal [llength $keys] 2
+        assert_equal [lindex $keys 0] "{0or}:key"
+        assert_equal [lindex $keys 1] "{4ZG}:key"
+
+        # Cursor is cross-node transition
+        assert_match "0-*-0" $cursor
+
+        # Now scan happens one slot at a time
+        set res [R 0 clusterscan "0-{4ZG}-0" COUNT 1]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        # Found key from slot 50
+        assert_equal [lindex $keys 0] "{4ZG}:key"
+
+        # Cursor jumped to slot 100 (next non-empty slot), not slot 51.
+        assert_match "*-{0or}-*" $cursor
+        assert_not_equal $cursor "0"
+
+        # Continue: scan slot 100
+        set res [R 0 clusterscan $cursor]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        assert_equal [lindex $keys 0] "{0or}:key"
+
+        # Migrate slot 51 this breaks contiguous range at slot 50
+        set source_id [R 0 cluster myid]
+        set target_id [R 1 cluster myid]
+        R 0 cluster setslot 51 migrating $target_id
+        R 1 cluster setslot 51 importing $source_id
+        R 0 cluster setslot 51 node $target_id
+        R 1 cluster setslot 51 node $target_id
+
+        # Re-scan from slot 50 — range now ends at 50 (slot 51 on node 1)
+        set res [R 0 clusterscan "0-{4ZG}-0"]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+
+        assert_equal [lindex $keys 0] "{4ZG}:key"
+        # Cross-node transition to slot 51 ({6od})
+        assert_equal $cursor "0-{6od}-0"
+
+        # Validate final slot of the cluster
+        R 1 set "{6ZJ}:key" "value"
+        set res [R 1 clusterscan "0-{6ZJ}-0"]
+        set keys [lindex $res 1]
+        set cursor [lindex $res 0]
+        assert_equal [lindex $keys 0] "{6ZJ}:key"
+        assert_equal $cursor "0"
     }
 }
 

--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -30,10 +30,14 @@ start_cluster 1 0 {tags {external:skip cluster}} {
         assert_error "*Invalid cursor*" {R 0 clusterscan "0-{0}"}
     }
 
-    test "CLUSTERSCAN rejects unknown options" {
+    test "CLUSTERSCAN rejects invalid options" {
         set valid_cursor "0-{06S}-0"
         assert_error "*syntax*" {R 0 clusterscan $valid_cursor UNKNOWNOPTION}
         assert_error "*syntax*" {R 0 clusterscan $valid_cursor COUNT 10 BADOPTION}
+        assert_error "*syntax*" {R 0 clusterscan 0 COUNT 0}
+        assert_error "*syntax*" {R 0 clusterscan 0 COUNT -1}
+        assert_error "*value is not an integer or out of range*" {R 0 clusterscan 0 COUNT not-an-integer}
+        assert_error "*unknown type name*" {R 0 clusterscan 0 TYPE notatype}
     }
 
     test "CLUSTERSCAN with SLOT restricts to single slot" {


### PR DESCRIPTION
Instead of scanning one slot at a time `CLUSTERSCAN` now scans the entire contiguous range of slots owned by the current node.

Implementation details

* Re-sharding safe as the hash slot is updated based on the local cursor position.
* Fingerprint remains stable across the entire contiguous slot range instead of being reset per slot.
* Parsing/validation of parameters for the SCAN commands is refactored and moved to a separate function.

```
   > CLUSTERSCAN 0
   "0-{06S}-0"                      # start at slot 0

   > CLUSTERSCAN 0-{06S}-0
   "aBcDeF-{06S}-48"                # scanning slot 0...

   > CLUSTERSCAN aBcDeF-{06S}-48
   "aBcDeF-{1Y7}-16"                 # slot 0 done, continues to slot 6 (same node hence FP is unchanged)

   > CLUSTERSCAN aBcDeF-{1Y7}-16
   "aBcDeF-{0or}-32"                # slot 6 done, continues to slot 100  (same node hence FP is unchanged)
   ...
   > CLUSTERSCAN aBcDeF-{...}-64
   "0-{8YG}-0"                      # Current continuous slot boundary reached hence cross-node transition 
```

Follow-up of #2934

