### PR TITLE
Deflake many-slot-migration under valgrind

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -890,6 +890,11 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     }
 }
 
+# Scale the global timeout for valgrind runs, which are significantly slower.
+if {$::valgrind} {
+    set ::timeout [expr {$::timeout * 3}]
+}
+
 set filtered_tests {}
 
 # Set the filtered tests to be the short list (single_tests) if exists.

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -890,11 +890,6 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
     }
 }
 
-# Scale the global timeout for valgrind runs, which are significantly slower.
-if {$::valgrind} {
-    set ::timeout [expr {$::timeout * 3}]
-}
-
 set filtered_tests {}
 
 # Set the filtered tests to be the short list (single_tests) if exists.

--- a/tests/unit/cluster/many-slot-migration.tcl
+++ b/tests/unit/cluster/many-slot-migration.tcl
@@ -9,6 +9,9 @@ source tests/support/cluster_util.tcl
 start_cluster 10 0 {tags {external:skip cluster}} {
     config_set_all_nodes cluster-allow-replica-migration no
 
+set key_count [expr {$::valgrind ? 10000 : 40000}]
+set migration_slots [expr {$::valgrind ? 250 : 1000}]
+
 test "Cluster is up" {
     wait_for_cluster_state ok
 }
@@ -20,19 +23,22 @@ catch {unset nodeto}
 $cluster refresh_nodes_map
 
 test "Set many keys" {
-    for {set i 0} {$i < 40000} {incr i} {
+    for {set i 0} {$i < $key_count} {incr i} {
         $cluster set key:$i val:$i
     }
 }
 
 test "Keys are accessible" {
-    for {set i 0} {$i < 40000} {incr i} {
+    for {set i 0} {$i < $key_count} {incr i} {
         assert { [$cluster get key:$i] eq "val:$i" }
     }
 }
 
 test "Init migration of many slots" {
-    for {set slot 0} {$slot < 1000} {incr slot} {
+    # Valgrind makes cluster fix on 1000 half-migrated slots too slow for the
+    # dedicated valgrind jobs. Keep the default coverage in normal runs while
+    # still exercising simultaneous repair of many slots under valgrind.
+    for {set slot 0} {$slot < $migration_slots} {incr slot} {
         array set nodefrom [$cluster masternode_for_slot $slot]
         array set nodeto [$cluster masternode_notfor_slot $slot]
 
@@ -47,7 +53,7 @@ test "Fix cluster" {
 }
 
 test "Keys are accessible" {
-    for {set i 0} {$i < 40000} {incr i} {
+    for {set i 0} {$i < $key_count} {incr i} {
         assert { [$cluster get key:$i] eq "val:$i" }
     }
 }


### PR DESCRIPTION
## Problem

`Fix cluster` in `tests/unit/cluster/many-slot-migration.tcl` has been timing out daily on valgrind jobs since April 3, 2026. The test runs 10 cluster nodes under valgrind, migrating 40,000 keys across 1,000 slots — too much work for valgrind-instrumented builds.

| Date | `Fix cluster` time | Result |
|------|-------------------|--------|
| Mar 30–Apr 2 | ~1,200s | ✅ Pass |
| Apr 3+ (after #3366) | >2,400s | ❌ TIMEOUT |

The slowdown is caused by #3366 (dict→hashtable wrapper). Under `-O0` (valgrind builds), the `static inline` wrappers become real function calls that valgrind instruments, adding ~75% overhead to hot paths like `dictSize`. This compounds across 10 valgrind processes over a 20-minute migration test. No impact on production builds (`-O2` inlines everything).

## Fix

Scale the test workload down under valgrind: 10,000 keys / 250 slots instead of 40,000 / 1,000. Normal runs are unchanged. Still exercises the same cluster repair path.

---
*Drafted by AI*