### PR TITLE
Reduce latency spikes during rehashing via incremental page release

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -565,10 +565,10 @@ static void rehashEntry(hashtable *ht, void *entry, uint64_t hash, uint8_t h2) {
     ht->used[1]++;
 }
 
-/* Release memory page of rehashed buckets back to the OS incrementally.
- * This function is called after each bucket is rehashed. When an entire page
- * worth of buckets has been processed, it advises the OS that the page
- * is no longer needed (MADV_DONTNEED). This spreads the memory release over
+/* Release memory pages of rehashed buckets back to the OS incrementally.
+ * This function is called after each bucket is rehashed. When an entire range
+ * worth of buckets has been processed, it advises the OS that the pages
+ * are no longer needed (MADV_DONTNEED). This spreads the memory release over
  * the entire rehashing process, avoiding a latency spike that would occur if
  * we released all the old table's memory at once when rehashing completes. */
 static void dismissRehashedBucketsIfNeeded(hashtable *ht) {
@@ -576,16 +576,18 @@ static void dismissRehashedBucketsIfNeeded(hashtable *ht) {
     if (page_size == 0) page_size = sysconf(_SC_PAGESIZE);
 
     size_t buckets_per_page = page_size / sizeof(bucket);
-    if (ht->rehash_idx % buckets_per_page != 0) {
+    const size_t pages_per_dismiss = 16;
+    size_t buckets_per_dismiss = buckets_per_page * pages_per_dismiss;
+    if (ht->rehash_idx % buckets_per_dismiss != 0) {
         return;
     }
 
-    bucket *ptr = ht->tables[0] + ht->rehash_idx - buckets_per_page;
+    bucket *ptr = ht->tables[0] + ht->rehash_idx - buckets_per_dismiss;
     ptr = (bucket *)((size_t)ptr & ~(page_size - 1));
     if (ptr < ht->tables[0]) {
         return;
     }
-    zmadvise_dontneed_range(ptr, page_size);
+    zmadvise_dontneed_range(ptr, pages_per_dismiss * page_size);
 }
 
 /* After migrating entries in a bucket chain from the old table

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -493,6 +493,9 @@ static void swapTables(hashtable *ht) {
 static void rehashingCompleted(hashtable *ht) {
     if (ht->type->rehashingCompleted) ht->type->rehashingCompleted(ht);
     if (ht->tables[0]) {
+        /* Although the old table is large, most of its pages have been
+         * incrementally released via MADV_DONTNEED during rehashing.
+         * The zfree() here will be fast and won't cause latency spikes. */
         zfree(ht->tables[0]);
         if (ht->type->trackMemUsage) {
             ht->type->trackMemUsage(ht, -sizeof(bucket) * numBuckets(ht->bucket_exp[0]));
@@ -565,6 +568,29 @@ static void rehashEntry(hashtable *ht, void *entry, uint64_t hash, uint8_t h2) {
     ht->used[1]++;
 }
 
+/* Release memory page of rehashed buckets back to the OS incrementally.
+ * This function is called after each bucket is rehashed. When an entire page
+ * worth of buckets has been processed, it advises the OS that the page
+ * is no longer needed (MADV_DONTNEED). This spreads the memory release over
+ * the entire rehashing process, avoiding a latency spike that would occur if
+ * we released all the old table's memory at once when rehashing completes. */
+static void dismissRehashedBucketsIfNeeded(hashtable *ht) {
+    static size_t page_size = 0;
+    if (page_size == 0) page_size = sysconf(_SC_PAGESIZE);
+
+    size_t buckets_per_page = page_size / sizeof(bucket);
+    if (ht->rehash_idx % buckets_per_page != 0) {
+        return;
+    }
+
+    bucket *ptr = ht->tables[0] + ht->rehash_idx - buckets_per_page;
+    ptr = (bucket *)((size_t)ptr & ~(page_size - 1));
+    if (ptr < ht->tables[0]) {
+        return;
+    }
+    zmadvise_dontneed_range(ptr, page_size);
+}
+
 /* After migrating entries in a bucket chain from the old table
  * to the new one, this function should be called immediately to
  * handle the cleanup of old buckets, such as clearing presence bits. */
@@ -587,6 +613,9 @@ static void rehashStepFinalize(hashtable *ht) {
 
     /* Advance to the next bucket. */
     ht->rehash_idx++;
+
+    /* Release page back to OS incrementally. */
+    dismissRehashedBucketsIfNeeded(ht);
 
     /* Check if we already rehashed the whole table. */
     if (ht->used[0] == 0 && ht->child_buckets[0] == 0) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -493,9 +493,6 @@ static void swapTables(hashtable *ht) {
 static void rehashingCompleted(hashtable *ht) {
     if (ht->type->rehashingCompleted) ht->type->rehashingCompleted(ht);
     if (ht->tables[0]) {
-        /* Although the old table is large, most of its pages have been
-         * incrementally released via MADV_DONTNEED during rehashing.
-         * The zfree() here will be fast and won't cause latency spikes. */
         zfree(ht->tables[0]);
         if (ht->type->trackMemUsage) {
             ht->type->trackMemUsage(ht, -sizeof(bucket) * numBuckets(ht->bucket_exp[0]));

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -488,6 +488,22 @@ void zmadvise_dontneed(void *ptr, size_t size_hint) {
 #endif
 }
 
+/* Release pages back to the OS using MADV_DONTNEED for a specific address range.
+ * Unlike zmadvise_dontneed(), this function does not query the allocator for
+ * the allocation size, and does not perform any pointer alignment. The caller
+ * must ensure that 'ptr' is page-aligned and 'size' is a multiple of page size.
+ * This is useful when we want to release a portion of a larger allocation that
+ * is no longer needed. */
+void zmadvise_dontneed_range(void *ptr, size_t size) {
+#if defined(__linux__)
+    if (ptr == NULL || size == 0) return;
+    madvise(ptr, size, MADV_DONTNEED);
+#else
+    (void)(ptr);
+    (void)(size);
+#endif
+}
+
 /* Get the RSS information in an OS-specific way.
  *
  * WARNING: the function zmalloc_get_rss() is not designed to be fast

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -140,6 +140,7 @@ size_t zmalloc_get_memory_size(void);
 void zlibc_free(void *ptr);
 void zlibc_trim(void);
 void zmadvise_dontneed(void *ptr, size_t size_hint);
+void zmadvise_dontneed_range(void *ptr, size_t size);
 
 #ifndef HAVE_MALLOC_SIZE
 size_t zmalloc_size(void *ptr);


### PR DESCRIPTION
Incrementally release memory to the OS using `madvice(MADV_DONTNEED)` when rehashing. This reduces the latency of the `free()` call at the end of the rehashing.

### Problem

Upon rehashing completion, `rehashingCompleted()` frees the old table via `zfree()`. For large tables (e.g., tens of millions of keys), this operation can take tens of milliseconds, causing noticeable latency spikes in the server.

### Solution

After each bucket migration, if 16 pages worth of buckets have been processed, we immediately release those pages to the OS via `madvise(MADV_DONTNEED)`. This incremental approach ensures that by the time `rehashingCompleted()` is called, most physical pages have already been returned to the OS, making the final cleanup fast and predictable.

### Benchmark

Write a batch of data into the server and record the max latency. The benchmark commands and env are as follows:

```
## Benchmark commands
taskset -c 1 ./src/valkey-server  --save '' --appendonly no
taskset -c 2,3 ./src/valkey-benchmark  -t set -n 100000000 -r 100000000 --threads 2 --sequential

## Env
CPU: AMD EPYC 9K65 192-Core Processor * 4
OS: Ubuntu Server 24.04 LTS 64bit
Memory: 16GB
VM: Tencent Cloud | SA9.LARGE16
```

As shown below, it can be seen that **after optimization, the max latency has dropped significantly.**

```
Summary before optimization
  throughput summary: 260061.80 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.176     0.024     0.167     0.263     0.327    23.279

Summary after optimization
  throughput summary: 260400.41 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
        0.176     0.024     0.167     0.263     0.335     5.103
```