### PR TITLE
valkey-benchmark: centralize RDMA WRITABLE kick via createFileEvent

### DIFF
--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -222,17 +222,12 @@ typedef struct serverConfig {
     sds appendonly;
 } serverConfig;
 
-/* Register a file event; for RDMA, also invoke the handler once when registering WRITABLE.
+/* Register a file event. For RDMA with AE_WRITABLE, invoke the handler once after
+ * registering: this fd is not POLLOUT-driven like TCP, so the loop may never deliver
+ * AE_WRITABLE without an explicit kick.
  *
- * Write path: RDMA is not driven by kernel POLLOUT on this fd the way TCP is, so the
- * event loop may never deliver AE_WRITABLE. The benchmark used to call writeHandler
- * directly (issueFirstRequestForClients on startup, resetClient after each pipeline).
- * We fold that into this helper when mask is AE_WRITABLE.
- *
- * Read path: libvalkey may already process inbound data while draining the CQ during a
- * write (lost EPOLLIN / "stuck until more traffic" before valkey-io/libvalkey#301).
- * Upstream libvalkey fixes that with an eventfd kick so the outer epoll still wakes.
- * Non-RDMA: plain aeCreate. */
+ * Non-RDMA: same as aeCreateFileEvent. Read-side wakeups when libvalkey drains the CQ on
+ * the write path require libvalkey to notify the outer poll (valkey-io/libvalkey#301). */
 static inline void createFileEvent(aeEventLoop *eventLoop, int fd, int mask, aeFileProc *proc, void *clientData) {
     aeCreateFileEvent(eventLoop, fd, mask, proc, clientData);
     if (config.ct == VALKEY_CONN_RDMA && (mask & AE_WRITABLE)) {

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -222,10 +222,12 @@ typedef struct serverConfig {
     sds appendonly;
 } serverConfig;
 
-/* Helper to create an event and optionally fire it immediately */
-static inline void createFileEvent(aeEventLoop *eventLoop, int fd, int mask, aeFileProc *proc, void *clientData, int fire) {
+/* Helper to create an event and optionally fire it immediately for RDMA connections.
+ * For RDMA, we need to speculatively invoke the handler to catch any data that may
+ * have been consumed during the write path's CQ draining (lost wakeup issue). */
+static inline void createFileEvent(aeEventLoop *eventLoop, int fd, int mask, aeFileProc *proc, void *clientData) {
     aeCreateFileEvent(eventLoop, fd, mask, proc, clientData);
-    if (fire) {
+    if (config.ct == VALKEY_CONN_RDMA) {
         proc(eventLoop, fd, clientData, mask);
     }
 }
@@ -568,7 +570,7 @@ static void resetClient(client c) {
     aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
     aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
     aeDeleteFileEvent(el, c->context->fd, AE_READABLE);
-    createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c, config.ct == VALKEY_CONN_RDMA);
+    createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c);
     c->written = 0;
     c->pending = config.pipeline * c->seqlen;
 }
@@ -896,7 +898,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 }
             } else {
                 aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
-                createFileEvent(el, c->context->fd, AE_READABLE, readHandler, c, config.ct == VALKEY_CONN_RDMA);
+                createFileEvent(el, c->context->fd, AE_READABLE, readHandler, c);
                 return;
             }
         }
@@ -1078,7 +1080,7 @@ static client createClient(char *cmd, int len, int seqlen, client from, int thre
         el = thread->el;
     }
     if (config.idlemode == 0) {
-        createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c, config.ct == VALKEY_CONN_RDMA);
+        createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c);
     } else
         /* In idle mode, clients still need to register readHandler for catching errors */
         aeCreateFileEvent(el, c->context->fd, AE_READABLE, readHandler, c);

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -222,6 +222,14 @@ typedef struct serverConfig {
     sds appendonly;
 } serverConfig;
 
+/* Helper to create an event and optionally fire it immediately */
+static inline void createFileEvent(aeEventLoop *eventLoop, int fd, int mask, aeFileProc *proc, void *clientData, int fire) {
+    aeCreateFileEvent(eventLoop, fd, mask, proc, clientData);
+    if (fire) {
+        proc(eventLoop, fd, clientData, mask);
+    }
+}
+
 /* Prototypes */
 static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask);
 static void createMissingClients(client c);
@@ -560,11 +568,7 @@ static void resetClient(client c) {
     aeEventLoop *el = CLIENT_GET_EVENTLOOP(c);
     aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
     aeDeleteFileEvent(el, c->context->fd, AE_READABLE);
-    if (config.ct == VALKEY_CONN_RDMA) {
-        writeHandler(el, c->context->fd, c, 0); /* RDMA context always writable, but it can't be invoked by AE_WRITABLE */
-    } else {
-        aeCreateFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c);
-    }
+    createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c, config.ct == VALKEY_CONN_RDMA);
     c->written = 0;
     c->pending = config.pipeline * c->seqlen;
 }
@@ -892,7 +896,7 @@ static void writeHandler(aeEventLoop *el, int fd, void *privdata, int mask) {
                 }
             } else {
                 aeDeleteFileEvent(el, c->context->fd, AE_WRITABLE);
-                aeCreateFileEvent(el, c->context->fd, AE_READABLE, readHandler, c);
+                createFileEvent(el, c->context->fd, AE_READABLE, readHandler, c, config.ct == VALKEY_CONN_RDMA);
                 return;
             }
         }
