### PR TITLE
Rewrite SET IFEQ to plain SET for replication consistency

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -184,18 +184,24 @@ void setGenericCommand(client *c,
         addReply(c, ok_reply ? ok_reply : shared.ok);
     }
 
-    /* Propagate without the GET argument (Isn't needed if we had expire since in that case we completely re-written the
+    /* Propagate without the GET and IFEQ arguments (Isn't needed if we had expire since in that case we completely re-written the
      * command argv) */
-    if ((flags & ARGS_SET_GET) && !expire) {
+    if ((flags & (ARGS_SET_GET | ARGS_SET_IFEQ)) && !expire) {
         int argc = 0;
         int j;
-        robj **argv = zmalloc((c->argc - 1) * sizeof(robj *));
+        robj **argv = zmalloc(c->argc * sizeof(robj *));
         for (j = 0; j < c->argc; j++) {
             char *a = objectGetVal(c->argv[j]);
             /* Skip GET which may be repeated multiple times. */
             if (j >= 3 && (a[0] == 'g' || a[0] == 'G') && (a[1] == 'e' || a[1] == 'E') &&
                 (a[2] == 't' || a[2] == 'T') && a[3] == '\0')
                 continue;
+            /* Skip IFEQ and its argument. */
+            if (j >= 3 && (a[0] == 'i' || a[0] == 'I') && (a[1] == 'f' || a[1] == 'F') &&
+                (a[2] == 'e' || a[2] == 'E') && (a[3] == 'q' || a[3] == 'Q') && a[4] == '\0') {
+                j++;
+                continue;
+            }
             argv[argc++] = c->argv[j];
             incrRefCount(c->argv[j]);
         }

--- a/tests/unit/type/string.tcl
+++ b/tests/unit/type/string.tcl
@@ -1182,4 +1182,40 @@ if {[string match {*jemalloc*} [s mem_allocator]]} {
     } {} {needs:debug}
 } ; # if jemalloc
 
+test {SET with IFEQ propagate as SET command to replica} {
+    set repl [attach_to_replication_stream]
+    r set foo "initial_value"
+    
+    # Test 1: SET with IFEQ success
+    r set foo "new_value" ifeq "initial_value"
+    
+    # Test 2: SET with IFEQ and GET success
+    r set foo "newer_value" ifeq "new_value" get
+    
+    assert_replication_stream $repl {
+        {select *}
+        {set foo initial_value}
+        {set foo new_value}
+        {set foo newer_value}
+    }
+    close_replication_stream $repl
+} {} {needs:repl}
+
+test {SET with IFEQ and EXPIRE propagate correctly} {
+    set repl [attach_to_replication_stream]
+    r set foo "initial_value"
+
+    # Test 3: SET with IFEQ and EX
+    r set foo "value_with_ex" ifeq "initial_value" ex 100
+
+    # We expect it to be rewritten with PXAT
+    assert_replication_stream $repl {
+        {select *}
+        {set foo initial_value}
+        {set foo value_with_ex PXAT *}
+    }
+
+    close_replication_stream $repl
+} {} {needs:repl}
+
 }


### PR DESCRIPTION
When using the IFEQ option with the SET command, the command was being propagated to replicas and the AOF exactly as received. This could lead to replication drift if a replica's state diverged from the master; the replica would evaluate the condition against its own (different) state and potentially skip the write.

This change ensures the master strips the IFEQ flag and its comparison value before propagation, rewriting the command as an unconditional SET. This guarantees that replicas remain consistent with the master's authoritative state.

Changes
[x] Bug fix: Updated setGenericCommand in src/t_string.c to strip IFEQ and its comparison value from the command vector before propagation.

[x] Verification: Added regression tests in tests/unit/type/string.tcl that inspect the replication stream to ensure the command is correctly rewritten as an absolute SET.

# Steps to Reproduce
Use the following steps to observe the drift issue and verify the fix:

1. Start Instances
Start a master and a replica in two separate terminal sessions.

Terminal 1 (Master):

Bash
./src/valkey-server --port 6379
Terminal 2 (Replica):

Bash
./src/valkey-server --port 6380 --replicaof 127.0.0.1 6379
2. Initialize and Desync
In a third terminal, set an initial value and manually force the replica out of sync to simulate a drift scenario.

Bash
# Initialize key on Master
./src/valkey-cli -p 6379 SET mykey "initial_value"

# Temporarily allow writes on replica to change its value independently
./src/valkey-cli -p 6380 CONFIG SET replica-read-only no
./src/valkey-cli -p 6380 SET mykey "out_of_sync_value"
./src/valkey-cli -p 6380 CONFIG SET replica-read-only yes
3. Run IFEQ on Master
Run a conditional SET on the Master that matches the Master's current value.

Bash
./src/valkey-cli -p 6379 SET mykey "new_value" IFEQ "initial_value"
4. Verify Consistency
Check the value on both. If the fix is working, both will return "new_value".

Bash
# Check Master
./src/valkey-cli -p 6379 GET mykey

# Check Replica
./src/valkey-cli -p 6380 GET mykey
Note: Without this fix, the Replica would return "out_of_sync_value" because the condition IFEQ "initial_value" would fail locally on the replica. This PR ensures the replica receives a simple SET mykey "new_value".