### PR TITLE
Env: Read VALKEYCLI_HOST and VALKEYCLI_PORT environment variables

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -91,6 +91,8 @@
 #define CLI_RCFILE_DEFAULT ".valkeyclirc"
 #define CLI_AUTH_ENV "VALKEYCLI_AUTH"
 #define OLD_CLI_AUTH_ENV "REDISCLI_AUTH"
+#define CLI_HOST_ENV "VALKEYCLI_HOST"
+#define CLI_PORT_ENV "VALKEYCLI_PORT"
 #define CLI_CLUSTER_YES_ENV "VALKEYCLI_CLUSTER_YES"
 #define OLD_CLI_CLUSTER_YES_ENV "REDISCLI_CLUSTER_YES"
 
@@ -2929,14 +2931,22 @@ static int parseOptions(int argc, char **argv) {
     return i;
 }
 
+/* Reads environment variables and overrides the global configuration */
 static void parseEnv(void) {
-    /* Set auth from env, but do not overwrite CLI arguments if passed */
     char *auth = getenv(CLI_AUTH_ENV);
     if (auth == NULL) {
         auth = getenv(OLD_CLI_AUTH_ENV);
     }
-    if (auth != NULL && config.conn_info.auth == NULL) {
+    if (auth != NULL) {
         config.conn_info.auth = auth;
+    }
+    char *host = getenv(CLI_HOST_ENV);
+    if (host != NULL) {
+        config.conn_info.hostip = sdsnew(host);
+    }
+    char *port = getenv(CLI_PORT_ENV);
+    if (port != NULL) {
+        config.conn_info.hostport = atoi(port);
     }
 
     /* Check for cluster yes flag with fallback to legacy env variable */
@@ -10043,6 +10053,7 @@ int main(int argc, char **argv) {
     int firstarg;
     struct timeval tv;
 
+    /* Valkey defaults */
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
     config.ct = VALKEY_CONN_TCP;
     config.conn_info.hostip = sdsnew("127.0.0.1");
@@ -10134,11 +10145,13 @@ int main(int argc, char **argv) {
     config.mb_delim = sdsnew("\n");
     config.cmd_delim = sdsnew("\n");
 
+    /* Override configuration based on environment variables */
+    parseEnv();
+
+    /* Override configuration based on explicit command-line arguments */
     firstarg = parseOptions(argc, argv);
     argc -= firstarg;
     argv += firstarg;
-
-    parseEnv();
 
     if (config.askpass) {
         config.conn_info.auth = askPassword("Please input password: ");


### PR DESCRIPTION
This allows setting the host and port using environment variables, which makes using valkey-cli way easier in some development environments. No need to recall the right host/port, just let your `.env` do the work.

---

Built locally and tested with,

```fish
VALKEY_PORT=36379 ./src/valkey-cli
```

```console
127.0.0.1:36379>
```

And using both,

```fish
VALKEYCLI_HOST=(hostname).local VALKEYCLI_PORT=36379 ./src/valkey-cli
```

```console
<HOSTNAME>.local:36379>
```