### PR TITLE
Add all-with-unit-tests Makefile target to fix weekly CI

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -390,6 +390,9 @@ all: $(REDIS_SERVER_NAME) $(REDIS_SENTINEL_NAME) $(REDIS_CLI_NAME) $(REDIS_BENCH
 	@echo "Hint: It's a good idea to run 'make test' ;)"
 	@echo ""
 
+all-with-unit-tests: all
+.PHONY: all-with-unit-tests
+
 Makefile.dep:
 	-$(REDIS_CC) -MM $(ALL_SOURCES) > Makefile.dep 2> /dev/null || true
 


### PR DESCRIPTION
The weekly workflow (weekly.yml on unstable) runs the daily.yml workflow against all release branches including 7.2. Since daily.yml uses `make all-with-unit-tests` (a target introduced in unstable with the unit test framework in #344), the build fails on 7.2 which doesn't have this target:

  make[1]: *** No rule to make target 'all-with-unit-tests'.  Stop.

This has been failing since #2702 introduced weekly test runs on release branches.

Add `all-with-unit-tests` as an alias for `all` since there are no gtest unit tests on this branch.