### PR TITLE
Unique samples in hashtableSampleEntries

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -384,6 +384,7 @@ struct hashtableStats {
 typedef struct {
     unsigned size;  /* Size of the entries array. */
     unsigned seen;  /* Number of entries seen. */
+    unsigned safe;  /* Number of entries safe from replacement. */
     void **entries; /* Array of sampled entries. */
 } scan_samples;
 
@@ -1099,10 +1100,16 @@ static void sampleEntriesScanFn(void *privdata, void *entry) {
         samples->entries[samples->seen++] = entry;
     } else {
         /* More entries than we wanted. This can happen if there are long
-         * bucket chains. Replace random entries using reservoir sampling. */
+         * bucket chains. Replace random entries using reservoir sampling,
+         * but only replace entries from the current bucket chain (indices
+         * >= safe), to avoid replacing already confirmed unique entries
+         * from previous bucket chains with potential duplicates. */
         samples->seen++;
-        unsigned idx = random() % samples->seen;
-        if (idx < samples->size) samples->entries[idx] = entry;
+        unsigned replaceable = samples->size - samples->safe;
+        if (replaceable > 0) {
+            unsigned idx = random() % (samples->seen - samples->safe);
+            if (idx < replaceable) samples->entries[samples->safe + idx] = entry;
+        }
     }
 }
 
@@ -2363,10 +2370,16 @@ unsigned hashtableSampleEntries(hashtable *ht, void **dst, unsigned count) {
     scan_samples samples;
     samples.size = count;
     samples.seen = 0;
+    samples.safe = 0;
     samples.entries = dst;
     size_t cursor = randomSizeT();
     while (samples.seen < count) {
         cursor = hashtableScan(ht, cursor, sampleEntriesScanFn, &samples);
+        /* Entries collected so far are from distinct buckets and guaranteed
+         * unique. Mark them safe so reservoir sampling in the next iteration
+         * won't overwrite them with potential duplicates if the cursor wraps
+         * around. */
+        samples.safe = samples.seen <= count ? samples.seen : count;
     }
     rehashStepOnReadIfNeeded(ht);
     /* samples.seen is the number of entries scanned. It may be greater than

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -384,7 +384,6 @@ struct hashtableStats {
 typedef struct {
     unsigned size;  /* Size of the entries array. */
     unsigned seen;  /* Number of entries seen. */
-    unsigned safe;  /* Number of entries safe from replacement. */
     void **entries; /* Array of sampled entries. */
 } scan_samples;
 
@@ -1100,16 +1099,10 @@ static void sampleEntriesScanFn(void *privdata, void *entry) {
         samples->entries[samples->seen++] = entry;
     } else {
         /* More entries than we wanted. This can happen if there are long
-         * bucket chains. Replace random entries using reservoir sampling,
-         * but only replace entries from the current bucket chain (indices
-         * >= safe), to avoid replacing already confirmed unique entries
-         * from previous bucket chains with potential duplicates. */
+         * bucket chains. Replace random entries using reservoir sampling. */
         samples->seen++;
-        unsigned replaceable = samples->size - samples->safe;
-        if (replaceable > 0) {
-            unsigned idx = random() % (samples->seen - samples->safe);
-            if (idx < replaceable) samples->entries[samples->safe + idx] = entry;
-        }
+        unsigned idx = random() % samples->seen;
+        if (idx < samples->size) samples->entries[idx] = entry;
     }
 }
 
