### PR TITLE
fix: the rdma test client uses sprintf() at lines 92... in rdma-test.c

### DIFF
--- a/tests/rdma/rdma-test.c
+++ b/tests/rdma/rdma-test.c
@@ -918,9 +918,9 @@ static void *test_routine(void *arg) {
     for (int i = 0; i < keys; i++) {
         kv_pair = &kv_pairs[i];
         /* build SET command */
-        outbytes = sprintf(outbuf, "*3\r\n$3\r\nSET\r\n$%ld\r\n%s\r\n$%ld\r\n%s\r\n",
-                           strlen(kv_pair->key), kv_pair->key,
-                           strlen(kv_pair->value), kv_pair->value);
+        outbytes = snprintf(outbuf, sizeof(outbuf), "*3\r\n$3\r\nSET\r\n$%ld\r\n%s\r\n$%ld\r\n%s\r\n",
+                            strlen(kv_pair->key), kv_pair->key,
+                            strlen(kv_pair->value), kv_pair->value);
         valkeyRdmaWrite(ctx, outbuf, outbytes);
         inbytes = valkeyRdmaReadFull(ctx, inbuf, strlen(okresp));
         assert(!strncmp("+OK\r\n", inbuf, inbytes));
@@ -946,8 +946,8 @@ static void *test_routine(void *arg) {
     for (int i = 0; i < keys; i++) {
         kv_pair = &kv_pairs[i];
         /* build GET command */
-        outbytes = sprintf(outbuf, "*2\r\n$3\r\nGET\r\n$%ld\r\n%s\r\n",
-                           strlen(kv_pair->key), kv_pair->key);
+        outbytes = snprintf(outbuf, sizeof(outbuf), "*2\r\n$3\r\nGET\r\n$%ld\r\n%s\r\n",
+                            strlen(kv_pair->key), kv_pair->key);
         valkeyRdmaWrite(ctx, outbuf, outbytes);
         inbytes = valkeyRdmaReadFull(ctx, inbuf, getrespprexlen + strlen(kv_pair->value) + 2);
         assert(!strncmp(getrespprex, inbuf, getrespprexlen));


### PR DESCRIPTION
## Summary
Fix medium severity security issue in `tests/rdma/rdma-test.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tests/rdma/rdma-test.c:921` |

**Description**: The RDMA test client uses sprintf() at lines 921 and 949 to format SET and GET command protocol frames into a fixed-size output buffer (outbuf) without any bounds checking. The %s format specifiers accept key and value strings whose lengths are not validated against the buffer size before formatting. An oversized key or value string will overflow the outbuf buffer, overwriting adjacent stack memory including saved return addresses or function pointers.

## Changes
- `tests/rdma/rdma-test.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
