### PR TITLE
Optimize infoCommand with SDS pre-allocation and getrusage caching

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -138,6 +138,7 @@ sds clusterEncodeOpenSlotsAuxField(int rdbflags);
 int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s);
 static int nodeExceedsHandshakeTimeout(clusterNode *node, mstime_t now);
 void clusterCommandFlushslot(client *c);
+int clusterAllReplicasThinkPrimaryIsFail(void);
 
 static inline clusterMsg *toClusterMsg(void *buf) {
     clusterMsgHeader *hdr = (clusterMsgHeader *)buf;
@@ -155,6 +156,16 @@ static inline clusterMsgLight *toClusterMsgLight(void *buf) {
  * Returns 1 if the node has voting rights, otherwise returns 0. */
 int clusterNodeIsVotingPrimary(clusterNode *n) {
     return (n->flags & CLUSTER_NODE_PRIMARY) && n->numslots;
+}
+
+/* Returns if myself is the best ranked replica in an automatic failover process.
+ * To avoid newly added empty replica from affecting the ranking, we will skip it. */
+static inline int myselfIsBestRankedReplica(void) {
+    return (server.cluster->mf_end == 0 &&
+            getNodeReplicationOffset(myself) != 0 &&
+            server.cluster->failover_auth_rank == 0 &&
+            server.cluster->failover_failed_primary_rank == 0 &&
+            clusterAllReplicasThinkPrimaryIsFail());
 }
 
 int getNodeDefaultClientPort(clusterNode *n) {
@@ -2535,6 +2546,10 @@ void markNodeAsFailing(clusterNode *node) {
 
     /* Immediately check if the failing node is our primary node. */
     if (nodeIsReplica(myself) && myself->replicaof == node) {
+        /* Mark my primary is FAIL so that we can bring out flags during gossip,
+         * so that other nodes know that my primary node has failed, so that other
+         * nodes know that my offset will no longer be updated. */
+        myself->flags |= CLUSTER_NODE_MY_PRIMARY_FAIL;
         /* We can start an automatic failover as soon as possible, setting a flag
          * here so that we don't need to waiting for the cron to kick in. */
         clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_FAILOVER);
@@ -2603,6 +2618,7 @@ void clearNodeFailureIfNeeded(clusterNode *node) {
         serverLog(LL_NOTICE, "Clear FAIL state for node %.40s (%s): %s is reachable again.", node->name,
                   humanNodename(node), nodeIsReplica(node) ? "replica" : "primary without slots");
         node->flags &= ~CLUSTER_NODE_FAIL;
+        if (nodeIsReplica(myself) && myself->replicaof == node) node->flags &= ~CLUSTER_NODE_MY_PRIMARY_FAIL;
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
     }
 
@@ -2617,6 +2633,7 @@ void clearNodeFailureIfNeeded(clusterNode *node) {
             "Clear FAIL state for node %.40s (%s): is reachable again and nobody is serving its slots after some time.",
             node->name, humanNodename(node));
         node->flags &= ~CLUSTER_NODE_FAIL;
+        if (nodeIsReplica(myself) && myself->replicaof == node) node->flags &= ~CLUSTER_NODE_MY_PRIMARY_FAIL;
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
     }
 }
@@ -3862,6 +3879,13 @@ int clusterProcessPacket(clusterLink *link) {
             sender->flags |= CLUSTER_NODE_MULTI_MEET_SUPPORTED;
         } else {
             sender->flags &= ~CLUSTER_NODE_MULTI_MEET_SUPPORTED;
+        }
+
+        /* Check if the sender has marked its primary node as FAIL. */
+        if (flags & CLUSTER_NODE_MY_PRIMARY_FAIL) {
+            sender->flags |= CLUSTER_NODE_MY_PRIMARY_FAIL;
+        } else {
+            sender->flags &= ~CLUSTER_NODE_MY_PRIMARY_FAIL;
         }
     }
 
@@ -5204,6 +5228,16 @@ void clusterRequestFailoverAuth(void) {
      * in the header to communicate the nodes receiving the message that
      * they should authorized the failover even if the primary is working. */
     if (server.cluster->mf_end) msgblock->data[0].msg.mflags[0] |= CLUSTERMSG_FLAG0_FORCEACK;
+
+    /* If this is an automatic failover and if myself is the best ranked replica,
+     * set the CLUSTERMSG_FLAG0_FORCEACK bit in the header as well.
+     *
+     * In this case, we hope that other primary nodes will not refuse to vote because
+     * they did not receive the FAIL message in time. */
+    if (server.cluster->mf_end == 0 && myselfIsBestRankedReplica()) {
+        msgblock->data[0].msg.mflags[0] |= CLUSTERMSG_FLAG0_FORCEACK;
+    }
+
     clusterBroadcastMessage(msgblock);
     clusterMsgSendBlockDecrRefCount(msgblock);
 }
@@ -5406,6 +5440,29 @@ int clusterGetFailedPrimaryRank(void) {
     dictReleaseIterator(di);
 
     return rank;
+}
+
+
+/* Returns 1 if all replicas under my primary think the primary is in FAIL state.
+ *
+ * This is useful in automatic failover. For example, from my perspective,
+ * if all other replicas, including myself, both mark the primary node as FAIL,
+ * which means that myself and other replicas have exchanged new gossip information
+ * after the primary node went down, and we know the latest replication offset of
+ * the replicas. If a replica finds that its ranking is optimal in all cases, then
+ * the replica can initiate an election immediately in automatic failover without
+ * waiting for the delay. */
+int clusterAllReplicasThinkPrimaryIsFail(void) {
+    serverAssert(nodeIsReplica(myself));
+    serverAssert(myself->replicaof);
+
+    clusterNode *primary = myself->replicaof;
+    for (int i = 0; i < primary->num_replicas; i++) {
+        if (!nodePrimaryIsFail(primary->replicas[i])) {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 /* This function is called by clusterHandleReplicaFailover() in order to
@@ -5621,10 +5678,22 @@ void clusterHandleReplicaFailover(void) {
             server.cluster->failover_auth_time = now;
             server.cluster->failover_auth_rank = 0;
             server.cluster->failover_failed_primary_rank = 0;
-            /* Reset auth_age since it is outdated now and we can bypass the auth_timeout
+        }
+
+        if (server.cluster->mf_end == 0 && myselfIsBestRankedReplica()) {
+            /* If we find that myself is the best ranked replica, we can initiate the
+             * failover immediately. */
+            server.cluster->failover_auth_time = now;
+            serverLog(LL_NOTICE, "This is the best ranked replica and can initiate the election immediately.");
+        }
+
+        if (server.cluster->failover_auth_time == now) {
+            /* If we happen to initiate a failover (automatic or manual) immediately.
+             * Reset auth_age since it is outdated now and we can bypass the auth_timeout
              * check in the next state and start the election ASAP. */
             auth_age = 0;
         }
+
         serverLog(LL_NOTICE,
                   "Start of election delayed for %lld milliseconds "
                   "(rank #%d, primary rank #%d, offset %lld).",
@@ -5648,8 +5717,13 @@ void clusterHandleReplicaFailover(void) {
      * It is also possible that we received the message that telling a
      * shard is up. Update the delay if our failed_primary_rank changed.
      *
+     * It is also possible that we received more message and then we figure
+     * out myself is the best ranked replica, in this case, we can initiate
+     * the election immediately.
+     *
      * Not performed if this is a manual failover. */
-    if (server.cluster->failover_auth_sent == 0 && server.cluster->mf_end == 0) {
+    if (server.cluster->failover_auth_sent == 0 && server.cluster->mf_end == 0 &&
+        server.cluster->failover_auth_time != now) {
         int newrank = clusterGetReplicaRank();
         if (newrank != server.cluster->failover_auth_rank) {
             long long added_delay = (newrank - server.cluster->failover_auth_rank) * (delay * 2);
@@ -5666,6 +5740,13 @@ void clusterHandleReplicaFailover(void) {
             server.cluster->failover_failed_primary_rank = new_failed_primary_rank;
             serverLog(LL_NOTICE, "Failed primary rank updated to #%d, added %lld milliseconds of delay.",
                       new_failed_primary_rank, added_delay);
+        }
+
+        if (myselfIsBestRankedReplica()) {
+            /* If we find that myself is the best ranked replica, we can initiate the
+             * failover immediately. */
+            server.cluster->failover_auth_time = now;
+            serverLog(LL_NOTICE, "Myself become the best ranked replica, initiate the election immediately.");
         }
     }
 

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -65,6 +65,11 @@ typedef struct clusterLink {
 #define CLUSTER_NODE_MULTI_MEET_SUPPORTED CLUSTER_NODE_LIGHT_HDR_MODULE_SUPPORTED /* This node handles multi meet packet.                             \
                                                                                      Light hdr for module and multi meet were both introduced in 8.1, \
                                                                                      so we could reduce the same flag value. */
+#define CLUSTER_NODE_MY_PRIMARY_FAIL (1 << 13)                                    /* myself is a replica and my primary is FAIL in my view. \
+                                                                                   * myself will gossip this flag to other replica in the   \
+                                                                                   * shard so that the replicas can make a better ranking   \
+                                                                                   * decisions to help with the failover. */
+
 #define CLUSTER_NODE_NULL_NAME                                                                                         \
     "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000" \
     "\000\000\000\000\000\000\000\000\000\000\000\000"
@@ -80,6 +85,7 @@ typedef struct clusterLink {
 #define nodeSupportsExtensions(n) ((n)->flags & CLUSTER_NODE_EXTENSIONS_SUPPORTED)
 #define nodeSupportsMultiMeet(n) ((n)->flags & CLUSTER_NODE_MULTI_MEET_SUPPORTED)
 #define nodeInNormalState(n) (!((n)->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_MEET | CLUSTER_NODE_PFAIL | CLUSTER_NODE_FAIL)))
+#define nodePrimaryIsFail(n) ((n)->flags & CLUSTER_NODE_MY_PRIMARY_FAIL)
 
 /* Cluster messages header */
 

--- a/src/server.c
+++ b/src/server.c
@@ -1464,6 +1464,8 @@ void cronUpdateMemoryStats(void) {
             &server.cron_malloc_stats.allocator_allocated, &server.cron_malloc_stats.allocator_active,
             &server.cron_malloc_stats.allocator_resident, NULL, &server.cron_malloc_stats.allocator_muzzy);
         server.cron_malloc_stats.allocator_frag_smallbins_bytes = allocatorDefragGetFragSmallbins();
+        getrusage(RUSAGE_SELF, &server.cron_rusage_self);
+        getrusage(RUSAGE_CHILDREN, &server.cron_rusage_children);
         /* in case the allocator isn't providing these stats, fake them so that
          * fragmentation info still shows some (inaccurate metrics) */
         if (!server.cron_malloc_stats.allocator_resident) {
@@ -5995,6 +5997,7 @@ void totalNumberOfStatefulKeys(unsigned long *blocking_keys,
  * on memory corruption problems. */
 sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
     sds info = sdsempty();
+    info = sdsMakeRoomFor(info, 4096);
     time_t uptime = server.unixtime - server.stat_starttime;
     int j;
     int sections = 0;
@@ -6550,18 +6553,17 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
     if (all_sections || (dictFind(section_dict, "cpu") != NULL)) {
         if (sections++) info = sdscat(info, "\r\n");
 
-        struct rusage self_ru, c_ru;
-        getrusage(RUSAGE_SELF, &self_ru);
-        getrusage(RUSAGE_CHILDREN, &c_ru);
+        struct rusage *self_ru = &server.cron_rusage_self;
+        struct rusage *c_ru = &server.cron_rusage_children;
         info = sdscatprintf(info,
                             "# CPU\r\n"
                             "used_cpu_sys:%ld.%06ld\r\n"
                             "used_cpu_user:%ld.%06ld\r\n"
                             "used_cpu_sys_children:%ld.%06ld\r\n"
                             "used_cpu_user_children:%ld.%06ld\r\n",
-                            (long)self_ru.ru_stime.tv_sec, (long)self_ru.ru_stime.tv_usec,
-                            (long)self_ru.ru_utime.tv_sec, (long)self_ru.ru_utime.tv_usec, (long)c_ru.ru_stime.tv_sec,
-                            (long)c_ru.ru_stime.tv_usec, (long)c_ru.ru_utime.tv_sec, (long)c_ru.ru_utime.tv_usec);
+                            (long)self_ru->ru_stime.tv_sec, (long)self_ru->ru_stime.tv_usec,
+                            (long)self_ru->ru_utime.tv_sec, (long)self_ru->ru_utime.tv_usec, (long)c_ru->ru_stime.tv_sec,
+                            (long)c_ru->ru_stime.tv_usec, (long)c_ru->ru_utime.tv_sec, (long)c_ru->ru_utime.tv_usec);
 #ifdef RUSAGE_THREAD
         struct rusage m_ru;
         getrusage(RUSAGE_THREAD, &m_ru);

--- a/src/server.h
+++ b/src/server.h
@@ -54,6 +54,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <signal.h>
+#include <sys/resource.h>
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>

--- a/src/server.h
+++ b/src/server.h
@@ -1926,6 +1926,8 @@ struct valkeyServer {
     long long stat_sync_partial_err;               /* Number of unaccepted PSYNC requests. */
     commandlog commandlog[COMMANDLOG_TYPE_NUM];    /* Logs of commands. */
     struct malloc_stats cron_malloc_stats;         /* sampled in serverCron(). */
+    struct rusage cron_rusage_self;                /* sampled in serverCron(). */
+    struct rusage cron_rusage_children;            /* sampled in serverCron(). */
     long long stat_net_input_bytes;                /* Bytes read from network. */
     long long stat_net_output_bytes;               /* Bytes written to network. */
     long long stat_net_repl_input_bytes;           /* Bytes read during replication, added to stat_net_input_bytes in 'info'. */

--- a/tests/support/util.tcl
+++ b/tests/support/util.tcl
@@ -201,7 +201,7 @@ proc verify_log_message {srv_idx pattern from_line} {
     incr from_line
     set result [exec tail -n +$from_line < [srv $srv_idx stdout]]
     if {![string match $pattern $result]} {
-        fail "expected pattern found in log file: $pattern, but instead got: $result"
+        fail "expected pattern found in srv $srv_idx log file: $pattern, but instead got: $result"
     }
 }
 
@@ -210,7 +210,7 @@ proc verify_no_log_message {srv_idx pattern from_line} {
     incr from_line
     set result [exec tail -n +$from_line < [srv $srv_idx stdout]]
     if {[string match $pattern $result]} {
-        fail "expected message found in log file: $pattern"
+        fail "expected pattern not found in srv $srv_idx log file: $pattern, but instead got: $result"
     }
 }
 
@@ -1298,4 +1298,19 @@ proc version_greater_or_equal {a b} {
     } else {
         return 1
     }
+}
+
+proc memcmp {string1 string2} {
+    set len1 [string length $string1]
+    set len2 [string length $string2]
+    set minLen [expr min($len1, $len2)]
+
+    for {set i 0} {$i < $minLen} {incr i} {
+        set char1 [scan [string index $string1 $i] %c]
+        set char2 [scan [string index $string2 $i] %c]
+        if {$char1 != $char2} {
+            return [expr {$char1 - $char2}]
+        }
+    }
+    return [expr {$len1 - $len2}]
 }

--- a/tests/unit/cluster/faster-failover.tcl
+++ b/tests/unit/cluster/faster-failover.tcl
@@ -1,0 +1,149 @@
+# Check the faster failover is working.
+
+# Allocate slot 0 to the first primary and allocate slot 1 to the second primary,
+# and then evenly distribute the remaining slots to the remaining primaries.
+proc my_slot_allocation {primaries replicas} {
+    R 0 cluster addslots 0
+    R 1 cluster addslots 1
+    R 2 cluster addslotsrange 2 5463
+    R 3 cluster addslotsrange 5464 10927
+    R 4 cluster addslotsrange 10928 16383
+}
+
+# We have the following nodes:
+# Primary:  R0  R1  R2  R3  R4
+# Replica1: R5  R6  R7  R8  R9
+# Replica2: R10 R11
+#
+# R0 own slot 0 and its replicas are R5 and R10, key key_977613 belong to slot 0.
+# R1 own slot 1 and its replicas are R6 and R11, key key_991803 belong to slot 1.
+#
+# We will test the scenario where both R0 and R1 shards are down at the same time
+# to test whether their faster failover is as expected.
+#
+# In the R0 shard, the offset of R10 will be greater than that of R5, so it is
+# expected that R10 will start failover faster.
+#
+# In the R1 shard, the offsets of R6 and R11 are the same, we have replica rank
+# to sure that there will not have failover timeout.
+#
+# Even if R0 and R1 down at the same time, we have failed primary rank to ensure
+# that there will not have failover timeout.
+#
+# Needs to run in the body of
+# start_cluster 5 7 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+proc test_best_ranked_replica {} {
+    test "The best replica can initiate an election immediately in an automatic failover" {
+        # We calculate their rankings so that we can make rank judgments later.
+        set R0_failed_primary_rank [expr [expr [memcmp [R 0 cluster myshardid] [R 1 cluster myshardid]] < 0] ? 0 : 1]
+        set R1_failed_primary_rank [expr [expr [memcmp [R 1 cluster myshardid] [R 0 cluster myshardid]] < 0] ? 0 : 1]
+
+        set R6_replica_rank [expr [expr [memcmp [R 6 cluster myid] [R 11 cluster myid]] < 0] ? 0 : 1]
+        set R11_replica_rank [expr [expr [memcmp [R 11 cluster myid] [R 6 cluster myid]] < 0] ? 0 : 1]
+
+        set R0_nodeid [R 0 cluster myid]
+        set R1_nodeid [R 1 cluster myid]
+
+        # Write some data to the R0 and wait the sync.
+        for {set i 0} {$i < 10} {incr i} {
+            R 0 incr key_977613
+        }
+        wait_for_ofs_sync [srv 0 client] [srv -5 client]
+        wait_for_ofs_sync [srv 0 client] [srv -10 client]
+
+        # Write some data to the R1 and wait the sync.
+        for {set i 0} {$i < 10} {incr i} {
+            R 1 incr key_991803
+        }
+        wait_for_ofs_sync [srv -1 client] [srv -6 client]
+        wait_for_ofs_sync [srv -1 client] [srv -11 client]
+
+        # Pause R5 so it has no chance to catch up with the offset.
+        pause_process [srv -5 pid]
+
+        # Kill the replica client of R0.
+        R 0 client kill type replica
+        R 0 incr key_977613
+
+        # Wait for R10 to catch up with the offset so it will have a better offset than R5.
+        wait_for_ofs_sync [srv 0 client] [srv -10 client]
+
+        # Pause R0 and R1, the replicas of each shard will do the automatic failover.
+        pause_process [srv 0 pid]
+        pause_process [srv -1 pid]
+
+        # Resume R5.
+        resume_process [srv -5 pid]
+
+        # Make sure both primaries R0 and R1 are FAIL from the replica's view.
+        wait_for_condition 1000 10 {
+            [cluster_has_flag [cluster_get_node_by_id 5 $R0_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 5 $R1_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 10 $R0_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 10 $R1_nodeid] fail] eq 1 &&
+
+            [cluster_has_flag [cluster_get_node_by_id 6 $R0_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 6 $R1_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 11 $R0_nodeid] fail] eq 1 &&
+            [cluster_has_flag [cluster_get_node_by_id 11 $R1_nodeid] fail] eq 1
+        } else {
+            fail "The node is not marked with the correct flag"
+        }
+
+        wait_for_condition 1000 100 {
+            [s -10 role] == "master" &&
+            ([s -6 role] == "master" || [s -11 role] == "master")
+        } else {
+            fail "No failover detected"
+        }
+
+        # case 1: R0 and R1 down in the same time, R0 have a better failed primary rank, R10 is
+        # the best ranked replica in the first place, if so, there is no delay.
+        if {$R0_failed_primary_rank == 0} {
+            if {[count_log_message -10 "This is the best ranked replica and can initiate the election immediately"] != 0} {
+                verify_log_message -10 "*Start of election delayed for 0 milliseconds*" 0
+            }
+        }
+        # No matter what, R10 will be the best ranked replica in R0.
+        # This is the best ranked replica and can initiate the election immediately
+        # Myself become the best ranked replica, initiate the election immediately
+        verify_log_message -10 "*best ranked replica*" 0
+        wait_for_log_messages -5 {"*Successful partial resynchronization with primary*"} 0 1000 50
+
+        # case 2: R0 and R1 down in the same time, R1 have a better failed primary rank, R6 or R11
+        # will be the best ranked replica in the first place, if so, there is no delay.
+        if {$R1_failed_primary_rank == 0 && $R6_replica_rank == 0} {
+            if {[count_log_message -6 "This is the best ranked replica and can initiate the election immediately"]} {
+                verify_log_message -6 "*Start of election delayed for 0 milliseconds*" 0
+            }
+        }
+        if {$R1_failed_primary_rank == 0 && $R11_replica_rank == 0} {
+            if {[count_log_message -11 "This is the best ranked replica and can initiate the election immediately"]} {
+                verify_log_message -11 "*Start of election delayed for 0 milliseconds*" 0
+            }
+        }
+        # No matter what, there will be a best ranked replica in R1.
+        # This is the best ranked replica and can initiate the election immediately
+        # Myself become the best ranked replica, initiate the election immediately
+        if {$R6_replica_rank == 0} {
+            verify_log_message -6 "*best ranked replica*" 0
+            wait_for_log_messages -11 {"*Successful partial resynchronization with primary*"} 0 1000 50
+        } else {
+            verify_log_message -11 "*best ranked replica*" 0
+            wait_for_log_messages -6 {"*Successful partial resynchronization with primary*"} 0 1000 50
+        }
+
+        # In any case, we do not expect timeouts.
+        verify_no_log_message -5 "*Failover attempt expired*" 0
+        verify_no_log_message -10 "*Failover attempt expired*" 0
+        verify_no_log_message -6 "*Failover attempt expired*" 0
+        verify_no_log_message -11 "*Failover attempt expired*" 0
+    }
+}
+
+# This change and test is quite important, so we want to run it a few more times.
+for {set i 0} {$i < 5} {incr i} {
+    start_cluster 5 7 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+        test_best_ranked_replica
+    } my_slot_allocation cluster_allocate_replicas ;# start_cluster
+}

--- a/tests/unit/moduleapi/testrdb.tcl
+++ b/tests/unit/moduleapi/testrdb.tcl
@@ -225,6 +225,12 @@ tags "modules" {
                     $replica debug populate 200 slave 10
                     $master debug populate 1000 master 100000
                     $master config set rdbcompression no
+                    
+                    if {$testType eq "Aborted"} {
+                        # Set master with a slow rdb generation, so that we can easily intercept loading
+                        # 10ms per key, with 1000 keys is 10 seconds
+                        $master config set rdb-key-save-delay 10000
+                    }
 
                     # Force the replica to try another full sync (this time it will have matching master replid)
                     $master multi
@@ -238,10 +244,6 @@ tags "modules" {
 
                     switch $testType {
                         "Aborted" {
-                            # Set master with a slow rdb generation, so that we can easily intercept loading
-                            # 10ms per key, with 1000 keys is 10 seconds
-                            $master config set rdb-key-save-delay 10000
-
                             test {Diskless load swapdb RedisModuleEvent_ReplAsyncLoad handling: during loading, can keep module variable same as before} {
                                 # Wait for the replica to start reading the rdb and module for acknowledgement
                                 # We wanna abort only after the temp db was populated by REDISMODULE_AUX_BEFORE_RDB


### PR DESCRIPTION
I think info command is one of the important command in Valkey. because it is necessary to monitor redis.
so its performance is very important. so small improvement is also important.

I optimized info command 2 ways. and increase "info all" performance around 5% in linux and Mac
1. pre allocation for result String as 4K. (Buffer sizes smaller than 4K or larger than 8K actually degrade performance. in my test)
2. caching rusage system call in cron. (we already use this way for stats)  

INFO ALL (rps) with valley-benchmark 

|branch|1|2|3|
|unstable|16283.99|15895.72|16126.43|
|PR|17137.96|16744.81|16871.94|