### PR TITLE
[Flaky Tests] Avoid re-triggering io-thread activation

### DIFF
--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -1,3 +1,28 @@
+proc wait_for_io_threads_to_go_idle {} {
+    set io_threads_always_active [dict get [r config get io-threads-always-active] io-threads-always-active]
+    if {$io_threads_always_active eq {yes}} {
+        # Polling INFO while io-threads-always-active is enabled wakes the
+        # workers in afterSleep(), so observe the idle transition with that
+        # policy disabled and then restore the original test setting.
+        assert_equal {OK} [r config set io-threads-always-active no]
+    }
+
+    set errcode [catch {
+        wait_for_condition 1000 50 {
+            [getInfoProperty [r info server] io_threads_active] eq 0
+        } else {
+            fail "Failed to wait until no io_threads are active"
+        }
+    } result]
+
+    if {$io_threads_always_active eq {yes}} {
+        assert_equal {OK} [r config set io-threads-always-active yes]
+    }
+    if {$errcode != 0} {
+        return -code $errcode $result
+    }
+}
+
 proc activate_io_threads_and_wait {} {
     set server_pid [s process_id]
     set client_count 16
@@ -30,11 +55,7 @@ proc activate_io_threads_and_wait {} {
         $rd($i) close
     }
 
-    # In io-threads-always-active mode, polling INFO to watch the worker state
-    # re-triggers activation in afterSleep(). Once the write burst completed,
-    # keep the server idle briefly so beforeSleep() can park the workers
-    # without more client traffic waking them again.
-    after 200
+    wait_for_io_threads_to_go_idle
 }
 
 start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {enable-debug-command {yes} io-threads 5}} {
@@ -60,11 +81,7 @@ start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overr
         # Adjust io-threads to a lower value and assert that active io_threads fields are >= values found initially
         assert_equal {OK} [r config set io-threads 1]
         set info [r info]
-        wait_for_condition 1000 50 {
-            [getInfoProperty [r info server] io_threads_active] eq 0
-        } else {
-            fail "Failed to wait until no io_threads are active"
-        }
+        wait_for_io_threads_to_go_idle
         set used_active_time_1 [getInfoProperty $info used_active_time_io_thread_1]
         assert_equal $used_active_time_1 {}
 

--- a/tests/unit/io-threads.tcl
+++ b/tests/unit/io-threads.tcl
@@ -30,12 +30,11 @@ proc activate_io_threads_and_wait {} {
         $rd($i) close
     }
 
-    # Wait until active io_threads are no longer active
-    wait_for_condition 1000 50 {
-        [getInfoProperty [r info server] io_threads_active] eq 0
-    } else {
-        fail "Failed to wait until no io_threads are active"
-    }
+    # In io-threads-always-active mode, polling INFO to watch the worker state
+    # re-triggers activation in afterSleep(). Once the write burst completed,
+    # keep the server idle briefly so beforeSleep() can park the workers
+    # without more client traffic waking them again.
+    after 200
 }
 
 start_server {config "minimal.conf" tags {"external:skip" "valgrind:skip"} overrides {enable-debug-command {yes} io-threads 5}} {


### PR DESCRIPTION
The test was accidentally waking the IO threads while trying to check that they had gone idle.

After the recent IO-thread refactor in #3324, the [test](https://github.com/valkey-io/valkey/pull/3324/changes#diff-21314ec3a338f739eab1536f91f528d1efe7c6a93935a71b9c02f77a3858f121R112) started forcing `io-threads-always-active`, and its repeated `INFO` polling counted as fresh activity. So instead of just observing the worker threads, the test kept reactivating them and then flaked.