### PR TITLE
Fix trivial double-free issue in rdbLoadObject

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2408,11 +2408,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
                     /* search for duplicate records */
                     sds field = sdstrynewlen(fstr, flen);
-                    if (!field || !hashtableAdd(dupSearchHashtable, field) ||
-                        !lpSafeToAdd(lp, (size_t)flen + vlen)) {
+                    int field_added = field && hashtableAdd(dupSearchHashtable, field);
+                    if (!field_added || !lpSafeToAdd(lp, (size_t)flen + vlen)) {
                         rdbReportCorruptRDB("Hash zipmap with dup elements, or big length (%u)", flen);
                         hashtableRelease(dupSearchHashtable);
-                        sdsfree(field);
+                        if (!field_added) sdsfree(field);
                         zfree(encoded);
                         zfree(lp);
                         objectSetVal(o, NULL);


### PR DESCRIPTION
Actually it rarely can happen.

in rdbLoadObject.

when sdstrynewlen is OK and hashtableAdd is OK. but lpSafeToAdd is FAIL.

field will be double-freed.

but lpSafeToAdd will fail len + add > LISTPACK_MAX_SAFETY_SIZE(1GB)

so it can rarely happened and trivial. I think.

