### PR TITLE
 Fix race condition in diskless swapdb RedisModuleEvent_ReplAsyncLoad tests

### DIFF
--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -225,8 +225,10 @@ tags "modules" {
                     $replica debug populate 200 slave 10
                     $master debug populate 1000 master 100000
                     $master config set rdbcompression no
-
+                    
                     if {$testType eq "Aborted"} {
+                        # Set master with a slow rdb generation, so that we can easily intercept loading
+                        # 10ms per key, with 1000 keys is 10 seconds
                         $master config set rdb-key-save-delay 10000
                     }
 

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -226,21 +226,22 @@ tags "modules" {
                     $master debug populate 1000 master 100000
                     $master config set rdbcompression no
 
-                    # Force the replica to try another full sync (this time it will have matching master replid)
-                    $master multi
-                    $master client kill type replica
-                    # Fill replication backlog with new content
-                    $master config set repl-backlog-size 16384
-                    for {set keyid 0} {$keyid < 10} {incr keyid} {
-                        $master set "$keyid string_$keyid" [string repeat A 16384]
-                    }
-                    $master exec
-
                     switch $testType {
                         "Aborted" {
                             # Set master with a slow rdb generation, so that we can easily intercept loading
                             # 10ms per key, with 1000 keys is 10 seconds
                             $master config set rdb-key-save-delay 10000
+
+                            # Force the replica to try another full sync (this time it will have matching master replid)
+                            # This must be done AFTER setting rdb-key-save-delay to ensure the slow RDB is in effect
+                            $master multi
+                            $master client kill type replica
+                            # Fill replication backlog with new content
+                            $master config set repl-backlog-size 16384
+                            for {set keyid 0} {$keyid < 10} {incr keyid} {
+                                $master set "$keyid string_$keyid" [string repeat A 16384]
+                            }
+                            $master exec
 
                             test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before} {
                                 # Wait for the replica to start reading the rdb and module for acknowledgement
@@ -277,6 +278,16 @@ tags "modules" {
                             $master config set rdb-key-save-delay 0
                         }
                         "Successful" {
+                            # Force the replica to try another full sync (this time it will have matching master replid)
+                            $master multi
+                            $master client kill type replica
+                            # Fill replication backlog with new content
+                            $master config set repl-backlog-size 16384
+                            for {set keyid 0} {$keyid < 10} {incr keyid} {
+                                $master set "$keyid string_$keyid" [string repeat A 16384]
+                            }
+                            $master exec
+
                             # Let replica finish sync with master
                             wait_for_condition 100 100 {
                                 [s -1 master_link_status] eq "up"

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -226,22 +226,22 @@ tags "modules" {
                     $master debug populate 1000 master 100000
                     $master config set rdbcompression no
 
+                    if {$testType eq "Aborted"} {
+                        $master config set rdb-key-save-delay 10000
+                    }
+
+                    # Force the replica to try another full sync (this time it will have matching master replid)
+                    $master multi
+                    $master client kill type replica
+                    # Fill replication backlog with new content
+                    $master config set repl-backlog-size 16384
+                    for {set keyid 0} {$keyid < 10} {incr keyid} {
+                        $master set "$keyid string_$keyid" [string repeat A 16384]
+                    }
+                    $master exec
+
                     switch $testType {
                         "Aborted" {
-                            # Set master with a slow rdb generation, so that we can easily intercept loading
-                            # 10ms per key, with 1000 keys is 10 seconds
-                            $master config set rdb-key-save-delay 10000
-
-                            # Force the replica to try another full sync (this time it will have matching master replid)
-                            $master multi
-                            $master client kill type replica
-                            # Fill replication backlog with new content
-                            $master config set repl-backlog-size 16384
-                            for {set keyid 0} {$keyid < 10} {incr keyid} {
-                                $master set "$keyid string_$keyid" [string repeat A 16384]
-                            }
-                            $master exec
-
                             test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before} {
                                 # Wait for the replica to start reading the rdb and module for acknowledgement
                                 # We wanna abort only after the temp db was populated by REDISMODULE_AUX_BEFORE_RDB
@@ -277,16 +277,6 @@ tags "modules" {
                             $master config set rdb-key-save-delay 0
                         }
                         "Successful" {
-                            # Force the replica to try another full sync (this time it will have matching master replid)
-                            $master multi
-                            $master client kill type replica
-                            # Fill replication backlog with new content
-                            $master config set repl-backlog-size 16384
-                            for {set keyid 0} {$keyid < 10} {incr keyid} {
-                                $master set "$keyid string_$keyid" [string repeat A 16384]
-                            }
-                            $master exec
-
                             # Let replica finish sync with master
                             wait_for_condition 100 100 {
                                 [s -1 master_link_status] eq "up"

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -233,7 +233,6 @@ tags "modules" {
                             $master config set rdb-key-save-delay 10000
 
                             # Force the replica to try another full sync (this time it will have matching master replid)
-                            # This must be done AFTER setting rdb-key-save-delay to ensure the slow RDB is in effect
                             $master multi
                             $master client kill type replica
                             # Fill replication backlog with new content


### PR DESCRIPTION
Resolves #3394 and #3395

These failures seem to be attributed to a race condition in the Aborted test case. 

`rdb-key-save-delay` 10000 was being set after `$master exec` triggered the full resync. Since repl-diskless-sync-delay 0 was set, the master would immediately start streaming the RDB to the replica once it reconnected. On the ARM runner, when it's fast enough, the entire RDB generation and transfer could complete in ~78ms, before the delay was ever applied. This meant the replica would complete the swap and have 1010 keys instead of the expected 200 and there would be no async_loading window to observe or abort which led to the failures.

We saw this in the daily test failure logs
```
92948:S * RDB memory usage when created 110.85 Mb
92948:S * Done loading RDB, keys loaded: 1010, keys expired: 0
```

The fix moves `rdb-key-save-delay 10000` to before `$master exec` to guarantee the delay is in effect on the master before the RDB generation begins.