### PR TITLE
Reduce corrupt-dump-fuzzer tests from 10 to 1 minute

### DIFF
--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -77,8 +77,8 @@ proc corrupt_payload {payload} {
 # valgrind will make sure there were no leaks in the rdb loader error handling code
 foreach sanitize_dump {no yes} {
     if {$::accurate} {
-        set min_duration [expr {60 * 10}] ;# run at least 10 minutes
-        set min_cycles 1000 ;# run at least 1k cycles (max 16 minutes)
+        set min_duration 60 ;# run at least 1 minute
+        set min_cycles 100 ;# run at least 100 cycles
     } else {
         set min_duration 10 ; # run at least 10 seconds
         set min_cycles 10 ; # run at least 10 cycles


### PR DESCRIPTION
In Daily test runs with the `--accurate` flag, the corrupt-dump-fuzzer test runs for 10 minutes (600 seconds) with "sanitize_dump: no" and then another 10 minutes with "sanitize_dump: yes". This causes the runner to time out the whole test job to be aborted with a sigterm from the runner.

Example:

    13697:signal-handler (1774917673) Received SIGTERM scheduling shutdown...

This change reduces this hard-coded fuzzer run from 10 to 1 minute. We have many tests jobs so the fuzzer gets plenty of time to run anyway.

Here is a job aborted by a SIGTERM from the runner in the middle of the maxmemory test:

https://github.com/valkey-io/valkey/actions/runs/23774277197/job/69272507752#step:8:7699