### PR TITLE
Fix use-after-unload crash in auth module's blocking thread

### DIFF
--- a/tests/modules/auth.c
+++ b/tests/modules/auth.c
@@ -14,6 +14,13 @@
 static ValkeyModuleUser *global = NULL;
 static long long client_change_delta = 0;
 
+/* Track the blocking auth thread so we can join it on unload to prevent
+ * use-after-unload crashes when dlclose() unmaps the module's code while
+ * the thread is still running. Only one blocking auth thread is tracked
+ * at a time — tests must not trigger concurrent blocking auths. */
+static pthread_t blocking_auth_tid;
+static int blocking_auth_tid_valid = 0;
+
 void UserChangedCallback(uint64_t client_id, void *privdata) {
     VALKEYMODULE_NOT_USED(privdata);
     VALKEYMODULE_NOT_USED(client_id);
@@ -197,15 +204,16 @@ int blocking_auth_cb(ValkeyModuleCtx *ctx, ValkeyModuleString *username, ValkeyM
         return VALKEYMODULE_AUTH_HANDLED;
     }
     ValkeyModule_BlockedClientMeasureTimeStart(bc);
-    pthread_t tid;
     /* Allocate memory for information needed. */
     void **targ = ValkeyModule_Alloc(sizeof(void*)*3);
     targ[0] = bc;
     targ[1] = ValkeyModule_CreateStringFromString(NULL, username);
     targ[2] = ValkeyModule_CreateStringFromString(NULL, password);
     /* Create bg thread and pass the blockedclient, username and password to it. */
-    if (pthread_create(&tid, NULL, AuthBlock_ThreadMain, targ) != 0) {
+    if (pthread_create(&blocking_auth_tid, NULL, AuthBlock_ThreadMain, targ) != 0) {
         ValkeyModule_AbortBlock(bc);
+    } else {
+        blocking_auth_tid_valid = 1;
     }
     return VALKEYMODULE_AUTH_HANDLED;
 }
@@ -263,6 +271,13 @@ int ValkeyModule_OnUnload(ValkeyModuleCtx *ctx) {
 
     if (global)
         ValkeyModule_FreeModuleUser(global);
+
+    /* Wait for any in-flight blocking auth thread to finish before the module
+     * is dlclose'd, otherwise the thread returns into unmapped code. */
+    if (blocking_auth_tid_valid) {
+        pthread_join(blocking_auth_tid, NULL);
+        blocking_auth_tid_valid = 0;
+    }
 
     return VALKEYMODULE_OK;
 }


### PR DESCRIPTION
## Problem

The test `Test module aof save on server start from empty` in `tests/unit/moduleapi/hooks.tcl` sporadically crashes with `I/O error reading reply`.

**Frequency:** 2 out of 15 days (March 26 on `centosstream9-tls-module-no-tls`, April 8 on `fedorarawhide-jemalloc`).

**Example failing run:** https://github.com/valkey-io/valkey/actions/runs/24110987718/job/70345236353

## Root Cause

The crash is a **use-after-unload** in the auth test module's blocking authentication thread, NOT a timing issue in the AOF test.

The crash log from April 8 shows:
```
71112:M 00:42:59.710 * Module testacl unloaded
71112:M 00:42:59.711 # crashed by signal: 11, si_code: 1
71112:M 00:42:59.711 # Crashed running the instruction at: 0x7f9dc717384b
```

The sequence:
1. `blocking_auth_cb` spawns a background thread (`AuthBlock_ThreadMain`) that sleeps 500ms
2. Thread wakes, calls `ValkeyModule_UnblockClient()` → main thread processes unblock, decrements `module->blocked_clients`
3. Auth command completes, test calls `r module unload testacl`
4. `moduleUnloadInternal` checks `blocked_clients == 0` if true, proceeds with `dlclose()`
5. **But the background thread is still executing cleanup code** (freeing strings, returning from function)
6. Thread returns into unmapped memory → **SIGSEGV**

The `invalidFunctionWasCalled` in the stack trace is the crash handler's safety stub, and the crashing address `0x7f9dc717384b` is in the unmapped auth.so address space.

## Fix

Track the background thread ID and `pthread_join()` it in `ValkeyModule_OnUnload` before the module is dlclose'd. This ensures the thread has fully exited before the code is unmapped.

The key insight is that `ValkeyModule_UnblockClient()` signals "auth is done" but not "thread is done" — the thread still has cleanup code to execute after that call. `pthread_join()` is the correct synchronization point because it only returns after the thread has fully exited.

No mutex is needed since both `blocking_auth_cb` (which creates the thread) and `OnUnload` (which joins it) run on the main event loop thread.

Changes to `tests/modules/auth.c`:
- Add global `blocking_auth_tid` and `blocking_auth_tid_valid` flag
- Set `blocking_auth_tid_valid = 1` after successful `pthread_create`
- In `OnUnload`, `pthread_join` the thread if one was created

## Testing

Ran `unit/moduleapi/hooks` 100 loops on rpm-distros and ubuntu runners — **all passed**:
- **Workflow run:** https://github.com/roshkhatri/valkey/actions/runs/24164276124
- **Config:** `--loops 100 --single unit/moduleapi/hooks` on `almalinux8`, `almalinux9`, `fedoralatest`, `fedorarawhide`, `centosstream9`, `ubuntu-jemalloc`, `ubuntu-arm`
- **Result:** 7/7 jobs ✅, zero failures across 700 total test iterations

