### PR TITLE
Introduce stubs for Raft cluster bus

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -45,6 +45,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/cluster.c
     ${CMAKE_SOURCE_DIR}/src/cluster_migrateslots.c
     ${CMAKE_SOURCE_DIR}/src/cluster_legacy.c
+    ${CMAKE_SOURCE_DIR}/src/cluster_raft.c
     ${CMAKE_SOURCE_DIR}/src/cluster_link.c
     ${CMAKE_SOURCE_DIR}/src/cluster_nodes.c
     ${CMAKE_SOURCE_DIR}/src/cluster_state.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -467,6 +467,7 @@ ENGINE_SERVER_OBJ = \
     cluster_link.o \
     cluster_nodes.o \
     cluster_state.o \
+    cluster_raft.o \
     cluster_migrateslots.o \
     cluster_slot_stats.o \
     commandlog.o \

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -52,6 +52,7 @@
 
 /* The active cluster bus protocol implementation. */
 extern clusterBusType clusterLegacyBus;
+extern clusterBusType clusterRaftBus;
 clusterBusType *clusterCurrentBus = &clusterLegacyBus;
 
 static void clusterCommandFlushslot(client *c);
@@ -61,6 +62,10 @@ static void clusterCommandFlushslot(client *c);
  * -------------------------------------------------------------------------- */
 
 void clusterInit(void) {
+    if (server.cluster_raft_enabled) {
+        clusterCurrentBus = &clusterRaftBus;
+    }
+
     server.cluster = zmalloc(sizeof(struct clusterState));
     server.cluster->myself = NULL;
     server.cluster->state = CLUSTER_FAIL;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1,0 +1,280 @@
+#include "server.h"
+#include "cluster.h"
+#include "cluster_state.h"
+#include "cluster_link.h"
+#include "cluster_bus.h"
+#include "cluster_raft.h"
+
+/* Access Raft protocol-specific state from the cluster. */
+#define RAFT_STATE() ((clusterRaftState *)server.cluster->protocol_data)
+
+/* Access Raft protocol-specific data from a clusterNode. */
+#define RAFT_DATA(n) ((clusterNodeRaftData *)(n)->protocol_data)
+
+/* Dictionary type for applied entries. */
+void raftAppliedEntryFree(void *val) {
+    raftAppliedEntry *ae = val;
+    sdsfree(ae->value);
+    zfree(ae);
+}
+
+static void clusterRaftAppliedEntryDictEntryDestructor(void *entry) {
+    dictEntry *de = entry;
+    dictSdsDestructor(dictGetKey(de));
+    raftAppliedEntryFree(dictGetVal(de));
+    zfree(de);
+}
+
+dictType clusterRaftAppliedEntryDictType = {
+    .entryGetKey = dictEntryGetKey,
+    .hashFunction = dictSdsHash,
+    .keyCompare = dictSdsKeyCompare,
+    .entryDestructor = clusterRaftAppliedEntryDictEntryDestructor,
+};
+
+static const char *raftRoleToString(int role) {
+    switch (role) {
+    case RAFT_ROLE_FOLLOWER: return "FOLLOWER";
+    case RAFT_ROLE_CANDIDATE: return "CANDIDATE";
+    case RAFT_ROLE_LEADER: return "LEADER";
+    default: return "UNKNOWN";
+    }
+}
+
+static void clusterRaftSetNodeRole(clusterNode *node, int new_role) {
+    serverLog(LL_NOTICE, "Raft: Node %.40s changing role: %s -> %s", node->name, raftRoleToString(RAFT_DATA(node)->role), raftRoleToString(new_role));
+    RAFT_DATA(node)->role = new_role;
+}
+
+void clusterRaftInit(void) {
+    server.cluster->protocol_data = zcalloc(sizeof(clusterRaftState));
+    RAFT_STATE()->enabled = server.cluster_raft_enabled;
+    RAFT_STATE()->applied_entries = dictCreate(&clusterRaftAppliedEntryDictType);
+    RAFT_STATE()->term = 0;
+}
+
+static void clusterRaftInitLast(void) {
+    /* Initialize fields that depend on server.cluster->myself */
+    RAFT_STATE()->leader = server.cluster->myself;
+    clusterRaftSetNodeRole(server.cluster->myself, RAFT_ROLE_LEADER);
+
+    /* Bootstrap our metadata with just the membership information of our 1-node
+     * group.*/
+    raftAppliedEntry *ae = zmalloc(sizeof(*ae));
+    ae->index = 1;
+    ae->term = 0;
+    ae->value = sdsnewlen(server.cluster->myself->name, CLUSTER_NAMELEN);
+    dictAdd(RAFT_STATE()->applied_entries, sdsnew("membership"), ae);
+    RAFT_STATE()->last_applied_index = 1;
+    RAFT_STATE()->last_applied_term = 0;
+
+    clusterListenerInit();
+}
+
+void clusterRaftCron(void) {
+}
+
+static void clusterRaftBeforeSleep(void) {
+}
+
+static void clusterRaftHandleServerShutdown(bool auto_failover) {
+    UNUSED(auto_failover);
+}
+
+static uint32_t clusterRaftValidateMessageHeader(char *header) {
+    UNUSED(header);
+    return 0;
+}
+
+static int clusterRaftProcessMessage(clusterLink *link) {
+    UNUSED(link);
+    return 1;
+}
+
+static void clusterRaftPostConnect(clusterLink *link) {
+    UNUSED(link);
+}
+
+static void clusterRaftOnMyselfUpdated(int old_flags) {
+    UNUSED(old_flags);
+}
+
+static void clusterRaftPropagatePublish(robj *channel, robj *message, int sharded) {
+    UNUSED(channel);
+    UNUSED(message);
+    UNUSED(sharded);
+}
+
+static int clusterRaftSendModuleMessage(const char *target, uint64_t module_id, uint8_t type, const char *payload, uint32_t len) {
+    UNUSED(target);
+    UNUSED(module_id);
+    UNUSED(type);
+    UNUSED(payload);
+    UNUSED(len);
+    return 0;
+}
+
+static unsigned long clusterRaftGetConnectionsCount(void) {
+    return 0;
+}
+
+static void clusterRaftResetStats(void) {
+}
+
+static sds clusterRaftAppendInfoFields(sds info) {
+    if (server.cluster == NULL) return info;
+
+    info = sdscatfmt(info, "raft_node_count:%U\r\n", (unsigned long long)dictSize(server.cluster->nodes));
+    info = sdscatfmt(info, "raft_role:%s\r\n", raftRoleToString(RAFT_DATA(myself)->role));
+    info = sdscatprintf(info, "raft_node_id:%.40s\r\n", server.cluster->myself->name);
+    info = sdscatprintf(info, "raft_term:%llu\r\n", (unsigned long long)RAFT_STATE()->term);
+    info = sdscatprintf(info, "raft_leader:%.40s\r\n", RAFT_STATE()->leader ? RAFT_STATE()->leader->name : "");
+    info = sdscatprintf(info, "raft_applied_key_count:%zu\r\n", dictSize(RAFT_STATE()->applied_entries));
+    info = sdscatprintf(info, "raft_applied_index:%llu\r\n", (unsigned long long)RAFT_STATE()->last_applied_index);
+
+    return info;
+}
+
+static int clusterRaftGetFailureReportsCount(clusterNode *node) {
+    UNUSED(node);
+    return 0;
+}
+
+static void clusterRaftGetNodePingPongEpoch(clusterNode *node, long long *ping_sent, long long *pong_received, uint64_t *config_epoch) {
+    UNUSED(node);
+    *ping_sent = 0;
+    *pong_received = 0;
+    *config_epoch = 0;
+}
+
+static void clusterRaftSetNodePingPongEpoch(clusterNode *node, int ping_active, int pong_active, uint64_t config_epoch) {
+    UNUSED(node);
+    UNUSED(ping_active);
+    UNUSED(pong_active);
+    UNUSED(config_epoch);
+}
+
+static void clusterRaftSetNodeFailed(clusterNode *node) {
+    UNUSED(node);
+}
+
+static sds clusterRaftAppendVarsLine(sds config) {
+    return config;
+}
+
+static int clusterRaftParseVarsLine(const char *name, const char *value) {
+    UNUSED(name);
+    UNUSED(value);
+    return 0;
+}
+
+static void clusterRaftPostLoad(void) {
+}
+
+void clusterRaftInitNodeData(clusterNode *node) {
+    node->protocol_data = zcalloc(sizeof(clusterNodeRaftData));
+}
+
+void clusterRaftFreeNodeData(clusterNode *node) {
+    if (node->protocol_data) {
+        zfree(node->protocol_data);
+        node->protocol_data = NULL;
+    }
+}
+
+static void clusterRaftSlotChange(slotRange *ranges, int numranges, clusterNode *target, void *ctx, void (*callback)(void *ctx, const char *error)) {
+    UNUSED(ranges);
+    UNUSED(numranges);
+    UNUSED(target);
+    if (callback) callback(ctx, NULL);
+}
+
+static void clusterRaftCancelManualFailover(void) {
+}
+
+static void clusterRaftCancelAutomaticFailover(void) {
+}
+
+static void clusterRaftForgetNode(const char *node_id, size_t id_len, void *ctx, void (*callback)(void *ctx, const char *error)) {
+    UNUSED(node_id);
+    UNUSED(id_len);
+    if (callback) callback(ctx, NULL);
+}
+
+static void clusterRaftSetReplicaOf(clusterNode *primary, void *ctx, void (*callback)(void *ctx, const char *error)) {
+    UNUSED(primary);
+    if (callback) callback(ctx, "Not supported in Raft mode");
+}
+
+static void clusterRaftFailover(int force, int takeover, void *ctx, void (*callback)(void *ctx, const char *error)) {
+    UNUSED(force);
+    UNUSED(takeover);
+    if (callback) callback(ctx, "Not supported in Raft mode");
+}
+
+static void clusterRaftMeet(const char *ip, int port, int cport, void *ctx, void (*callback)(void *ctx, const char *error)) {
+    UNUSED(ip);
+    UNUSED(port);
+    UNUSED(cport);
+    if (callback) callback(ctx, NULL);
+}
+
+static void clusterRaftReset(int hard) {
+    UNUSED(hard);
+}
+
+static int clusterRaftProtocolSubcommand(client *c) {
+    UNUSED(c);
+    return 0;
+}
+
+void clusterRaftFree(void) {
+    if (RAFT_STATE()) {
+        dictRelease(RAFT_STATE()->applied_entries);
+        zfree(RAFT_STATE());
+        server.cluster->protocol_data = NULL;
+    }
+}
+
+void clusterRaftGetMetadata(client *c) {
+    UNUSED(c);
+}
+
+void clusterRaftSetMetadata(client *c) {
+    UNUSED(c);
+}
+
+clusterBusType clusterRaftBus = {
+    .init = clusterRaftInit,
+    .initLast = clusterRaftInitLast,
+    .cron = clusterRaftCron,
+    .beforeSleep = clusterRaftBeforeSleep,
+    .handleServerShutdown = clusterRaftHandleServerShutdown,
+    .validateMessageHeader = clusterRaftValidateMessageHeader,
+    .processMessage = clusterRaftProcessMessage,
+    .postConnect = clusterRaftPostConnect,
+    .onMyselfUpdated = clusterRaftOnMyselfUpdated,
+    .propagatePublish = clusterRaftPropagatePublish,
+    .sendModuleMessage = clusterRaftSendModuleMessage,
+    .getConnectionsCount = clusterRaftGetConnectionsCount,
+    .resetStats = clusterRaftResetStats,
+    .appendInfoFields = clusterRaftAppendInfoFields,
+    .getFailureReportsCount = clusterRaftGetFailureReportsCount,
+    .getNodePingPongEpoch = clusterRaftGetNodePingPongEpoch,
+    .setNodePingPongEpoch = clusterRaftSetNodePingPongEpoch,
+    .setNodeFailed = clusterRaftSetNodeFailed,
+    .appendVarsLine = clusterRaftAppendVarsLine,
+    .parseVarsLine = clusterRaftParseVarsLine,
+    .postLoad = clusterRaftPostLoad,
+    .initNodeData = clusterRaftInitNodeData,
+    .freeNodeData = clusterRaftFreeNodeData,
+    .slotChange = clusterRaftSlotChange,
+    .cancelManualFailover = clusterRaftCancelManualFailover,
+    .cancelAutomaticFailover = clusterRaftCancelAutomaticFailover,
+    .forgetNode = clusterRaftForgetNode,
+    .setReplicaOf = clusterRaftSetReplicaOf,
+    .failover = clusterRaftFailover,
+    .meet = clusterRaftMeet,
+    .resetCluster = clusterRaftReset,
+    .protocolSubcommand = clusterRaftProtocolSubcommand,
+};

--- a/src/cluster_raft.h
+++ b/src/cluster_raft.h
@@ -1,0 +1,38 @@
+#ifndef __CLUSTER_RAFT_H
+#define __CLUSTER_RAFT_H
+
+#include "server.h"
+#include "sds.h"
+#include "cluster.h"
+
+/* Forward declarations */
+typedef struct clusterMsg clusterMsg;
+typedef struct clusterMsgPingExt clusterMsgPingExt;
+
+/* Raft roles */
+#define RAFT_ROLE_UNKNOWN 0
+#define RAFT_ROLE_FOLLOWER 1
+#define RAFT_ROLE_CANDIDATE 2
+#define RAFT_ROLE_LEADER 3
+
+typedef struct raftAppliedEntry {
+    uint64_t index;
+    uint64_t term;
+    sds value;
+} raftAppliedEntry;
+
+typedef struct clusterRaftState {
+    bool enabled;
+    uint64_t term;       /* Current term */
+    clusterNode *leader; /* Pointer to the current leader */
+
+    uint64_t last_applied_index; /* Index of the newest entry in applied_entries */
+    uint64_t last_applied_term;  /* Term of the newest entry in applied_entries */
+    dict *applied_entries;       /* Map of key -> raftAppliedEntry */
+} clusterRaftState;
+
+typedef struct clusterNodeRaftData {
+    int role;
+} clusterNodeRaftData;
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -3287,6 +3287,7 @@ standardConfig static_configs[] = {
     createBoolConfig("activedefrag", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.active_defrag_enabled, CONFIG_ACTIVE_DEFRAG_DEFAULT, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, server.syslog_enabled, 0, NULL, NULL),
     createBoolConfig("cluster-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_enabled, 0, NULL, NULL),
+    createBoolConfig("cluster-raft-enabled", NULL, IMMUTABLE_CONFIG, server.cluster_raft_enabled, 0, NULL, NULL),
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG | DENY_LOADING_CONFIG, server.aof_enabled, 0, NULL, updateAppendOnly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("cluster-allow-pubsubshard-when-down", NULL, MODIFIABLE_CONFIG, server.cluster_allow_pubsubshard_when_down, 1, NULL, NULL),

--- a/src/server.c
+++ b/src/server.c
@@ -2346,6 +2346,7 @@ void initServerConfig(void) {
     server.shutdown_flags = 0;
     server.shutdown_mstime = 0;
     server.cluster_module_flags = CLUSTER_MODULE_FLAG_NONE;
+    server.cluster_raft_enabled = 0;
     server.migrate_cached_sockets = dictCreate(&migrateCacheDictType);
     server.next_client_id = 1; /* Client IDs, start from 1 .*/
     server.page_size = sysconf(_SC_PAGESIZE);

--- a/src/server.h
+++ b/src/server.h
@@ -2254,6 +2254,7 @@ struct valkeyServer {
     unsigned int watching_clients; /* # of clients are watching keys */
     /* Cluster */
     int cluster_enabled;                                   /* Is cluster enabled? */
+    int cluster_raft_enabled;                              /* Is Raft enabled for metadata? */
     int cluster_port;                                      /* Set the cluster port for a node. */
     mstime_t cluster_node_timeout;                         /* Cluster node timeout. */
     mstime_t cluster_ping_interval;                        /* A debug configuration for setting how often cluster nodes send ping messages. */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1228,6 +1228,7 @@ start_server {tags {"introspection"}} {
             always-show-logo
             syslog-enabled
             cluster-enabled
+            cluster-raft-enabled
             disable-thp
             aclfile
             unixsocket


### PR DESCRIPTION
Following the cluster bus separation, introduce the stubs for a Raft-based cluster bus.