### PR TITLE
Minor optimizations for CLUSTER SHARDS

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1441,6 +1441,7 @@ void clusterInit(void) {
     server.cluster->safe_to_join = 0;
     server.cluster->size = 0;
     server.cluster->todo_before_sleep = 0;
+    server.cluster->slots_info_dirty = 1;
     server.cluster->nodes = dictCreate(&clusterNodesDictType);
     server.cluster->shards = dictCreate(&clusterSdsToListType);
     server.cluster->nodes_black_list = dictCreate(&clusterNodesBlackListDictType);
@@ -2200,6 +2201,7 @@ void freeClusterNode(clusterNode *n) {
     sdsfree(n->announce_client_ipv4);
     sdsfree(n->announce_client_ipv6);
     raxFree(n->fail_reports);
+    zfree(n->slot_info_pairs);
     zfree(n->replicas);
     zfree(n);
 }
@@ -6457,6 +6459,7 @@ int clusterAddSlot(clusterNode *n, int slot) {
     server.cluster->slots[slot] = n;
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
+    server.cluster->slots_info_dirty = 1;
     return C_OK;
 }
 
@@ -6476,6 +6479,7 @@ int clusterDelSlot(int slot) {
     /* Make owner_not_claiming_slot flag consistent with slot ownership information. */
     bitmapClearBit(server.cluster->owner_not_claiming_slot, slot);
     clusterSlotStatReset(slot);
+    server.cluster->slots_info_dirty = 1;
     return C_OK;
 }
 
@@ -6961,6 +6965,13 @@ sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
  * of clusterGenNodesDescription() because it removes looping of the slot space
  * for generating the slot info for each node individually. */
 void clusterGenNodesSlotsInfo(int filter) {
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterFreeNodesSlotsInfo(dictGetVal(de));
+    }
+    dictReleaseIterator(di);
+
     clusterNode *n = NULL;
     int start = -1;
 
@@ -7017,8 +7028,8 @@ sds clusterGenNodesDescription(client *c, int filter, int tls_primary) {
     dictIterator *di;
     dictEntry *de;
 
-    /* Generate all nodes slots info firstly. */
     clusterGenNodesSlotsInfo(filter);
+    server.cluster->slots_info_dirty = 1;
 
     di = dictGetSafeIterator(server.cluster->nodes);
     while ((de = dictNext(di)) != NULL) {
@@ -7252,8 +7263,10 @@ void addNodeDetailsToShardReply(client *c, clusterNode *node) {
  */
 void clusterCommandShards(client *c) {
     addReplyArrayLen(c, dictSize(server.cluster->shards));
-    /* This call will add slot_info_pairs to all nodes */
-    clusterGenNodesSlotsInfo(0);
+    if (server.cluster->slots_info_dirty) {
+        clusterGenNodesSlotsInfo(0);
+        server.cluster->slots_info_dirty = 0;
+    }
     dictIterator *di = dictGetSafeIterator(server.cluster->shards);
     for (dictEntry *de = dictNext(di); de != NULL; de = dictNext(di)) {
         list *nodes = dictGetVal(de);
@@ -7289,7 +7302,6 @@ void clusterCommandShards(client *c) {
         for (listNode *ln = listNext(&li); ln != NULL; ln = listNext(&li)) {
             clusterNode *n = listNodeValue(ln);
             addNodeDetailsToShardReply(c, n);
-            clusterFreeNodesSlotsInfo(n);
         }
         addReplyBulkCString(c, "id");
         addReplyBulkCBuffer(c, dictGetKey(de), CLUSTER_NAMELEN);

--- a/src/cluster_legacy.h
+++ b/src/cluster_legacy.h
@@ -442,6 +442,7 @@ struct clusterState {
     dict *migrating_slots_to;
     dict *importing_slots_from;
     clusterNode *slots[CLUSTER_SLOTS];
+    int slots_info_dirty;      /* True when slot_info_pairs on nodes need recomputation. */
     list *slot_migration_jobs; /* List storing all slot migration jobs. Stored
                                 * in order from most recent to least recently
                                 * created. */

--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -53,3 +53,25 @@ start_cluster 3 3 {tags {external:skip cluster}} {
         assert_equal $shard_0_slot_coverage [dict get [get_node_info_from_shard $node_0_id $validation_node "shard"] "slots"]
     }
 }
+
+start_cluster 2 0 {tags {external:skip cluster}} {
+
+    test "CLUSTER SHARDS refreshes cached slots after resharding" {
+        set node0_id [R 0 CLUSTER MYID]
+        set node1_id [R 1 CLUSTER MYID]
+
+        # Verify initial slot distribution
+        assert_equal {0 8191} [dict get [get_node_info_from_shard $node0_id 0 shard] slots]
+        assert_equal {8192 16383} [dict get [get_node_info_from_shard $node1_id 0 shard] slots]
+
+        # Move slot 0 from node 0 to node 1
+        R 0 CLUSTER SETSLOT 0 MIGRATING $node1_id
+        R 1 CLUSTER SETSLOT 0 IMPORTING $node0_id
+        R 0 CLUSTER SETSLOT 0 NODE $node1_id
+        R 1 CLUSTER SETSLOT 0 NODE $node1_id
+
+        # Cached result must reflect the new ownership
+        assert_equal {1 8191} [dict get [get_node_info_from_shard $node0_id 0 shard] slots]
+        assert_equal {0 0 8192 16383} [dict get [get_node_info_from_shard $node1_id 0 shard] slots]
+    }
+}


### PR DESCRIPTION
Cache the slot range used by `CLUSTER SHARDS` and recompute it only when slot ownership changes. This avoids rebuilding the same per-node slot mapping on every `CLUSTER SHARDS` call and updates it only if there is a resharding. Added a TCL test to validate the same case.