### PR TITLE
Ignore stale replica messages for failed primaries

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1404,18 +1404,6 @@ static inline uint64_t nodeEpoch(clusterNode *n) {
     return n->replicaof ? n->replicaof->configEpoch : n->configEpoch;
 }
 
-static clusterNode *clusterGetSubReplicaPrimary(clusterNode *node) {
-    if (node == NULL || node->replicaof == NULL) return NULL;
-
-    clusterNode *primary = node->replicaof;
-    clusterNode *grand_primary = primary->replicaof;
-
-    if (grand_primary == NULL || grand_primary == node) return NULL;
-    if (nodeFailed(grand_primary)) return NULL;
-
-    return grand_primary;
-}
-
 /* Update my hostname based on server configuration values */
 void clusterUpdateMyselfHostname(void) {
     if (!myself) return;
@@ -4185,11 +4173,19 @@ int clusterProcessPacket(clusterLink *link) {
             } else {
                 /* Node is a replica. */
                 clusterNode *sender_claimed_primary = clusterLookupNode(msg->replicaof, CLUSTER_NAMELEN);
+                int ignore_failed_primary_msg = sender_claimed_primary && nodeFailed(sender_claimed_primary);
 
-                if (sender_last_reported_as_primary) {
+                if (ignore_failed_primary_msg) {
+                    serverLog(LL_NOTICE,
+                              "Ignore stale replica message from %.40s (%s) in shard %.40s; claimed primary %.40s "
+                              "(%s) is marked FAIL",
+                              sender->name, humanNodename(sender), sender->shard_id, sender_claimed_primary->name,
+                              humanNodename(sender_claimed_primary));
+                }
+
+                if (sender_last_reported_as_primary && !ignore_failed_primary_msg) {
                     serverLog(LL_DEBUG, "node %.40s (%s) announces that it is a %s in shard %.40s", sender->name,
                               humanNodename(sender), sender_claims_to_be_primary ? "primary" : "replica", sender->shard_id);
-
                     /* Primary turned into a replica! Reconfigure the node. */
                     if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
                         /* `sender` was a primary and was in the same shard as its new primary */
@@ -4261,7 +4257,8 @@ int clusterProcessPacket(clusterLink *link) {
                 }
 
                 /* Primary node changed for this replica? */
-                if (sender_claimed_primary && sender->replicaof != sender_claimed_primary) {
+                if (sender_claimed_primary && !ignore_failed_primary_msg &&
+                    sender->replicaof != sender_claimed_primary) {
                     if (sender->replicaof) clusterNodeRemoveReplica(sender->replicaof, sender);
                     serverLog(LL_NOTICE, "Node %.40s (%s) is now a replica of node %.40s (%s) in shard %.40s",
                               sender->name, humanNodename(sender), sender_claimed_primary->name,
@@ -4283,8 +4280,7 @@ int clusterProcessPacket(clusterLink *link) {
                      *
                      * Therefore, it's essential to delay any shard_id updates until after the replication
                      * relationship has been properly established and verified. */
-                    clusterNode *subreplica_primary = clusterGetSubReplicaPrimary(myself);
-                    if (subreplica_primary) {
+                    if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
                         /* Safeguard against sub-replicas.
                          *
                          * A replica's primary can turn itself into a replica if its last slot
@@ -4296,20 +4292,11 @@ int clusterProcessPacket(clusterLink *link) {
                          * replica during a failover. In this case, they are in the same shard,
                          * so we can try a psync. */
                         serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
-                                  subreplica_primary->name, myself->replicaof->name);
-                        clusterSetPrimary(subreplica_primary, 1,
-                                          !areInSameShard(subreplica_primary, myself));
+                                  myself->replicaof->replicaof->name, myself->replicaof->name);
+                        clusterSetPrimary(myself->replicaof->replicaof, 1,
+                                          !areInSameShard(myself->replicaof->replicaof, myself));
                         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
                                              CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
-                    } else if (myself->replicaof && myself->replicaof->replicaof &&
-                               myself->replicaof->replicaof != myself) {
-                        serverLog(LL_NOTICE,
-                                  "I'm a sub-replica, but node %.40s (%s) is failed. "
-                                  "Keeping my current primary %.40s (%s)",
-                                  myself->replicaof->replicaof->name,
-                                  humanNodename(myself->replicaof->replicaof),
-                                  myself->replicaof->name,
-                                  humanNodename(myself->replicaof));
                     }
 
                     /* Update the shard_id when a replica is connected to its

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -4302,8 +4302,7 @@ int clusterProcessPacket(clusterLink *link) {
                         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
                                              CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
                     } else if (myself->replicaof && myself->replicaof->replicaof &&
-                               myself->replicaof->replicaof != myself &&
-                               nodeFailed(myself->replicaof->replicaof)) {
+                               myself->replicaof->replicaof != myself) {
                         serverLog(LL_NOTICE,
                                   "I'm a sub-replica, but node %.40s (%s) is failed. "
                                   "Keeping my current primary %.40s (%s)",

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1404,6 +1404,18 @@ static inline uint64_t nodeEpoch(clusterNode *n) {
     return n->replicaof ? n->replicaof->configEpoch : n->configEpoch;
 }
 
+static clusterNode *clusterGetSubReplicaPrimary(clusterNode *node) {
+    if (node == NULL || node->replicaof == NULL) return NULL;
+
+    clusterNode *primary = node->replicaof;
+    clusterNode *grand_primary = primary->replicaof;
+
+    if (grand_primary == NULL || grand_primary == node) return NULL;
+    if (nodeFailed(grand_primary)) return NULL;
+
+    return grand_primary;
+}
+
 /* Update my hostname based on server configuration values */
 void clusterUpdateMyselfHostname(void) {
     if (!myself) return;
@@ -4271,7 +4283,8 @@ int clusterProcessPacket(clusterLink *link) {
                      *
                      * Therefore, it's essential to delay any shard_id updates until after the replication
                      * relationship has been properly established and verified. */
-                    if (myself->replicaof && myself->replicaof->replicaof && myself->replicaof->replicaof != myself) {
+                    clusterNode *subreplica_primary = clusterGetSubReplicaPrimary(myself);
+                    if (subreplica_primary) {
                         /* Safeguard against sub-replicas.
                          *
                          * A replica's primary can turn itself into a replica if its last slot
@@ -4283,11 +4296,21 @@ int clusterProcessPacket(clusterLink *link) {
                          * replica during a failover. In this case, they are in the same shard,
                          * so we can try a psync. */
                         serverLog(LL_NOTICE, "I'm a sub-replica! Reconfiguring myself as a replica of %.40s from %.40s",
-                                  myself->replicaof->replicaof->name, myself->replicaof->name);
-                        clusterSetPrimary(myself->replicaof->replicaof, 1,
-                                          !areInSameShard(myself->replicaof->replicaof, myself));
+                                  subreplica_primary->name, myself->replicaof->name);
+                        clusterSetPrimary(subreplica_primary, 1,
+                                          !areInSameShard(subreplica_primary, myself));
                         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE |
                                              CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
+                    } else if (myself->replicaof && myself->replicaof->replicaof &&
+                               myself->replicaof->replicaof != myself &&
+                               nodeFailed(myself->replicaof->replicaof)) {
+                        serverLog(LL_NOTICE,
+                                  "I'm a sub-replica, but node %.40s (%s) is failed. "
+                                  "Keeping my current primary %.40s (%s)",
+                                  myself->replicaof->replicaof->name,
+                                  humanNodename(myself->replicaof->replicaof),
+                                  myself->replicaof->name,
+                                  humanNodename(myself->replicaof));
                     }
 
                     /* Update the shard_id when a replica is connected to its


### PR DESCRIPTION
This fixes the case from [valkey-fuzzer#85](https://github.com/valkey-io/valkey-fuzzer/issues/85)

The short version is:

- `A` is the old primary
- `B` is a replica of `A`
- `C` is another replica in the same shard

`A` dies, `B` wins failover, and `C` starts following `B`, which is the right thing.

The problem is that `C` can then process a stale view where `B` still looks like a replica of `A`. At that point `C` briefly thinks the topology is `C -> B -> A`.

We already have logic to flatten that kind of sub-replica chain by making `C` follow the grand-primary directly. Normally that is fine. Here it is not, because the grand-primary is `A`, and `A` is already failed.

So instead of staying on healthy `B`, `C` gets rewired back to dead `A`. Once that happens, the reconnect fails, `C` can start another failover, and we can end up with an extra slotless primary while `B` still owns the shard slots. That lines up with the fuzzer result.

The fix here is small: ignore stale replica messages for failed primaries

Healthy sub-replica repair should still behave the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster replication reliability by preventing replicas from updating their primary node relationship based on messages from failed primaries. The system now detects and ignores such stale announcements, ensuring accurate replica configurations are maintained in clustered deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey/pull/3468)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->