### PR TITLE
Improve listpack threshold guidance in valkey.conf

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -2279,6 +2279,17 @@ notify-keyspace-events ""
 
 ############################### ADVANCED CONFIG ###############################
 
+# Small hashes, sets and sorted sets can use listpacks to save memory.
+# The "*-max-listpack-entries" settings limit how many entries can stay in
+# listpack encoding. The "*-max-listpack-value" settings limit the largest
+# entry that can stay in listpack encoding.
+#
+# Higher limits usually save memory, but can make some updates or lookups more
+# expensive because larger listpacks take longer to traverse. Lower limits use
+# more memory, but can reduce the cost of operations on larger values.
+#
+# Change these only after measuring your actual dataset and workload.
+#
 # Hashes are encoded using a memory efficient data structure when they have a
 # small number of entries, and the biggest entry does not exceed a given
 # threshold. These thresholds can be configured using the following directives.

--- a/valkey.conf
+++ b/valkey.conf
@@ -2279,26 +2279,30 @@ notify-keyspace-events ""
 
 ############################### ADVANCED CONFIG ###############################
 
-# Small hashes, sets and sorted sets can use listpacks to save memory.
-# The "*-max-listpack-entries" settings limit how many entries can stay in
-# listpack encoding. The "*-max-listpack-value" settings limit the largest
-# entry that can stay in listpack encoding.
+# Valkey uses listpacks for some small hashes, sets, sorted sets, and
+# quicklist nodes.
+# A listpack is a compact, memory-efficient representation that stores multiple
+# elements in a contiguous block of memory. This usually saves memory, but
+# larger listpacks can make some updates or lookups more expensive because more
+# data may need to be traversed or rewritten.
 #
-# Higher limits usually save memory, but can make some updates or lookups more
-# expensive because larger listpacks take longer to traverse. Lower limits use
-# more memory, but can reduce the cost of operations on larger values.
+# The "*-max-listpack-entries" settings limit how many entries can stay in a
+# listpack. The "*-max-listpack-value" settings limit the largest element,
+# field, or value that can stay in a listpack.
+#
+# This section also includes related settings for list compression and for sets
+# that can use intset encoding instead of listpacks.
 #
 # Change these only after measuring your actual dataset and workload.
 #
-# Hashes are encoded using a memory efficient data structure when they have a
-# small number of entries, and the biggest entry does not exceed a given
-# threshold. These thresholds can be configured using the following directives.
+# Hashes use listpacks when they have a small number of entries, and the
+# biggest field or value does not exceed the following limits.
 hash-max-listpack-entries 512
 hash-max-listpack-value 64
 
-# Lists are also encoded in a special way to save a lot of space.
-# The number of entries allowed per internal list node can be specified
-# as a fixed maximum size or a maximum number of elements.
+# Lists are stored as quicklists, where each internal node is a listpack.
+# The number of entries allowed per listpack node can be specified as a fixed
+# maximum size or a maximum number of elements.
 # For a fixed maximum size, use -5 through -1, meaning:
 # -5: max size: 64 Kb  <-- not recommended for normal workloads
 # -4: max size: 32 Kb  <-- not recommended
@@ -2312,7 +2316,7 @@ hash-max-listpack-value 64
 list-max-listpack-size -2
 
 # Lists may also be compressed.
-# Compress depth is the number of quicklist ziplist nodes from *each* side of
+# Compress depth is the number of quicklist nodes from *each* side of
 # the list to *exclude* from compression.  The head and tail of the list
 # are always uncompressed for fast push/pop operations.  Settings are:
 # 0: disable all list compression
@@ -2327,23 +2331,18 @@ list-max-listpack-size -2
 # etc.
 list-compress-depth 0
 
-# Sets have a special encoding when a set is composed
-# of just strings that happen to be integers in radix 10 in the range
-# of 64 bit signed integers.
-# The following configuration setting sets the limit in the size of the
-# set in order to use this special memory saving encoding.
+# Sets containing only integers can use intset encoding.
+# The following setting limits the largest set that can use intset encoding.
 set-max-intset-entries 512
 
-# Sets containing non-integer values are also encoded using a memory efficient
-# data structure when they have a small number of entries, and the biggest entry
-# does not exceed a given threshold. These thresholds can be configured using
-# the following directives.
+# Sets containing non-integer values use listpacks when they have a small
+# number of entries, and the biggest member does not exceed the following
+# limits.
 set-max-listpack-entries 128
 set-max-listpack-value 64
 
-# Similarly to hashes and lists, sorted sets are also specially encoded in
-# order to save a lot of space. This encoding is only used when the length and
-# elements of a sorted set are below the following limits:
+# Sorted sets use listpacks when they have a small number of entries, and the
+# biggest member does not exceed the following limits:
 zset-max-listpack-entries 128
 zset-max-listpack-value 64
 

--- a/valkey.conf
+++ b/valkey.conf
@@ -2280,7 +2280,7 @@ notify-keyspace-events ""
 ############################### ADVANCED CONFIG ###############################
 
 # Valkey uses listpacks for some small hashes, sets, sorted sets, and
-# quicklist nodes.
+# list nodes.
 # A listpack is a compact, memory-efficient representation that stores multiple
 # elements in a contiguous block of memory. This usually saves memory, but
 # larger listpacks can make some updates or lookups more expensive because more


### PR DESCRIPTION
Fixes #3299

Add brief guidance in valkey.conf explaining what the listpack thresholds control and the memory/CPU tradeoff when tuning them.