### PR TITLE
Backport test stability fixes to 8.0

### DIFF
--- a/src/unit/test_rax.c
+++ b/src/unit/test_rax.c
@@ -165,7 +165,7 @@ static uint32_t int2int(uint32_t input) {
         r = l ^ F;
         l = nl;
     }
-    return (r << 16) | l;
+    return ((uint32_t)r << 16) | l;
 }
 
 /* Turn an uint32_t integer into an alphanumerical key and return its

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -15,6 +15,7 @@ if { ! [ catch {
 
 proc generate_collections {suffix elements} {
     set rd [valkey_deferring_client]
+    $rd client reply off
     for {set j 0} {$j < $elements} {incr j} {
         # add both string values and integers
         if {$j % 2 == 0} {set val $j} else {set val "_$j"}
@@ -24,9 +25,8 @@ proc generate_collections {suffix elements} {
         $rd sadd set$suffix $val
         $rd xadd stream$suffix * item 1 value $val
     }
-    for {set j 0} {$j < $elements * 5} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
     $rd close
 }
 

--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -33,6 +33,8 @@ start_server {overrides {save {}}} {
         $node_2 replicaof $node_0_host $node_0_port
         wait_for_sync $node_1
         wait_for_sync $node_2
+        verify_replica_online $node_0 0 50
+        verify_replica_online $node_0 1 50
     }
 
     test {failover command fails with invalid host} {

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -263,16 +263,15 @@ start_server {overrides {save ""}} {
         # changing some keys and read the reported COW size, we are using small key size to prevent from
         # the "dismiss mechanism" free memory and reduce the COW size)
         set rd [valkey_deferring_client 0]
+        $rd client reply off
         set size 500 ;# aim for the 512 bin (sds overhead)
         set cmd_count 10000
+        set AAA [string repeat A $size]
         for {set k 0} {$k < $cmd_count} {incr k} {
-            $rd set key$k [string repeat A $size]
+            $rd set key$k $AAA
         }
-
-        for {set k 0} {$k < $cmd_count} {incr k} {
-            catch { $rd read }
-        }
-
+        $rd client reply on
+        assert_equal OK [$rd read]
         $rd close
 
         # start background rdb save
@@ -301,8 +300,9 @@ start_server {overrides {save ""}} {
 
             # trigger copy-on-write
             set modified_keys 16
+            set BBB [string repeat B $size]
             for {set k 0} {$k < $modified_keys} {incr k} {
-                r setrange key$key_idx 0 [string repeat B $size]
+                r setrange key$key_idx 0 $BBB
                 incr key_idx 1
             }
 

--- a/tests/unit/cluster/diskless-load-swapdb.tcl
+++ b/tests/unit/cluster/diskless-load-swapdb.tcl
@@ -48,12 +48,13 @@ test "Main db not affected when fail to diskless load" {
     set num 10000
     set value [string repeat A 1024]
     set rd [valkey_deferring_client valkey $master_id]
+    $rd client reply off
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
+        if {$j % 1000 == 0} {$rd flush}
     }
-    for {set j 0} {$j < $num} {incr j} {
-        $rd read
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
 
     # Start the replica again
     resume_process [srv $replica_id pid]

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -182,17 +182,17 @@ proc test_replica_config_epoch_failover {type} {
 
         # Make sure both the automatic and the manual failover will fail in the first time.
         if {$type == "automatic"} {
-            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1000 10
+            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1200 50
         } elseif {$type == "manual"} {
             R 3 cluster failover force
-            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1000 10
+            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
         }
 
         # Make sure the primaries prints the relevant logs.
-        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
-        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
+        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
+        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
 
         # Make sure the replica has updated the config epoch.
         wait_for_condition 1000 10 {

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -104,13 +104,15 @@ proc test_migrated_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 
@@ -198,11 +200,13 @@ proc test_nonempty_replica {type} {
         # Make sure the key exists and is consistent.
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 4 get key_991803] == 1024 &&
-            [R 7 get key_991803] == 1024
+            [catch {expr {
+                [R 4 get key_991803] == 1024 &&
+                [R 7 get key_991803] == 1024
+            }} result] == 0 && $result
         } else {
-            puts "R 4: [R 4 get key_991803]"
-            puts "R 7: [R 7 get key_991803]"
+            catch {puts "R 4: [R 4 get key_991803]"}
+            catch {puts "R 7: [R 7 get key_991803]"}
             fail "Key not consistent"
         }
 
@@ -320,13 +324,15 @@ proc test_sub_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -371,12 +371,15 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [valkey_deferring_client -1]
+                $rd_master client reply off
+                $rd_master flush
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $rd_master setrange key:0 0 [string repeat A $payload_len]
+                    if {$k % 10000 == 0} {$rd_master flush}
                 }
-                for {set k 0} {$k < $cmd_count} {incr k} {
-                    $rd_master read
-                }
+                $rd_master client reply on
+                $rd_master flush
+                $rd_master read ;# read the +OK from CLIENT REPLY ON
             } else {
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $master setrange key:0 0 [string repeat A $payload_len]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1,6 +1,8 @@
 proc test_memory_efficiency {range} {
     r flushall
     set rd [valkey_deferring_client]
+    $rd client reply off
+    $rd flush
     set base_mem [s used_memory]
     set written 0
     for {set j 0} {$j < 10000} {incr j} {
@@ -11,9 +13,9 @@ proc test_memory_efficiency {range} {
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
     }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    $rd flush
+    $rd read ;# read the +OK from CLIENT REPLY ON
     $rd close
     set current_mem [s used_memory]
     set used [expr {$current_mem-$base_mem}]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -206,10 +206,12 @@ run_solo {defrag} {
             set dummy_script "--[string repeat x 400]\nreturn "
             set rd [valkey_deferring_client]
             $rd client reply off
+            $rd flush
             for {set j 0} {$j < $n} {incr j} {
                 set val "$dummy_script[format "%06d" $j]"
                 $rd script load $val
                 $rd set k$j $val
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             after 120 ;# serverCron only updates the info once in 100ms
@@ -224,6 +226,7 @@ run_solo {defrag} {
             # Delete all the keys to create fragmentation
             for {set j 0} {$j < $n} {incr j} {
                 $rd del k$j
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             $rd close
@@ -321,6 +324,7 @@ run_solo {defrag} {
                 # scale the hash to 1m fields in order to have a measurable the latency
                 for {set j 10000} {$j < 1000000} {incr j} {
                     $rd hset bighash $j [concat "asdfasdfasdf" $j]
+                    if {$j % 100 == 0} {$rd flush}
                     if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
                 # creating that big hash, increased used_memory, so the relative frag goes down
@@ -448,6 +452,7 @@ run_solo {defrag} {
             $rd client reply off
             for {set j 0} {$j < $n} {incr j} {
                 $rd del k$j
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             $rd close

--- a/tests/unit/moduleapi/test_lazyfree.tcl
+++ b/tests/unit/moduleapi/test_lazyfree.tcl
@@ -8,13 +8,13 @@ start_server {tags {"modules"}} {
         set rd [valkey_deferring_client]
 
         # LAZYFREE_THRESHOLD is 64
+        $rd client reply off
         for {set i 0} {$i < 10000} {incr i} {
             $rd lazyfreelink.insert lazykey $i
+            if {$i % 1000 == 0} {$rd flush}
         }
-
-        for {set j 0} {$j < 10000} {incr j} {
-            $rd read 
-        }
+        $rd client reply on
+        assert_equal OK [$rd read]
 
         assert {[r lazyfreelink.len lazykey] == 10000}
 

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -291,7 +291,9 @@ catch {
 }
 if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
 
-    set str_length 5000000000
+    # Reduced from 5GB to fit in 16GB CI runners with ASAN overhead
+    # Must exceed 2^32 (4294967296) to test >4GiB (32-bit boundary) behavior
+    set str_length 4300000000
 
     # repeating all the plain nodes basic checks with 5gb values
     test {Test LPUSH and LPOP on plain nodes over 4GB} {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1281,7 +1281,9 @@ catch {
 }
 if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
 
-    set str_length 4400000000 ;#~4.4GB
+    # Reduced from 4.4GB to fit in 16GB CI runners with ASAN overhead
+    # Must exceed 2^32 (4294967296) to test >4GiB (32-bit boundary) behavior
+    set str_length 4300000000 ;#~4GiB, >2^32
 
     test {SADD, SCARD, SISMEMBER - large data} {
         r flushdb

--- a/tests/unit/violations.tcl
+++ b/tests/unit/violations.tcl
@@ -1,4 +1,5 @@
-# One XADD with one huge 5GB field
+# One XADD with one huge >4GiB field (reduced from 5GB for CI memory limits)
+# Must exceed 2^32 to require more than 32 bits to address
 # Expected to fail resulting in an empty stream
 run_solo {violations} {
 start_server [list overrides [list save ""] ] {
@@ -8,7 +9,7 @@ start_server [list overrides [list save ""] ] {
         r write "*5\r\n\$4\r\nXADD\r\n\$2\r\nS1\r\n\$1\r\n*\r\n"
         r write "\$1\r\nA\r\n"
         catch {
-            write_big_bulk 5000000000 ;#5gb
+            write_big_bulk 4300000000 ;#~4GiB, >2^32
         } err
         assert_match {*too large*} $err
         r xlen S1
@@ -33,15 +34,16 @@ start_server [list overrides [list save ""] ] {
 }
 
 # Gradually add big stream fields using repeated XADD calls
+# Reduced from 10 to 3 iterations to fit in 16GB CI runners with ASAN overhead
 start_server [list overrides [list save ""] ] {
     test {several XADD big fields} {
         r config set stream-node-max-bytes 0
-        for {set j 0} {$j<10} {incr j} {
+        for {set j 0} {$j<3} {incr j} {
             r xadd stream * 1 $::str500 2 $::str500
         }
         r ping
         r xlen stream
-    } {10} {large-memory}
+    } {3} {large-memory}
 }
 
 # Add over 4GB to a single stream listpack (one XADD command)
@@ -75,6 +77,7 @@ start_server [list overrides [list save ""] ] {
 
 # Add over 4GB to a single hash field (one HSET command)
 # Object will be converted to hashtable encoding
+# Reduced from 5GB; must exceed 2^32 to test >4GiB (32-bit boundary) behavior
 start_server [list overrides [list save ""] ] {
     test {hash with one huge field} {
         catch {r config set hash-max-ziplist-value 10000000000} ;#10gb
@@ -82,7 +85,7 @@ start_server [list overrides [list save ""] ] {
         r config set client-query-buffer-limit 10000000000 ;#10gb
         r write "*4\r\n\$4\r\nHSET\r\n\$2\r\nH1\r\n"
         r write "\$1\r\nA\r\n"
-        write_big_bulk 5000000000 ;#5gb
+        write_big_bulk 4300000000 ;#~4GiB, >2^32
         r object encoding H1
     } {hashtable} {large-memory}
 }


### PR DESCRIPTION
Cherry-picks of #3430, #3452, #3241, and #3263 to fix flaky tests on 8.0. Weekly CI context: https://github.com/valkey-io/valkey/actions/runs/24300553351