### PR TITLE
Fix HPERSIST RESP protocol violation on wrong-type key

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2018,12 +2018,12 @@ void hpersistCommand(client *c) {
         return;
     }
 
-    /* From this point we would return array reply */
-    addReplyArrayLen(c, num_fields);
-
     robj *hash = lookupKeyWrite(c->db, c->argv[1]);
     if (checkType(c, hash, OBJ_HASH))
         return;
+
+    /* From this point we would return array reply */
+    addReplyArrayLen(c, num_fields);
 
     bool has_volatile_fields = hashTypeHasVolatileFields(hash);
 

--- a/tests/unit/hashexpire.tcl
+++ b/tests/unit/hashexpire.tcl
@@ -1395,6 +1395,11 @@ start_server {tags {"hashexpire"}} {
 
     #################### HPERSIST ##################
 
+    test {HPERSIST - wrong type key returns error} {
+        r SET mystr hello
+        assert_error {*WRONGTYPE*} {r HPERSIST mystr FIELDS 1 f1}
+    }
+
     test "HPERSIST - field does not exist" {
         r FLUSHALL
         r hset myhash field1 value1


### PR DESCRIPTION
`hpersistCommand` calls `addReplyArrayLen` before `lookupKeyWrite` + `checkType`. When HPERSIST targets a non-hash key, the server writes a RESP array header followed by a WRONGTYPE error — a malformed response that permanently desynchronizes the client connection.

This moves `lookupKeyWrite` + `checkType` before `addReplyArrayLen`, matching the pattern used by every other HFE command (e.g. `hgetdelCommand`, `hexpireGenericCommand`).

Added a test for HPERSIST on a wrong-type key.