### PR TITLE
[trivial] remove unnecessary text for extractLongLatOrReply

### DIFF
--- a/src/geo.c
+++ b/src/geo.c
@@ -113,7 +113,7 @@ int extractLongLatOrReply(client *c, robj **argv, double *xy) {
         }
     }
     if (xy[0] < GEO_LONG_MIN || xy[0] > GEO_LONG_MAX || xy[1] < GEO_LAT_MIN || xy[1] > GEO_LAT_MAX) {
-        addReplyErrorFormat(c, "-ERR invalid longitude,latitude pair %f,%f\r\n", xy[0], xy[1]);
+        addReplyErrorFormat(c, "invalid longitude,latitude pair %f,%f", xy[0], xy[1]);
         return C_ERR;
     }
     return C_OK;


### PR DESCRIPTION
actually in addReplyErrorLength, addReplyErrorFormatInternal, 
It will add "-ERR" when text doesn't start "-", so first -ERR is unnecessary.
It will tirm "\r\n" so "\r\n" is not unnecessary.

This is purely for consistency and does not change the code’s behavior.