### PR TITLE
Fix EntryTest.entryUpdate failure on macOS due to allocator differences

### DIFF
--- a/src/unit/test_entry.cpp
+++ b/src/unit/test_entry.cpp
@@ -107,7 +107,7 @@ TEST_F(EntryTest, entryCreate) {
  * 7. Update from non-embedded back to embedded value
  * 8. Update entry to less then 3/4 allocation size
  * 9. Update entry to more than 3/4 allocation size
- * 8. Update entry to exactly 3/4 allocation size
+ * 10. Update entry to exactly the same allocation size
  */
 TEST_F(EntryTest, entryUpdate) {
     // Create embedded entry
@@ -171,7 +171,7 @@ TEST_F(EntryTest, entryUpdate) {
     // Update the value so that memory usage is less than 3/4 of the current allocation size
     // Ensuring required_embedded_size < current_embedded_allocation_size * 3 / 4, which creates a new entry
     size_t current_embedded_allocation_size = entryMemUsage(e9);
-    sds value10 = sdsnew("xxxxxxxxxxxxxxxxxxxxx");
+    sds value10 = sdsnew("xxxxxxxxxxxxx");
     sds value_copy10 = sdsdup(value10);
     long long expiry10 = expiry9;
     entry *e10 = entryUpdate(e9, value10, expiry10);
@@ -182,7 +182,7 @@ TEST_F(EntryTest, entryUpdate) {
     // Update the value so that memory usage is at least 3/4 of the current memory usage
     // Ensuring required_embedded_size > current_embedded_allocation_size * 3 / 4 without creating a new entry
     current_embedded_allocation_size = entryMemUsage(e10);
-    sds value11 = sdsnew("yyyyyyyyyyyyy");
+    sds value11 = sdsnew("yyyyyy");
     sds value_copy11 = sdsdup(value11);
     long long expiry11 = expiry10;
     entry *e11 = entryUpdate(e10, value11, expiry11);
@@ -195,7 +195,7 @@ TEST_F(EntryTest, entryUpdate) {
     // Update the value so that memory usage is exactly equal to the current allocation size
     // Ensuring required_embedded_size == current_embedded_allocation_size without creating a new entry
     current_embedded_allocation_size = entryMemUsage(e11);
-    sds value12 = sdsnew("zzzzzzzzzzzzz");
+    sds value12 = sdsnew("zzzzzz");
     sds value_copy12 = sdsdup(value12);
     long long expiry12 = expiry11;
     entry *e12 = entryUpdate(e11, value12, expiry12);


### PR DESCRIPTION
## Problem

The `EntryTest.entryUpdate` unit test fails on macOS with (mentioned in #3200): 

    Expected: (entryMemUsage(e10)) < (current_embedded_allocation_size * 3 / 4)
      actual: 48 vs 48

## Root Cause

`entryMemUsage` for embedded entries reflects the actual zmalloc allocation size, which depends on the platform allocator's bucket sizes.

Valkey's bundled jemalloc is configured with `LG_QUANTUM=3` (8-byte granularity), giving size classes: 8, 16, 24, 32, 40, 48, 56, 64, ...
However, macOS libc uses 16-byte aligned buckets: 16, 32, 48, 64, 80, ...

The test's value10 (21 chars) produces an entryReqSize of 40 bytes. Jemalloc has a 40-byte size class, so entryMemUsage returns 40. macOS rounds up to 48, which equals 3/4 of e9's 64-byte allocation, causing
the strict less-than assertion to fail.

## Fix

Shrink value10 from 21 to 13 characters, reducing entryReqSize from 40 to 32 bytes. Both allocators have a 32-byte bucket, and 32 < 48 holds on both platforms.

## Test

All tests pass on macOS.