### PR TITLE
Fix integer overflow in WAIT and WAITAOF numreplicas parameter

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -657,7 +657,7 @@ static void handleClientsBlockedOnKey(readyList *rl) {
 }
 
 /* block a client for replica acknowledgement */
-void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, long numreplicas, int numlocal) {
+void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, int numreplicas, int numlocal) {
     initClientBlockingState(c);
     c->bstate->timeout = timeout;
     c->bstate->reploffset = offset;

--- a/src/replication.c
+++ b/src/replication.c
@@ -5004,7 +5004,7 @@ void waitCommand(client *c) {
     }
 
     /* Argument parsing. */
-    if (getLongFromObjectOrReply(c, c->argv[1], &numreplicas, NULL) != C_OK) return;
+    if (getRangeLongFromObjectOrReply(c, c->argv[1], 0, INT_MAX, &numreplicas, NULL) != C_OK) return;
     if (getTimeoutFromObjectOrReply(c, c->argv[2], &timeout, UNIT_MILLISECONDS) != C_OK) return;
 
     /* First try without blocking at all. */
@@ -5031,7 +5031,7 @@ void waitaofCommand(client *c) {
 
     /* Argument parsing. */
     if (getRangeLongFromObjectOrReply(c, c->argv[1], 0, 1, &numlocal, NULL) != C_OK) return;
-    if (getPositiveLongFromObjectOrReply(c, c->argv[2], &numreplicas, NULL) != C_OK) return;
+    if (getRangeLongFromObjectOrReply(c, c->argv[2], 0, INT_MAX, &numreplicas, NULL) != C_OK) return;
     if (getTimeoutFromObjectOrReply(c, c->argv[3], &timeout, UNIT_MILLISECONDS) != C_OK) return;
 
     if (server.primary_host) {

--- a/src/server.h
+++ b/src/server.h
@@ -3880,7 +3880,7 @@ void signalKeyAsReady(serverDb *db, robj *key, int type);
 void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeout, int unblock_on_nokey);
 void blockClientShutdown(client *c);
 void blockPostponeClient(client *c);
-void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, long numreplicas, int numlocal);
+void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, int numreplicas, int numlocal);
 void replicationRequestAckFromReplicas(void);
 void signalDeletedKeyAsReady(serverDb *db, robj *key, int type);
 void updateStatsOnUnblock(client *c, long blocked_us, long reply_us, int failed_or_rejected);

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -19,6 +19,14 @@ start_server {} {
         }
     }
 
+    test {WAIT out of range numreplicas} {
+        # numreplicas is stored in blockingState as int, so it must be
+        # validated to fit within [0, INT_MAX] to prevent overflow.
+        assert_error "*out of range*" {$master wait -1 0}
+        assert_error "*out of range*" {$master wait 2147483648 0}
+        assert_error "*out of range*" {$master wait 9223372036854775808 0}
+    }
+
     test {WAIT out of range timeout (milliseconds)} {
         # Timeout is parsed as milliseconds by getLongLongFromObjectOrReply().
         # Verify we get out of range message if value is behind LLONG_MAX
@@ -133,6 +141,27 @@ start_server {} {
 tags {"wait aof network external:skip"} {
     start_server {overrides {appendonly {yes} auto-aof-rewrite-percentage {0}}} {
         set master [srv 0 client]
+
+        test {WAITAOF out of range numlocal} {
+            # numlocal must be 0 or 1.
+            assert_error "*out of range*" {$master waitaof -1 0 0}
+            assert_error "*out of range*" {$master waitaof 2 0 0}
+        }
+
+        test {WAITAOF out of range numreplicas} {
+            # numreplicas is stored in blockingState as int, so it must be
+            # validated to fit within [0, INT_MAX] to prevent overflow.
+            assert_error "*out of range*" {$master waitaof 0 -1 0}
+            assert_error "*out of range*" {$master waitaof 0 2147483648 0}
+            assert_error "*out of range*" {$master waitaof 0 9223372036854775808 0}
+        }
+
+        test {WAITAOF out of range timeout (milliseconds)} {
+            # Verify timeout validation for WAITAOF, similar to WAIT.
+            assert_error "*out of range*" {$master waitaof 0 0 9223372036854775808}
+            assert_error "*timeout is out of range*" {$master waitaof 0 0 9223372036854775807}
+            assert_error "*timeout is negative*" {$master waitaof 0 0 -1}
+        }
 
         test {WAITAOF local copy before fsync} {
             r config set appendfsync no


### PR DESCRIPTION
The numreplicas parameter in WAIT and WAITAOF commands is parsed as
`long` but stored in `blockingState.numreplicas` which is `int`. When a
value larger than INT_MAX (e.g., 2147483648) is passed, the implicit
narrowing conversion from `long` to `int` causes overflow, resulting in
a negative value that breaks the blocking logic.

Example: If `wait 2147483648 0` the client enters a blocked state, it
will unblock immediately after receiving ACKs from the replicas since
`numreplicas` is a negative value, we consider the `numreplicas`
requirement to be satisfied.

It's not a major issue, but it is indeed a bug.

Additionally, the WAIT command used `getLongFromObjectOrReply()` which
accepted negative values for numreplicas. A negative number should be
an invalid value. And in WAITAOF command we will reject negative number.

It is not a major issue, it is an inconsistency in error handling between
WAIT and WAITAOF.

Fix both issues by using `getRangeLongFromObjectOrReply()` with range
[0, INT_MAX] for numreplicas validation in both WAIT and WAITAOF. This
ensures:
- Negative values are rejected with an error.
- Values exceeding INT_MAX are rejected, preventing integer overflow.
- Both commands now have consistent validation for numreplicas.

This could be a **potentially breaking change**. In the past, we allowed:
- WAIT allows negative numreplicas values.
- WAIT and WAITAOF allows numreplicas to exceed INT_MAX.

Add tests for numreplicas boundary validation in both commands, and
add missing parameter validation tests for WAITAOF (numlocal range,
numreplicas range, and timeout range).