### PR TITLE
Increase timeout for `diskless no replicas drop during rdb pipe` flaky test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -951,7 +951,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    set bgsave_wait [expr {$all_drop eq "no" ? 1500 : 500}]
+                    set bgsave_wait [expr {$all_drop eq "no" ? 1000 : 500}]
                     wait_for_condition $bgsave_wait 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -951,7 +951,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    set bgsave_wait [expr {$all_drop eq "no" ? 1000 : 500}]
+                    set bgsave_wait [expr {$all_drop eq "no" ? 1500 : 500}]
                     wait_for_condition $bgsave_wait 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -951,7 +951,8 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    wait_for_condition 500 100 {
+                    set bgsave_wait [expr {$all_drop eq "no" ? 1500 : 500}]
+                    wait_for_condition $bgsave_wait 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"


### PR DESCRIPTION
The `diskless no replicas drop during rdb pipe` test was flaky on slow CI runners. The ~200MB diskless RDB transfer with a slow replica was taking around 52-104 seconds which exceeds the 50s wait_for_condition timeout. I increased the wait time from 50s to 150s just for the `no` case since this is the only case that waits for the full transfer to complete. 

Daily Run Failure: https://github.com/valkey-io/valkey/actions/runs/24013803047/job/70029595592
CI Failure: https://github.com/valkey-io/valkey/actions/runs/23620016622/job/68796847829?pr=3397