@@ -1074,9 +1078,7 @@ static client createClient(char *cmd, int len, int seqlen, client from, int thre
         el = thread->el;
     }
     if (config.idlemode == 0) {
-        if (config.ct != VALKEY_CONN_RDMA) {
-            aeCreateFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c);
-        }
+        createFileEvent(el, c->context->fd, AE_WRITABLE, writeHandler, c, config.ct == VALKEY_CONN_RDMA);
     } else
         /* In idle mode, clients still need to register readHandler for catching errors */
         aeCreateFileEvent(el, c->context->fd, AE_READABLE, readHandler, c);
@@ -1239,20 +1241,6 @@ static void startBenchmarkThreads(void) {
     for (i = 0; i < config.num_threads; i++) pthread_join(config.threads[i]->thread, NULL);
 }
 
-#ifdef USE_RDMA
-static void issueFirstRequestForClients(aeEventLoop *el, int this_thread, int nt) {
-    listNode *ln = config.clients->head;
-    int count = 0;
-    while (ln) {
-        if (count++ % nt == this_thread) {
-            client c = ln->value;
-            writeHandler(el, c->context->fd, c, 0);
-        }
-        ln = ln->next;
-    }
-}
-#endif
-
 /* Benchmark a sequence of commands. The cmd is RESP encoded of length len and
  * seqlen is the number of commands included in cmd. */
 static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen) {
@@ -1295,11 +1283,6 @@ static void benchmarkSequence(const char *title, char *cmd, int len, int seqlen)
 
     config.start = mstime();
     if (!config.num_threads) {
-#ifdef USE_RDMA
-        if (config.idlemode == 0 && config.ct == VALKEY_CONN_RDMA) {
-            issueFirstRequestForClients(config.el, 0, 1);
-        }
-#endif
         aeMain(config.el);
     } else
         startBenchmarkThreads();
@@ -1347,11 +1330,6 @@ static void freeBenchmarkThreads(void) {
 
 static void *execBenchmarkThread(void *ptr) {
     benchmarkThread *thread = (benchmarkThread *)ptr;
-#ifdef USE_RDMA
-    if (config.idlemode == 0 && config.ct == VALKEY_CONN_RDMA) {
-        issueFirstRequestForClients(thread->el, thread->index, config.num_threads);
-    }
-#endif
     aeMain(thread->el);
     return NULL;
 }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -222,12 +222,20 @@ typedef struct serverConfig {
     sds appendonly;
 } serverConfig;
 
-/* Helper to create an event and optionally fire it immediately for RDMA connections.
- * For RDMA, we need to speculatively invoke the handler to catch any data that may
- * have been consumed during the write path's CQ draining (lost wakeup issue). */
+/* Register a file event; for RDMA, also invoke the handler once when registering WRITABLE.
+ *
+ * Write path: RDMA is not driven by kernel POLLOUT on this fd the way TCP is, so the
+ * event loop may never deliver AE_WRITABLE. The benchmark used to call writeHandler
+ * directly (issueFirstRequestForClients on startup, resetClient after each pipeline).
+ * We fold that into this helper when mask is AE_WRITABLE.
+ *
+ * Read path: libvalkey may already process inbound data while draining the CQ during a
+ * write (lost EPOLLIN / "stuck until more traffic" before valkey-io/libvalkey#301).
+ * Upstream libvalkey fixes that with an eventfd kick so the outer epoll still wakes.
+ * Non-RDMA: plain aeCreate. */
 static inline void createFileEvent(aeEventLoop *eventLoop, int fd, int mask, aeFileProc *proc, void *clientData) {
     aeCreateFileEvent(eventLoop, fd, mask, proc, clientData);
-    if (config.ct == VALKEY_CONN_RDMA) {
+    if (config.ct == VALKEY_CONN_RDMA && (mask & AE_WRITABLE)) {
         proc(eventLoop, fd, clientData, mask);
     }
 }


### PR DESCRIPTION
# Description:

## Problem
`valkey-benchmark --rdma` could hang or stall (e.g. GET-heavy workloads). Part of that was lost EPOLLIN when libvalkey drained the CQ and processed inbound data on the write path: the outer poll never saw a “new” edge. That belongs in libvalkey and is addressed by valkey-io/libvalkey#301 (eventfd re-arm / nested epoll integration).

Separately, RDMA is not driven by kernel POLLOUT on the benchmark’s fd the way TCP is, so AE_WRITABLE may never fire unless we explicitly run the write path once after registration. The code previously did that with ad-hoc writeHandler calls (issueFirstRequestForClients, resetClient).

## Change

Add createFileEvent(): for non-RDMA, it is just aeCreateFileEvent.
For RDMA, when registering AE_WRITABLE, register the event and call the handler once (same as the old direct writeHandler kick).
Do not speculatively call readHandler after registering AE_READABLE **(My Previous Approach)** : that interacts badly with libvalkey’s valkey-io/libvalkey#301 wakeup path and can stall the benchmark after the first request.

## Depends on
Benchmark RDMA runs should use a libvalkey tree that includes valkey-io/libvalkey#301 (or equivalent fix).