### PR TITLE
Add LCS LEN fast path using rolling two-row DP

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -784,6 +784,54 @@ void strlenCommand(client *c) {
     addReplyLongLong(c, stringObjectLen(o));
 }
 
+/* Compute only the LCS length using two rolling rows, and reply to the client.
+ * Used when LCS is invoked with LEN (and without IDX), since recovering the
+ * actual subsequence or match indices is not required. Memory usage is
+ * O(min(|a|,|b|)) instead of O(|a|*|b|). On allocation/limit failures this
+ * sends an error reply; in all cases the client receives exactly one reply. */
+static void lcsReplyLength(client *c, sds a, sds b) {
+    uint32_t alen = sdslen(a);
+    uint32_t blen = sdslen(b);
+    /* Use the shorter string for the inner dimension to minimize memory. */
+    const char *astr = a;
+    const char *bstr = b;
+    if (blen > alen) {
+        uint32_t tmp_len = alen; alen = blen; blen = tmp_len;
+        const char *tmp_str = astr; astr = bstr; bstr = tmp_str;
+    }
+
+    size_t row_bytes = ((size_t)blen + 1) * sizeof(uint32_t);
+    if (row_bytes * 2 > (size_t)server.proto_max_bulk_len) {
+        addReplyError(c, "Insufficient memory, transient memory for LCS exceeds proto-max-bulk-len");
+        return;
+    }
+    uint32_t *prev = ztrycalloc(row_bytes);
+    uint32_t *curr = ztrycalloc(row_bytes);
+    if (!prev || !curr) {
+        if (prev) zfree(prev);
+        if (curr) zfree(curr);
+        addReplyError(c, "Insufficient memory, failed allocating transient memory for LCS");
+        return;
+    }
+
+    for (uint32_t ii = 1; ii <= alen; ii++) {
+        curr[0] = 0;
+        for (uint32_t jj = 1; jj <= blen; jj++) {
+            if (astr[ii - 1] == bstr[jj - 1]) {
+                curr[jj] = prev[jj - 1] + 1;
+            } else {
+                uint32_t v1 = prev[jj];
+                uint32_t v2 = curr[jj - 1];
+                curr[jj] = v1 > v2 ? v1 : v2;
+            }
+        }
+        uint32_t *tmp = prev; prev = curr; curr = tmp;
+    }
+    addReplyLongLong(c, prev[blen]);
+    zfree(prev);
+    zfree(curr);
+}
+
 /* LCS key1 key2 [LEN] [IDX] [MINMATCHLEN <len>] [WITHMATCHLEN] */
 void lcsCommand(client *c) {
     uint32_t i, j;
@@ -839,6 +887,13 @@ void lcsCommand(client *c) {
     /* Detect string truncation or later overflows. */
     if (sdslen(a) >= UINT32_MAX - 1 || sdslen(b) >= UINT32_MAX - 1) {
         addReplyError(c, "String too long for LCS");
+        goto cleanup;
+    }
+
+    /* Fast path: when only LEN is requested, compute with rolling DP
+     * to avoid allocating the full O(n*m) table. */
+    if (getlen && !getidx) {
+        lcsReplyLength(c, a, b);
         goto cleanup;
     }
 


### PR DESCRIPTION
 LCS key1 key2 LEN currently allocates and fills the full (|a|+1) × (|b|+1) DP table even though only the final cell is read. This change
  introduces a fast path for the LEN-only case (LEN without IDX) that computes the length using a rolling two-row DP, reducing transient memory
  from O(|a|·|b|) to O(min(|a|, |b|)). The rolling computation is extracted into a small helper, lcsReplyLength(), so lcsCommand() stays focused
  on argument parsing and dispatch.

  # LCS LEN Fast Path — Benchmark Results

  ## Valkey (feature/enhance_lcs vs unstable)

  ```
  === baseline ===
    size=64    avg=2.454 ms/op  (over 200 iters)
    size=256   avg=2.407 ms/op  (over 200 iters)
    size=1024  avg=2.693 ms/op  (over 200 iters)
    size=2048  avg=4.230 ms/op  (over 200 iters)
    size=4096  avg=11.527 ms/op (over 200 iters)
    size=8192  avg=61.290 ms/op (over 200 iters)
  === feature ===
    size=64    avg=2.156 ms/op  (over 200 iters)
    size=256   avg=2.179 ms/op  (over 200 iters)
    size=1024  avg=2.606 ms/op  (over 200 iters)
    size=2048  avg=4.110 ms/op  (over 200 iters)
    size=4096  avg=9.660 ms/op  (over 200 iters)
    size=8192  avg=32.158 ms/op (over 200 iters)
  ```

  Extended range (feature only; baseline returns `ERR ... exceeds proto-max-bulk-len`):

  ```
    size=16384  avg=~131 ms/op
    size=32768  avg=~498 ms/op
  ```

  | size  | baseline  | feature  | speedup |
  |---:|---:|---:|---:|
  |    64 |   2.45 ms |   2.16 ms | ~1.14× |
  |   256 |   2.41 ms |   2.18 ms | ~1.10× |
  |  1024 |   2.69 ms |   2.61 ms | ~1.03× |
  |  2048 |   4.23 ms |   4.11 ms | ~1.03× |
  |  4096 |  11.53 ms |   9.66 ms | ~1.19× |
  |  8192 |  61.29 ms |  32.16 ms | **~1.91×** |
  | 16384 |    ERR    | ~131 ms   | newly possible |
  | 32768 |    ERR    | ~498 ms   | newly possible |