### PR TITLE
Fixes server crash when RDMA benchmark clients disconnect

### DIFF
--- a/src/rdma.c
+++ b/src/rdma.c
@@ -532,8 +532,10 @@ static int rdmaHandleDisconnect(aeEventLoop *el, struct rdma_cm_event *ev) {
     conn->state = CONN_STATE_CLOSED;
 
     /* we can't close connection now, let's mark this connection as closed state */
-    listAddNodeTail(pending_list, conn);
-    rdma_conn->pending_list_node = listLast(pending_list);
+    if (rdma_conn->pending_list_node == NULL) {
+        listAddNodeTail(pending_list, conn);
+        rdma_conn->pending_list_node = listLast(pending_list);
+    }
 
     return C_OK;
 }
@@ -953,8 +955,10 @@ static int connRdmaSetWriteHandler(connection *conn, ConnectionCallbackFunc func
 
     /* does this connection has pending write data? */
     if (func) {
-        listAddNodeTail(pending_list, conn);
-        rdma_conn->pending_list_node = listLast(pending_list);
+        if (rdma_conn->pending_list_node == NULL) {
+            listAddNodeTail(pending_list, conn);
+            rdma_conn->pending_list_node = listLast(pending_list);
+        }
     } else if (rdma_conn->pending_list_node) {
         listDelNode(pending_list, rdma_conn->pending_list_node);
         rdma_conn->pending_list_node = NULL;
@@ -1776,14 +1780,15 @@ static int rdmaProcessPendingData(void) {
         /* a connection can be disconnected by remote peer, CM event mark state as CONN_STATE_CLOSED, kick connection
          * read/write handler to close connection */
         if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
-            listDelNode(pending_list, rdma_conn->pending_list_node);
-            rdma_conn->pending_list_node = NULL;
             /* Invoke both read_handler and write_handler, unless read_handler
                returns 0, indicating the connection has closed, in which case
                write_handler will be skipped. */
             if (callHandler(conn, conn->read_handler)) {
                 callHandler(conn, conn->write_handler);
             }
+
+            listDelNode(pending_list, ln);
+            rdma_conn->pending_list_node = NULL;
 
             ++processed;
             continue;


### PR DESCRIPTION
Fixes server crash when RDMA benchmark clients disconnect (part of #3345).

This PR focuses on the server-side crash fix. The benchmark
client-side fix will be submitted in a separate PR.

## Server Crash on Client Disconnect 

​	When interrupting valkey-benchmark with Ctrl+C, the server would crash with a segmentation fault in handleReadResult, accessing address 0x8 (NULL pointer dereference).

### Root Cause

The same RDMA connection could be added to pending_list multiple times, leading to use-after-free:

1. When a client disconnects, rdmaHandleDisconnect() adds the connection to pending_list and sets conn->state = CONN_STATE_CLOSED
2. Before rdmaProcessPendingData() processes it, event-driven callbacks (e.g., connRdmaSetWriteHandler) could add the same connection again to pending_list
3. In rdmaProcessPendingData(), the first iteration processes and may free the connection, but the second iteration accesses the already freed connection → SIGSEGV at address 0x8 (NULL + offset)

The problem was exacerbated because:

  - valkey-benchmark creates multiple concurrent connections
  - On Ctrl+C, these connections disconnect nearly simultaneously
  - Event callbacks can re-add connections before processing completes

 **Stack trace from crash:**

  	handleReadResult+0x100
  	readQueryFromClient+0x63
  	rdmaProcessPendingData (0x1b1eb9)
  	beforeSleep+0x82

### Solution

 Four targeted fixes in `src/rdma.c`:

1. `rdmaHandleDisconnect (line 535)`: Check if pending_list_node is NULL before adding to pending_list to prevent duplicates

   ```C
   /* we can't close connection now, let's mark this connection as closed state */
   if (rdma_conn->pending_list_node == NULL) {
       listAddNodeTail(pending_list, conn);
       rdma_conn->pending_list_node = listLast(pending_list);
   }
   ```

2. `connRdmaSetWriteHandler (line 956)`: Add same check before adding to pending_list to prevent duplicates during write handler updates

   ```C
   /* does this connection has pending write data? */
   if (func) {
       if (rdma_conn->pending_list_node == NULL) {
           listAddNodeTail(pending_list, conn);
           rdma_conn->pending_list_node = listLast(pending_list);
       }
   } else if (rdma_conn->pending_list_node) {
       listDelNode(pending_list, rdma_conn->pending_list_node);
       rdma_conn->pending_list_node = NULL;
   }
   ```

3. `rdmaProcessPendingData (line 1786)`: Use iterator node 'ln' instead of rdma_conn->pending_list_node when deleting, as the latter may have been overwritten if the connection was re-added

   ```C
   listDelNode(pending_list, ln);  // Use ln, not rdma_conn->pending_list_node
   rdma_conn->pending_list_node = NULL;
   ```

4. `rdmaProcessPendingData (line 1782-1787)`: Reorder operations to call handlers before deleting from list, ensuring connection structure remains valid during handler execution

   ```C
   if (conn->state == CONN_STATE_ERROR || conn->state == CONN_STATE_CLOSED) {
       /* Invoke handlers first, then remove from list */
       if (callHandler(conn, conn->read_handler)) {
           callHandler(conn, conn->write_handler);
       }

       listDelNode(pending_list, ln);
       rdma_conn->pending_list_node = NULL;

       ++processed;
       continue;
   }
   ```

The fix uses **pending_list_node** as both a list pointer and a "**already in list**" flag:

  - NULL = not in list, safe to add
  - non-NULL = already in list, skip adding

This ensures each connection appears in pending_list at most once, preventing use-after-free crashes.

## Testing
I use `  ./src/valkey-benchmark --rdma -h 10.0.0.1 -t get -n 100000 -c 1` to test this:

```bash
====== GET ======                                                                  
  100000 requests completed in 4.64 seconds
  50 parallel clients
  3 bytes payload
  keep alive: 1
  host configuration "save": 3600 1 300 100 60 10000
  host configuration "appendonly": no
  multi-thread: no

Latency by percentile distribution:
0.000% <= 0.007 milliseconds (cumulative count 4601)
50.000% <= 0.023 milliseconds (cumulative count 98267)
98.438% <= 0.031 milliseconds (cumulative count 99802)
99.805% <= 0.039 milliseconds (cumulative count 99886)
99.902% <= 0.055 milliseconds (cumulative count 99907)
99.951% <= 0.199 milliseconds (cumulative count 99954)
99.976% <= 0.215 milliseconds (cumulative count 99977)
99.988% <= 0.239 milliseconds (cumulative count 99991)
99.994% <= 0.255 milliseconds (cumulative count 99997)
99.998% <= 0.463 milliseconds (cumulative count 99999)
99.999% <= 0.935 milliseconds (cumulative count 100000)
100.000% <= 0.935 milliseconds (cumulative count 100000)

Cumulative distribution of latencies:
99.934% <= 0.103 milliseconds (cumulative count 99934)
99.965% <= 0.207 milliseconds (cumulative count 99965)
99.998% <= 0.303 milliseconds (cumulative count 99998)
99.999% <= 0.503 milliseconds (cumulative count 99999)
100.000% <= 1.007 milliseconds (cumulative count 100000)

Summary:
  throughput summary: 21561.02 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.016     0.000     0.023     0.023     0.031     0.935
```