### PR TITLE
enhance raxLowWalk: use memchr() for child-edge lookup in non-compressed nodes

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -457,13 +457,15 @@ raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode **stopnode, raxNode *
             }
             if (j != h->size) break;
         } else {
-            /* Even when h->size is large, linear scan provides good
-             * performances compared to other approaches that are in theory
-             * more sounding, like performing a binary search. */
-            for (j = 0; j < h->size; j++) {
-                if (v[j] == s[i]) break;
-            }
-            if (j == h->size) break;
+            /* Lookup the matching child edge. memchr() is used instead of an
+             * open-coded scalar loop because libc implementations on most
+             * platforms are SIMD-optimized (SSE2/AVX2 on x86, NEON on arm64),
+             * which is significantly faster than a byte-by-byte scan and also
+             * faster than binary search at the small fan-out sizes (<= 256)
+             * that rax nodes can have. */
+            unsigned char *p = memchr(v, s[i], h->size);
+            if (p == NULL) break;
+            j = (size_t)(p - v);
             i++;
         }
 


### PR DESCRIPTION
Replace the open-coded byte-by-byte loop in raxLowWalk() with memchr(). libc implementations of memchr() on common platforms are SIMD-optimized (SSE2/AVX2 on x86_64, NEON on arm64), which significantly outperforms a scalar loop while remaining faster than a binary search at the small fan-out sizes (<= 256) that rax nodes can have.

# in macOS ARM(M4 pro)
## Lookup Performance (Mops/s, , Avg with 5 Repeats)
  | nkeys | keylen | unstable (scalar) | memchr | speedup |
  |-------|--------|-------------------|--------|---------|
  | 10K   | 8      | 15.62             | 30.19  | 1.93x   |
  | 100K  | 4      | 8.18              | 20.53  | 2.51x   |
  | 200K  | 16     | 5.00              | 13.71  | 2.74x   |
  | 500K  | 20     | 3.33              | 7.63   | 2.29x   |
  | 1M    | 16     | 2.92              | 6.53   | 2.24x   |
  | 200K  | 64     | 3.59              | 5.05   | 1.41x   |

## Insert Performance (Mops/s, Avg with 5 Repeats)

  | nkeys | keylen | unstable (scalar) | memchr | speedup |
  |-------|--------|-------------------|--------|---------|
  | 10K   | 8      | 5.14              | 5.79   | 1.13x   |
  | 100K  | 4      | 4.60              | 6.11   | 1.33x   |
  | 200K  | 16     | 4.08              | 5.20   | 1.28x   |
  | 500K  | 20     | 3.52              | 5.06   | 1.44x   |
  | 1M    | 16     | 3.68              | 4.73   | 1.29x   |
  | 200K  | 64     | 3.85              | 4.86   | 1.26x   |

# in Linux(Linux x86_64 (Ryzen 7 8845HS, GCC 13.3, Avg with 5 Repeats)
## Lookup Performance (Mops/s, , Avg with 5 Repeats)
  | nkeys | keylen | unstable (scalar) | memchr | speedup |
  |-------|--------|-------------------|--------|---------|
  | 10K   | 8      | 16.68             | 33.99  | 2.04x   |
  | 100K  | 4      | 9.55              | 21.13  | 2.21x   |
  | 200K  | 16     | 5.62              | 8.18   | 1.46x   |
  | 500K  | 20     | 3.84              | 5.47   | 1.42x   |
  | 1M    | 16     | 3.55              | 4.93   | 1.39x   |
  | 200K  | 64     | 3.54              | 4.40   | 1.24x   |
  
## Insert Performance (Mops/s, Avg with 5 Repeats)
  | nkeys | keylen | unstable (scalar) | memchr | speedup |
  |-------|--------|-------------------|--------|---------|
  | 10K   | 8      | 4.97              | 6.32   | 1.27x   |
  | 100K  | 4      | 4.37              | 5.29   | 1.21x   |
  | 200K  | 16     | 4.00              | 4.85   | 1.21x   |
  | 500K  | 20     | 3.79              | 4.79   | 1.26x   |
  | 1M    | 16     | 3.50              | 4.36   | 1.25x   |
  | 200K  | 64     | 3.50              | 4.29   | 1.23x   |  

Actually I tested binary search method if h->size is greater than T(8, 16, 32) and SIMD implementation. SIMD(especially NEON in arm is a little bit faster than this PR). but memchr is stable and robust and it is more readable.

Thanks.