### PR TITLE
Show uname -a in RDMA CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           make -j4 BUILD_RDMA=yes USE_LIBBACKTRACE=yes
       - name: clone-rxe-kmod
         run: |
+          uname -a
           mkdir -p tests/rdma/rxe
           git clone https://github.com/pizhenwei/rxe.git tests/rdma/rxe
           make -C tests/rdma/rxe


### PR DESCRIPTION
The RXE project should keep the same version with the CI machine, showing uname in RDMA CI job to find out the reason of kmod installing failure.