### PR TITLE
Backport 9.0: Fix some flaky tests (#3430)

### DIFF
--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -181,17 +181,17 @@ proc test_replica_config_epoch_failover {type} {
 
         # Make sure both the automatic and the manual failover will fail in the first time.
         if {$type == "automatic"} {
-            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1000 10
+            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1200 50
         } elseif {$type == "manual"} {
             R 3 cluster failover force
-            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1000 10
+            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
         }
 
         # Make sure the primaries prints the relevant logs.
-        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
-        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
+        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
+        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
 
         # Make sure the replica has updated the config epoch.
         wait_for_condition 1000 10 {

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -106,13 +106,15 @@ proc test_migrated_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 
@@ -201,11 +203,13 @@ proc test_nonempty_replica {type} {
         # Make sure the key exists and is consistent.
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 4 get key_991803] == 1024 &&
-            [R 7 get key_991803] == 1024
+            [catch {expr {
+                [R 4 get key_991803] == 1024 &&
+                [R 7 get key_991803] == 1024
+            }} result] == 0 && $result
         } else {
-            puts "R 4: [R 4 get key_991803]"
-            puts "R 7: [R 7 get key_991803]"
+            catch {puts "R 4: [R 4 get key_991803]"}
+            catch {puts "R 7: [R 7 get key_991803]"}
             fail "Key not consistent"
         }
 
@@ -325,13 +329,15 @@ proc test_sub_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -336,12 +336,15 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [valkey_deferring_client -1]
+                $rd_master client reply off
+                $rd_master flush
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $rd_master setrange key:0 0 [string repeat A $payload_len]
+                    if {$k % 10000 == 0} {$rd_master flush}
                 }
-                for {set k 0} {$k < $cmd_count} {incr k} {
-                    $rd_master read
-                }
+                $rd_master client reply on
+                $rd_master flush
+                $rd_master read ;# read the +OK from CLIENT REPLY ON
             } else {
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $master setrange key:0 0 [string repeat A $payload_len]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1,6 +1,8 @@
 proc test_memory_efficiency {range} {
     r flushall
     set rd [valkey_deferring_client]
+    $rd client reply off
+    $rd flush
     set base_mem [s used_memory]
     set written 0
     for {set j 0} {$j < 10000} {incr j} {
@@ -11,9 +13,9 @@ proc test_memory_efficiency {range} {
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
     }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    $rd flush
+    $rd read ;# read the +OK from CLIENT REPLY ON
 
     set current_mem [s used_memory]
     set used [expr {$current_mem-$base_mem}]


### PR DESCRIPTION
Cherry-pick of f3b647050 from unstable.
Skipped dual-channel-replication.tcl (lazyfree test doesn't exist on 9.0).