### PR TITLE
Big endian bitmap byte order mismatch fix

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4329,6 +4329,7 @@ int clusterProcessPacket(clusterLink *link) {
             for (size_t w = 0; w < CLUSTER_SLOT_WORDS && !found_new_owner; w++) {
                 uint64_t word;
                 memcpy(&word, msg->myslots + SLOT_WORD_OFFSET(w), sizeof(word));
+                memrev64ifbe(&word);
                 while (word) {
                     const int slot = clusterExtractSlotFromWord(&word, w);
 
@@ -5321,6 +5322,7 @@ void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request) {
     for (size_t w = 0; w < CLUSTER_SLOT_WORDS; w++) {
         uint64_t word;
         memcpy(&word, claimed_slots + SLOT_WORD_OFFSET(w), sizeof(word));
+        memrev64ifbe(&word);
         while (word) {
             slot = clusterExtractSlotFromWord(&word, w);
 

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -136,3 +136,21 @@ start_cluster 3 6 {tags {external:skip cluster}} {
     }
 
 } ;# start_cluster
+
+# Verify failover works when slot boundaries are not 64-bit aligned.
+# When we use 3-shard layout, it puts boundaries at 5461 and 10922 (mid-word in the bitmap).
+# We need memrev64ifbe after memcpy so ctzll returns the right bit positions
+# on big-endian hosts, otherwise this test will fail early if there is no failover consensus.
+start_cluster 3 1 {tags {external:skip cluster}} {
+
+test "Failover succeeds with non 64 bit aligned slot boundaries" {
+    R 3 cluster failover
+    wait_for_condition 1000 50 {
+        [s -3 role] eq {master} &&
+        [s 0 role] eq {slave}
+    } else {
+        fail "Failover did not happen"
+    }
+}
+
+} ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -142,15 +142,13 @@ start_cluster 3 6 {tags {external:skip cluster}} {
 # We need memrev64ifbe after memcpy so ctzll returns the right bit positions
 # on big-endian hosts, otherwise this test will fail early if there is no failover consensus.
 start_cluster 3 1 {tags {external:skip cluster}} {
-
-test "Failover succeeds with non 64 bit aligned slot boundaries" {
-    R 3 cluster failover
-    wait_for_condition 1000 50 {
-        [s -3 role] eq {master} &&
-        [s 0 role] eq {slave}
-    } else {
-        fail "Failover did not happen"
+    test "Failover succeeds with non 64 bit aligned slot boundaries" {
+        R 3 cluster failover
+        wait_for_condition 1000 50 {
+            [s -3 role] eq {master} &&
+            [s 0 role] eq {slave}
+        } else {
+            fail "Failover did not happen"
+        }
     }
-}
-
 } ;# start_cluster


### PR DESCRIPTION
Found while implementing `clusterNodeGetSlotRangeEnd` for `CLUSTERSCAN` range bounded scanning, which uses the simlilar approach.

When tested on s390x via Docker and QEMU. Slot boundary came as 5440 instead of 5461.

```
127.0.0.1:6001> clusterscan 0-{06S}-0
1) "0-{4HD}-0"
2) 1) "{06S}key1"
127.0.0.1:6001> keyslot 0-{4HD}-0
(error) ERR unknown command 'keyslot', with args beginning with: '0-{4HD}-0'
127.0.0.1:6001> cluster keyslot 0-{4HD}-0
(integer) 5440
127.0.0.1:6001> cluster nodes
08e28d7e8dcfc731ac537d0518bfa32577da6ec7 127.0.0.1:6002@16002 master - 0 1774415944347 2 connected 5461-10922
53f6d4e61eee13ea98441eec05b3c4c95c6c83a4 127.0.0.1:6003@16003 master - 0 1774415943314 3 connected 10923-16383
46664ac624f001cc0708e8ddcfcc9e45e8f444a0 127.0.0.1:6001@16001 myself,master - 0 0 1 connected 0-5460
```

Updating here as it is same approach and does not follow `memrev64ifbe` followed by `memcpy`