### PR TITLE
hashtable: fix dismissHashtable madvise size

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1568,7 +1568,7 @@ hashtable *hashtableDefragTables(hashtable *ht, void *(*defragfn)(void *)) {
  * forked and memory won't be used again. See zmadvise_dontneed() */
 void dismissHashtable(hashtable *ht) {
     for (int i = 0; i < 2; i++) {
-        zmadvise_dontneed(ht->tables[i], numBuckets(ht->bucket_exp[i]) * sizeof(bucket *));
+        zmadvise_dontneed(ht->tables[i], numBuckets(ht->bucket_exp[i]) * sizeof(bucket));
     }
 }
 


### PR DESCRIPTION
The bug was in dismissHashtable(), which computes the size passed to zmadvise_dontneed() for the top-level hashtable
  tables.

  ht->tables[i] points to a contiguous array of bucket objects, but the code used sizeof(bucket *) instead of
  sizeof(bucket) when calculating the length. That means it treated the allocation like an array of pointers rather than an
  array of buckets.

  As a result, the advised range was much smaller than the actual table allocation. On 64-bit builds, bucket is 64 bytes
  while bucket * is 8 bytes, so only about one eighth of the table was covered. This does not usually break correctness,
  but it defeats the purpose of the function: after a fork, we want to tell the kernel that the hashtable pages are no
  longer needed so we reduce copy-on-write overhead. With the wrong size, most of the table memory was never included in
  that hint.

  The fix is to use sizeof(bucket) so the full top-level bucket array is passed to zmadvise_dontneed().