### PR TITLE
Client blocking mechanism for keys in use (forkless)

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -77,6 +77,7 @@ static void handleClientsBlockedOnKey(readyList *rl);
 static void unblockClientOnKey(client *c, robj *key);
 static void moduleUnblockClientOnKey(client *c, robj *key);
 static void releaseBlockedEntry(client *c, dictEntry *de, int remove_key);
+static void unlinkBlockInUseClient(client *c);
 
 void initClientBlockingState(client *c) {
     if (c->bstate) return;
@@ -164,6 +165,7 @@ void processUnblockedClients(void) {
         serverAssert(ln != NULL);
         c = ln->value;
         listDelNode(server.unblocked_clients, ln);
+        serverAssert(c->flag.module || !c->flag.blocked);
         c->flag.unblocked = 0;
 
         if (c->flag.module) {
@@ -173,15 +175,15 @@ void processUnblockedClients(void) {
             continue;
         }
 
-        /* Process remaining data in the input buffer, unless the client
-         * is blocked again. Actually processInputBuffer() checks that the
-         * client is not blocked before to proceed, but things may change and
-         * the code is conceptually more correct this way. */
-        if (!c->flag.blocked) {
-            /* If we have a queued command, execute it now. */
-            if (processPendingCommandAndInputBuffer(c) == C_ERR) {
+        if (c->conn && !connHasReadHandler(c->conn)) {
+            if (connSetReadHandler(c->conn, readQueryFromClient) == C_ERR) {
+                freeClient(c);
                 continue;
             }
+        }
+        /* If we have a queued command, execute it now. */
+        if (processPendingCommandAndInputBuffer(c) == C_ERR) {
+            continue;
         }
         beforeNextClient(c);
     }
@@ -215,20 +217,31 @@ void queueClientForReprocessing(client *c) {
 /* Unblock a client calling the right function depending on the kind
  * of operation the client is blocking for. */
 void unblockClient(client *c, int queue_for_reprocessing) {
-    if (c->bstate->btype == BLOCKED_LIST || c->bstate->btype == BLOCKED_ZSET || c->bstate->btype == BLOCKED_STREAM) {
+    switch (c->bstate->btype) {
+    case BLOCKED_LIST:
+    case BLOCKED_ZSET:
+    case BLOCKED_STREAM:
         unblockClientWaitingData(c);
-    } else if (c->bstate->btype == BLOCKED_WAIT) {
+        break;
+    case BLOCKED_WAIT:
         unblockClientWaitingReplicas(c);
-    } else if (c->bstate->btype == BLOCKED_MODULE) {
+        break;
+    case BLOCKED_MODULE:
         if (moduleClientIsBlockedOnKeys(c)) unblockClientWaitingData(c);
         unblockClientFromModule(c);
-    } else if (c->bstate->btype == BLOCKED_POSTPONE) {
+        break;
+    case BLOCKED_POSTPONE:
         serverAssert(c->bstate->postponed_list_node);
         listDelNode(server.postponed_clients, c->bstate->postponed_list_node);
         c->bstate->postponed_list_node = NULL;
-    } else if (c->bstate->btype == BLOCKED_SHUTDOWN) {
+        break;
+    case BLOCKED_SHUTDOWN:
         /* No special cleanup. */
-    } else {
+        break;
+    case BLOCKED_INUSE:
+        unlinkBlockInUseClient(c);
+        break;
+    default:
         serverPanic("Unknown btype in unblockClient().");
     }
 
@@ -337,6 +350,10 @@ void disconnectOrRedirectAllBlockedClients(void) {
              * be either executed or rejected. (unlike LIST blocked clients for
              * which the command is already in progress in a way. */
             if (c->bstate->btype == BLOCKED_POSTPONE) continue;
+
+            /* BLOCKED_INUSE clients will reprocess their command when unblocked
+             * by the caller. Sending error replies here would be incorrect. */
+            if (c->bstate->btype == BLOCKED_INUSE) continue;
 
             if (server.cluster_enabled) {
                 if (clusterRedirectBlockedClientIfNeeded(c))
@@ -787,6 +804,197 @@ void unblockClientOnError(client *c, const char *err_str) {
     unblockClient(c, 1);
 }
 
+/* ========================== BlockInUse ====================================
+ *
+ * Client blocking mechanism for keys currently being processed by a
+ * background thread.
+ *
+ * Note: All blockInUse APIs must be called from the main thread only.
+ *
+ * This uses the BLOCKED_INUSE blocking type (via blockClient()) and tracks
+ * blocked keys per client in c->bstate->keys and a key→clients mapping in
+ * a static hashtable (inuse_key_to_clients).
+ *
+ * Workflow:
+ *   1. blockClientInUseOnKeys() blocks the client via
+ *      blockClient(c, BLOCKED_INUSE) and records mappings in both
+ *      c->bstate->keys and inuse_key_to_clients.
+ *   2. unblockClientsInUseOnKey() unblocks a single key. A client remains
+ *      blocked until all its keys are unblocked.
+ *   3. A client is fully unblocked only when it has no remaining keys in its
+ *      c->bstate->keys dict.
+ *   4. processUnblockedClients() restores the read handler and resumes the
+ *      pending command.
+ */
+
+/* Internal blockInUse data structures.
+ *
+ * Clients are blocked on key name, regardless of DB. This avoids complexity
+ * with DB swaps. A BLOCKED_INUSE client may get unblocked early due to
+ * unblocking a key with the same name on a different DB. In this case, the
+ * client will get reblocked when attempting to reprocess the command. */
+static hashtable *inuse_key_to_clients; /* Maps keys to keyToClientsEntry. */
+
+/* ----------------------------- key_to_clients Hashtable Util ------------------------- */
+
+typedef struct {
+    robj *key;
+    list *clients;
+} keyToClientsEntry;
+
+// hashtable callback, returns an robj containing a string
+static const void *keyToClientsGetKey(const void *entry) {
+    return ((keyToClientsEntry *)entry)->key;
+}
+
+// hashtable callback
+static void keyToClientsDestructor(void *entry) {
+    keyToClientsEntry *e = entry;
+    decrRefCount(e->key);
+    listRelease(e->clients);
+    zfree(e);
+}
+
+static hashtableType keyToClientsHashtableType = {
+    .entryGetKey = keyToClientsGetKey,
+    .hashFunction = dictEncObjHash,
+    .keyCompare = dictEncObjKeyCompare,
+    .entryDestructor = keyToClientsDestructor,
+};
+
+// Return the list of clients blocked on key, or NULL if none exist.
+static list *keyToClients_getBlockedClientsList(robj *key) {
+    keyToClientsEntry *entry;
+    if (hashtableFind(inuse_key_to_clients, key, (void **)&entry)) {
+        return entry->clients;
+    }
+    return NULL;
+}
+
+/* Create a new keyToClientsEntry for key, add it to key_to_clients,
+ * and return its clients list. Precondition: the key must not already exist. */
+static list *keyToClients_addEntry(robj *key) {
+    keyToClientsEntry *entry = zcalloc(sizeof(keyToClientsEntry));
+    entry->key = key;
+    incrRefCount(key);
+    entry->clients = listCreate();
+    serverAssert(hashtableAdd(inuse_key_to_clients, entry));
+    return entry->clients;
+}
+
+/* ----------------------------- blockInUse API ----------------------------- */
+
+static bool isClientBlockedInUse(client *c) {
+    return c->flag.blocked && c->bstate->btype == BLOCKED_INUSE;
+}
+
+/* Block a client on a set of keys. Duplicate keys are deduplicated.
+ *
+ * Each key robj must contain an sds string value. Keys are simple names,
+ * independent of DB — a client may be unblocked early if the same key name
+ * in another DB is unblocked.
+ *
+ * The client remains blocked until ALL of its keys are unblocked via
+ * unblockClientsInUseOnKey().
+ *
+ * The caller MUST set c->flag.pending_command = 1 before calling this function.
+ * This ensures the pending command is executed when the client is later
+ * unblocked via processPendingCommandAndInputBuffer().
+ * The caller should then return without executing the command. */
+void blockClientInUseOnKeys(client *c, int num_keys, robj *keys[]) {
+    serverAssert(!c->flag.blocked && !c->flag.unblocked);
+    serverAssert(c->flag.pending_command == 1);
+    serverAssert(num_keys > 0);
+    serverAssert(!c->flag.replica);
+
+    if (!inuse_key_to_clients) inuse_key_to_clients = hashtableCreate(&keyToClientsHashtableType);
+
+    initClientBlockingState(c);
+    c->bstate->timeout = 0;
+    serverAssert(dictSize(c->bstate->keys) == 0);
+
+    for (int i = 0; i < num_keys; ++i) {
+        robj *key = keys[i];
+        serverAssert(key->type == OBJ_STRING);
+
+        /* Deduplicate via bstate->keys dict */
+        if (dictAdd(c->bstate->keys, key, NULL) != DICT_OK) continue;
+        incrRefCount(key);
+
+        list *blockedClientsList = keyToClients_getBlockedClientsList(key);
+        if (!blockedClientsList) blockedClientsList = keyToClients_addEntry(key);
+        listAddNodeTail(blockedClientsList, c);
+    }
+
+    serverAssert(dictSize(c->bstate->keys) > 0);
+    blockClient(c, BLOCKED_INUSE);
+
+    /* Disable client's Read Handler to prevent reading commands while blocked */
+    if (c->conn) {
+        connSetReadHandler(c->conn, NULL);
+    }
+}
+
+/* Unblock clients blocked on the given key.
+ *
+ * A client is fully unblocked only when it has no remaining keys in its
+ * bstate->keys dict. Such clients are queued for reprocessing and resumed
+ * later during processUnblockedClients(). */
+void unblockClientsInUseOnKey(robj *key) {
+    list *blockedClientsList = keyToClients_getBlockedClientsList(key);
+    if (blockedClientsList == NULL) return;
+
+    serverAssert(listLength(blockedClientsList) > 0);
+
+    while (listLength(blockedClientsList) > 0) {
+        listNode *ln = listFirst(blockedClientsList);
+        client *c = listNodeValue(ln);
+        serverAssert(isClientBlockedInUse(c) && c->flag.unblocked == 0);
+        listDelNode(blockedClientsList, ln);
+        dictDelete(c->bstate->keys, key);
+
+        if (dictSize(c->bstate->keys) == 0) {
+            unblockClient(c, 1);
+        }
+    }
+
+    hashtableDelete(inuse_key_to_clients, key);
+}
+
+/* Unblock all clients that are currently blocked by blockInUse, across all
+ * keys. Unblocked clients are queued for reprocessing and resumed during
+ * processUnblockedClients(). After this call, no clients remain blocked
+ * by blockInUse. */
+void unblockClientsInUseOnAllKeys(void) {
+    if (!inuse_key_to_clients) return;
+    hashtableIterator iter;
+    hashtableInitIterator(&iter, inuse_key_to_clients, HASHTABLE_ITER_SAFE);
+    keyToClientsEntry *e;
+    while (hashtableNext(&iter, (void **)&e)) {
+        unblockClientsInUseOnKey(e->key);
+    }
+    hashtableCleanupIterator(&iter);
+    serverAssert(server.blocked_clients_by_type[BLOCKED_INUSE] == 0);
+    serverAssert(hashtableSize(inuse_key_to_clients) == 0);
+}
+
+/* Remove a client from all blockInUse key-to-clients mappings.
+ * Called from unblockClient() for BLOCKED_INUSE cleanup. */
+static void unlinkBlockInUseClient(client *c) {
+    if (!c->bstate->keys || dictSize(c->bstate->keys) == 0) return;
+    dictIterator *di = dictGetIterator(c->bstate->keys);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        robj *key = dictGetKey(de);
+        list *clientList = keyToClients_getBlockedClientsList(key);
+        serverAssert(clientList != NULL);
+        listDelNode(clientList, listSearchKey(clientList, c));
+        if (listLength(clientList) == 0) hashtableDelete(inuse_key_to_clients, key);
+    }
+    dictReleaseIterator(di);
+    dictEmpty(c->bstate->keys, NULL);
+}
+
 void blockedBeforeSleep(void) {
     /* Handle precise timeouts of blocked clients. */
     handleBlockedClientsTimeout();
@@ -809,4 +1017,22 @@ void blockedBeforeSleep(void) {
 
     /* Try to process pending commands for clients that were just unblocked. */
     if (listLength(server.unblocked_clients)) processUnblockedClients();
+}
+
+/* --------------------------------------------------------------------------
+ * Test-only APIs for blockInUse
+ * -------------------------------------------------------------------------- */
+
+/* Test-only: get the current number of blocked keys by blockInUse. */
+int getBlockInUseKeyCount(void) {
+    return inuse_key_to_clients ? hashtableSize(inuse_key_to_clients) : 0;
+}
+
+/* Test-only: release the blockInUse hashtable. */
+void releaseBlockInUse(void) {
+    unblockClientsInUseOnAllKeys();
+    if (inuse_key_to_clients) {
+        hashtableRelease(inuse_key_to_clients);
+        inuse_key_to_clients = NULL;
+    }
 }

--- a/src/connection.h
+++ b/src/connection.h
@@ -153,7 +153,8 @@ typedef struct ConnectionType {
     struct user *(*get_peer_user)(connection *conn, sds *cert_username);
 
     /* Miscellaneous */
-    int (*connIntegrityChecked)(void); // return 1 if connection type has built-in integrity checks
+    int (*connIntegrityChecked)(void);   // return 1 if connection type has built-in integrity checks
+    int (*is_closing)(connection *conn); // return 1 if connection is closed
 } ConnectionType;
 
 struct connection {
@@ -389,6 +390,15 @@ static inline int connHasWriteHandler(connection *conn) {
 static inline int connHasReadHandler(connection *conn) {
     return conn->read_handler != NULL;
 }
+
+/* Check if the remote side has closed the connection. */
+static inline int connIsClosing(connection *conn) {
+    if (!conn->type->is_closing) return 0;
+    return conn->type->is_closing(conn);
+}
+
+/* Shared is_closing implementation for socket-based connections. */
+int connSocketIsClosing(connection *conn);
 
 /* Associate a private data pointer with the connection */
 static inline void connSetPrivateData(connection *conn, void *data) {

--- a/src/module.c
+++ b/src/module.c
@@ -6830,6 +6830,16 @@ ValkeyModuleCallReply *VM_Call(ValkeyModuleCtx *ctx, const char *cmdname, const 
     server.replication_allowed = prev_replication_allowed;
 
     if (c->flag.blocked) {
+        if (c->flag.deny_blocking) {
+            /* The module did not pass ALLOW_BLOCK — it does not expect the
+             * command to block. Unblock the client and return an error. */
+            c->flag.pending_command = 0;
+            unblockClient(c, 0);
+            addReplyError(c, "INUSE key is being processed.");
+            reply = moduleParseReply(c, (ctx->flags & VALKEYMODULE_CTX_AUTO_MEMORY) ? ctx : NULL);
+            goto cleanup;
+        }
+
         /* Blocking commands are not allowed when calling commands in scripting engines. */
         serverAssert(!is_running_script);
         serverAssert(flags & VALKEYMODULE_ARGV_ALLOW_BLOCK);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1996,6 +1996,10 @@ void unlinkClient(client *c) {
 
     /* Clear the tracking status. */
     if (c->flag.tracking) disableTracking(c);
+
+    /* Client must not be in blocked or unblocked state at this point.
+     * Guaranteed by freeClient ordering: unblockClient -> freeClientBlockingState -> unlinkClient. */
+    serverAssert(!c->flag.blocked && !c->flag.unblocked);
 }
 
 /* Clear the client state to resemble a newly connected client. */
@@ -2117,7 +2121,7 @@ void freeClient(client *c) {
     /* Deallocate structures used to block on blocking ops. */
     /* If there is any in-flight command, we don't record their duration. */
     c->duration = 0;
-    if (c->flag.blocked) unblockClient(c, 1);
+    if (c->flag.blocked) unblockClient(c, 0);
 
     freeClientBlockingState(c);
     freeClientPubSubData(c);
@@ -3831,6 +3835,7 @@ int processPendingCommandAndInputBuffer(client *c) {
      * But in case of a module blocked client (see RM_Call 'K' flag) we do not reach this code path.
      * So whenever we change the code here we need to consider if we need this change on module
      * blocked client as well */
+    if (c->flag.close_asap) return C_ERR;
     if (c->flag.pending_command) {
         c->flag.pending_command = 0;
         if (processCommandAndResetClient(c) == C_ERR) {

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -1858,6 +1858,7 @@ static ConnectionType CT_RDMA = {
 
     /* Miscellaneous */
     .connIntegrityChecked = NULL,
+    .is_closing = NULL,
 };
 
 ConnectionType *connectionTypeRdma(void) {

--- a/src/server.c
+++ b/src/server.c
@@ -1184,6 +1184,24 @@ void getExpensiveClientsInfo(size_t *in_usage, size_t *out_usage) {
     *out_usage = o;
 }
 
+/* Detect and free zombie connections whose read handler was removed (e.g.
+ * BLOCKED_INUSE). Without a read handler the event loop won't notice the
+ * remote side closing, so these fds would leak until the fd limit is hit. */
+static bool clientsCronTcpIsClosing(client *c) {
+    if (!c->conn) return false;
+
+    if (!connIsClosing(c->conn)) return false;
+
+    if (server.verbosity <= LL_VERBOSE) {
+        sds client_info = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
+        serverLog(LL_VERBOSE, "Client closed connection while blocked %s", client_info);
+        sdsfree(client_info);
+    }
+
+    freeClientAsync(c);
+    return true;
+}
+
 /* This function is called by clientsTimeProc() and is used in order to perform
  * operations on clients that are important to perform constantly. For instance
  * we use this function in order to disconnect clients after a timeout, including
@@ -1238,6 +1256,7 @@ static void clientsCron(int clients_this_cycle) {
         if (clientsCronResizeQueryBuffer(c)) continue;
         if (clientsCronResizeOutputBuffer(c, now)) continue;
         if (clientsCronTrackExpensiveClients(c, curr_peak_mem_usage_slot)) continue;
+        if (clientsCronTcpIsClosing(c)) continue;
 
         /* Iterating all the clients in getMemoryOverheadData() is too slow and
          * in turn would make the INFO command too slow. So we perform this
@@ -4273,6 +4292,8 @@ void unprepareCommand(client *c) {
  * other operations can be performed by the caller. Otherwise
  * if C_ERR is returned the client was destroyed (i.e. after QUIT). */
 int processCommand(client *c) {
+    serverAssert(!c->flag.blocked && !c->flag.unblocked);
+
     if (!scriptIsTimedout()) {
         /* Both EXEC and scripts call call() directly so there should be
          * no way in_exec or scriptIsRunning() is 1.

--- a/src/server.h
+++ b/src/server.h
@@ -344,6 +344,7 @@ typedef enum blocking_type {
     BLOCKED_ZSET,     /* BZPOP et al. */
     BLOCKED_POSTPONE, /* Blocked by processCommand, re-try processing later. */
     BLOCKED_SHUTDOWN, /* SHUTDOWN. */
+    BLOCKED_INUSE,    /* Key in use by background thread. */
     BLOCKED_NUM,      /* Number of blocked states. */
     BLOCKED_END       /* End of enumeration */
 } blocking_type;
@@ -3848,6 +3849,9 @@ void signalKeyAsReady(serverDb *db, robj *key, int type);
 void blockForKeys(client *c, int btype, robj **keys, int numkeys, mstime_t timeout, int unblock_on_nokey);
 void blockClientShutdown(client *c);
 void blockPostponeClient(client *c);
+void blockClientInUseOnKeys(client *c, int num_keys, robj *keys[]);
+void unblockClientsInUseOnKey(robj *key);
+void unblockClientsInUseOnAllKeys(void);
 void blockClientForReplicaAck(client *c, mstime_t timeout, long long offset, long numreplicas, int numlocal);
 void replicationRequestAckFromReplicas(void);
 void signalDeletedKeyAsReady(serverDb *db, robj *key, int type);

--- a/src/socket.c
+++ b/src/socket.c
@@ -30,6 +30,10 @@
 #include "server.h"
 #include "connhelpers.h"
 #include "io_threads.h"
+#include <netinet/tcp.h>
+#ifdef __APPLE__
+#include <netinet/tcp_fsm.h>
+#endif
 
 /* The connections module provides a lean abstraction of network connections
  * to avoid direct socket and async event management across the server code base.
@@ -405,6 +409,25 @@ static int connSocketGetType(void) {
     return CONN_TYPE_SOCKET;
 }
 
+int connSocketIsClosing(connection *conn) {
+    if (aeGetFileEvents(server.el, conn->fd) != AE_NONE) return false;
+#if defined(__linux__)
+    struct tcp_info info;
+    socklen_t infolen = sizeof(info);
+    if (getsockopt(conn->fd, IPPROTO_TCP, TCP_INFO, &info, &infolen) != 0 || infolen < sizeof(info)) return false; // Cannot retrieve TCP info
+    return (info.tcpi_state == TCP_CLOSE_WAIT || info.tcpi_state == TCP_CLOSE);
+#elif defined(__APPLE__)
+    struct tcp_connection_info info;
+    socklen_t infolen = sizeof(info);
+    if (getsockopt(conn->fd, IPPROTO_TCP, TCP_CONNECTION_INFO, &info, &infolen) != 0 || infolen < sizeof(info)) return false; // Cannot retrieve TCP info
+    return (info.tcpi_state == TCPS_CLOSE_WAIT || info.tcpi_state == TCPS_CLOSED);
+#else
+    /* Unsupported platform: zombie connection detection is not available. */
+    UNUSED(conn);
+    return false;
+#endif
+}
+
 static ConnectionType CT_Socket = {
     /* connection type */
     .get_type = connSocketGetType,
@@ -452,6 +475,7 @@ static ConnectionType CT_Socket = {
 
     /* Miscellaneous */
     .connIntegrityChecked = NULL,
+    .is_closing = connSocketIsClosing,
 };
 
 int connBlock(connection *conn) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -1940,6 +1940,7 @@ static ConnectionType CT_TLS = {
 
     /* Miscellaneous */
     .connIntegrityChecked = connTLSIsIntegrityChecked,
+    .is_closing = connSocketIsClosing,
 
 };
 

--- a/src/unit/test_blocked.cpp
+++ b/src/unit/test_blocked.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+extern "C" {
+#include "server.h"
+int getBlockInUseKeyCount(void);
+void releaseBlockInUse(void);
+}
+
+/* These unit tests were introduced at the time of inuse key blocking. Functions
+ * introduced earlier are tested only indirectly through integration tests. */
+class BlockedInuseTest : public ::testing::Test {
+  protected:
+    MockValkey mock;
+    RealValkey real;
+    static inline ConnectionType dummyConnType = {0};
+
+    static void SetUpTestSuite() {
+        memset(&server, 0, sizeof(valkeyServer));
+        server.hz = CONFIG_DEFAULT_HZ;
+        dummyConnType.set_read_handler = dummySetReadHandler;
+    }
+
+    static void TearDownTestSuite() {
+        releaseBlockInUse();
+    }
+
+    void SetUp() override {
+        server.unblocked_clients = listCreate();
+        ASSERT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+        ASSERT_EQ(getBlockInUseKeyCount(), 0);
+    }
+
+    void TearDown() override {
+        ASSERT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+        ASSERT_EQ(getBlockInUseKeyCount(), 0);
+        ASSERT_EQ(listLength(server.unblocked_clients), 0UL);
+        listRelease(server.unblocked_clients);
+        server.unblocked_clients = NULL;
+    }
+
+
+    static int dummySetReadHandler(connection *conn, ConnectionCallbackFunc func) {
+        conn->read_handler = func;
+        return C_OK;
+    }
+
+    client *createFakeClient(int client_id) {
+        client *c = (client *)zcalloc(sizeof(client));
+        c->id = client_id;
+        c->conn = (connection *)zcalloc(sizeof(connection));
+        c->conn->type = &dummyConnType;
+        c->conn->read_handler = (ConnectionCallbackFunc)1;
+        c->flag.pending_command = 1;
+        return c;
+    }
+
+    void freeFakeClient(client *c) {
+        freeClientBlockingState(c);
+        if (c->conn) zfree(c->conn);
+        zfree(c);
+    }
+
+    void verifyClientBlockState(client *c, bool blocked, bool unblocked) {
+        EXPECT_EQ(c->flag.unblocked, unblocked);
+        EXPECT_EQ(c->flag.blocked && c->bstate->btype == BLOCKED_INUSE, blocked);
+        if (blocked || unblocked) {
+            EXPECT_EQ(c->conn->read_handler, nullptr);
+        } else {
+            EXPECT_NE(c->conn->read_handler, nullptr);
+        }
+    }
+};
+
+using BlockedInuseDeathTest = BlockedInuseTest;
+
+
+TEST_F(BlockedInuseTest, blockInitialState) {
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+    ASSERT_NE(server.unblocked_clients, nullptr);
+}
+
+TEST_F(BlockedInuseTest, blockClientOnSingleKey) {
+    client *c = createFakeClient(1);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    // Block
+    blockClientInUseOnKeys(c, 1, keys);
+    verifyClientBlockState(c, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 1u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 1);
+    EXPECT_EQ(key->refcount, 3u);
+
+    // Unblock
+    unblockClientsInUseOnKey(key);
+    verifyClientBlockState(c, 0, 1);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(key->refcount, 1u);
+    EXPECT_EQ(listLength(server.unblocked_clients), 1UL);
+    EXPECT_EQ(listFirst(server.unblocked_clients)->value, c);
+
+    // Process unblocked client in event loop
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c)).Times(1);
+    processUnblockedClients();
+    verifyClientBlockState(c, 0, 0);
+    EXPECT_EQ(key->refcount, 1u);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseTest, blockClientClearsLeftoverTimeout) {
+    client *c = createFakeClient(1);
+    initClientBlockingState(c);
+    c->bstate->timeout = 1000;
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    blockClientInUseOnKeys(c, 1, keys);
+    EXPECT_EQ(c->bstate->timeout, 0);
+
+    unblockClientsInUseOnKey(key);
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c)).Times(1);
+    processUnblockedClients();
+
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseTest, blockClientOnMultipleKeys) {
+    client *c = createFakeClient(1);
+    robj *key1 = createObject(OBJ_STRING, sdsnew("key1"));
+    robj *key2 = createObject(OBJ_STRING, sdsnew("key2"));
+    robj *keys[] = {key1, key2};
+
+    // Block
+    blockClientInUseOnKeys(c, 2, keys);
+    verifyClientBlockState(c, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 1u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 2);
+    EXPECT_EQ(key1->refcount, 3u);
+    EXPECT_EQ(key2->refcount, 3u);
+
+    // Unblock key1
+    unblockClientsInUseOnKey(key1);
+    verifyClientBlockState(c, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 1u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 1);
+    EXPECT_EQ(key1->refcount, 1u);
+    EXPECT_EQ(key2->refcount, 3u);
+
+    // Unblock key2, client gets unblocked
+    unblockClientsInUseOnKey(key2);
+    verifyClientBlockState(c, 0, 1);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(key1->refcount, 1u);
+    EXPECT_EQ(key2->refcount, 1u);
+    EXPECT_EQ(listLength(server.unblocked_clients), 1UL);
+    EXPECT_EQ(listFirst(server.unblocked_clients)->value, c);
+
+    // Process unblocked client in event loop
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c)).Times(1);
+    processUnblockedClients();
+    verifyClientBlockState(c, 0, 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+
+    EXPECT_EQ(key1->refcount, 1u);
+    EXPECT_EQ(key2->refcount, 1u);
+    decrRefCount(key1);
+    decrRefCount(key2);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseTest, blockMultipleClientsOnSameKey) {
+    client *c1 = createFakeClient(1);
+    client *c2 = createFakeClient(2);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    // Block
+    blockClientInUseOnKeys(c1, 1, keys);
+    blockClientInUseOnKeys(c2, 1, keys);
+    verifyClientBlockState(c1, 1, 0);
+    verifyClientBlockState(c2, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 2u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 1);
+    EXPECT_EQ(key->refcount, 4u);
+
+    // Unblock
+    unblockClientsInUseOnKey(key);
+    verifyClientBlockState(c1, 0, 1);
+    verifyClientBlockState(c2, 0, 1);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(key->refcount, 1u);
+    EXPECT_EQ(listLength(server.unblocked_clients), 2UL);
+
+    // Process client in event loop
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c1)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c1)).Times(1);
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c2)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c2)).Times(1);
+    processUnblockedClients();
+    verifyClientBlockState(c1, 0, 0);
+    verifyClientBlockState(c2, 0, 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+
+    EXPECT_EQ(key->refcount, 1u);
+    decrRefCount(key);
+    freeFakeClient(c1);
+    freeFakeClient(c2);
+}
+
+TEST_F(BlockedInuseTest, unblockBlockedClient) {
+    client *c = createFakeClient(1);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    // Block
+    blockClientInUseOnKeys(c, 1, keys);
+    verifyClientBlockState(c, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 1u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 1);
+    EXPECT_EQ(key->refcount, 3u);
+
+    // Unblock client, simulate freeClient
+    unblockClient(c, 0);
+    EXPECT_FALSE(c->flag.blocked);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+    EXPECT_EQ(key->refcount, 1u);
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseTest, blockClientOnDuplicateKeys) {
+    client *c = createFakeClient(1);
+    robj *key1 = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *key2 = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key1, key2};
+
+    // Block
+    blockClientInUseOnKeys(c, 2, keys);
+    verifyClientBlockState(c, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 1u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 1);
+    EXPECT_EQ(key1->refcount, 3u);
+    EXPECT_EQ(key2->refcount, 1u); // Key is deduplicated, only blocked once
+
+    // Unblock
+    unblockClientsInUseOnKey(key1);
+    verifyClientBlockState(c, 0, 1);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 1UL);
+    EXPECT_EQ(listFirst(server.unblocked_clients)->value, c);
+
+    // Process client in event loop
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c)).Times(1);
+    processUnblockedClients();
+    verifyClientBlockState(c, 0, 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+    EXPECT_EQ(key1->refcount, 1u);
+    EXPECT_EQ(key2->refcount, 1u);
+    decrRefCount(key1);
+    decrRefCount(key2);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseTest, unblockAllKeys) {
+    client *c1 = createFakeClient(1);
+    client *c2 = createFakeClient(2);
+    robj *key1 = createObject(OBJ_STRING, sdsnew("key1"));
+    robj *key2 = createObject(OBJ_STRING, sdsnew("key2"));
+    robj *keys1[] = {key1};
+    robj *keys2[] = {key2};
+
+    // Block c1 on key1, c2 on key2
+    blockClientInUseOnKeys(c1, 1, keys1);
+    blockClientInUseOnKeys(c2, 1, keys2);
+    verifyClientBlockState(c1, 1, 0);
+    verifyClientBlockState(c2, 1, 0);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 2u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 2);
+    EXPECT_EQ(key1->refcount, 3u);
+    EXPECT_EQ(key2->refcount, 3u);
+
+    // Unblock all
+    unblockClientsInUseOnAllKeys();
+    verifyClientBlockState(c1, 0, 1);
+    verifyClientBlockState(c2, 0, 1);
+    EXPECT_EQ(server.blocked_clients_by_type[BLOCKED_INUSE], 0u);
+    EXPECT_EQ(getBlockInUseKeyCount(), 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 2UL);
+
+    // Process clients
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c1)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c1)).Times(1);
+    EXPECT_CALL(mock, processPendingCommandAndInputBuffer(c2)).WillOnce(Return(C_OK));
+    EXPECT_CALL(mock, beforeNextClient(c2)).Times(1);
+    processUnblockedClients();
+    verifyClientBlockState(c1, 0, 0);
+    verifyClientBlockState(c2, 0, 0);
+    EXPECT_EQ(listLength(server.unblocked_clients), 0UL);
+    EXPECT_EQ(key1->refcount, 1u);
+    EXPECT_EQ(key2->refcount, 1u);
+    decrRefCount(key1);
+    decrRefCount(key2);
+    freeFakeClient(c1);
+    freeFakeClient(c2);
+}
+
+TEST_F(BlockedInuseDeathTest, blockingOnKeysReplicaClient) {
+    client *c = createFakeClient(1);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    c->flag.replica = 1;
+    EXPECT_DEATH(blockClientInUseOnKeys(c, 1, keys), "");
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseDeathTest, blockingOnKeysNonStringType) {
+    client *c = createFakeClient(1);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    keys[0]->type = OBJ_LIST;
+    EXPECT_DEATH(blockClientInUseOnKeys(c, 1, keys), "");
+    keys[0]->type = OBJ_STRING;
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseDeathTest, blockingOnKeysZeroKeys) {
+    client *c = createFakeClient(1);
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    EXPECT_DEATH(blockClientInUseOnKeys(c, 0, keys), "");
+    decrRefCount(key);
+    freeFakeClient(c);
+}
+
+TEST_F(BlockedInuseDeathTest, blockingOnKeysWithoutPendingCommand) {
+    client *c = createFakeClient(1);
+    c->flag.pending_command = 0;
+    robj *key = createObject(OBJ_STRING, sdsnew("foo"));
+    robj *keys[] = {key};
+
+    EXPECT_DEATH(blockClientInUseOnKeys(c, 1, keys), "");
+    decrRefCount(key);
+    freeFakeClient(c);
+}

--- a/src/unit/wrappers.h
+++ b/src/unit/wrappers.h
@@ -59,6 +59,8 @@ extern "C" {
  *       Example: serverLog(int level, const char *fmt, ...) should NOT be mocked.
  */
 long long __wrap_aeCreateTimeEvent(aeEventLoop *eventLoop, long long milliseconds, aeTimeProc *proc, void *clientData, aeEventFinalizerProc *finalizerProc);
+int __wrap_processPendingCommandAndInputBuffer(client *c);
+void __wrap_beforeNextClient(client *c);
 #undef protected
 #undef _Bool
 #undef typename

--- a/src/unix.c
+++ b/src/unix.c
@@ -214,6 +214,7 @@ static ConnectionType CT_Unix = {
 
     /* Miscellaneous */
     .connIntegrityChecked = NULL,
+    .is_closing = NULL,
 };
 
 int RedisRegisterConnectionTypeUnix(void) {


### PR DESCRIPTION
## Summary

This is a building block for upcoming bgIteration that require exclusive key access without stalling the event loop.

This PR adds blockInUse, a server-initiated client blocking mechanism that prevents concurrent access to keys held exclusively by internal operations. When a client command targets a key that is currently in use, the client is blocked and its read handler is removed to prevent unbounded input buffering. Once the internal operation releases the key, the client is automatically resumed and its pending command is re-executed.

When a client is blocked by blockInUse, its read handler is removed so the event loop stops monitoring read events for that connection, preventing new commands from being buffered into c->querybuf while the client is waiting. Clients would otherwise continue buffering incoming commands during the entire blocking period, leading to unbounded memory growth across all blocked clients. The read handler is restored in processUnblockedClients() when the client is unblocked.

The tradeoff is that removing the read handler also makes the event loop blind to TCP disconnects on that client connection. To avoid leaking zombie file descriptors, clientsCronTcpIsClosing() is added to detect and free connections that were closed by the remote side while the read handler was removed.

### Design decisions
#### Timeout

`BLOCKED_INUSE` clients do not time out. The timeout is explicitly set to zero before blocking, so clients remain blocked until the key is released by the internal operation.

#### Module commands without `ALLOW_BLOCK`

Module commands registered without `ALLOW_BLOCK` that target a key held by an internal operation will receive a `INUSE key is being processed` error. This is a new failure mode.

#### `processUnblockedClients` refactor
Replaced the silent skip of blocked non-module clients with an assert, since a non-module client being both
blocked and in the unblocked list is a bug. Added read handler restoration unblocked clients; for other blocking types
this is a no-op.

### Testing
Unit tests (src/unit/test_blocked.cpp) cover each public API.