### PR TITLE
Increase wait for diskless replication child exit test

### DIFF
--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -950,8 +950,10 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         after 2000
                     }
 
-                    # wait for rdb child to exit
-                    wait_for_condition 1200 100 {
+                    # The "no" case keeps both replicas connected and can take
+                    # longer on slow CI runners to finish streaming the full RDB.
+                    set rdb_child_wait_tries [expr {$all_drop == "no" ? 1500 : 1200}]
+                    wait_for_condition $rdb_child_wait_tries 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"


### PR DESCRIPTION
## Summary

Increase the wait budget for the `diskless no replicas drop during rdb pipe` subcase in `tests/integration/replication.tcl`.

## Problem

`#3461` increased the shared `rdb_bgsave_in_progress` wait to 120 seconds, but the `no` subcase is still timing out on slow runners.

Example failure from `#3504`:
https://github.com/valkey-io/valkey/actions/runs/24414358596/job/71319466814

That run started the `no` subcase at `17:59:02` and only killed the child at `18:01:06`, which is about 124 seconds later. That slightly exceeds the current 120 second wait and fails with `rdb child didn't terminate`.

## Change

- keep the current wait for the faster subcases
- increase the wait only for the `no` subcase from 120s to 150s

## Validation

- inspected the failing GitHub Actions logs for the current failure window
- local macOS validation is limited here because the TLS-module harness is not available in this build and unrelated replication tests are already flaky on this host
- a fresh `Daily` run is being dispatched on this branch for the real verification
