### PR TITLE
add key_len parameter to hashtable lookup api - enables copy-avoidance work

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -271,13 +271,16 @@ dictType clusterSdsToListType = {
     .entryDestructor = dictEntryDestructorSdsKeyListValue,
 };
 
-static uint64_t dictPtrHash(const void *key) {
+static uint64_t dictPtrHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     /* We hash the pointer value itself. */
     return dictGenHashFunction((const char *)&key, sizeof(key));
 }
 
-static int dictPtrCompare(const void *key1, const void *key2) {
-    return key1 == key2;
+static int dictPtrCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
+    return key1 != key2;
 }
 
 /* Dictionary type for mapping hash slots to cluster nodes.

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -249,7 +249,7 @@ static_assert(offsetof(clusterMsg, type) + sizeof(uint16_t) == RCVBUF_MIN_READ_L
 dictType clusterNodesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -259,7 +259,7 @@ dictType clusterNodesDictType = {
 dictType clusterNodesBlackListDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -267,7 +267,7 @@ dictType clusterNodesBlackListDictType = {
 dictType clusterSdsToListType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKeyListValue,
 };
 
@@ -277,10 +277,10 @@ static uint64_t dictPtrHash(const void *key, size_t key_len) {
     return dictGenHashFunction((const char *)&key, sizeof(key));
 }
 
-static int dictPtrCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+static bool dictPtrKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
-    return key1 != key2;
+    return key1 == key2;
 }
 
 /* Dictionary type for mapping hash slots to cluster nodes.
@@ -288,7 +288,7 @@ static int dictPtrCompare(const void *key1, size_t key1_len, const void *key2, s
 dictType clusterSlotDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictPtrHash,
-    .keyCompare = dictPtrCompare,
+    .keysEqual = dictPtrKeysEqual,
     .entryDestructor = zfree,
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -1043,14 +1043,14 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state);
 dictType optionToLineDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyListValue,
 };
 
 dictType optionSetDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -552,7 +552,7 @@ void loadServerConfigFromString(sds config) {
 
             /* If the target command name is the empty string we just
              * remove it from the command table. */
-            serverAssert(hashtableDelete(server.commands, argv[1]));
+            serverAssert(hashtableDelete(server.commands, argv[1], sdslen(argv[1])));
 
             /* Otherwise we re-add the command under a different name. */
             if (sdslen(argv[2]) != 0) {

--- a/src/db.c
+++ b/src/db.c
@@ -199,21 +199,22 @@ void dbUpdateObjectWithVolatileItemsTracking(serverDb *db, robj *o) {
  * If the update_if_existing argument is false, the program is aborted
  * if the key already exists, otherwise, it can fall back to dbOverwrite. */
 static void dbAddInternal(serverDb *db, robj *key, robj **valref, int update_if_existing) {
-    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+    sds keyval = objectGetVal(key);
+    int dict_index = getKVStoreIndexForKey(keyval);
     void **oldref = NULL;
     if (update_if_existing) {
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
+        oldref = kvstoreHashtableFindRef(db->keys, dict_index, keyval, sdslen(keyval));
         if (oldref != NULL) {
             dbSetValue(db, key, valref, 1, oldref);
             return;
         }
     } else {
-        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key)) == NULL);
+        debugServerAssertWithInfo(NULL, key, kvstoreHashtableFindRef(db->keys, dict_index, keyval, sdslen(keyval)) == NULL);
     }
 
     /* Not existing. Convert val to valkey object and insert. */
     robj *val = *valref;
-    val = objectSetKeyAndExpire(val, objectGetVal(key), -1);
+    val = objectSetKeyAndExpire(val, keyval, -1);
     /* Track hash object if it has volatile fields (for active expiry).
      * For example, this is needed when a hash is moved to a new DB (e.g. MOVE). */
     dbTrackKeyWithVolatileItems(db, val);
