### PR TITLE
Skip faster-failover test under TLS 

### DIFF
--- a/tests/unit/cluster/faster-failover.tcl
+++ b/tests/unit/cluster/faster-failover.tcl
@@ -144,7 +144,7 @@ proc test_best_ranked_replica {} {
 
 # This change and test is quite important, so we want to run it a few more times.
 for {set i 0} {$i < 5} {incr i} {
-    start_cluster 5 7 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+    start_cluster 5 7 {tags {external:skip cluster tls:skip} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
         test_best_ranked_replica
     } my_slot_allocation cluster_allocate_replicas ;# start_cluster
 }


### PR DESCRIPTION
`test-ubuntu-latest-cmake-tls` has been consistently failing in https://github.com/valkey-io/valkey/pull/3391/commits and on some other PRs intermittently. 
   
The faster-failover.tcl test starts 12 cluster nodes  5 times with TLS, which is CPU intensive due to the volume of TLS handshakes. Running alongside other tests on CI runners causes random I/O timeouts in unrelated tests.
                                                                                                                                                                         
Tagging it as `tls:skip` 