### PR TITLE
Attempt to deflake 'diskless no replicas drop during rdb pipe'

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -951,7 +951,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    wait_for_condition 500 100 {
+                    wait_for_condition 1200 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"


### PR DESCRIPTION
Increase time to wait for bgsave to complete. This wait has been seen failing in these test cases.

The test case loops with 'no', 'slow', 'fast', 'all' and 'timeout' replicas, in tests/integration/replication.tcl

Example:

    *** [err]: diskless fast replicas drop during rdb pipe in tests/integration/replication.tcl
    rdb child didn't terminate

https://github.com/valkey-io/valkey/actions/runs/24110987718/job/70345236355#step:9:8083