@@ -2370,16 +2363,10 @@ unsigned hashtableSampleEntries(hashtable *ht, void **dst, unsigned count) {
     scan_samples samples;
     samples.size = count;
     samples.seen = 0;
-    samples.safe = 0;
     samples.entries = dst;
     size_t cursor = randomSizeT();
     while (samples.seen < count) {
         cursor = hashtableScan(ht, cursor, sampleEntriesScanFn, &samples);
-        /* Entries collected so far are from distinct buckets and guaranteed
-         * unique. Mark them safe so reservoir sampling in the next iteration
-         * won't overwrite them with potential duplicates if the cursor wraps
-         * around. */
-        samples.safe = samples.seen <= count ? samples.seen : count;
     }
     rehashStepOnReadIfNeeded(ht);
     /* samples.seen is the number of entries scanned. It may be greater than

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2330,6 +2330,7 @@ bool hashtableNext(hashtableIterator *iterator, void **elemptr) {
  * results, this picks a new random bucket each time for fair sampling at the
  * cost of possible duplicates. */
 static unsigned sampleRandomBuckets(hashtable *ht, void **dst, unsigned count) {
+    if (count > hashtableSize(ht)) count = hashtableSize(ht);
     scan_samples samples;
     samples.size = count;
     samples.seen = 0;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2325,11 +2325,27 @@ bool hashtableNext(hashtableIterator *iterator, void **elemptr) {
 
 /* --- Random entries --- */
 
+/* Scan independent random buckets and collect entries using reservoir sampling.
+ * Unlike hashtableSampleEntries which scans contiguous buckets for unique
+ * results, this picks a new random bucket each time for fair sampling at the
+ * cost of possible duplicates. */
+static unsigned sampleRandomBuckets(hashtable *ht, void **dst, unsigned count) {
+    scan_samples samples;
+    samples.size = count;
+    samples.seen = 0;
+    samples.entries = dst;
+    while (samples.seen < count) {
+        hashtableScan(ht, randomSizeT(), sampleEntriesScanFn, &samples);
+    }
+    rehashStepOnReadIfNeeded(ht);
+    return samples.seen <= count ? samples.seen : count;
+}
+
 /* Points 'found' to a random entry in the hash table and returns true. Returns false
  * if the table is empty. */
 bool hashtableRandomEntry(hashtable *ht, void **found) {
     void *samples[WEAK_RANDOM_SAMPLE_SIZE];
-    unsigned count = hashtableSampleEntries(ht, &samples[0], WEAK_RANDOM_SAMPLE_SIZE);
+    unsigned count = sampleRandomBuckets(ht, &samples[0], WEAK_RANDOM_SAMPLE_SIZE);
     if (count == 0) return false;
     unsigned idx = random() % count;
     *found = samples[idx];
@@ -2342,7 +2358,7 @@ bool hashtableFairRandomEntry(hashtable *ht, void **found) {
     /* Sample less if it's very sparse. */
     size_t num_samples = hashtableSize(ht) >= hashtableBuckets(ht) ? FAIR_RANDOM_SAMPLE_SIZE : WEAK_RANDOM_SAMPLE_SIZE;
     void *samples[num_samples];
-    unsigned count = hashtableSampleEntries(ht, &samples[0], num_samples);
+    unsigned count = sampleRandomBuckets(ht, &samples[0], num_samples);
     if (count == 0) return false;
     unsigned idx = random() % count;
     *found = samples[idx];

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2364,8 +2364,9 @@ unsigned hashtableSampleEntries(hashtable *ht, void **dst, unsigned count) {
     samples.size = count;
     samples.seen = 0;
     samples.entries = dst;
+    size_t cursor = randomSizeT();
     while (samples.seen < count) {
-        hashtableScan(ht, randomSizeT(), sampleEntriesScanFn, &samples);
+        cursor = hashtableScan(ht, cursor, sampleEntriesScanFn, &samples);
     }
     rehashStepOnReadIfNeeded(ht);
     /* samples.seen is the number of entries scanned. It may be greater than

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -134,7 +134,7 @@ start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
         binary scan $reply @14Su count
 
         assert_equal 1 $type
-        assert_morethan $count 7
+        assert_morethan_equal $count 7
         assert_lessthan_equal $count 9
     }
 }

--- a/tests/unit/cluster/packet.tcl
+++ b/tests/unit/cluster/packet.tcl
@@ -134,7 +134,7 @@ start_cluster 10 0 {tags {external:skip cluster tls:skip}} {
         binary scan $reply @14Su count
 
         assert_equal 1 $type
-        assert_morethan $count 3
+        assert_morethan $count 7
         assert_lessthan_equal $count 9
     }
 }


### PR DESCRIPTION
Instead of "scanning" random bucket chains using a random cursor for each scan call, start at a random cursor and then continue sampling buckets in scan order. The scan stops when we have sampled all elements, so the cursor never wraps around to sample the same buckets again. This ensures that we don't get any duplicate samples.

The functions hashtableRandomEntry and hashtableFairRandomEntry keeps the old behavior using another sampling function preserving their behavior. The fairness tests fail if we use the modified hashtableSampleEntries.

This restores the behavior of dictGetSomeKeys (which is now an alias of hashtableSampleEntries) and deflakes the test case:

    Gossip count scales with higher percentage of `cluster-message-gossip-perc`
    in tests/unit/cluster/packet.tcl

Fixes #3454