### PR TITLE
Add AUTH/AUTH2 options to CLUSTER MIGRATESLOTS

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -8,6 +8,8 @@
 #include "bio.h"
 #include "module.h"
 #include "functions.h"
+#include "sds.h"
+#include "server.h"
 
 #include <sys/wait.h>
 #include <fcntl.h>
@@ -88,6 +90,8 @@ typedef struct slotMigrationJob {
     /* State needed during client establishment */
     connection *conn; /* Connection to slot import source node. */
     sds response_buf;
+    sds auth_user; /* User used for AUTH of the export job. */
+    sds auth_password; /* Password used for AUTH of the export job */
 } slotMigrationJob;
 
 static bool isSlotMigrationJobFinished(slotMigrationJob *job);
@@ -103,7 +107,7 @@ static void updateSlotMigrationJobState(slotMigrationJob *job,
 static void sendSyncSlotsMessage(slotMigrationJob *job, const char *subcommand);
 static void proceedWithSlotMigration(slotMigrationJob *job);
 static slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                             list *slot_ranges);
+                                             list *slot_ranges, sds auth_user, sds auth_password);
 static bool isSlotExportPauseTimedOut(slotMigrationJob *job);
 static void resetSlotMigrationJob(slotMigrationJob *job);
 static void finishSlotMigrationJob(slotMigrationJob *job,
@@ -1153,6 +1157,8 @@ void clusterCommandMigrateSlots(client *c) {
     list *new_slot_migrations = listCreate();
     listSetFreeMethod(new_slot_migrations, freeSlotMigrationJob);
     list *slot_ranges = NULL;
+    sds auth_user = NULL;
+    sds auth_pass = NULL;
 
     while (curr_index < c->argc) {
         if (strcasecmp(objectGetVal(c->argv[curr_index]), "slotsrange")) {
@@ -1219,9 +1225,34 @@ void clusterCommandMigrateSlots(client *c) {
         }
         curr_index++;
 
-        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges);
+        if (curr_index < c->argc) {
+            sds token = objectGetVal(c->argv[curr_index]);
+            if (!strcasecmp(token, "auth")) {
+                if (curr_index + 1 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                curr_index += 2;
+            } else if (!strcasecmp(token, "auth2")) {
+                if (curr_index + 2 >= c->argc) {
+                    addReplyErrorObject(c, shared.syntaxerr);
+                    goto cleanup;
+                }
+                auth_user = sdsdup(objectGetVal(c->argv[curr_index + 1]));
+                redactClientCommandArgument(c, curr_index + 1);
+                auth_pass = sdsdup(objectGetVal(c->argv[curr_index + 2]));
+                redactClientCommandArgument(c, curr_index + 2);
+                curr_index +=3;
+            }
+        }
+
+        slotMigrationJob *job = createSlotExportJob(target_node, slot_ranges, auth_user, auth_pass);
         listAddNodeHead(new_slot_migrations, job);
         slot_ranges = NULL;
+        auth_user = NULL;
+        auth_pass = NULL;
     }
 
     /* If we reach here, we have successfully parsed all arguments */
@@ -1249,6 +1280,13 @@ void clusterCommandMigrateSlots(client *c) {
 cleanup:
     if (slot_ranges) listRelease(slot_ranges);
     listRelease(new_slot_migrations);
+    if (auth_user) {
+        sdsfree(auth_user);
+    }
+    if (auth_pass) {
+        memset(auth_pass, 0, sdslen(auth_pass));
+        sdsfree(auth_pass);
+    }
 }
 
 slotMigrationJob *clusterLookupMigrationJob(sds name) {
@@ -1367,9 +1405,11 @@ void slotMigrationJobReadAuthResponse(connection *conn) {
  * job's connection. */
 void slotMigrationJobSendAuth(slotMigrationJob *job) {
     serverAssert(job->type == SLOT_MIGRATION_EXPORT);
-    serverAssert(server.primary_auth);
+    sds user = job->auth_user ? job->auth_user : server.primary_user;
+    sds pass = job->auth_password ? job->auth_password : server.primary_auth;
+    serverAssert(pass);
 
-    sds err = replicationSendAuth(job->conn);
+    sds err = replicationSendAuth(job->conn, user, pass, sdslen(pass));
     if (err) {
         sds status_msg = sdscatfmt(sdsempty(), "Failed to send AUTH command to target node: %s", err);
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_FAILED, status_msg);
@@ -1857,7 +1897,7 @@ size_t clusterGetTotalSlotExportBufferMemory(void) {
 
 /* Create a slot export job with the given target and slot ranges. */
 slotMigrationJob *createSlotExportJob(clusterNode *target_node,
-                                      list *slot_ranges) {
+                                      list *slot_ranges,  sds auth_user, sds auth_password) {
     slotMigrationJob *job = zcalloc(sizeof(slotMigrationJob));
 
     job->ctime = server.unixtime;
@@ -1871,6 +1911,8 @@ slotMigrationJob *createSlotExportJob(clusterNode *target_node,
     memcpy(job->target_node_name, target_node->name, CLUSTER_NAMELEN);
     memcpy(job->source_node_name, server.cluster->myself->name, CLUSTER_NAMELEN);
     job->description = generateSlotMigrationJobDescription(job, target_node);
+    job->auth_user =  auth_user;
+    job->auth_password = auth_password;
     return job;
 }
 
@@ -2007,7 +2049,7 @@ void proceedWithSlotMigration(slotMigrationJob *job) {
             if (!completed) return;
             serverLog(LL_NOTICE, "Slot migration %s connection established.",
                       job->description);
-            if (server.primary_auth) {
+            if (job->auth_password || server.primary_auth) {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_AUTH);
             } else {
                 updateSlotMigrationJobState(job, SLOT_EXPORT_SEND_ESTABLISH);
@@ -2164,6 +2206,13 @@ void freeSlotMigrationJob(void *o) {
     sdsfree(job->status_msg);
     sdsfree(job->response_buf);
     sdsfree(job->description);
+    if (job->auth_user) {
+        sdsfree(job->auth_user);
+    }
+    if (job->auth_password) {
+        memset(job->auth_password, 0, sdslen(job->auth_password));
+        sdsfree(job->auth_password);
+    }
     zfree(o);
 }
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -3002,17 +3002,17 @@ int sendCurrentOffsetToReplica(client *replica) {
     return C_OK;
 }
 
-sds replicationSendAuth(connection *conn) {
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len) {
     char *args[] = {"AUTH", NULL, NULL};
     size_t lens[] = {4, 0, 0};
     int argc = 1;
-    if (server.primary_user) {
-        args[argc] = server.primary_user;
-        lens[argc] = strlen(server.primary_user);
+    if (user) {
+        args[argc] = (char *)user;
+        lens[argc] = strlen(user);
         argc++;
     }
-    args[argc] = server.primary_auth;
-    lens[argc] = sdslen(server.primary_auth);
+    args[argc] = (char *)pass;
+    lens[argc] = pass_len;
     argc++;
     return sendCommandArgv(conn, argc, args, lens);
 }
@@ -3033,7 +3033,7 @@ static int dualChannelReplHandleHandshake(connection *conn, sds *err) {
     dualChannelServerLog(LL_DEBUG, "Received first reply from primary using rdb connection.");
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        *err = replicationSendAuth(conn);
+        *err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (*err) {
             dualChannelServerLog(LL_WARNING, "Sending command to primary in dual channel replication handshake: %s", *err);
             return C_ERR;
@@ -3807,7 +3807,7 @@ int syncWithPrimaryHandleSendHandshakeState(connection *conn) {
     sds err;
     /* AUTH with the primary if required. */
     if (server.primary_auth) {
-        err = replicationSendAuth(conn);
+        err = replicationSendAuth(conn, server.primary_user, server.primary_auth, sdslen(server.primary_auth));
         if (err) goto err;
     }
 

--- a/src/server.h
+++ b/src/server.h
@@ -3227,7 +3227,7 @@ void addRdbReplicaToPsyncWait(client *replica);
 void initClientReplicationData(client *c);
 void freeClientReplicationData(client *c);
 void replicaReceiveRDBFromPrimaryToDisk(connection *conn, int is_dual_channel);
-sds replicationSendAuth(connection *conn);
+sds replicationSendAuth(connection *conn, const char *user, const char *pass, size_t pass_len);
 sds receiveSynchronousResponse(connection *conn);
 ConnectionType *connTypeOfReplication(void);
 robj *generateSelectCommand(int dictid);


### PR DESCRIPTION
Fixes #2392. 


TODO:
- [ ] update command description
- [ ] tests for AUTH/AUTH2 happy path
- [ ] tests for wrong password, syntax errors
- [ ] tests for per-job auth overriding masterauth
- [ ] test for multi-target with different credentials
- [ ] PR for valkey-doc repo needed