@@ -277,7 +278,7 @@ int getKeySlot(sds key) {
 int dbAddRDBLoad(serverDb *db, sds key, robj **valref) {
     int dict_index = getKVStoreIndexForKey(key);
     hashtablePosition pos;
-    if (!kvstoreHashtableFindPositionForInsert(db->keys, dict_index, key, &pos, NULL)) {
+    if (!kvstoreHashtableFindPositionForInsert(db->keys, dict_index, key, sdslen(key), &pos, NULL)) {
         return 0;
     }
     robj *val = *valref;
@@ -318,8 +319,9 @@ int dbAddRDBLoad(serverDb *db, sds key, robj **valref) {
 static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, void **oldref) {
     robj *val = *valref;
     if (oldref == NULL) {
-        int dict_index = getKVStoreIndexForKey(objectGetVal(key));
-        oldref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
+        sds keyval = objectGetVal(key);
+        int dict_index = getKVStoreIndexForKey(keyval);
+        oldref = kvstoreHashtableFindRef(db->keys, dict_index, keyval, sdslen(keyval));
     }
     serverAssertWithInfo(NULL, key, oldref != NULL);
     robj *old = *oldref;
@@ -360,12 +362,13 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
         /* Replace the old value at its location in the key space. */
         val->lru = old->lru;
         long long expire = objectGetExpire(old);
-        new = objectSetKeyAndExpire(val, objectGetVal(key), expire);
+        sds keyval = objectGetVal(key);
+        new = objectSetKeyAndExpire(val, keyval, expire);
         *oldref = new;
         /* Replace the old value at its location in the expire space. */
         if (expire >= 0) {
-            int dict_index = getKVStoreIndexForKey(objectGetVal(key));
-            void **expireref = kvstoreHashtableFindRef(db->expires, dict_index, objectGetVal(key));
+            int dict_index = getKVStoreIndexForKey(keyval);
+            void **expireref = kvstoreHashtableFindRef(db->expires, dict_index, keyval, sdslen(keyval));
             serverAssert(expireref != NULL);
             *expireref = new;
         }
@@ -472,8 +475,9 @@ robj *dbRandomKey(serverDb *db) {
 }
 
 int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, int dict_index) {
+    sds keyval = objectGetVal(key);
     hashtablePosition pos;
-    void **ref = kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, objectGetVal(key), &pos);
+    void **ref = kvstoreHashtableTwoPhasePopFindRef(db->keys, dict_index, keyval, sdslen(keyval), &pos);
     if (ref != NULL) {
         robj *val = *ref;
         /* VM_StringDMA may call dbUnshareStringValue which may free val, so we
@@ -492,10 +496,10 @@ int dbGenericDeleteWithDictIndex(serverDb *db, robj *key, int async, int flags, 
          * (The expires table has no destructor callback.) */
         kvstoreHashtableTwoPhasePopDelete(db->keys, dict_index, &pos);
         if (objectGetExpire(val) != -1) {
-            bool deleted = kvstoreHashtableDelete(db->expires, dict_index, objectGetVal(key));
+            bool deleted = kvstoreHashtableDelete(db->expires, dict_index, keyval, sdslen(keyval));
             serverAssert(deleted);
         } else {
-            debugServerAssert(!kvstoreHashtableDelete(db->expires, dict_index, objectGetVal(key)));
+            debugServerAssert(!kvstoreHashtableDelete(db->expires, dict_index, keyval, sdslen(keyval)));
         }
 
         /* If deleting a hash object, un-track it from the volatile items tracking if it contains volatile items.*/
@@ -531,8 +535,9 @@ void dbTrackKeyWithVolatileItems(serverDb *db, robj *o) {
 
 /* Delete a key from the keys with volatile entries tracking kvstore */
 void dbUntrackKeyWithVolatileItems(serverDb *db, robj *o) {
-    int dict_index = getKVStoreIndexForKey(objectGetKey(o));
-    kvstoreHashtableDelete(db->keys_with_volatile_items, dict_index, objectGetKey(o));
+    sds key = objectGetKey(o);
+    int dict_index = getKVStoreIndexForKey(key);
+    kvstoreHashtableDelete(db->keys_with_volatile_items, dict_index, key, sdslen(key));
 }
 
 /* Delete a key, value, and associated expiration entry if any, from the DB */
@@ -1859,9 +1864,10 @@ void swapdbCommand(client *c) {
  *----------------------------------------------------------------------------*/
 
 int removeExpire(serverDb *db, robj *key) {
-    int dict_index = getKVStoreIndexForKey(objectGetVal(key));
+    sds keyval = objectGetVal(key);
+    int dict_index = getKVStoreIndexForKey(keyval);
     void *popped;
-    if (kvstoreHashtablePop(db->expires, dict_index, objectGetVal(key), &popped)) {
+    if (kvstoreHashtablePop(db->expires, dict_index, keyval, sdslen(keyval), &popped)) {
         robj *val = popped;
         robj *newval = objectSetExpire(val, -1);
         serverAssert(newval == val);
@@ -1886,7 +1892,8 @@ robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
      * expire in an robj, it's potentially reallocated. We need to updates the
      * pointer(s) to it. */
     int dict_index = getKVStoreIndexForKey(objectGetVal(key));
-    void **valref = kvstoreHashtableFindRef(db->keys, dict_index, objectGetVal(key));
+    sds keyval = objectGetVal(key);
+    void **valref = kvstoreHashtableFindRef(db->keys, dict_index, keyval, sdslen(keyval));
     serverAssertWithInfo(NULL, key, valref != NULL);
     val = *valref;
     long long old_when = objectGetExpire(val);
@@ -2234,7 +2241,7 @@ int dbExpandExpires(serverDb *db, uint64_t db_size, int try_expand) {
 
 static robj *dbFindWithDictIndex(serverDb *db, sds key, int dict_index) {
     void *existing = NULL;
-    kvstoreHashtableFind(db->keys, dict_index, key, &existing);
+    kvstoreHashtableFind(db->keys, dict_index, key, sdslen(key), &existing);
     return existing;
 }
 
@@ -2245,7 +2252,7 @@ robj *dbFind(serverDb *db, sds key) {
 
 robj *dbFindExpiresWithDictIndex(serverDb *db, sds key, int dict_index) {
     void *existing = NULL;
-    kvstoreHashtableFind(db->expires, dict_index, key, &existing);
+    kvstoreHashtableFind(db->expires, dict_index, key, sdslen(key), &existing);
     return existing;
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -855,7 +855,7 @@ static doneStatus defragLaterStep(monotime endtime, void *privdata) {
         listNode *head = listFirst(defrag_later);
         sds key = head->value;
         void *found = NULL;
-        kvstoreHashtableFind(ctx->kvstate.kvs, ctx->kvstate.slot, key, &found);
+        kvstoreHashtableFind(ctx->kvstate.kvs, ctx->kvstate.slot, key, sdslen(key), &found);
         robj *ob = found;
 
         long long key_defragged = server.stat_active_defrag_hits;

--- a/src/dict.h
+++ b/src/dict.h
@@ -126,7 +126,8 @@ static inline void *dictGetKey(const dictEntry *de) {
 }
 
 /* Callback for dictType.entryGetKey, which expects void pointers. */
-static inline const void *dictEntryGetKey(const void *entry) {
+static inline const void *dictEntryGetKey(const void *entry, size_t *len) {
+    if (len) *len = 0;
     return dictGetKey((const dictEntry *)entry);
 }
 
@@ -162,7 +163,7 @@ static inline size_t dictMemUsage(const dict *d) {
  * or NULL if the key doesn't exist. */
 static inline dictEntry *dictFind(dict *d, const void *key) {
     void *found = NULL;
-    return hashtableFind(d, key, &found) ? (dictEntry *)found : NULL;
+    return hashtableFind(d, key, 0, &found) ? (dictEntry *)found : NULL;
 }
 
 /* Fetch the value associated with a key. Returns the value if the key exists,
@@ -175,7 +176,7 @@ static inline void *dictFetchValue(dict *d, const void *key) {
 /* Remove a key from the dictionary. Returns DICT_OK if the key was found
  * and removed, DICT_ERR if the key was not found. */
 static inline int dictDelete(dict *d, const void *key) {
-    return hashtableDelete(d, key) ? DICT_OK : DICT_ERR;
+    return hashtableDelete(d, key, 0) ? DICT_OK : DICT_ERR;
 }
 
 /* Free an entry that was previously unlinked with dictUnlink().
@@ -210,7 +211,7 @@ static inline dictEntry *dictGetFairRandomKey(dict *d) {
  * Without this function the pattern would require two lookups. */
 static inline dictEntry *dictUnlink(dict *d, const void *key) {
     void *entry = NULL;
-    return hashtablePop(d, key, &entry) ? (dictEntry *)entry : NULL;
+    return hashtablePop(d, key, 0, &entry) ? (dictEntry *)entry : NULL;
 }
 
 /* Add an entry to the dictionary. */
@@ -218,7 +219,7 @@ static inline int dictAdd(dict *d, void *key, void *val) {
     hashtablePosition pos;
     void *existing = NULL;
 
-    if (!hashtableFindPositionForInsert(d, key, &pos, &existing)) {
+    if (!hashtableFindPositionForInsert(d, key, 0, &pos, &existing)) {
         return DICT_ERR; /* Key already exists */
     }
 
@@ -240,7 +241,7 @@ static inline dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing) {
     hashtablePosition pos;
     void *existing_entry = NULL;
 
-    if (!hashtableFindPositionForInsert(d, key, &pos, &existing_entry)) {
+    if (!hashtableFindPositionForInsert(d, key, 0, &pos, &existing_entry)) {
         if (existing) *existing = (dictEntry *)existing_entry;
         return NULL;
     }

--- a/src/eval.c
+++ b/src/eval.c
@@ -83,7 +83,7 @@ static void dictEntryDestructorSdsKeyScriptValue(void *entry) {
 dictType shaScriptObjectDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyScriptValue,
 };
 

--- a/src/evict.c
+++ b/src/evict.c
@@ -494,7 +494,7 @@ int performEvictions(void) {
                     }
                     void *entry = NULL;
 
-                    bool found = kvstoreHashtableFind(kvs, pool[k].slot, pool[k].key, &entry);
+                    bool found = kvstoreHashtableFind(kvs, pool[k].slot, pool[k].key, sdslen(pool[k].key), &entry);
 
                     /* Remove the entry from the pool. */
                     if (pool[k].key != pool[k].cached) sdsfree(pool[k].key);

--- a/src/expire.c
+++ b/src/expire.c
@@ -611,7 +611,7 @@ void rememberReplicaKeyWithExpire(serverDb *db, robj *key) {
         static dictType dt = {
             .entryGetKey = dictEntryGetKey,
             .hashFunction = dictSdsHash,
-            .keyCompare = dictSdsKeyCompare,
+            .keysEqual = dictSdsKeysEqual,
             .entryDestructor = dictEntryDestructorSdsKey,
         };
         replicaKeysWithExpire = dictCreate(&dt);

--- a/src/functions.c
+++ b/src/functions.c
@@ -72,7 +72,7 @@ typedef struct functionsLibMetaData {
 dictType functionDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -86,7 +86,7 @@ static void dictEntryDestructorSdsKeyEngineStatsValue(void *entry) {
 dictType engineStatsDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyEngineStatsValue,
 };
 
@@ -100,7 +100,7 @@ static void dictEntryDestructorSdsKeyEngineFunctionValue(void *entry) {
 dictType libraryFunctionDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKeyEngineFunctionValue,
 };
 
@@ -114,7 +114,7 @@ static void dictEntryDestructorSdsKeyEngineLibraryValue(void *entry) {
 dictType librariesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKeyEngineLibraryValue,
 };
 

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -287,15 +287,18 @@ void configDictValDestructor(void *val) {
     zfree(entry);
 }
 
-static int sdsKeyCompare(const void *key1, const void *key2) {
+static int sdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 0;
-    return memcmp(key1, key2, l1) == 0;
+    if (l1 != l2) return 1;
+    return memcmp(key1, key2, l1);
 }
 
-static uint64_t sdsHash(const void *key) {
+static uint64_t sdsHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenHashFunction(key, sdslen(key));
 }
 

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -287,14 +287,14 @@ void configDictValDestructor(void *val) {
     zfree(entry);
 }
 
-static int sdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+static bool sdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 1;
-    return memcmp(key1, key2, l1);
+    if (l1 != l2) return false;
+    return memcmp(key1, key2, l1) == 0;
 }
 
 static uint64_t sdsHash(const void *key, size_t key_len) {
@@ -313,7 +313,7 @@ static void dictEntryDestructorSdsKeyConfigVal(void *entry) {
 static dictType configDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = sdsHash,
-    .keyCompare = sdsKeyCompare,
+    .keysEqual = sdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKeyConfigVal,
 };
 

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -403,11 +403,11 @@ static inline void freeEntry(hashtable *ht, void *entry) {
     if (ht->type->entryDestructor) ht->type->entryDestructor(entry);
 }
 
-static inline int compareKeys(hashtable *ht, const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
-    if (ht->type->keyCompare != NULL) {
-        return ht->type->keyCompare(lookup_key, lookup_key_len, entry_key, entry_key_len);
+static inline bool keysEqual(hashtable *ht, const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (ht->type->keysEqual != NULL) {
+        return ht->type->keysEqual(lookup_key, lookup_key_len, entry_key, entry_key_len);
     } else {
-        return lookup_key != entry_key;
+        return lookup_key == entry_key;
     }
 }
 
@@ -805,7 +805,7 @@ static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, cons
     void *entry = b->entries[pos];
     size_t entry_key_len;
     const void *elem_key = entryGetKey(ht, entry, &entry_key_len);
-    if (compareKeys(ht, key, key_len, elem_key, entry_key_len) == 0) {
+    if (keysEqual(ht, key, key_len, elem_key, entry_key_len)) {
         /* It's a match. */
         assert(pos_in_bucket != NULL);
         if (!validateElementIfNeeded(ht, entry)) {
@@ -1887,7 +1887,7 @@ bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
             void *entry = data->bucket->entries[data->pos];
             size_t entry_key_len;
             const void *elem_key = entryGetKey(ht, entry, &entry_key_len);
-            if (compareKeys(ht, data->key, data->key_len, elem_key, entry_key_len) == 0) {
+            if (keysEqual(ht, data->key, data->key_len, elem_key, entry_key_len)) {
                 /* It's a match. */
                 data->state = HASHTABLE_FOUND;
                 return false;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -360,6 +360,7 @@ typedef struct {
     hashtable *hashtable;
     bucket *bucket;
     const void *key;
+    size_t key_len;
     uint64_t hash;
 } incrementalFind;
 
@@ -402,25 +403,26 @@ static inline void freeEntry(hashtable *ht, void *entry) {
     if (ht->type->entryDestructor) ht->type->entryDestructor(entry);
 }
 
-static inline int compareKeys(hashtable *ht, const void *key1, const void *key2) {
+static inline int compareKeys(hashtable *ht, const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
     if (ht->type->keyCompare != NULL) {
-        return ht->type->keyCompare(key1, key2);
+        return ht->type->keyCompare(lookup_key, lookup_key_len, entry_key, entry_key_len);
     } else {
-        return key1 == key2;
+        return lookup_key != entry_key;
     }
 }
 
-static inline const void *entryGetKey(hashtable *ht, const void *entry) {
+static inline const void *entryGetKey(hashtable *ht, const void *entry, size_t *len) {
     if (ht->type->entryGetKey != NULL) {
-        return ht->type->entryGetKey(entry);
+        return ht->type->entryGetKey(entry, len);
     } else {
+        *len = 0;
         return entry;
     }
 }
 
-static inline uint64_t hashKey(hashtable *ht, const void *key) {
+static inline uint64_t hashKey(hashtable *ht, const void *key, size_t key_len) {
     if (ht->type->hashFunction != NULL) {
-        return ht->type->hashFunction(key);
+        return ht->type->hashFunction(key, key_len);
     } else {
         return hashtableGenHashFunction((const char *)&key, sizeof(key));
     }
@@ -615,6 +617,7 @@ static bucket *fetchEntriesForExpand(bucket *b, void *buf[], int *size, int max_
 static void rehashStepExpand(hashtable *ht) {
     void *entry_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
     const void *key_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
+    size_t key_len_buf[FETCH_ENTRY_BUFFER_SIZE_WHEN_EXPAND];
     size_t idx = ht->rehash_idx;
     bucket *b = ht->tables[0] + idx;
     int size = 0;
@@ -624,11 +627,11 @@ static void rehashStepExpand(hashtable *ht) {
         /* Key optimization: no loop-carried dependency enables concurrent memory access,
          * reducing CPU stall cycles. */
         for (int i = 0; i < size; i++) {
-            key_buf[i] = entryGetKey(ht, entry_buf[i]);
+            key_buf[i] = entryGetKey(ht, entry_buf[i], &key_len_buf[i]);
         }
 
         for (int i = 0; i < size; i++) {
-            uint64_t hash = hashKey(ht, key_buf[i]);
+            uint64_t hash = hashKey(ht, key_buf[i], key_len_buf[i]);
             rehashEntry(ht, entry_buf[i], hash, highBits(hash));
         }
     }
@@ -797,11 +800,12 @@ static bool expand(hashtable *ht, size_t size, int *malloc_failed) {
  * entry at that position matches the provided key. If a match is found, it
  * updates the position and table index pointers and returns 1. Otherwise,
  * it returns 0. */
-static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, int table, int *pos_in_bucket, int *table_index) {
+static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, const void *key, size_t key_len, int table, int *pos_in_bucket, int *table_index) {
     /* It's a candidate. */
     void *entry = b->entries[pos];
-    const void *elem_key = entryGetKey(ht, entry);
-    if (compareKeys(ht, key, elem_key)) {
+    size_t entry_key_len;
+    const void *elem_key = entryGetKey(ht, entry, &entry_key_len);
+    if (compareKeys(ht, key, key_len, elem_key, entry_key_len) == 0) {
         /* It's a match. */
         assert(pos_in_bucket != NULL);
         if (!validateElementIfNeeded(ht, entry)) {
@@ -816,7 +820,7 @@ static inline int checkCandidateInBucket(hashtable *ht, bucket *b, int pos, cons
 
 #if HAVE_X86_SIMD
 ATTRIBUTE_TARGET_SSE2
-static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
+static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void *key, size_t key_len, int table, int *pos_in_bucket, int *table_index) {
     /* Get the bucket's presence mask - indicates which positions are filled. */
     BUCKET_BITS_TYPE presence_mask = b->presence & ((1 << ENTRIES_PER_BUCKET) - 1);
     __m128i hash_vector = _mm_loadu_si128((__m128i *)b->hashes);
@@ -831,7 +835,7 @@ static int findKeyInBucketSSE2(hashtable *ht, bucket *b, uint8_t h2, const void 
     newmask &= presence_mask;
     while (newmask > 0) {
         int pos = __builtin_ctz(newmask);
-        if (checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index)) return 1;
+        if (checkCandidateInBucket(ht, b, pos, key, key_len, table, pos_in_bucket, table_index)) return 1;
         /* Clear the processed bit and continue with next match. */
         newmask &= ~(1 << pos);
     }
@@ -851,7 +855,7 @@ static inline int popMatchBitmask(uint64_t *mask) {
     return pos;
 }
 
-static int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void *key, int table, int *pos_in_bucket, int *table_index) {
+static int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void *key, size_t key_len, int table, int *pos_in_bucket, int *table_index) {
     const uint8x8_t hash_vector = vld1_u8(b->hashes);             /* simple load */
     const uint8x8_t h2_vector = vdup_n_u8(h2);                    /* duplicated into every byte */
     const uint8x8_t equal_mask = vceq_u8(hash_vector, h2_vector); /* compare: 8 bits per item, 0xFF or 0x00 */
@@ -864,7 +868,7 @@ static int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void 
     while (matches) {
         int pos = popMatchBitmask(&matches);
         if ((b->presence & (1 << pos)) &&
-            checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index))
+            checkCandidateInBucket(ht, b, pos, key, key_len, table, pos_in_bucket, table_index))
             return 1;
     }
     return 0; /* No match */
@@ -877,7 +881,7 @@ static int findKeyInBucketNeon(hashtable *ht, bucket *b, uint8_t h2, const void 
  *
  * If 'table_index' is provided, it is set to the index of the table (0 or 1)
  * the returned bucket belongs to. */
-static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *pos_in_bucket, int *table_index) {
+static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, size_t key_len, int *pos_in_bucket, int *table_index) {
     if (hashtableSize(ht) == 0) return 0;
     uint8_t h2 = highBits(hash);
     int table;
@@ -897,14 +901,14 @@ static bucket *findBucket(hashtable *ht, uint64_t hash, const void *key, int *po
         do {
 #if HAVE_X86_SIMD
             /* All x86-64 CPUs have SSE2. */
-            if (findKeyInBucketSSE2(ht, b, h2, key, table, pos_in_bucket, table_index)) return b;
+            if (findKeyInBucketSSE2(ht, b, h2, key, key_len, table, pos_in_bucket, table_index)) return b;
 #elif HAVE_ARM_NEON && ENTRIES_PER_BUCKET <= 8
-            if (findKeyInBucketNeon(ht, b, h2, key, table, pos_in_bucket, table_index)) return b;
+            if (findKeyInBucketNeon(ht, b, h2, key, key_len, table, pos_in_bucket, table_index)) return b;
 #else
             /* Find candidate entries with presence flag set and matching h2 hash. */
             for (int pos = 0; pos < numBucketPositions(b); pos++) {
                 if (isPositionFilled(b, pos) && b->hashes[pos] == h2 &&
-                    checkCandidateInBucket(ht, b, pos, key, table, pos_in_bucket, table_index)) return b;
+                    checkCandidateInBucket(ht, b, pos, key, key_len, table, pos_in_bucket, table_index)) return b;
             }
 #endif
             b = getChildBucket(b);
@@ -1574,11 +1578,11 @@ void dismissHashtable(hashtable *ht) {
 
 /* Returns true if an entry was found matching the key. Also points *found to it,
  * if found is provided. Returns false if no matching entry was found. */
-bool hashtableFind(hashtable *ht, const void *key, void **found) {
+bool hashtableFind(hashtable *ht, const void *key, size_t key_len, void **found) {
     if (hashtableSize(ht) == 0) return false;
-    uint64_t hash = hashKey(ht, key);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, NULL);
     if (b) {
         if (found) *found = b->entries[pos_in_bucket];
         return true;
@@ -1591,11 +1595,11 @@ bool hashtableFind(hashtable *ht, const void *key, void **found) {
  * pointer can be used to replace the entry with an equivalent entry (same
  * key, same hash value), but note that the pointer may be invalidated by future
  * accesses to the hash table due to incermental rehashing, so use with care. */
-void **hashtableFindRef(hashtable *ht, const void *key) {
+void **hashtableFindRef(hashtable *ht, const void *key, size_t key_len) {
     if (hashtableSize(ht) == 0) return NULL;
-    uint64_t hash = hashKey(ht, key);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, NULL);
     return b ? &b->entries[pos_in_bucket] : NULL;
 }
 
@@ -1609,10 +1613,11 @@ bool hashtableAdd(hashtable *ht, void *entry) {
  * entry with the same key and, if an 'existing' pointer is provided, it is
  * pointed to the existing entry. */
 bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
-    const void *key = entryGetKey(ht, entry);
-    uint64_t hash = hashKey(ht, key);
+    size_t key_len;
+    const void *key = entryGetKey(ht, entry, &key_len);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, NULL);
     if (b != NULL) {
         if (existing) *existing = b->entries[pos_in_bucket];
         return false;
@@ -1650,11 +1655,11 @@ bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing) {
  *         doSomethingWithExistingEntry(existing);
  *     }
  */
-bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *pos, void **existing) {
+bool hashtableFindPositionForInsert(hashtable *ht, void *key, size_t key_len, hashtablePosition *pos, void **existing) {
     position *p = positionFromOpaque(pos);
-    uint64_t hash = hashKey(ht, key);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket, table_index;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, NULL);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, NULL);
     if (b != NULL) {
         if (existing) *existing = b->entries[pos_in_bucket];
         return false;
@@ -1696,12 +1701,12 @@ void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *po
 /* Removes the entry with the matching key and returns it. The entry
  * destructor is not called. Returns true and points 'popped' to the entry if a
  * matching entry was found. Returns false if no matching entry was found. */
-bool hashtablePop(hashtable *ht, const void *key, void **popped) {
+bool hashtablePop(hashtable *ht, const void *key, size_t key_len, void **popped) {
     if (hashtableSize(ht) == 0) return false;
-    uint64_t hash = hashKey(ht, key);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket = 0;
     int table_index = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, &table_index);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, &table_index);
     if (b) {
         if (popped) *popped = b->entries[pos_in_bucket];
         b->presence &= ~(1 << pos_in_bucket);
@@ -1720,9 +1725,9 @@ bool hashtablePop(hashtable *ht, const void *key, void **popped) {
 
 /* Deletes the entry with the matching key. Returns true if an entry was
  * deleted, false if no matching entry was found. */
-bool hashtableDelete(hashtable *ht, const void *key) {
+bool hashtableDelete(hashtable *ht, const void *key, size_t key_len) {
     void *entry;
-    if (hashtablePop(ht, key, &entry)) {
+    if (hashtablePop(ht, key, key_len, &entry)) {
         freeEntry(ht, entry);
         return true;
     }
@@ -1735,8 +1740,9 @@ bool hashtableDelete(hashtable *ht, const void *key) {
  * replacing it with the new entry. Returns true if the entry was replaced and false if
  * the entry wasn't found. */
 bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry) {
-    const void *key = entryGetKey(ht, new_entry);
-    uint64_t hash = hashKey(ht, key);
+    size_t key_len;
+    const void *key = entryGetKey(ht, new_entry, &key_len);
+    uint64_t hash = hashKey(ht, key, key_len);
     uint8_t h2 = highBits(hash);
     for (int table = 0; table <= 1; table++) {
         if (ht->used[table] == 0) continue;
@@ -1797,13 +1803,13 @@ bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void
  * argument is populated with a representation of where the entry is stored.
  * This must be provided to hashtableTwoPhasePopDelete to complete the
  * operation. */
-void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *pos) {
+void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, size_t key_len, hashtablePosition *pos) {
     position *p = positionFromOpaque(pos);
     if (hashtableSize(ht) == 0) return NULL;
-    uint64_t hash = hashKey(ht, key);
+    uint64_t hash = hashKey(ht, key, key_len);
     int pos_in_bucket = 0;
     int table_index = 0;
-    bucket *b = findBucket(ht, hash, key, &pos_in_bucket, &table_index);
+    bucket *b = findBucket(ht, hash, key, key_len, &pos_in_bucket, &table_index);
     if (b) {
         hashtablePauseRehashing(ht);
 
@@ -1854,7 +1860,7 @@ void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *pos) {
  * hashtableIncrementalFindStep on them in a round-robin order until all of them
  * are complete. Finally, if necessary, call hashtableIncrementalFindGetResult.
  */
-void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key) {
+void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key, size_t key_len) {
     incrementalFind *data = incrementalFindFromOpaque(state);
     if (hashtableSize(ht) == 0) {
         data->state = HASHTABLE_NOT_FOUND;
@@ -1863,7 +1869,8 @@ void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtabl
         data->bucket = NULL;
         data->hashtable = ht;
         data->key = key;
-        data->hash = hashKey(ht, key);
+        data->key_len = key_len;
+        data->hash = hashKey(ht, key, key_len);
     }
 }
 
@@ -1878,8 +1885,9 @@ bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state) {
         {
             hashtable *ht = data->hashtable;
             void *entry = data->bucket->entries[data->pos];
-            const void *elem_key = entryGetKey(ht, entry);
-            if (compareKeys(ht, data->key, elem_key)) {
+            size_t entry_key_len;
+            const void *elem_key = entryGetKey(ht, entry, &entry_key_len);
+            if (compareKeys(ht, data->key, data->key_len, elem_key, entry_key_len) == 0) {
                 /* It's a match. */
                 data->state = HASHTABLE_FOUND;
                 return false;
@@ -2496,8 +2504,9 @@ void hashtableDump(hashtable *ht) {
                 printf("  Bucket %d:%zu level:%d\n", table, idx, level);
                 for (int pos = 0; pos < ENTRIES_PER_BUCKET; pos++) {
                     if (isPositionFilled(b, pos)) {
+                        size_t dump_key_len;
                         printf("    %d h2 %02x, key \"%s\"\n", pos, b->hashes[pos],
-                               (const char *)entryGetKey(ht, b->entries[pos]));
+                               (const char *)entryGetKey(ht, b->entries[pos], &dump_key_len));
                     }
                 }
                 b = getChildBucket(b);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -59,11 +59,11 @@ typedef struct {
      * hashing the bits in the pointer, effectively treating the pointer as an
      * integer (ignoring key_len). */
     uint64_t (*hashFunction)(const void *key, size_t key_len);
-    /* Compare function, returns 0 if the keys are equal. The lookup_key and
-     * lookup_key_len are from the caller; entry_key and entry_key_len are from
-     * entryGetKey on a stored entry. Defaults to just comparing the pointers
-     * for equality (ignoring lengths). */
-    int (*keyCompare)(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+    /* Key equality function, returns true if the keys are equal. The lookup_key
+     * and lookup_key_len are from the caller; entry_key and entry_key_len are
+     * from entryGetKey on a stored entry. Defaults to just comparing the
+     * pointers for equality (ignoring lengths). */
+    bool (*keysEqual)(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
     /* Check for entry access should be masked or not. Masked access will just treat the entry as not-exist. */
     bool (*validateEntry)(hashtable *ht, void *entry);
     /* Callback to free an entry when it's overwritten or deleted.

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -41,7 +41,7 @@ typedef struct hashtableStats hashtableStats;
 /* Can types that can be stack allocated. */
 typedef uint64_t hashtableIterator[6];
 typedef uint64_t hashtablePosition[2];
-typedef uint64_t hashtableIncrementalFindState[5];
+typedef uint64_t hashtableIncrementalFindState[6];
 
 /* --- Non-opaque types --- */
 
@@ -50,14 +50,20 @@ typedef uint64_t hashtableIncrementalFindState[5];
  * pointer-sized integers. */
 typedef struct {
     /* If the type of an entry is not the same as the type of a key used for
-     * lookup, this callback needs to return the key within an entry. */
-    const void *(*entryGetKey)(const void *entry);
-    /* Hash function. Defaults to hashing the bits in the pointer, effectively
-     * treating the pointer as an integer. */
-    uint64_t (*hashFunction)(const void *key);
-    /* Compare function, returns 0 if the keys are equal. Defaults to just
-     * comparing the pointers for equality. */
-    int (*keyCompare)(const void *key1, const void *key2);
+     * lookup, this callback needs to return the key within an entry. The key
+     * length is returned via the 'len' output parameter. When this callback is
+     * NULL, the entry itself is used as the key and *len is set to 0. */
+    const void *(*entryGetKey)(const void *entry, size_t *len);
+    /* Hash function. The key_len is the length of the key as returned by
+     * entryGetKey, or as passed by the caller for lookup functions. Defaults to
+     * hashing the bits in the pointer, effectively treating the pointer as an
+     * integer (ignoring key_len). */
+    uint64_t (*hashFunction)(const void *key, size_t key_len);
+    /* Compare function, returns 0 if the keys are equal. The lookup_key and
+     * lookup_key_len are from the caller; entry_key and entry_key_len are from
+     * entryGetKey on a stored entry. Defaults to just comparing the pointers
+     * for equality (ignoring lengths). */
+    int (*keyCompare)(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
     /* Check for entry access should be masked or not. Masked access will just treat the entry as not-exist. */
     bool (*validateEntry)(hashtable *ht, void *entry);
     /* Callback to free an entry when it's overwritten or deleted.
@@ -143,18 +149,18 @@ void dismissHashtable(hashtable *ht);
 void hashtableSetCanAbortShrink(bool can_abort);
 
 /* Entries */
-bool hashtableFind(hashtable *ht, const void *key, void **found);
-void **hashtableFindRef(hashtable *ht, const void *key);
+bool hashtableFind(hashtable *ht, const void *key, size_t key_len, void **found);
+void **hashtableFindRef(hashtable *ht, const void *key, size_t key_len);
 bool hashtableAdd(hashtable *ht, void *entry);
 bool hashtableAddOrFind(hashtable *ht, void *entry, void **existing);
-bool hashtableFindPositionForInsert(hashtable *ht, void *key, hashtablePosition *position, void **existing);
+bool hashtableFindPositionForInsert(hashtable *ht, void *key, size_t key_len, hashtablePosition *position, void **existing);
 void hashtableInsertAtPosition(hashtable *ht, void *entry, hashtablePosition *position);
-bool hashtablePop(hashtable *ht, const void *key, void **popped);
-bool hashtableDelete(hashtable *ht, const void *key);
-void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, hashtablePosition *position);
+bool hashtablePop(hashtable *ht, const void *key, size_t key_len, void **popped);
+bool hashtableDelete(hashtable *ht, const void *key, size_t key_len);
+void **hashtableTwoPhasePopFindRef(hashtable *ht, const void *key, size_t key_len, hashtablePosition *position);
 void hashtableTwoPhasePopDelete(hashtable *ht, hashtablePosition *position);
 bool hashtableReplaceReallocatedEntry(hashtable *ht, const void *old_entry, void *new_entry);
-void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key);
+void hashtableIncrementalFindInit(hashtableIncrementalFindState *state, hashtable *ht, const void *key, size_t key_len);
 bool hashtableIncrementalFindStep(hashtableIncrementalFindState *state);
 bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, void **found);
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -148,7 +148,7 @@ static int getAndClearHashtableIndexFromCursor(kvstore *kvs, unsigned long long 
 
 int kvstoreIsImporting(kvstore *kvs, int didx) {
     assert(didx < kvs->num_hashtables);
-    return hashtableFind(kvs->importing, (void *)(intptr_t)didx, NULL);
+    return hashtableFind(kvs->importing, (void *)(intptr_t)didx, 0, NULL);
 }
 
 /* Updates binary index tree (also known as Fenwick tree), increasing key count for a given hashtable.
@@ -863,20 +863,20 @@ unsigned long kvstoreHashtableDefragTables(kvstore *kvs, unsigned long cursor, v
     return 0;
 }
 
-uint64_t kvstoreGetHash(kvstore *kvs, const void *key) {
-    return kvs->dtype->hashFunction(key);
+uint64_t kvstoreGetHash(kvstore *kvs, const void *key, size_t key_len) {
+    return kvs->dtype->hashFunction(key, key_len);
 }
 
-bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found) {
+bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, size_t key_len, void **found) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return false;
-    return hashtableFind(ht, key, found);
+    return hashtableFind(ht, key, key_len, found);
 }
 
-void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key) {
+void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, size_t key_len) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return NULL;
-    return hashtableFindRef(ht, key);
+    return hashtableFindRef(ht, key, key_len);
 }
 
 bool kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry) {
@@ -886,9 +886,9 @@ bool kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry) {
     return ret;
 }
 
-bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing) {
+bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, size_t key_len, hashtablePosition *position, void **existing) {
     hashtable *ht = createHashtableIfNeeded(kvs, didx);
-    return hashtableFindPositionForInsert(ht, key, position, existing);
+    return hashtableFindPositionForInsert(ht, key, key_len, position, existing);
 }
 
 /* Must be used together with kvstoreHashtableFindPositionForInsert, with returned
@@ -899,10 +899,10 @@ void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, void 
     cumulativeKeyCountAdd(kvs, didx, 1);
 }
 
-void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, void *position) {
+void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, size_t key_len, void *position) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return NULL;
-    return hashtableTwoPhasePopFindRef(ht, key, position);
+    return hashtableTwoPhasePopFindRef(ht, key, key_len, position);
 }
 
 void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position) {
@@ -912,10 +912,10 @@ void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position) {
     freeHashtableIfNeeded(kvs, didx);
 }
 
-bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped) {
+bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, size_t key_len, void **popped) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return false;
-    bool ret = hashtablePop(ht, key, popped);
+    bool ret = hashtablePop(ht, key, key_len, popped);
     if (ret) {
         cumulativeKeyCountAdd(kvs, didx, -1);
         freeHashtableIfNeeded(kvs, didx);
@@ -923,10 +923,10 @@ bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped)
     return ret;
 }
 
-bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key) {
+bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key, size_t key_len) {
     hashtable *ht = kvstoreGetHashtable(kvs, didx);
     if (!ht) return false;
-    bool ret = hashtableDelete(ht, key);
+    bool ret = hashtableDelete(ht, key, key_len);
     if (ret) {
         cumulativeKeyCountAdd(kvs, didx, -1);
         freeHashtableIfNeeded(kvs, didx);
@@ -951,7 +951,7 @@ void kvstoreSetIsImporting(kvstore *kvs, int didx, int is_importing) {
 
     /* Once we mark a hashtable as not importing, we need to begin tracking in
      * the kvstore metadata */
-    if (hashtableDelete(kvs->importing, (void *)(intptr_t)didx) && ht && hashtableSize(ht) != 0) {
+    if (hashtableDelete(kvs->importing, (void *)(intptr_t)didx, 0) && ht && hashtableSize(ht) != 0) {
         cumulativeKeyCountAdd(kvs, didx, hashtableSize(ht));
         kvs->importing_key_count -= hashtableSize(ht);
     }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -42,7 +42,7 @@ int kvstoreGetNextNonEmptyHashtableIndex(kvstore *kvs, int didx);
 int kvstoreNumNonEmptyHashtables(kvstore *kvs);
 int kvstoreNumAllocatedHashtables(kvstore *kvs);
 int kvstoreNumHashtables(kvstore *kvs);
-uint64_t kvstoreGetHash(kvstore *kvs, const void *key);
+uint64_t kvstoreGetHash(kvstore *kvs, const void *key, size_t key_len);
 
 void kvstoreHashtableRehashingStarted(hashtable *d);
 void kvstoreHashtableRehashingCompleted(hashtable *d);
@@ -82,17 +82,17 @@ unsigned long kvstoreHashtableScanDefrag(kvstore *kvs,
                                          void *(*defragfn)(void *),
                                          int flags);
 unsigned long kvstoreHashtableDefragTables(kvstore *kvs, unsigned long cursor, void *(*defragfn)(void *));
-bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, void **found);
-void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key);
+bool kvstoreHashtableFind(kvstore *kvs, int didx, void *key, size_t key_len, void **found);
+void **kvstoreHashtableFindRef(kvstore *kvs, int didx, const void *key, size_t key_len);
 bool kvstoreHashtableAdd(kvstore *kvs, int didx, void *entry);
 
-bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, hashtablePosition *position, void **existing);
+bool kvstoreHashtableFindPositionForInsert(kvstore *kvs, int didx, void *key, size_t key_len, hashtablePosition *position, void **existing);
 void kvstoreHashtableInsertAtPosition(kvstore *kvs, int didx, void *entry, void *position);
 
-void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, void *position);
+void **kvstoreHashtableTwoPhasePopFindRef(kvstore *kvs, int didx, const void *key, size_t key_len, void *position);
 void kvstoreHashtableTwoPhasePopDelete(kvstore *kvs, int didx, void *position);
-bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, void **popped);
-bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key);
+bool kvstoreHashtablePop(kvstore *kvs, int didx, const void *key, size_t key_len, void **popped);
+bool kvstoreHashtableDelete(kvstore *kvs, int didx, const void *key, size_t key_len);
 hashtable *kvstoreGetHashtable(kvstore *kvs, int didx);
 
 #endif /* KVSTORE_H */

--- a/src/latency.c
+++ b/src/latency.c
@@ -48,7 +48,7 @@ static void dictEntryDestructorHeapKeyValue(void *entry) {
 dictType latencyTimeSeriesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrHash,
-    .keyCompare = dictCStrKeyCompare,
+    .keysEqual = dictCStrKeysEqual,
     .entryDestructor = dictEntryDestructorHeapKeyValue,
 };
 

--- a/src/memory_prefetch.c
+++ b/src/memory_prefetch.c
@@ -115,7 +115,7 @@ static void initBatchInfo(hashtable **tables) {
             continue;
         }
         info->state = PREFETCH_ENTRY;
-        hashtableIncrementalFindInit(&info->hashtab_state, tables[i], batch->keys[i]);
+        hashtableIncrementalFindInit(&info->hashtab_state, tables[i], batch->keys[i], sdslen(batch->keys[i]));
     }
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -12469,7 +12469,7 @@ size_t moduleGetMemUsage(robj *key, robj *val, size_t sample_size, int dbid) {
 dictType moduleAPIDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrHash,
-    .keyCompare = dictCStrKeyCompare,
+    .keysEqual = dictCStrKeysEqual,
     .entryDestructor = zfree,
 };
 
@@ -12496,7 +12496,7 @@ void moduleInitModulesSystemLast(void) {
 dictType sdsKeyValueHashDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyValue,
 };
 

--- a/src/module.c
+++ b/src/module.c
@@ -12715,7 +12715,7 @@ int moduleFreeCommand(struct ValkeyModule *module, struct serverCommand *cmd) {
             struct serverCommand *sub = next;
             if (moduleFreeCommand(module, sub) != C_OK) continue;
 
-            serverAssert(hashtableDelete(cmd->subcommands_ht, sub->declared_name));
+            serverAssert(hashtableDelete(cmd->subcommands_ht, sub->declared_name, strlen(sub->declared_name)));
             sdsfree((sds)sub->declared_name);
             sdsfree(sub->fullname);
             zfree(sub);
@@ -12738,8 +12738,8 @@ void moduleUnregisterCommands(struct ValkeyModule *module) {
         struct serverCommand *cmd = next;
         if (moduleFreeCommand(module, cmd) != C_OK) continue;
 
-        serverAssert(hashtableDelete(server.commands, cmd->fullname));
-        serverAssert(hashtableDelete(server.orig_commands, cmd->fullname));
+        serverAssert(hashtableDelete(server.commands, cmd->fullname, sdslen(cmd->fullname)));
+        serverAssert(hashtableDelete(server.orig_commands, cmd->fullname, sdslen(cmd->fullname)));
         sdsfree((sds)cmd->declared_name);
         sdsfree(cmd->fullname);
         zfree(cmd);

--- a/src/multi.c
+++ b/src/multi.c
@@ -333,7 +333,7 @@ static const void *watchedKeyGetKey(const void *entry, size_t *len) {
 hashtableType watchedKeysHashtableType = {
     .entryGetKey = watchedKeyGetKey,
     .hashFunction = hashtableEncObjHash,
-    .keyCompare = hashtableEncObjKeyCompare,
+    .keysEqual = hashtableEncObjKeysEqual,
 };
 
 /* Attach a watchedKey to the list of clients watching that key. */

--- a/src/multi.c
+++ b/src/multi.c
@@ -321,8 +321,9 @@ typedef struct watchedKey {
 
 /* Callback used for watchedKeysHashtableType where the entries are watchedKey *
  * and it already contains the key. */
-static const void *watchedKeyGetKey(const void *entry) {
+static const void *watchedKeyGetKey(const void *entry, size_t *len) {
     const watchedKey *wk = entry;
+    if (len) *len = 0;
     return wk->key;
 }
 
@@ -331,8 +332,8 @@ static const void *watchedKeyGetKey(const void *entry) {
  * actual memory is managed by the multiState->watched_keys list. */
 hashtableType watchedKeysHashtableType = {
     .entryGetKey = watchedKeyGetKey,
-    .hashFunction = dictEncObjHash,
-    .keyCompare = dictEncObjKeyCompare,
+    .hashFunction = hashtableEncObjHash,
+    .keyCompare = hashtableEncObjKeyCompare,
 };
 
 /* Attach a watchedKey to the list of clients watching that key. */
@@ -370,7 +371,7 @@ void watchForKey(client *c, robj *key) {
     }
 
     /* Check if we are already watching for this key */
-    if (hashtableFind(c->mstate->watched_keys_by_db[c->db->id], key, NULL)) {
+    if (hashtableFind(c->mstate->watched_keys_by_db[c->db->id], key, 0, NULL)) {
         return; /* Key already watched */
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -3991,7 +3991,8 @@ static int addKeysToIncrFindBatch(client *c,
             for (int i = 0; i < numkeys && num < max; i++) {
                 hashtableIncrementalFindState *incr_state = &incr_states[num++];
                 robj *keyobj = argv[result.keys[i].pos];
-                hashtableIncrementalFindInit(incr_state, ht, objectGetVal(keyobj));
+                sds key = objectGetVal(keyobj);
+                hashtableIncrementalFindInit(incr_state, ht, key, sdslen(key));
             }
         }
     }

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -296,7 +296,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
 
     /* Add the channel to the client -> channels hash table */
     hashtablePosition position;
-    if (hashtableFindPositionForInsert(type.clientPubSubChannels(c), channel, &position, NULL)) {
+    if (hashtableFindPositionForInsert(type.clientPubSubChannels(c), channel, 0, &position, NULL)) {
         /* Not yet subscribed to this channel */
         retval = 1;
         /* Add the client to the channel -> list of clients hash table */
@@ -306,7 +306,7 @@ int pubsubSubscribeChannel(client *c, robj *channel, pubsubtype type) {
 
         hashtablePosition pos;
         void *existing;
-        if (!kvstoreHashtableFindPositionForInsert(*type.serverPubSubChannels, slot, channel, &pos, &existing)) {
+        if (!kvstoreHashtableFindPositionForInsert(*type.serverPubSubChannels, slot, channel, 0, &pos, &existing)) {
             clients = existing;
             channel = *(robj **)hashtableMetadata(clients);
         } else {
@@ -337,7 +337,7 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
     /* Remove the channel from the client -> channels hash table */
     incrRefCount(channel); /* channel may be just a pointer to the same object
                             we have in the hash tables. Protect it... */
-    if (hashtableDelete(type.clientPubSubChannels(c), channel)) {
+    if (hashtableDelete(type.clientPubSubChannels(c), channel, 0)) {
         retval = 1;
         /* Remove the client from the channel -> clients list hash table */
         if (server.cluster_enabled && type.shard) {
@@ -346,15 +346,15 @@ int pubsubUnsubscribeChannel(client *c, robj *channel, int notify, pubsubtype ty
             slot = keyHashSlot(objectGetVal(channel), (int)sdslen(objectGetVal(channel)));
         }
         void *found = NULL;
-        kvstoreHashtableFind(*type.serverPubSubChannels, slot, channel, &found);
+        kvstoreHashtableFind(*type.serverPubSubChannels, slot, channel, 0, &found);
         serverAssertWithInfo(c, NULL, found);
         clients = found;
-        serverAssertWithInfo(c, NULL, hashtableDelete(clients, c));
+        serverAssertWithInfo(c, NULL, hashtableDelete(clients, c, 0));
         if (hashtableSize(clients) == 0) {
             /* Free the dict and associated hash entry at all if this was
              * the latest client, so that it will be possible to abuse
              * PUBSUB creating millions of channels. */
-            kvstoreHashtableDelete(*type.serverPubSubChannels, slot, channel);
+            kvstoreHashtableDelete(*type.serverPubSubChannels, slot, channel, 0);
         }
     }
     /* Notify the client */
@@ -380,7 +380,7 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
         void *next_client;
         while (hashtableNext(&client_iter, &next_client)) {
             client *c = next_client;
-            int retval = hashtableDelete(c->pubsub_data->pubsubshard_channels, channel);
+            int retval = hashtableDelete(c->pubsub_data->pubsubshard_channels, channel, 0);
             serverAssertWithInfo(c, channel, retval);
             addReplyPubsubUnsubscribed(c, channel, pubSubShardType);
             /* If the client has no other pubsub subscription,
@@ -390,7 +390,7 @@ void pubsubShardUnsubscribeAllChannelsInSlot(unsigned int slot) {
             }
         }
         hashtableCleanupIterator(&client_iter);
-        kvstoreHashtableDelete(server.pubsubshard_channels, slot, channel);
+        kvstoreHashtableDelete(server.pubsubshard_channels, slot, channel, 0);
     }
     kvstoreReleaseHashtableIterator(kvs_di);
 }
@@ -425,13 +425,13 @@ int pubsubUnsubscribePattern(client *c, robj *pattern, int notify) {
     if (!c->pubsub_data) initClientPubSubData(c);
 
     incrRefCount(pattern); /* Protect the object. May be the same we remove */
-    int pattern_deleted = hashtableDelete(c->pubsub_data->pubsub_patterns, pattern);
+    int pattern_deleted = hashtableDelete(c->pubsub_data->pubsub_patterns, pattern, 0);
     if (pattern_deleted) {
         /* Remove the client from the pattern -> clients list hash table */
         dictEntry *de = dictFind(server.pubsub_patterns, pattern);
         serverAssertWithInfo(c, NULL, de != NULL);
         hashtable *clients = dictGetVal(de);
-        serverAssertWithInfo(c, NULL, hashtableDelete(clients, c));
+        serverAssertWithInfo(c, NULL, hashtableDelete(clients, c, 0));
         if (hashtableSize(clients) == 0) {
             /* Free the clients hashtable if this was the last client. */
             dictDelete(server.pubsub_patterns, pattern);
@@ -516,7 +516,7 @@ int pubsubPublishMessageInternal(robj *channel, robj *message, pubsubtype type) 
     if (server.cluster_enabled && type.shard) {
         slot = keyHashSlot(objectGetVal(channel), sdslen(objectGetVal(channel)));
     }
-    if (kvstoreHashtableFind(*type.serverPubSubChannels, (slot == -1) ? 0 : slot, channel, &element)) {
+    if (kvstoreHashtableFind(*type.serverPubSubChannels, (slot == -1) ? 0 : slot, channel, 0, &element)) {
         hashtable *clients = element;
         hashtableIterator iter;
         hashtableInitIterator(&iter, clients, 0);
@@ -686,7 +686,7 @@ void pubsubCommand(client *c) {
         addReplyArrayLen(c, (c->argc - 2) * 2);
         for (j = 2; j < c->argc; j++) {
             void *found = NULL;
-            kvstoreHashtableFind(server.pubsub_channels, 0, c->argv[j], &found);
+            kvstoreHashtableFind(server.pubsub_channels, 0, c->argv[j], 0, &found);
             dict *d = found;
             addReplyBulk(c, c->argv[j]);
             addReplyLongLong(c, d ? dictSize(d) : 0);
@@ -706,7 +706,7 @@ void pubsubCommand(client *c) {
             sds key = objectGetVal(c->argv[j]);
             unsigned int slot = server.cluster_enabled ? keyHashSlot(key, (int)sdslen(key)) : 0;
             void *found = NULL;
-            kvstoreHashtableFind(server.pubsubshard_channels, slot, c->argv[j], &found);
+            kvstoreHashtableFind(server.pubsubshard_channels, slot, c->argv[j], 0, &found);
             hashtable *clients = found;
             addReplyBulk(c, c->argv[j]);
             addReplyLongLong(c, clients ? hashtableSize(clients) : 0);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -154,7 +154,7 @@ static void dictEntryDestructorSdsKeyHeapValue(void *entry) {
 dictType rdbAuxFieldDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyHeapValue,
 };
 

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -68,7 +68,7 @@ static engineManager engineMgr = {
 dictType engineDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = zfree,
 };
 

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -449,7 +449,7 @@ static void dictEntryDestructorInstancesValue(void *entry) {
 dictType instancesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorInstancesValue,
 };
 
@@ -460,7 +460,7 @@ dictType instancesDictType = {
 dictType leaderVotesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = zfree,
 };
 
@@ -468,7 +468,7 @@ dictType leaderVotesDictType = {
 dictType renamedCommandsDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyValue,
 };
 
@@ -4337,7 +4337,7 @@ void sentinelSetCommand(client *c) {
 
             /* If the target name is the same as the source name there
              * is no need to add an entry mapping to itself. */
-            if (dictSdsKeyCaseCompare(oldname, 0, newname, 0)) {
+            if (!dictSdsKeyCaseEqual(oldname, 0, newname, 0)) {
                 oldname = sdsdup(oldname);
                 newname = sdsdup(newname);
                 dictAdd(ri->renamed_commands, oldname, newname);

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -4337,7 +4337,7 @@ void sentinelSetCommand(client *c) {
 
             /* If the target name is the same as the source name there
              * is no need to add an entry mapping to itself. */
-            if (!dictSdsKeyCaseCompare(oldname, newname)) {
+            if (dictSdsKeyCaseCompare(oldname, 0, newname, 0)) {
                 oldname = sdsdup(oldname);
                 newname = sdsdup(newname);
                 dictAdd(ri->renamed_commands, oldname, newname);

--- a/src/server.c
+++ b/src/server.c
@@ -437,7 +437,6 @@ uint64_t genHashFunctionConfigurableSeed(const char *buf, size_t len) {
 }
 
 uint64_t sdsHashConfigurableSeed(const void *key, size_t key_len) {
-    if (key_len == 0) key_len = sdslen(key);
     return genHashFunctionConfigurableSeed(key, key_len);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -376,19 +376,35 @@ void dictHashtableDestructor(void *val) {
     hashtableRelease((hashtable *)val);
 }
 
-/* Returns 1 when keys match */
-int dictSdsKeyCompare(const void *key1, const void *key2) {
+/* Returns 0 when keys match */
+int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 0;
-    return memcmp(key1, key2, l1) == 0;
+    if (l1 != l2) return 1;
+    return memcmp(key1, key2, l1);
+}
+
+/* Returns 0 when keys match */
+int hashtableRawKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return 1;
+    return memcmp(lookup_key, entry_key, lookup_key_len);
 }
 
 /* A case insensitive version used for the command lookup table and other
  * places where case insensitive non binary-safe comparison is needed. */
-int dictSdsKeyCaseCompare(const void *key1, const void *key2) {
-    return strcasecmp(key1, key2) == 0;
+int dictSdsKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
+    return strcasecmp(key1, key2);
+}
+
+/* Case insensitive key comparison */
+int hashtableStringCaseCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return 1;
+    return strncasecmp(lookup_key, entry_key, lookup_key_len);
 }
 
 void dictObjectDestructor(void *val) {
@@ -400,17 +416,8 @@ void dictSdsDestructor(void *val) {
     sdsfree(val);
 }
 
-int dictObjKeyCompare(const void *key1, const void *key2) {
-    const robj *o1 = key1, *o2 = key2;
-    return dictSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
-}
-
-uint64_t dictObjHash(const void *key) {
-    const robj *o = key;
-    return dictGenHashFunction(objectGetVal(o), sdslen((sds)objectGetVal(o)));
-}
-
-uint64_t dictSdsHash(const void *key) {
+uint64_t dictSdsHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenHashFunction(key, sdslen(key));
 }
 
@@ -429,76 +436,68 @@ uint64_t genHashFunctionConfigurableSeed(const char *buf, size_t len) {
     return siphash((const uint8_t *)buf, len, configurable_hash_seed);
 }
 
-uint64_t sdsHashConfigurableSeed(const void *key) {
-    return genHashFunctionConfigurableSeed(key, sdslen(key));
+uint64_t sdsHashConfigurableSeed(const void *key, size_t key_len) {
+    if (key_len == 0) key_len = sdslen(key);
+    return genHashFunctionConfigurableSeed(key, key_len);
 }
 
-uint64_t dictSdsCaseHash(const void *key) {
+uint64_t dictSdsCaseHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenCaseHashFunction(key, sdslen(key));
 }
 
 /* Dict hash function for null terminated string */
-uint64_t dictCStrHash(const void *key) {
+uint64_t dictCStrHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenHashFunction(key, strlen(key));
 }
 
 /* Dict hash function for null terminated string */
-uint64_t dictCStrCaseHash(const void *key) {
+uint64_t dictCStrCaseHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenCaseHashFunction(key, strlen((char *)key));
 }
 
 /* Hash function for client */
-uint64_t hashtableClientHash(const void *key) {
+uint64_t hashtableClientHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return ((client *)key)->id;
 }
 
-/* Hashtable compare function for client */
-int hashtableClientKeyCompare(const void *key1, const void *key2) {
-    return ((client *)key1)->id == ((client *)key2)->id;
+/* Hashtable compare function for client, 0 means equal. */
+int hashtableClientKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    UNUSED(lookup_key_len);
+    UNUSED(entry_key_len);
+    return ((client *)lookup_key)->id != ((client *)entry_key)->id;
 }
 
 /* Dict compare function for null terminated string */
-int dictCStrKeyCompare(const void *key1, const void *key2) {
-    return strcmp(key1, key2) == 0;
+int dictCStrKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
+    return strcmp(key1, key2);
 }
 
 /* Dict case insensitive compare function for null terminated string */
-int dictCStrKeyCaseCompare(const void *key1, const void *key2) {
-    return strcasecmp(key1, key2) == 0;
+int dictCStrKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
+    return strcasecmp(key1, key2);
 }
 
-int dictEncObjKeyCompare(const void *key1, const void *key2) {
-    robj *o1 = (robj *)key1, *o2 = (robj *)key2;
+int hashtableEncObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    robj *o1 = (robj *)lookup_key, *o2 = (robj *)entry_key;
     int cmp;
 
-    if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT) return objectGetVal(o1) == objectGetVal(o2);
+    if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT)
+        return objectGetVal(o1) != objectGetVal(o2);
 
-    /* Due to OBJ_STATIC_REFCOUNT, we avoid calling getDecodedObject() without
-     * good reasons, because it would incrRefCount() the object, which
-     * is invalid. So we check to make sure dictFind() works with static
-     * objects as well. */
     if (o1->refcount != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
-    cmp = dictSdsKeyCompare(objectGetVal(o1), objectGetVal(o2));
+    cmp = dictSdsKeyCompare(objectGetVal(o1), lookup_key_len, objectGetVal(o2), entry_key_len);
     if (o1->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
     return cmp;
-}
-
-uint64_t dictEncObjHash(const void *key) {
-    robj *o = (robj *)key;
-
-    if (sdsEncodedObject(o)) {
-        return dictGenHashFunction(objectGetVal(o), sdslen((sds)objectGetVal(o)));
-    } else if (o->encoding == OBJ_ENCODING_INT) {
-        char buf[32];
-        int len;
-
-        len = ll2string(buf, 32, (long)objectGetVal(o));
-        return dictGenHashFunction(buf, len);
-    } else {
-        serverPanic("Unknown string encoding");
-    }
 }
 
 /* Return 1 if we allow a hash table to expand. It may allocate a huge amount of
@@ -514,19 +513,25 @@ int hashtableResizeAllowed(size_t moreMem, double usedRatio) {
     return !overMaxmemoryAfterAlloc(moreMem);
 }
 
-const void *hashtableCommandGetCurrentName(const void *element) {
+const void *hashtableCommandGetCurrentName(const void *element, size_t *len) {
     struct serverCommand *command = (struct serverCommand *)element;
-    return command->current_name;
+    sds name = command->current_name;
+    *len = sdslen(name);
+    return name;
 }
 
-const void *hashtableCommandGetOriginalName(const void *element) {
+const void *hashtableCommandGetOriginalName(const void *element, size_t *len) {
     struct serverCommand *command = (struct serverCommand *)element;
-    return command->fullname;
+    sds name = command->fullname;
+    *len = sdslen(name);
+    return name;
 }
 
-const void *hashtableSubcommandGetKey(const void *element) {
+const void *hashtableSubcommandGetKey(const void *element, size_t *len) {
     struct serverCommand *command = (struct serverCommand *)element;
-    return command->declared_name;
+    const char *name = command->declared_name;
+    *len = strlen(name);
+    return name;
 }
 
 /* Entry destructor that frees object key and the dictEntry itself */
@@ -594,8 +599,8 @@ void dictEntryDestructorSdsKeyHeapValue(void *entry) {
  * dummy pointers. */
 dictType objectKeyPointerValueDictType = {
     .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictEncObjHash,
-    .keyCompare = dictEncObjKeyCompare,
+    .hashFunction = hashtableEncObjHash,
+    .keyCompare = hashtableEncObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKey,
 };
 
@@ -603,42 +608,81 @@ dictType objectKeyPointerValueDictType = {
  * not NULL, calling zfree(). */
 dictType objectKeyHeapPointerValueDictType = {
     .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictEncObjHash,
-    .keyCompare = dictEncObjKeyCompare,
+    .hashFunction = hashtableEncObjHash,
+    .keyCompare = hashtableEncObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyHeapValue,
 };
 
 /* Generic hashtable type: set of robj elements */
 hashtableType objectHashtableType = {
-    .hashFunction = dictEncObjHash,
-    .keyCompare = dictEncObjKeyCompare,
+    .hashFunction = hashtableEncObjHash,
+    .keyCompare = hashtableEncObjKeyCompare,
     .entryDestructor = dictObjectDestructor,
 };
 
 /* Set hashtable type. Items are SDS strings */
+const void *hashtableSdsGetKey(const void *entry, size_t *len) {
+    *len = sdslen((const sds)entry);
+    return entry;
+}
+
 hashtableType setHashtableType = {
+    .entryGetKey = hashtableSdsGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
     .entryDestructor = dictSdsDestructor};
 
-const void *zsetHashtableGetKey(const void *element) {
+const void *zsetHashtableGetKey(const void *element, size_t *len) {
     const zskiplistNode *node = element;
-    return zslGetNodeElement(node);
+    sds element_sds = zslGetNodeElement(node);
+    *len = sdslen(element_sds);
+    return element_sds;
 }
 
 /* Sorted sets hash (note: a skiplist is used in addition to the hash table) */
 hashtableType zsetHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = zsetHashtableGetKey,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
 };
 
-uint64_t hashtableSdsHash(const void *key) {
-    return hashtableGenHashFunction((const char *)key, sdslen((char *)key));
+uint64_t hashtableStringHash(const void *key, size_t key_len) {
+    return hashtableGenHashFunction((const char *)key, key_len);
 }
 
-const void *hashtableObjectGetKey(const void *entry) {
-    return objectGetKey(entry);
+uint64_t hashtableStringCaseHash(const void *key, size_t key_len) {
+    return hashtableGenCaseHashFunction((const char *)key, key_len);
+}
+
+uint64_t hashtableEncObjHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
+    robj *o = (robj *)key;
+
+    if (sdsEncodedObject(o)) {
+        sds s = objectGetVal(o);
+        return hashtableGenHashFunction(s, sdslen(s));
+    } else if (o->encoding == OBJ_ENCODING_INT) {
+        char buf[32];
+        int len;
+
+        len = ll2string(buf, 32, (long)objectGetVal(o));
+        return hashtableGenHashFunction(buf, len);
+    } else {
+        serverPanic("Unknown string encoding");
+    }
+}
+
+uint64_t hashtableObjHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
+    const robj *o = key;
+    sds s = objectGetVal(o);
+    return hashtableGenHashFunction(s, sdslen(s));
+}
+
+const void *hashtableObjectGetKey(const void *entry, size_t *len) {
+    sds key = objectGetKey(entry);
+    *len = sdslen(key);
+    return key;
 }
 
 /* Prefetch the value if it's not embedded. */
@@ -648,6 +692,16 @@ void hashtableObjectPrefetchValue(const void *entry) {
         obj->encoding != OBJ_ENCODING_INT) {
         valkey_prefetch(objectGetVal(obj));
     }
+}
+
+int hashtableObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    UNUSED(lookup_key_len);
+    UNUSED(entry_key_len);
+    const robj *o1 = lookup_key, *o2 = entry_key;
+    sds s1 = objectGetVal(o1), s2 = objectGetVal(o2);
+    size_t l1 = sdslen(s1), l2 = sdslen(s2);
+    if (l1 != l2) return 1;
+    return memcmp(s1, s2, l1);
 }
 
 void hashtableObjectDestructor(void *val) {
@@ -660,7 +714,7 @@ hashtableType kvstoreKeysHashtableType = {
     .entryPrefetchValue = hashtableObjectPrefetchValue,
     .entryGetKey = hashtableObjectGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
     .entryDestructor = hashtableObjectDestructor,
     .resizeAllowed = hashtableResizeAllowed,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
@@ -674,7 +728,7 @@ hashtableType kvstoreExpiresHashtableType = {
     .entryPrefetchValue = hashtableObjectPrefetchValue,
     .entryGetKey = hashtableObjectGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
     .entryDestructor = NULL, /* shared with keyspace table */
     .resizeAllowed = hashtableResizeAllowed,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
@@ -685,25 +739,27 @@ hashtableType kvstoreExpiresHashtableType = {
 
 /* Command set, hashed by current command name, stores serverCommand structs. */
 hashtableType commandSetType = {.entryGetKey = hashtableCommandGetCurrentName,
-                                .hashFunction = dictSdsCaseHash,
-                                .keyCompare = dictCStrKeyCaseCompare,
+                                .hashFunction = hashtableStringCaseHash,
+                                .keyCompare = hashtableStringCaseCompare,
                                 .instant_rehashing = 1};
 
 /* Command set, hashed by original command name, stores serverCommand structs. */
 hashtableType originalCommandSetType = {.entryGetKey = hashtableCommandGetOriginalName,
-                                        .hashFunction = dictSdsCaseHash,
-                                        .keyCompare = dictCStrKeyCaseCompare,
+                                        .hashFunction = hashtableStringCaseHash,
+                                        .keyCompare = hashtableStringCaseCompare,
                                         .instant_rehashing = 1};
 
 /* Sub-command set, hashed by char* string, stores serverCommand structs. */
 hashtableType subcommandSetType = {.entryGetKey = hashtableSubcommandGetKey,
-                                   .hashFunction = dictCStrCaseHash,
-                                   .keyCompare = dictCStrKeyCaseCompare,
+                                   .hashFunction = hashtableStringCaseHash,
+                                   .keyCompare = hashtableStringCaseCompare,
                                    .instant_rehashing = 1};
 
 /* Hash type hash table (note that small hashes are represented with listpacks) */
-const void *hashHashtableTypeGetKey(const void *entry) {
-    return (const void *)entryGetField(entry);
+const void *hashHashtableTypeGetKey(const void *entry, size_t *len) {
+    sds field = entryGetField(entry);
+    *len = sdslen(field);
+    return (const void *)field;
 }
 
 void hashHashtableTypeDestructor(void *entry) {
@@ -719,7 +775,7 @@ extern bool hashHashtableTypeValidate(hashtable *ht, void *entry);
 hashtableType hashHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = hashHashtableTypeGetKey,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
     .entryDestructor = hashHashtableTypeDestructor,
     .getMetadataSize = hashHashtableTypeMetadataSize,
 };
@@ -727,7 +783,7 @@ hashtableType hashHashtableType = {
 hashtableType hashWithVolatileItemsHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = hashHashtableTypeGetKey,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = hashtableRawKeyCompare,
     .entryDestructor = hashHashtableTypeDestructor,
     .getMetadataSize = hashHashtableTypeMetadataSize,
     .validateEntry = hashHashtableTypeValidate,
@@ -735,16 +791,17 @@ hashtableType hashWithVolatileItemsHashtableType = {
 
 /* Hashtable type without destructor */
 hashtableType sdsReplyHashtableType = {
-    .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCompare};
+    .entryGetKey = hashtableSdsGetKey,
+    .hashFunction = hashtableStringCaseHash,
+    .keyCompare = hashtableRawKeyCompare};
 
 /* Keylist hash table type has unencoded Objects as keys and
  * lists as values. It's used for blocking operations (BLPOP) and to
  * map swapped keys to a list of clients waiting for this keys to be loaded. */
 dictType keylistDictType = {
     .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictObjHash,
-    .keyCompare = dictObjKeyCompare,
+    .hashFunction = hashtableObjHash,
+    .keyCompare = hashtableObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyListValue,
 };
 
@@ -752,16 +809,18 @@ dictType keylistDictType = {
  * hashtables as values. It's used for PUBSUB command to track clients subscribing the patterns. */
 dictType objToHashtableDictType = {
     .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictObjHash,
-    .keyCompare = dictObjKeyCompare,
+    .hashFunction = hashtableObjHash,
+    .keyCompare = hashtableObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyHashtableValue,
 };
 
 /* Callback used for hash tables where the entries are dicts and the key
  * (channel name) is stored in each dict's metadata. */
-const void *hashtableChannelsGetKey(const void *entry) {
+const void *hashtableChannelsGetKey(const void *entry, size_t *len) {
     hashtable *ht = (hashtable *)entry;
-    return *((const void **)hashtableMetadata(ht));
+    robj *val = *((robj **)hashtableMetadata(ht));
+    *len = sdslen(objectGetVal(val));
+    return val;
 }
 
 void hashtableChannelsDestructor(void *entry) {
@@ -777,8 +836,8 @@ void hashtableChannelsDestructor(void *entry) {
  * each dict stores a pointer to the channel name. */
 hashtableType kvstoreChannelHashtableType = {
     .entryGetKey = hashtableChannelsGetKey,
-    .hashFunction = dictObjHash,
-    .keyCompare = dictObjKeyCompare,
+    .hashFunction = hashtableObjHash,
+    .keyCompare = hashtableObjKeyCompare,
     .entryDestructor = hashtableChannelsDestructor,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
     .rehashingCompleted = kvstoreHashtableRehashingCompleted,
@@ -3472,14 +3531,14 @@ void serverOpArrayFree(serverOpArray *oa) {
 
 bool isContainerCommandBySds(sds s) {
     void *entry;
-    bool found_command = hashtableFind(server.commands, s, &entry);
+    bool found_command = hashtableFind(server.commands, s, sdslen(s), &entry);
     struct serverCommand *base_cmd = entry;
     return found_command && base_cmd->subcommands_ht;
 }
 
 struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_name) {
     void *entry = NULL;
-    hashtableFind(container->subcommands_ht, sub_name, &entry);
+    hashtableFind(container->subcommands_ht, sub_name, sdslen(sub_name), &entry);
     struct serverCommand *subcommand = entry;
     return subcommand;
 }
@@ -3494,7 +3553,7 @@ struct serverCommand *lookupSubcommand(struct serverCommand *container, sds sub_
  */
 struct serverCommand *lookupCommandLogic(hashtable *commands, robj **argv, int argc, int strict) {
     void *entry = NULL;
-    bool found_command = hashtableFind(commands, objectGetVal(argv[0]), &entry);
+    bool found_command = hashtableFind(commands, objectGetVal(argv[0]), sdslen(objectGetVal(argv[0])), &entry);
     struct serverCommand *base_cmd = entry;
     bool has_subcommands = found_command && base_cmd->subcommands_ht;
     if (argc == 1 || !has_subcommands) {
@@ -4285,7 +4344,8 @@ int processCommand(client *c) {
         struct serverCommand *cmd = c->parsed_cmd;
         if (!cmd) {
             /* Handle possible security attacks. */
-            if (!strcasecmp(objectGetVal(c->argv[0]), "host:") || !strcasecmp(objectGetVal(c->argv[0]), "post")) {
+            if (!strcasecmp(objectGetVal(c->argv[0]), "host:") ||
+                !strcasecmp(objectGetVal(c->argv[0]), "post")) {
                 securityWarningCommand(c);
                 return C_ERR;
             }

--- a/src/server.c
+++ b/src/server.c
@@ -376,35 +376,35 @@ void dictHashtableDestructor(void *val) {
     hashtableRelease((hashtable *)val);
 }
 
-/* Returns 0 when keys match */
-int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+/* Returns true when keys match */
+bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 1;
-    return memcmp(key1, key2, l1);
+    if (l1 != l2) return false;
+    return memcmp(key1, key2, l1) == 0;
 }
 
-/* Returns 0 when keys match */
-int hashtableRawKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
-    if (lookup_key_len != entry_key_len) return 1;
-    return memcmp(lookup_key, entry_key, lookup_key_len);
+/* Returns true when keys match */
+bool hashtableRawKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return false;
+    return memcmp(lookup_key, entry_key, lookup_key_len) == 0;
 }
 
 /* A case insensitive version used for the command lookup table and other
  * places where case insensitive non binary-safe comparison is needed. */
-int dictSdsKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+bool dictSdsKeyCaseEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
-    return strcasecmp(key1, key2);
+    return strcasecmp(key1, key2) == 0;
 }
 
-/* Case insensitive key comparison */
-int hashtableStringCaseCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
-    if (lookup_key_len != entry_key_len) return 1;
-    return strncasecmp(lookup_key, entry_key, lookup_key_len);
+/* Case insensitive key equality check */
+bool hashtableStringCaseEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return false;
+    return strncasecmp(lookup_key, entry_key, lookup_key_len) == 0;
 }
 
 void dictObjectDestructor(void *val) {
@@ -464,40 +464,40 @@ uint64_t hashtableClientHash(const void *key, size_t key_len) {
     return ((client *)key)->id;
 }
 
-/* Hashtable compare function for client, 0 means equal. */
-int hashtableClientKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+/* Hashtable equality check for client, returns true when equal. */
+bool hashtableClientKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
     UNUSED(lookup_key_len);
     UNUSED(entry_key_len);
-    return ((client *)lookup_key)->id != ((client *)entry_key)->id;
+    return ((client *)lookup_key)->id == ((client *)entry_key)->id;
 }
 
-/* Dict compare function for null terminated string */
-int dictCStrKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+/* Dict equality check for null terminated string */
+bool dictCStrKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
-    return strcmp(key1, key2);
+    return strcmp(key1, key2) == 0;
 }
 
-/* Dict case insensitive compare function for null terminated string */
-int dictCStrKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+/* Dict case insensitive equality check for null terminated string */
+bool dictCStrKeyCaseEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
-    return strcasecmp(key1, key2);
+    return strcasecmp(key1, key2) == 0;
 }
 
-int hashtableEncObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+bool hashtableEncObjKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
     robj *o1 = (robj *)lookup_key, *o2 = (robj *)entry_key;
-    int cmp;
+    bool eq;
 
     if (o1->encoding == OBJ_ENCODING_INT && o2->encoding == OBJ_ENCODING_INT)
-        return objectGetVal(o1) != objectGetVal(o2);
+        return objectGetVal(o1) == objectGetVal(o2);
 
     if (o1->refcount != OBJ_STATIC_REFCOUNT) o1 = getDecodedObject(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) o2 = getDecodedObject(o2);
-    cmp = dictSdsKeyCompare(objectGetVal(o1), lookup_key_len, objectGetVal(o2), entry_key_len);
+    eq = dictSdsKeysEqual(objectGetVal(o1), lookup_key_len, objectGetVal(o2), entry_key_len);
     if (o1->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o1);
     if (o2->refcount != OBJ_STATIC_REFCOUNT) decrRefCount(o2);
-    return cmp;
+    return eq;
 }
 
 /* Return 1 if we allow a hash table to expand. It may allocate a huge amount of
@@ -600,7 +600,7 @@ void dictEntryDestructorSdsKeyHeapValue(void *entry) {
 dictType objectKeyPointerValueDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = hashtableEncObjHash,
-    .keyCompare = hashtableEncObjKeyCompare,
+    .keysEqual = hashtableEncObjKeysEqual,
     .entryDestructor = dictEntryDestructorObjectKey,
 };
 
@@ -609,14 +609,14 @@ dictType objectKeyPointerValueDictType = {
 dictType objectKeyHeapPointerValueDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = hashtableEncObjHash,
-    .keyCompare = hashtableEncObjKeyCompare,
+    .keysEqual = hashtableEncObjKeysEqual,
     .entryDestructor = dictEntryDestructorObjectKeyHeapValue,
 };
 
 /* Generic hashtable type: set of robj elements */
 hashtableType objectHashtableType = {
     .hashFunction = hashtableEncObjHash,
-    .keyCompare = hashtableEncObjKeyCompare,
+    .keysEqual = hashtableEncObjKeysEqual,
     .entryDestructor = dictObjectDestructor,
 };
 
@@ -629,7 +629,7 @@ const void *hashtableSdsGetKey(const void *entry, size_t *len) {
 hashtableType setHashtableType = {
     .entryGetKey = hashtableSdsGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
     .entryDestructor = dictSdsDestructor};
 
 const void *zsetHashtableGetKey(const void *element, size_t *len) {
@@ -643,7 +643,7 @@ const void *zsetHashtableGetKey(const void *element, size_t *len) {
 hashtableType zsetHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = zsetHashtableGetKey,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
 };
 
 uint64_t hashtableStringHash(const void *key, size_t key_len) {
@@ -694,14 +694,14 @@ void hashtableObjectPrefetchValue(const void *entry) {
     }
 }
 
-int hashtableObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+bool hashtableObjKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
     UNUSED(lookup_key_len);
     UNUSED(entry_key_len);
     const robj *o1 = lookup_key, *o2 = entry_key;
     sds s1 = objectGetVal(o1), s2 = objectGetVal(o2);
     size_t l1 = sdslen(s1), l2 = sdslen(s2);
-    if (l1 != l2) return 1;
-    return memcmp(s1, s2, l1);
+    if (l1 != l2) return false;
+    return memcmp(s1, s2, l1) == 0;
 }
 
 void hashtableObjectDestructor(void *val) {
@@ -714,7 +714,7 @@ hashtableType kvstoreKeysHashtableType = {
     .entryPrefetchValue = hashtableObjectPrefetchValue,
     .entryGetKey = hashtableObjectGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
     .entryDestructor = hashtableObjectDestructor,
     .resizeAllowed = hashtableResizeAllowed,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
@@ -728,7 +728,7 @@ hashtableType kvstoreExpiresHashtableType = {
     .entryPrefetchValue = hashtableObjectPrefetchValue,
     .entryGetKey = hashtableObjectGetKey,
     .hashFunction = sdsHashConfigurableSeed,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
     .entryDestructor = NULL, /* shared with keyspace table */
     .resizeAllowed = hashtableResizeAllowed,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
@@ -740,19 +740,19 @@ hashtableType kvstoreExpiresHashtableType = {
 /* Command set, hashed by current command name, stores serverCommand structs. */
 hashtableType commandSetType = {.entryGetKey = hashtableCommandGetCurrentName,
                                 .hashFunction = hashtableStringCaseHash,
-                                .keyCompare = hashtableStringCaseCompare,
+                                .keysEqual = hashtableStringCaseEqual,
                                 .instant_rehashing = 1};
 
 /* Command set, hashed by original command name, stores serverCommand structs. */
 hashtableType originalCommandSetType = {.entryGetKey = hashtableCommandGetOriginalName,
                                         .hashFunction = hashtableStringCaseHash,
-                                        .keyCompare = hashtableStringCaseCompare,
+                                        .keysEqual = hashtableStringCaseEqual,
                                         .instant_rehashing = 1};
 
 /* Sub-command set, hashed by char* string, stores serverCommand structs. */
 hashtableType subcommandSetType = {.entryGetKey = hashtableSubcommandGetKey,
                                    .hashFunction = hashtableStringCaseHash,
-                                   .keyCompare = hashtableStringCaseCompare,
+                                   .keysEqual = hashtableStringCaseEqual,
                                    .instant_rehashing = 1};
 
 /* Hash type hash table (note that small hashes are represented with listpacks) */
@@ -775,7 +775,7 @@ extern bool hashHashtableTypeValidate(hashtable *ht, void *entry);
 hashtableType hashHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = hashHashtableTypeGetKey,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
     .entryDestructor = hashHashtableTypeDestructor,
     .getMetadataSize = hashHashtableTypeMetadataSize,
 };
@@ -783,7 +783,7 @@ hashtableType hashHashtableType = {
 hashtableType hashWithVolatileItemsHashtableType = {
     .hashFunction = sdsHashConfigurableSeed,
     .entryGetKey = hashHashtableTypeGetKey,
-    .keyCompare = hashtableRawKeyCompare,
+    .keysEqual = hashtableRawKeysEqual,
     .entryDestructor = hashHashtableTypeDestructor,
     .getMetadataSize = hashHashtableTypeMetadataSize,
     .validateEntry = hashHashtableTypeValidate,
@@ -793,7 +793,7 @@ hashtableType hashWithVolatileItemsHashtableType = {
 hashtableType sdsReplyHashtableType = {
     .entryGetKey = hashtableSdsGetKey,
     .hashFunction = hashtableStringCaseHash,
-    .keyCompare = hashtableRawKeyCompare};
+    .keysEqual = hashtableRawKeysEqual};
 
 /* Keylist hash table type has unencoded Objects as keys and
  * lists as values. It's used for blocking operations (BLPOP) and to
@@ -801,7 +801,7 @@ hashtableType sdsReplyHashtableType = {
 dictType keylistDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = hashtableObjHash,
-    .keyCompare = hashtableObjKeyCompare,
+    .keysEqual = hashtableObjKeysEqual,
     .entryDestructor = dictEntryDestructorObjectKeyListValue,
 };
 
@@ -810,7 +810,7 @@ dictType keylistDictType = {
 dictType objToHashtableDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = hashtableObjHash,
-    .keyCompare = hashtableObjKeyCompare,
+    .keysEqual = hashtableObjKeysEqual,
     .entryDestructor = dictEntryDestructorObjectKeyHashtableValue,
 };
 
@@ -837,7 +837,7 @@ void hashtableChannelsDestructor(void *entry) {
 hashtableType kvstoreChannelHashtableType = {
     .entryGetKey = hashtableChannelsGetKey,
     .hashFunction = hashtableObjHash,
-    .keyCompare = hashtableObjKeyCompare,
+    .keysEqual = hashtableObjKeysEqual,
     .entryDestructor = hashtableChannelsDestructor,
     .rehashingStarted = kvstoreHashtableRehashingStarted,
     .rehashingCompleted = kvstoreHashtableRehashingCompleted,
@@ -850,7 +850,7 @@ hashtableType kvstoreChannelHashtableType = {
 dictType modulesDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -858,7 +858,7 @@ dictType modulesDictType = {
 dictType migrateCacheDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -867,7 +867,7 @@ dictType migrateCacheDictType = {
 dictType stringSetDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictCStrKeyCaseCompare,
+    .keysEqual = dictCStrKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
@@ -876,7 +876,7 @@ dictType stringSetDictType = {
 dictType externalStringType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictCStrKeyCaseCompare,
+    .keysEqual = dictCStrKeyCaseEqual,
     .entryDestructor = zfree,
 };
 
@@ -885,7 +885,7 @@ dictType externalStringType = {
 dictType sdsHashDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
+    .keysEqual = dictSdsKeyCaseEqual,
     .entryDestructor = dictEntryDestructorSdsKeyHeapValue,
 };
 
@@ -896,7 +896,7 @@ size_t clientHashtableTypeMetadataSize(void) {
 /* Hashtable type: set of clients, with a metadata field to store one pointer. */
 hashtableType clientHashtableType = {
     .hashFunction = hashtableClientHash,
-    .keyCompare = hashtableClientKeyCompare,
+    .keysEqual = hashtableClientKeysEqual,
     .getMetadataSize = clientHashtableTypeMetadataSize,
 };
 

--- a/src/server.h
+++ b/src/server.h
@@ -3509,11 +3509,11 @@ unsigned long long dbScan(serverDb *db, unsigned long long cursor, kvstoreScanFu
 /* Set data type */
 robj *setTypeCreate(sds value, size_t size_hint);
 int setTypeAdd(robj *subject, sds value);
-int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds);
+int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval);
 int setTypeRemove(robj *subject, sds value);
-int setTypeRemoveAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds);
+int setTypeRemoveAux(robj *set, char *str, size_t len, int64_t llval);
 int setTypeIsMember(robj *subject, sds value);
-int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds);
+int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval);
 setTypeIterator *setTypeInitIterator(robj *subject);
 void setTypeReleaseIterator(setTypeIterator *si);
 int setTypeNext(setTypeIterator *si, char **str, size_t *len, int64_t *llele);
@@ -3869,21 +3869,36 @@ int performEvictions(void);
 void startEvictionTimeProc(void);
 
 /* Keys hashing/comparison functions for dict.c and hashtable.c hash tables. */
-uint64_t dictSdsHash(const void *key);
-uint64_t dictSdsCaseHash(const void *key);
-uint64_t dictCStrHash(const void *key);
-uint64_t dictCStrCaseHash(const void *key);
-uint64_t dictEncObjHash(const void *key);
-int dictSdsKeyCompare(const void *key1, const void *key2);
-int dictSdsKeyCaseCompare(const void *key1, const void *key2);
-int dictCStrKeyCompare(const void *key1, const void *key2);
-int dictCStrKeyCaseCompare(const void *key1, const void *key2);
-int dictEncObjKeyCompare(const void *key1, const void *key2);
+uint64_t dictSdsHash(const void *key, size_t key_len);
+uint64_t dictSdsCaseHash(const void *key, size_t key_len);
+uint64_t dictCStrHash(const void *key, size_t key_len);
+uint64_t dictCStrCaseHash(const void *key, size_t key_len);
+int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+int dictSdsKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+int dictCStrKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+int dictCStrKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 void dictSdsDestructor(void *val);
 void dictListDestructor(void *val);
 void dictEntryDestructorSdsKey(void *entry);
 void dictEntryDestructorSdsKeyValue(void *entry);
 void dictEntryDestructorSdsKeyListValue(void *entry);
+
+/* Hashtable-specific hash functions */
+uint64_t hashtableStringHash(const void *key, size_t key_len);
+uint64_t hashtableStringCaseHash(const void *key, size_t key_len);
+uint64_t hashtableEncObjHash(const void *key, size_t key_len);
+uint64_t hashtableObjHash(const void *key, size_t key_len);
+uint64_t hashtableClientHash(const void *key, size_t key_len);
+
+/* Hashtable-specific key compare functions */
+int hashtableRawKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+int hashtableStringCaseCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+int hashtableEncObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+int hashtableObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+int hashtableClientKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+
+/* Hashtable-specific entryGetKey callbacks */
+const void *hashtableSdsGetKey(const void *entry, size_t *len);
 
 /* Git SHA1 */
 char *serverGitSHA1(void);

--- a/src/server.h
+++ b/src/server.h
@@ -3873,10 +3873,10 @@ uint64_t dictSdsHash(const void *key, size_t key_len);
 uint64_t dictSdsCaseHash(const void *key, size_t key_len);
 uint64_t dictCStrHash(const void *key, size_t key_len);
 uint64_t dictCStrCaseHash(const void *key, size_t key_len);
-int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
-int dictSdsKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
-int dictCStrKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
-int dictCStrKeyCaseCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+bool dictSdsKeyCaseEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+bool dictCStrKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+bool dictCStrKeyCaseEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 void dictSdsDestructor(void *val);
 void dictListDestructor(void *val);
 void dictEntryDestructorSdsKey(void *entry);
@@ -3890,12 +3890,12 @@ uint64_t hashtableEncObjHash(const void *key, size_t key_len);
 uint64_t hashtableObjHash(const void *key, size_t key_len);
 uint64_t hashtableClientHash(const void *key, size_t key_len);
 
-/* Hashtable-specific key compare functions */
-int hashtableRawKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
-int hashtableStringCaseCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
-int hashtableEncObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
-int hashtableObjKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
-int hashtableClientKeyCompare(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+/* Hashtable-specific key equality functions */
+bool hashtableRawKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+bool hashtableStringCaseEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+bool hashtableEncObjKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+bool hashtableObjKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
+bool hashtableClientKeysEqual(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len);
 
 /* Hashtable-specific entryGetKey callbacks */
 const void *hashtableSdsGetKey(const void *entry, size_t *len);

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -240,7 +240,7 @@ int hashTypeGetValue(robj *o, sds field, unsigned char **vstr, unsigned int *vle
         }
     } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
         void *entry = NULL;
-        hashtableFind(objectGetVal(o), field, &entry);
+        hashtableFind(objectGetVal(o), field, sdslen(field), &entry);
         if (entry) {
             size_t len = 0;
             char *value = entryGetValue(entry, &len);
@@ -268,7 +268,7 @@ int hashTypeGetExpiry(robj *o, sds field, mstime_t *expiry) {
         }
     } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
         void *found_element = NULL;
-        if (hashtableFind(objectGetVal(o), field, &found_element)) {
+        if (hashtableFind(objectGetVal(o), field, sdslen(field), &found_element)) {
             if (expiry) *expiry = entryGetExpiry(found_element);
             return C_OK;
         }
@@ -321,7 +321,7 @@ int hashTypeExists(robj *o, sds field) {
 bool hashTypeHasStringRef(robj *o, sds field) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) return false;
     hashtable *ht = objectGetVal(o);
-    void **entry_ref = hashtableFindRef(ht, field);
+    void **entry_ref = hashtableFindRef(ht, field, sdslen(field));
     return (entryHasStringRef(*entry_ref));
 }
 
@@ -337,7 +337,7 @@ int hashTypeUpdateAsStringRef(robj *o, sds field, const char *buf, size_t len) {
     if (o->encoding == OBJ_ENCODING_LISTPACK) hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
 
     hashtable *ht = objectGetVal(o);
-    void **entry_ref = hashtableFindRef(ht, field);
+    void **entry_ref = hashtableFindRef(ht, field, sdslen(field));
     entry *entry = *entry_ref;
     mstime_t expiry = entryGetExpiry(entry);
     void *new_entry = entryUpdateAsStringRef(entry, buf, len, expiry);
@@ -419,7 +419,7 @@ int hashTypeSet(robj *o, sds field, sds value, mstime_t expiry, int flags, bool 
         hashTypeIgnoreTTL(o, true);
         hashtablePosition position;
         void *existing;
-        if (hashtableFindPositionForInsert(ht, field, &position, &existing)) {
+        if (hashtableFindPositionForInsert(ht, field, sdslen(field), &position, &existing)) {
             /* does not exist yet */
             entry *entry = entryCreate(field, v, expiry);
             hashtableInsertAtPosition(ht, entry, &position);
@@ -501,7 +501,7 @@ static expiryModificationResult hashTypeSetExpire(robj *o, sds field, mstime_t e
 
     hashtable *ht = objectGetVal(o);
     void **entry_ref = NULL;
-    if ((entry_ref = hashtableFindRef(ht, field))) {
+    if ((entry_ref = hashtableFindRef(ht, field, sdslen(field)))) {
         entry *current_entry = *entry_ref;
         mstime_t current_expire = entryGetExpiry(current_entry);
         if (flag) {
@@ -565,7 +565,7 @@ static expiryModificationResult hashTypePersist(robj *o, sds field) {
 
     hashtable *ht = objectGetVal(o);
     void **entry_ref = NULL;
-    if ((entry_ref = hashtableFindRef(ht, field))) {
+    if ((entry_ref = hashtableFindRef(ht, field, sdslen(field)))) {
         entry *current_entry = *entry_ref;
         mstime_t current_expire = entryGetExpiry(current_entry);
         if (current_expire != EXPIRY_NONE) {
@@ -600,7 +600,7 @@ bool hashTypeDelete(robj *o, sds field) {
     } else if (o->encoding == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(o);
         void *entry = NULL;
-        deleted = hashtablePop(ht, field, &entry);
+        deleted = hashtablePop(ht, field, sdslen(field), &entry);
         if (deleted) {
             hashTypeUntrackEntry(o, entry);
             entryFree(entry);
@@ -2267,7 +2267,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         while (reply_size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            hashtableDelete(ht, element);
+            hashtableDelete(ht, element, sdslen((sds)element));
             reply_size--;
         }
 
@@ -2382,7 +2382,7 @@ static int hashTypeExpireEntry(void *entry, void *c) {
     serverAssert(o->encoding == OBJ_ENCODING_HASHTABLE && hashtableSize(objectGetVal(o)) > 0);
     hashtable *ht = objectGetVal(o);
     void *entry_ptr = NULL;
-    bool deleted = hashtablePop(ht, entry, &entry_ptr);
+    bool deleted = hashtablePop(ht, entry, sdslen((sds)entry), &entry_ptr);
     if (deleted) {
         if (ctx->fields)
             ctx->fields[ctx->n_fields++] = createStringObjectFromSds(entryGetField(entry));

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -115,16 +115,15 @@ static void maybeConvertToIntset(robj *set) {
  * If the value was already member of the set, nothing is done and 0 is
  * returned, otherwise the new element is added and 1 is returned. */
 int setTypeAdd(robj *subject, sds value) {
-    return setTypeAddAux(subject, value, sdslen(value), 0, 1);
+    return setTypeAddAux(subject, value, sdslen(value), 0);
 }
 
 /* Add member. This function is optimized for the different encodings. The
- * value can be provided as an sds string (indicated by passing str_is_sds =
- * 1), as string and length (str_is_sds = 0) or as an integer in which case str
- * is set to NULL and llval is provided instead.
+ * value can be provided as a string and length, or as an integer in which case
+ * str is set to NULL and llval is provided instead.
  *
  * Returns 1 if the value was added and 0 if it was already a member. */
-int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds) {
+int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
         if (set->encoding == OBJ_ENCODING_INTSET) {
@@ -136,25 +135,18 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         /* Convert int to string. */
         len = ll2string(tmpbuf, sizeof tmpbuf, llval);
         str = tmpbuf;
-        str_is_sds = 0;
     }
 
     serverAssert(str);
     if (set->encoding == OBJ_ENCODING_HASHTABLE) {
-        /* Avoid duping the string if it is an sds string. */
-        sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
         hashtable *ht = objectGetVal(set);
         hashtablePosition position;
-        if (hashtableFindPositionForInsert(ht, sdsval, &position, NULL)) {
-            /* Key doesn't already exist in the set. Add it but dup the key. */
-            if (sdsval == str) sdsval = sdsdup(sdsval);
-            hashtableInsertAtPosition(ht, sdsval, &position);
+        if (hashtableFindPositionForInsert(ht, str, len, &position, NULL)) {
+            /* Key doesn't already exist in the set. Add it. */
+            hashtableInsertAtPosition(ht, sdsnewlen(str, len), &position);
             return 1;
-        } else if (sdsval != str) {
-            /* String is already a member. Free our temporary sds copy. */
-            sdsfree(sdsval);
-            return 0;
         }
+        return 0;
     } else if (set->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
@@ -227,16 +219,15 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
 /* Deletes a value provided as an sds string from the set. Returns 1 if the
  * value was deleted and 0 if it was not a member of the set. */
 int setTypeRemove(robj *setobj, sds value) {
-    return setTypeRemoveAux(setobj, value, sdslen(value), 0, 1);
+    return setTypeRemoveAux(setobj, value, sdslen(value), 0);
 }
 
 /* Remove a member. This function is optimized for the different encodings. The
- * value can be provided as an sds string (indicated by passing str_is_sds =
- * 1), as string and length (str_is_sds = 0) or as an integer in which case str
- * is set to NULL and llval is provided instead.
+ * value can be provided as a string and length, or as an integer in which case
+ * str is set to NULL and llval is provided instead.
  *
  * Returns 1 if the value was deleted and 0 if it was not a member of the set. */
-int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str_is_sds) {
+int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
         if (setobj->encoding == OBJ_ENCODING_INTSET) {
@@ -246,13 +237,10 @@ int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str
         }
         len = ll2string(tmpbuf, sizeof tmpbuf, llval);
         str = tmpbuf;
-        str_is_sds = 0;
     }
 
     if (setobj->encoding == OBJ_ENCODING_HASHTABLE) {
-        sds sdsval = str_is_sds ? (sds)str : sdsnewlen(str, len);
-        int deleted = hashtableDelete(objectGetVal(setobj), sdsval);
-        if (sdsval != str) sdsfree(sdsval); /* free temp copy */
+        int deleted = hashtableDelete(objectGetVal(setobj), str, len);
         return deleted;
     } else if (setobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(setobj);
@@ -280,22 +268,20 @@ int setTypeRemoveAux(robj *setobj, char *str, size_t len, int64_t llval, int str
 /* Check if an sds string is a member of the set. Returns 1 if the value is a
  * member of the set and 0 if it isn't. */
 int setTypeIsMember(robj *subject, sds value) {
-    return setTypeIsMemberAux(subject, value, sdslen(value), 0, 1);
+    return setTypeIsMemberAux(subject, value, sdslen(value), 0);
 }
 
 /* Membership checking optimized for the different encodings. The value can be
- * provided as an sds string (indicated by passing str_is_sds = 1), as string
- * and length (str_is_sds = 0) or as an integer in which case str is set to NULL
- * and llval is provided instead.
+ * provided as a string and length, or as an integer in which case str is set
+ * to NULL and llval is provided instead.
  *
  * Returns 1 if the value is a member of the set and 0 if it isn't. */
-int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sds) {
+int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval) {
     char tmpbuf[LONG_STR_SIZE];
     if (!str) {
         if (set->encoding == OBJ_ENCODING_INTSET) return intsetFind(objectGetVal(set), llval);
         len = ll2string(tmpbuf, sizeof tmpbuf, llval);
         str = tmpbuf;
-        str_is_sds = 0;
     }
 
     if (set->encoding == OBJ_ENCODING_LISTPACK) {
@@ -305,13 +291,8 @@ int setTypeIsMemberAux(robj *set, char *str, size_t len, int64_t llval, int str_
     } else if (set->encoding == OBJ_ENCODING_INTSET) {
         long long llval;
         return string2ll(str, len, &llval) && intsetFind(objectGetVal(set), llval);
-    } else if (set->encoding == OBJ_ENCODING_HASHTABLE && str_is_sds) {
-        return hashtableFind(objectGetVal(set), (sds)str, NULL);
     } else if (set->encoding == OBJ_ENCODING_HASHTABLE) {
-        sds sdsval = sdsnewlen(str, len);
-        int result = hashtableFind(objectGetVal(set), sdsval, NULL);
-        sdsfree(sdsval);
-        return result;
+        return hashtableFind(objectGetVal(set), str, len, NULL);
     } else {
         serverPanic("Unknown set encoding");
     }
@@ -460,12 +441,12 @@ robj *setTypePopRandom(robj *set) {
         char *str;
         size_t len = 0;
         int64_t llele = 0;
-        int encoding = setTypeRandomElement(set, &str, &len, &llele);
+        setTypeRandomElement(set, &str, &len, &llele);
         if (str)
             obj = createStringObject(str, len);
         else
             obj = createStringObjectFromLongLong(llele);
-        setTypeRemoveAux(set, str, len, llele, encoding == OBJ_ENCODING_HASHTABLE);
+        setTypeRemoveAux(set, str, len, llele);
     }
     return obj;
 }
@@ -888,7 +869,7 @@ void spopWithCountCommand(client *c) {
                 p = lpNextRandom(lp, p, &index, remaining - i, 0);
                 unsigned int len;
                 str = (char *)lpGetValue(p, &len, (long long *)&llele);
-                setTypeAddAux(newset, str, len, llele, 0);
+                setTypeAddAux(newset, str, len, llele);
                 ps[i] = p;
                 p = lpNext(lp, p);
                 index++;
@@ -898,12 +879,12 @@ void spopWithCountCommand(client *c) {
             objectSetVal(set, lp);
         } else {
             while (remaining--) {
-                int encoding = setTypeRandomElement(set, &str, &len, &llele);
+                setTypeRandomElement(set, &str, &len, &llele);
                 if (!newset) {
                     newset = str ? createSetListpackObject() : createIntsetObject();
                 }
-                setTypeAddAux(newset, str, len, llele, encoding == OBJ_ENCODING_HASHTABLE);
-                setTypeRemoveAux(set, str, len, llele, encoding == OBJ_ENCODING_HASHTABLE);
+                setTypeAddAux(newset, str, len, llele);
+                setTypeRemoveAux(set, str, len, llele);
             }
         }
         /* Transfer the old set to the client. */
@@ -1151,7 +1132,7 @@ void srandmemberWithCountCommand(client *c) {
         while (size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            hashtableDelete(ht, element);
+            hashtableDelete(ht, element, sdslen((sds)element));
             sdsfree((sds)element);
             size--;
         }
@@ -1341,7 +1322,7 @@ void sinterGenericCommand(client *c,
     while ((encoding = setTypeNext(si, &str, &len, &intobj)) != -1) {
         for (j = 1; j < setnum; j++) {
             if (sets[j] == sets[0]) continue;
-            if (!setTypeIsMemberAux(sets[j], str, len, intobj, encoding == OBJ_ENCODING_HASHTABLE)) break;
+            if (!setTypeIsMemberAux(sets[j], str, len, intobj)) break;
         }
 
         /* Only take action when all sets contain the member */
@@ -1370,7 +1351,7 @@ void sinterGenericCommand(client *c,
                         only_integers = 0;
                     }
                 }
-                setTypeAddAux(dstset, str, len, intobj, encoding == OBJ_ENCODING_HASHTABLE);
+                setTypeAddAux(dstset, str, len, intobj);
             }
         }
     }
@@ -1541,7 +1522,7 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
 
             si = setTypeInitIterator(sets[j]);
             while ((encoding = setTypeNext(si, &str, &len, &llval)) != -1) {
-                cardinality += setTypeAddAux(dstset, str, len, llval, encoding == OBJ_ENCODING_HASHTABLE);
+                cardinality += setTypeAddAux(dstset, str, len, llval);
             }
             setTypeReleaseIterator(si);
         }
@@ -1561,11 +1542,11 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
             for (j = 1; j < setnum; j++) {
                 if (!sets[j]) continue;        /* no key is an empty set. */
                 if (sets[j] == sets[0]) break; /* same set! */
-                if (setTypeIsMemberAux(sets[j], str, len, llval, encoding == OBJ_ENCODING_HASHTABLE)) break;
+                if (setTypeIsMemberAux(sets[j], str, len, llval)) break;
             }
             if (j == setnum) {
                 /* There is no other set with this element. Add it. */
-                cardinality += setTypeAddAux(dstset, str, len, llval, encoding == OBJ_ENCODING_HASHTABLE);
+                cardinality += setTypeAddAux(dstset, str, len, llval);
             }
         }
         setTypeReleaseIterator(si);
@@ -1583,9 +1564,9 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
             si = setTypeInitIterator(sets[j]);
             while ((encoding = setTypeNext(si, &str, &len, &llval)) != -1) {
                 if (j == 0) {
-                    cardinality += setTypeAddAux(dstset, str, len, llval, encoding == OBJ_ENCODING_HASHTABLE);
+                    cardinality += setTypeAddAux(dstset, str, len, llval);
                 } else {
-                    cardinality -= setTypeRemoveAux(dstset, str, len, llval, encoding == OBJ_ENCODING_HASHTABLE);
+                    cardinality -= setTypeRemoveAux(dstset, str, len, llval);
                 }
             }
             setTypeReleaseIterator(si);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -513,7 +513,7 @@ static unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, ha
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
         sds ele = zslGetNodeElement(x);
-        hashtablePop(ht, ele, NULL);
+        hashtablePop(ht, ele, sdslen(ele), NULL);
         zslFreeNode(x);
         removed++;
         x = next;
@@ -543,7 +543,8 @@ static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, h
     while (x && zslLexValueLteMax(zslGetNodeElement(x), range)) {
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
-        hashtableDelete(ht, zslGetNodeElement(x));
+        sds ele = zslGetNodeElement(x);
+        hashtableDelete(ht, ele, sdslen(ele));
         zslFreeNode(x); /* Here is where x->ele is actually released. */
         removed++;
         x = next;
@@ -572,7 +573,8 @@ static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, un
     while (x && traversed <= end) {
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
-        hashtableDelete(ht, zslGetNodeElement(x));
+        sds ele = zslGetNodeElement(x);
+        hashtableDelete(ht, ele, sdslen(ele));
         zslFreeNode(x);
         removed++;
         traversed++;
@@ -1407,7 +1409,7 @@ int zsetScore(robj *zobj, sds member, double *score) {
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
         void *entry;
-        if (!hashtableFind(zs->ht, member, &entry)) return C_ERR;
+        if (!hashtableFind(zs->ht, member, sdslen(member), &entry)) return C_ERR;
         zskiplistNode *setElement = entry;
         *score = setElement->score;
     } else {
@@ -1535,7 +1537,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
     if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
 
-        void **node_ref_in_hashtable = hashtableFindRef(zs->ht, ele);
+        void **node_ref_in_hashtable = hashtableFindRef(zs->ht, ele, sdslen(ele));
         if (node_ref_in_hashtable != NULL) {
             /* NX? Return, same element already exists. */
             if (nx) {
@@ -1593,7 +1595,7 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
  * element was not there). */
 static int zsetRemoveFromSkiplist(zset *zs, sds ele) {
     void *entry;
-    if (!hashtablePop(zs->ht, ele, &entry)) return 0;
+    if (!hashtablePop(zs->ht, ele, sdslen(ele), &entry)) return 0;
     zskiplistNode *node = entry;
 
     /* hashtable only contains pointers to skiplist nodes. Nothing to free. */
@@ -1671,7 +1673,7 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
         zset *zs = objectGetVal(zobj);
 
         void *entry;
-        if (!hashtableFind(zs->ht, ele, &entry)) return -1;
+        if (!hashtableFind(zs->ht, ele, sdslen(ele), &entry)) return -1;
         zskiplistNode *node = entry;
 
         rank = zslGetRank(zs->zsl, node);
@@ -2323,7 +2325,7 @@ static int zuiFind(zsetopsrc *op, zsetopval *val, double *score) {
     if (op->type == OBJ_SET) {
         char *str = val->ele ? val->ele : (char *)val->estr;
         size_t len = val->ele ? sdslen(val->ele) : val->elen;
-        if (setTypeIsMemberAux(op->subject, str, len, val->ell, val->ele != NULL)) {
+        if (setTypeIsMemberAux(op->subject, str, len, val->ell)) {
             *score = 1.0;
             return 1;
         } else {
@@ -2342,7 +2344,7 @@ static int zuiFind(zsetopsrc *op, zsetopval *val, double *score) {
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(op->subject);
             void *entry;
-            if (hashtableFind(zs->ht, val->ele, &entry)) {
+            if (hashtableFind(zs->ht, val->ele, sdslen(val->ele), &entry)) {
                 zskiplistNode *node = entry;
                 *score = node->score;
                 return 1;
@@ -2784,7 +2786,7 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                 hashtablePosition position;
                 /* If we don't have it, we need to create a new entry. */
                 void *existing;
-                if (hashtableFindPositionForInsert(dstzset->ht, sdsval, &position, &existing)) {
+                if (hashtableFindPositionForInsert(dstzset->ht, sdsval, sdslen(sdsval), &position, &existing)) {
                     sds tmp_ele = zuiNewSdsFromValue(&zval);
                     zskiplistNode *new_node = zslCreateNode(zslRandomLevel(), score, tmp_ele);
                     sdsfree(tmp_ele);
@@ -4267,7 +4269,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         while (size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            hashtableDelete(ht, zslGetNodeElement((zskiplistNode *)element));
+            sds ele = zslGetNodeElement((zskiplistNode *)element);
+            hashtableDelete(ht, ele, sdslen(ele));
             size--;
         }
         hashtableCleanupIterator(&iter);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -72,9 +72,9 @@ static uint64_t hashfunc(const void *key, size_t key_len) {
     return hashtableGenHashFunction((const char *)key, key_len);
 }
 
-static int keycmp(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
-    if (lookup_key_len != entry_key_len) return 1;
-    return memcmp(lookup_key, entry_key, lookup_key_len);
+static bool keycmp(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return false;
+    return memcmp(lookup_key, entry_key, lookup_key_len) == 0;
 }
 
 static void freekeyval(void *keyval) {
@@ -114,7 +114,7 @@ class HashtableTest : public ::testing::Test {
         memset(&keyval_type, 0, sizeof(keyval_type));
         keyval_type.entryGetKey = getkey;
         keyval_type.hashFunction = hashfunc;
-        keyval_type.keyCompare = keycmp;
+        keyval_type.keysEqual = keycmp;
         keyval_type.entryDestructor = freekeyval;
         keyval_type.trackMemUsage = trackmemusage;
     }

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -57,8 +57,9 @@ static keyval *create_keyval(const char *key, const char *val) {
     return e;
 }
 
-static const void *getkey(const void *entry) {
+static const void *getkey(const void *entry, size_t *len) {
     const keyval *e = (const keyval *)entry;
+    *len = e->keysize - 1; /* exclude null terminator */
     return e->data;
 }
 
@@ -67,12 +68,13 @@ static const void *getval(const void *entry) {
     return e->data + e->keysize;
 }
 
-static uint64_t hashfunc(const void *key) {
-    return hashtableGenHashFunction((const char *)key, strlen((const char *)key));
+static uint64_t hashfunc(const void *key, size_t key_len) {
+    return hashtableGenHashFunction((const char *)key, key_len);
 }
 
-static int keycmp(const void *key1, const void *key2) {
-    return strcmp((const char *)key1, (const char *)key2) == 0;
+static int keycmp(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return 1;
+    return memcmp(lookup_key, entry_key, lookup_key_len);
 }
 
 static void freekeyval(void *keyval) {
@@ -169,7 +171,7 @@ static void add_find_delete_test_helper() {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", count - j + 42);
         void *found;
-        ASSERT_TRUE(hashtableFind(ht, key, &found));
+        ASSERT_TRUE(hashtableFind(ht, key, strlen(key), &found));
         keyval *e = (keyval *)found;
         ASSERT_EQ(strcmp((const char *)getval(e), val), 0);
     }
@@ -183,12 +185,12 @@ static void add_find_delete_test_helper() {
             char val[32];
             snprintf(val, sizeof(val), "%d", count - j + 42);
             void *popped;
-            ASSERT_TRUE(hashtablePop(ht, key, &popped));
+            ASSERT_TRUE(hashtablePop(ht, key, strlen(key), &popped));
             keyval *e = (keyval *)popped;
             ASSERT_EQ(strcmp((const char *)getval(e), val), 0);
             free(e);
         } else {
-            ASSERT_TRUE(hashtableDelete(ht, key));
+            ASSERT_TRUE(hashtableDelete(ht, key, strlen(key)));
         }
     }
     ASSERT_EQ(hashtableMemUsage(ht), mem_usage);
@@ -234,7 +236,7 @@ TEST_F(HashtableTest, instant_rehashing) {
 
     /* Delete and check that rehashing is never ongoing. */
     for (j = 0; j < count; j++) {
-        ASSERT_TRUE(hashtableDelete(ht, (void *)j));
+        ASSERT_TRUE(hashtableDelete(ht, (void *)j, 0));
         ASSERT_FALSE(hashtableIsRehashing(ht));
     }
 
@@ -274,7 +276,7 @@ TEST_F(HashtableTest, empty_buckets_rehashing) {
     hashtablePauseAutoShrink(ht);
     for (j = 0; j < 1000; j++) {
         if (j == keep) continue;
-        ASSERT_TRUE(hashtableDelete(ht, (void *)j));
+        ASSERT_TRUE(hashtableDelete(ht, (void *)j, 0));
     }
     hashtableResumeAutoShrink(ht);
     ASSERT_EQ(hashtableSize(ht), 1u);
@@ -324,7 +326,7 @@ TEST_F(HashtableTest, shrink_rehashing_abort) {
     hashtablePauseAutoShrink(ht);
     for (j = 0; j < 20000; j++) {
         if (j == keep) continue;
-        ASSERT_TRUE(hashtableDelete(ht, (void *)j));
+        ASSERT_TRUE(hashtableDelete(ht, (void *)j, 0));
     }
     hashtableResumeAutoShrink(ht);
     ASSERT_EQ(hashtableSize(ht), 1u);
@@ -343,7 +345,7 @@ TEST_F(HashtableTest, shrink_rehashing_abort) {
     /* Fuzzy test around normal add and delete to make sure we are ok. */
     for (j = 0; j < 20000; j++) {
         hashtableAdd(ht, (void *)j);
-        ASSERT_TRUE(hashtableDelete(ht, (void *)j));
+        ASSERT_TRUE(hashtableDelete(ht, (void *)j, 0));
     }
 
     hashtableRelease(ht);
@@ -393,7 +395,7 @@ TEST_F(HashtableTest, two_phase_insert_and_pop) {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", count - j + 42);
         hashtablePosition position;
-        bool ret = hashtableFindPositionForInsert(ht, key, &position, nullptr);
+        bool ret = hashtableFindPositionForInsert(ht, key, strlen(key), &position, nullptr);
         ASSERT_TRUE(ret);
         keyval *e = create_keyval(key, val);
         hashtableInsertAtPosition(ht, e, &position);
@@ -409,7 +411,7 @@ TEST_F(HashtableTest, two_phase_insert_and_pop) {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", count - j + 42);
         void *found;
-        ASSERT_TRUE(hashtableFind(ht, key, &found));
+        ASSERT_TRUE(hashtableFind(ht, key, strlen(key), &found));
         keyval *e = (keyval *)found;
         ASSERT_EQ(strcmp((const char *)getval(e), val), 0);
     }
@@ -421,7 +423,7 @@ TEST_F(HashtableTest, two_phase_insert_and_pop) {
         snprintf(val, sizeof(val), "%d", count - j + 42);
         hashtablePosition position;
         size_t size_before_find = hashtableSize(ht);
-        void **ref = hashtableTwoPhasePopFindRef(ht, key, &position);
+        void **ref = hashtableTwoPhasePopFindRef(ht, key, strlen(key), &position);
         ASSERT_NE(ref, nullptr);
         keyval *e = *(keyval **)ref;
         ASSERT_EQ(strcmp((const char *)getval(e), val), 0);
@@ -456,9 +458,10 @@ TEST_F(HashtableTest, replace_reallocated_entry) {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", count - j + 42);
         void *found;
-        ASSERT_TRUE(hashtableFind(ht, key, &found));
+        ASSERT_TRUE(hashtableFind(ht, key, strlen(key), &found));
         keyval *old = (keyval *)found;
-        ASSERT_EQ(strcmp((const char *)getkey(old), key), 0);
+        size_t old_key_len;
+        ASSERT_EQ(strcmp((const char *)getkey(old, &old_key_len), key), 0);
         ASSERT_EQ(strcmp((const char *)getval(old), val), 0);
         snprintf(val, sizeof(val), "%d", j + 1234);
         keyval *new_entry = create_keyval(key, val);
@@ -477,7 +480,7 @@ TEST_F(HashtableTest, replace_reallocated_entry) {
         snprintf(key, sizeof(key), "%d", j);
         snprintf(val, sizeof(val), "%d", j + 1234);
         void *found;
-        ASSERT_TRUE(hashtableFind(ht, key, &found));
+        ASSERT_TRUE(hashtableFind(ht, key, strlen(key), &found));
         keyval *e = (keyval *)found;
         ASSERT_EQ(strcmp((const char *)getval(e), val), 0);
     }
@@ -507,7 +510,7 @@ TEST_F(HashtableTest, incremental_find) {
     for (size_t i = 0; i < count; i++) {
         uint8_t *key = &element_array[i];
         void *found;
-        ASSERT_EQ(hashtableFind(ht, key, &found), 1);
+        ASSERT_EQ(hashtableFind(ht, key, 0, &found), 1);
         ASSERT_EQ(found, key);
     }
     uint64_t us2 = elapsedUs(timer);
@@ -522,7 +525,7 @@ TEST_F(HashtableTest, incremental_find) {
             hashtableIncrementalFindState *states = (hashtableIncrementalFindState *)malloc(sizeof(hashtableIncrementalFindState) * batch_size);
             for (size_t i = 0; i < batch_size; i++) {
                 void *key = &element_array[batch * batch_size + i];
-                hashtableIncrementalFindInit(&states[i], ht, key);
+                hashtableIncrementalFindInit(&states[i], ht, key, 0);
             }
             /* Work on batches in round-robin order until all are done. */
             size_t num_left;
@@ -633,9 +636,10 @@ static mock_hash_entry *mock_hash_entry_create(uint64_t value, uint64_t hash) {
     return entry;
 }
 
-static uint64_t mock_hash_entry_get_hash(const void *entry) {
-    if (entry == nullptr) return 0UL;
-    const mock_hash_entry *mock = (const mock_hash_entry *)entry;
+static uint64_t mock_hash_entry_hash(const void *key, size_t key_len) {
+    UNUSED(key_len);
+    if (key == nullptr) return 0UL;
+    const mock_hash_entry *mock = (const mock_hash_entry *)key;
     return (mock->hash != 0) ? mock->hash : mock->value;
 }
 
@@ -706,7 +710,7 @@ TEST_F(HashtableTest, safe_iterator) {
         /* increment entry at this position as a counter */
         (*entry)++;
         if (index % 4 == 0) {
-            ASSERT_TRUE(hashtableDelete(ht, entry));
+            ASSERT_TRUE(hashtableDelete(ht, entry, 0));
         }
         /* Add new item each time we see one of the original items */
         if (index < count) {
@@ -766,7 +770,7 @@ TEST_F(HashtableTest, compact_bucket_chain) {
         ASSERT_EQ(hashtableChainedBuckets(ht, 0), num_chained_buckets);
         num_returned++;
         if (num_returned % 2 == 0) {
-            ASSERT_TRUE(hashtableDelete(ht, entry));
+            ASSERT_TRUE(hashtableDelete(ht, entry, 0));
         }
         if (num_returned == count) {
             printf("Last iteration. Half of them have been deleted.\n");
@@ -921,7 +925,7 @@ TEST_F(HashtableTest, random_entry_with_long_chain) {
     const size_t num_samples = (size_t)n + 1;
 
     hashtableType type = {};
-    type.hashFunction = mock_hash_entry_get_hash;
+    type.hashFunction = mock_hash_entry_hash;
     type.entryDestructor = freekeyval;
 
     hashtable *ht = hashtableCreate(&type);
@@ -970,7 +974,7 @@ TEST_F(HashtableTest, random_entry_with_long_chain) {
 /* Helper function for scan tests */
 static void deleteScanFn(void *privdata, void *entry) {
     hashtable *ht = (hashtable *)privdata;
-    hashtableDelete(ht, entry);
+    hashtableDelete(ht, entry, 0);
 }
 
 /* This is a test for random entry selection in sparse hashtables.

--- a/src/unit/test_kvstore.cpp
+++ b/src/unit/test_kvstore.cpp
@@ -10,21 +10,28 @@ extern "C" {
 #include "kvstore.h"
 }
 
-uint64_t hashTestCallback(const void *key) {
-    return hashtableGenHashFunction((const char *)key, strlen((const char *)key));
+uint64_t hashTestCallback(const void *key, size_t key_len) {
+    return hashtableGenHashFunction((const char *)key, key_len);
 }
 
-uint64_t hashConflictTestCallback(const void *key) {
+uint64_t hashConflictTestCallback(const void *key, size_t key_len) {
     UNUSED(key);
+    UNUSED(key_len);
     return 0;
 }
 
-int cmpTestCallback(const void *k1, const void *k2) {
-    return strcmp((const char *)k1, (const char *)k2) == 0;
+int cmpTestCallback(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return 1;
+    return memcmp(lookup_key, entry_key, lookup_key_len);
 }
 
 void freeTestCallback(void *val) {
     zfree(val);
+}
+
+const void *entryGetKeyTestCallback(const void *entry, size_t *len) {
+    if (len) *len = strlen((const char *)entry);
+    return entry;
 }
 
 /* Hashtable types used for tests - initialized in SetUpTestSuite */
@@ -49,6 +56,7 @@ class KvstoreTest : public ::testing::Test {
         /* Initialize KvstoreHashtableTestType explicitly by field name to avoid
          * dependency on field order (designated initializers require C++20). */
         memset(&KvstoreHashtableTestType, 0, sizeof(KvstoreHashtableTestType));
+        KvstoreHashtableTestType.entryGetKey = entryGetKeyTestCallback;
         KvstoreHashtableTestType.hashFunction = hashTestCallback;
         KvstoreHashtableTestType.keyCompare = cmpTestCallback;
         KvstoreHashtableTestType.entryDestructor = freeTestCallback;
@@ -59,6 +67,7 @@ class KvstoreTest : public ::testing::Test {
 
         /* Initialize KvstoreConflictHashtableTestType */
         memset(&KvstoreConflictHashtableTestType, 0, sizeof(KvstoreConflictHashtableTestType));
+        KvstoreConflictHashtableTestType.entryGetKey = entryGetKeyTestCallback;
         KvstoreConflictHashtableTestType.hashFunction = hashConflictTestCallback;
         KvstoreConflictHashtableTestType.keyCompare = cmpTestCallback;
         KvstoreConflictHashtableTestType.entryDestructor = freeTestCallback;
@@ -120,7 +129,7 @@ TEST_F(KvstoreTest, kvstoreIteratorRemoveAllKeysNoDeleteEmptyHashtable) {
         kvs_it = kvstoreIteratorInit(kvs1, HASHTABLE_ITER_SAFE);
         while (kvstoreIteratorNext(kvs_it, &key)) {
             curr_slot = kvstoreIteratorGetCurrentHashtableIndex(kvs_it);
-            ASSERT_TRUE(kvstoreHashtableDelete(kvs1, curr_slot, key));
+            ASSERT_TRUE(kvstoreHashtableDelete(kvs1, curr_slot, key, strlen((const char *)key)));
         }
         kvstoreIteratorRelease(kvs_it);
 
@@ -149,7 +158,7 @@ TEST_F(KvstoreTest, kvstoreIteratorRemoveAllKeysDeleteEmptyHashtable) {
     kvs_it = kvstoreIteratorInit(kvs2, HASHTABLE_ITER_SAFE);
     while (kvstoreIteratorNext(kvs_it, &key)) {
         curr_slot = kvstoreIteratorGetCurrentHashtableIndex(kvs_it);
-        ASSERT_TRUE(kvstoreHashtableDelete(kvs2, curr_slot, key));
+        ASSERT_TRUE(kvstoreHashtableDelete(kvs2, curr_slot, key, strlen((const char *)key)));
     }
     kvstoreIteratorRelease(kvs_it);
 
@@ -179,7 +188,7 @@ TEST_F(KvstoreTest, kvstoreHashtableIteratorRemoveAllKeysNoDeleteEmptyHashtable)
 
     kvs_di = kvstoreGetHashtableIterator(kvs1, didx, HASHTABLE_ITER_SAFE);
     while (kvstoreHashtableIteratorNext(kvs_di, &key)) {
-        ASSERT_TRUE(kvstoreHashtableDelete(kvs1, didx, key));
+        ASSERT_TRUE(kvstoreHashtableDelete(kvs1, didx, key, strlen((const char *)key)));
     }
     kvstoreReleaseHashtableIterator(kvs_di);
 
@@ -205,7 +214,7 @@ TEST_F(KvstoreTest, kvstoreHashtableIteratorRemoveAllKeysDeleteEmptyHashtable) {
 
     kvs_di = kvstoreGetHashtableIterator(kvs2, didx, HASHTABLE_ITER_SAFE);
     while (kvstoreHashtableIteratorNext(kvs_di, &key)) {
-        ASSERT_TRUE(kvstoreHashtableDelete(kvs2, didx, key));
+        ASSERT_TRUE(kvstoreHashtableDelete(kvs2, didx, key, strlen((const char *)key)));
     }
     kvstoreReleaseHashtableIterator(kvs_di);
 

--- a/src/unit/test_kvstore.cpp
+++ b/src/unit/test_kvstore.cpp
@@ -20,9 +20,9 @@ uint64_t hashConflictTestCallback(const void *key, size_t key_len) {
     return 0;
 }
 
-int cmpTestCallback(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
-    if (lookup_key_len != entry_key_len) return 1;
-    return memcmp(lookup_key, entry_key, lookup_key_len);
+bool cmpTestCallback(const void *lookup_key, size_t lookup_key_len, const void *entry_key, size_t entry_key_len) {
+    if (lookup_key_len != entry_key_len) return false;
+    return memcmp(lookup_key, entry_key, lookup_key_len) == 0;
 }
 
 void freeTestCallback(void *val) {
@@ -58,7 +58,7 @@ class KvstoreTest : public ::testing::Test {
         memset(&KvstoreHashtableTestType, 0, sizeof(KvstoreHashtableTestType));
         KvstoreHashtableTestType.entryGetKey = entryGetKeyTestCallback;
         KvstoreHashtableTestType.hashFunction = hashTestCallback;
-        KvstoreHashtableTestType.keyCompare = cmpTestCallback;
+        KvstoreHashtableTestType.keysEqual = cmpTestCallback;
         KvstoreHashtableTestType.entryDestructor = freeTestCallback;
         KvstoreHashtableTestType.rehashingStarted = kvstoreHashtableRehashingStarted;
         KvstoreHashtableTestType.rehashingCompleted = kvstoreHashtableRehashingCompleted;
@@ -69,7 +69,7 @@ class KvstoreTest : public ::testing::Test {
         memset(&KvstoreConflictHashtableTestType, 0, sizeof(KvstoreConflictHashtableTestType));
         KvstoreConflictHashtableTestType.entryGetKey = entryGetKeyTestCallback;
         KvstoreConflictHashtableTestType.hashFunction = hashConflictTestCallback;
-        KvstoreConflictHashtableTestType.keyCompare = cmpTestCallback;
+        KvstoreConflictHashtableTestType.keysEqual = cmpTestCallback;
         KvstoreConflictHashtableTestType.entryDestructor = freeTestCallback;
         KvstoreConflictHashtableTestType.rehashingStarted = kvstoreHashtableRehashingStarted;
         KvstoreConflictHashtableTestType.rehashingCompleted = kvstoreHashtableRehashingCompleted;

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -240,7 +240,7 @@ int runFuzzerClients(const char *host, int port, int max_commands, int parallel_
 
 /* Dict callbacks */
 static uint64_t dictSdsHash(const void *key, size_t key_len);
-static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+static bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 
 /* Implementation */
 static long long ustime(void) {
@@ -283,20 +283,20 @@ static uint64_t dictSdsHash(const void *key, size_t key_len) {
     return dictGenHashFunction(key, sdslen(key));
 }
 
-static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+static bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 1;
-    return memcmp(key1, key2, l1);
+    if (l1 != l2) return false;
+    return memcmp(key1, key2, l1) == 0;
 }
 
 static dictType dtype = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = zfree,
 };
 

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -239,8 +239,8 @@ static long long showThroughput(struct aeEventLoop *eventLoop, long long id, voi
 int runFuzzerClients(const char *host, int port, int max_commands, int parallel_clients, int cluster_mode, int num_keys, cliSSLconfig *ssl_config, const char *log_level, int fuzz_flags);
 
 /* Dict callbacks */
-static uint64_t dictSdsHash(const void *key);
-static int dictSdsKeyCompare(const void *key1, const void *key2);
+static uint64_t dictSdsHash(const void *key, size_t key_len);
+static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 
 /* Implementation */
 static long long ustime(void) {
@@ -278,16 +278,19 @@ static bool isBenchmarkFinished(int request_count) {
     return false;
 }
 
-static uint64_t dictSdsHash(const void *key) {
+static uint64_t dictSdsHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenHashFunction(key, sdslen(key));
 }
 
-static int dictSdsKeyCompare(const void *key1, const void *key2) {
+static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 0;
-    return memcmp(key1, key2, l1) == 0;
+    if (l1 != l2) return 1;
+    return memcmp(key1, key2, l1);
 }
 
 static dictType dtype = {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -188,8 +188,8 @@ static int orig_termios_saved = 0;
 static struct termios orig_termios; /* To restore terminal at exit.*/
 
 /* Dict Helpers */
-static uint64_t dictSdsHash(const void *key);
-static int dictSdsKeyCompare(const void *key1, const void *key2);
+static uint64_t dictSdsHash(const void *key, size_t key_len);
+static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 
 /* Cluster Manager Command Info */
 typedef struct clusterManagerCommand {
@@ -376,16 +376,19 @@ static sds getDotfilePath(char *envoverride, char *envoverride_old, char *dotfil
     return dotPath;
 }
 
-static uint64_t dictSdsHash(const void *key) {
+static uint64_t dictSdsHash(const void *key, size_t key_len) {
+    UNUSED(key_len);
     return dictGenHashFunction(key, sdslen(key));
 }
 
-static int dictSdsKeyCompare(const void *key1, const void *key2) {
+static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+    UNUSED(key1_len);
+    UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 0;
-    return memcmp(key1, key2, l1) == 0;
+    if (l1 != l2) return 1;
+    return memcmp(key1, key2, l1);
 }
 
 static void dictEntryDestructorSdsKeyNoVal(void *entry) {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -189,7 +189,7 @@ static struct termios orig_termios; /* To restore terminal at exit.*/
 
 /* Dict Helpers */
 static uint64_t dictSdsHash(const void *key, size_t key_len);
-static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
+static bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len);
 
 /* Cluster Manager Command Info */
 typedef struct clusterManagerCommand {
@@ -381,14 +381,14 @@ static uint64_t dictSdsHash(const void *key, size_t key_len) {
     return dictGenHashFunction(key, sdslen(key));
 }
 
-static int dictSdsKeyCompare(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
+static bool dictSdsKeysEqual(const void *key1, size_t key1_len, const void *key2, size_t key2_len) {
     UNUSED(key1_len);
     UNUSED(key2_len);
     int l1, l2;
     l1 = sdslen((sds)key1);
     l2 = sdslen((sds)key2);
-    if (l1 != l2) return 1;
-    return memcmp(key1, key2, l1);
+    if (l1 != l2) return false;
+    return memcmp(key1, key2, l1) == 0;
 }
 
 static void dictEntryDestructorSdsKeyNoVal(void *entry) {
@@ -904,7 +904,7 @@ static void cliInitHelp(void) {
     dictType groupsdt = {
         .entryGetKey = dictEntryGetKey,
         .hashFunction = dictSdsHash,
-        .keyCompare = dictSdsKeyCompare,
+        .keysEqual = dictSdsKeysEqual,
         .entryDestructor = dictEntryDestructorSdsKeyNoVal,
     };
     valkeyReply *commandTable;
@@ -3673,14 +3673,14 @@ typedef struct clusterManagerLink {
 static dictType clusterManagerDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsVal,
 };
 
 static dictType clusterManagerLinkDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorSdsKeyListVal,
 };
 
@@ -9232,7 +9232,7 @@ static void dictEntryDestructorTypeinfoVal(void *entry) {
 static dictType typeinfoDictType = {
     .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .keysEqual = dictSdsKeysEqual,
     .entryDestructor = dictEntryDestructorTypeinfoVal,
 };
 

--- a/src/vset.c
+++ b/src/vset.c
@@ -1041,7 +1041,8 @@ static uint32_t findSplitPosition(vsetGetExpiryFunc getExpiry, vsetBucket *bucke
  *
  * Returns:
  *   A 64-bit hash value derived from the input pointer. */
-static uint64_t hash_pointer(const void *ptr) {
+static uint64_t hash_pointer(const void *ptr, size_t key_len) {
+    UNUSED(key_len);
     uintptr_t x = (uintptr_t)ptr;
 #if UINTPTR_MAX == 0xFFFFFFFF
     // 32-bit platform
@@ -1346,7 +1347,7 @@ static inline vsetBucket *removeFromBucket_HASHTABLE(vsetGetExpiryFunc getExpiry
     bool success = false;
     vsetBucket *new_bucket = bucket;
     hashtable *ht = vsetBucketHashtable(bucket);
-    if (hashtableDelete(ht, entry)) {
+    if (hashtableDelete(ht, entry, 0)) {
         success = true;
         assert(hashtableSize(ht) > 0);
         if (hashtableSize(ht) == 1) {
@@ -1499,7 +1500,7 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     size_t count = 0;
     hashtableInitIterator(&it, ht, HASHTABLE_ITER_SAFE);
     while (count < max_count && hashtableNext(&it, &entry)) {
-        assert(hashtableDelete(ht, entry));
+        assert(hashtableDelete(ht, entry, 0));
         expiryFunc(entry, ctx);
         count++;
     }
@@ -1910,7 +1911,7 @@ static inline vsetBucket *vsetBucketUpdateEntry_HASHTABLE(vsetBucket *bucket, vs
         return bucket;
 
     hashtable *ht = vsetBucketHashtable(bucket);
-    hashtableDelete(ht, old_entry);
+    hashtableDelete(ht, old_entry, 0);
     assert(hashtableAdd(ht, new_entry));
     return bucket;
 }


### PR DESCRIPTION
With this change hashtable lookup, delete, and find-position functions now accept an explicit (key, key_len) pair instead of relying on the key being a self-describing type like sds. This enables callers to perform lookups with raw pointers and lengths. This can help with copy-avoidance work now for SET, in the near future for my ZSET work, and generally with copy-avoidance optimizations in the future.

One concrete win: setTypeAddAux no longer allocates a temporary sds for the duplicate-check path in SADD. The sds is now created only when the element is actually inserted. This also removes the str_is_sds parameter from setTypeAddAux, setTypeRemoveAux, and setTypeIsMemberAux, since all three can now operate on raw (str, len) pairs directly.

Cleanup: removed duplicate hashtableCStrCaseHash (identical to hashtableSdsCaseHash), and renamed hash/compare functions to reflect that they operate on raw bytes, not a specific string type:
  hashtableSdsHash -> hashtableStringHash
  hashtableSdsCaseHash -> hashtableStringCaseHash
  hashtableStringKeyCaseCompare -> hashtableStringCaseCompare
  
This directly supports my ZSET optimization work for #3166 where I plan to embed score and element into a single sds for the new fbtree data structure. Without this change I would need to make the embedded sds my "key" to have access to length information and lookups would need to duplicate sds with 8 dummy bytes prepended to match this expected "key" format. (I also considered pointer tagging to distinguish hashtable lookup key from existing entry, but sds header offsets affect the least significant bits and 32 bit has no high bits to spare.)
