### PR TITLE
Fix VLA warning in io_threads

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -149,6 +149,7 @@ void IOThreadsBeforeSleep(long long current_time) {
 #define IO_IGNITION_CPU_SYS 30.0
 #define IO_IGNITION_CPU_SYS_LOW 5.0
 #define IO_IGNITION_CPU_USER 50.0
+#define BATCH_SIZE 32
 
 void IOThreadsAfterSleep(int numevents) {
     if (server.io_threads_num == 1) return;
@@ -301,7 +302,6 @@ static void *IOThreadMain(void *myid) {
     pthread_cleanup_push(cleanupThreadResources, NULL);
 
     thread_id = (int)id;
-    const int BATCH_SIZE = 32;
     void *batch_jobs[BATCH_SIZE];
     int processed = 0;
     monotime work_start_time = 0;


### PR DESCRIPTION
https://github.com/valkey-io/valkey/pull/3324 introduced `BATCH_SIZE` as a const int local variable and used it as an array bound. Clang 17 rejects this with:
```
io_threads.c:305:22: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  305 |     void *batch_jobs[BATCH_SIZE];
      |                      ^~~~~~~~~~
1 error generated.
make[1]: *** [io_threads.o] Error 1
make: *** [all] Error 2

```
Old Clang versions do not emit this warning, maybe that is why the CI passed. Fix by promoting `BATCH_SIZE` to a file-scope `#define`.