### PR TITLE
Fix multiline brace placement for clang

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -8,7 +8,16 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 100
 PenaltyExcessCharacter: 100
 MaxEmptyLinesToKeep: 2
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterControlStatement: MultiLine
+  AfterFunction: false
+  AfterStruct: false
+  AfterEnum: false
+  AfterUnion: false
+  BeforeElse: false
+  BeforeCatch: false
+  SplitEmptyFunction: false
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true

--- a/src/acl.c
+++ b/src/acl.c
@@ -1801,7 +1801,8 @@ static int ACLCheckChannelAgainstList(list *reference, const char *channel, int 
         /* Channel patterns are matched literally against the channels in
          * the list. Regular channels perform pattern matching. */
         if ((is_pattern && !strcmp(pattern, channel)) ||
-            (!is_pattern && stringmatchlen(pattern, plen, channel, channellen, 0))) {
+            (!is_pattern && stringmatchlen(pattern, plen, channel, channellen, 0)))
+        {
             return ACL_OK;
         }
     }
@@ -2662,7 +2663,8 @@ static sds ACLLoadFromFile(const char *filename) {
             user *new_user = ACLGetUserByName(c->user->name, sdslen(c->user->name));
             if (new_user && user_channels) {
                 if (!raxFind(user_channels, (unsigned char *)(new_user->name), sdslen(new_user->name),
-                             (void **)&channels)) {
+                             (void **)&channels))
+                {
                     channels = getUpcomingChannelList(new_user, original);
                     raxInsert(user_channels, (unsigned char *)(new_user->name), sdslen(new_user->name), channels, NULL);
                 }
@@ -2920,7 +2922,8 @@ void addACLLogEntry(client *c, int reason, int context, int argpos, sds username
     le->cinfo = catClientInfoString(sdsempty(), realclient, 0);
 
     if (context == ACL_LOG_CTX_SCRIPT &&
-        strcmp(scriptGetRunningEngineName(), "LUA") == 0) {
+        strcmp(scriptGetRunningEngineName(), "LUA") == 0)
+    {
         /* For backward compatibility, we track that it's Lua using a special
          * lua ACL log context. Any other scripting language is just "script" in
          * the ACL log. */

--- a/src/anet.c
+++ b/src/anet.c
@@ -681,7 +681,8 @@ int anetRetryAcceptOnError(int err) {
        and ENETUNREACH. */
     if (err == ENETDOWN || err == EPROTO || err == ENOPROTOOPT ||
         err == EHOSTDOWN || err == ENONET || err == EHOSTUNREACH ||
-        err == EOPNOTSUPP || err == ENETUNREACH) {
+        err == EOPNOTSUPP || err == ENETUNREACH)
+    {
         return 1;
     }
 #endif

--- a/src/aof.c
+++ b/src/aof.c
@@ -657,7 +657,8 @@ void aofUpgradePrepare(aofManifest *am) {
  */
 int aofDelHistoryFiles(void) {
     if (server.aof_manifest == NULL || server.aof_disable_auto_gc == 1 ||
-        !listLength(server.aof_manifest->history_aof_list)) {
+        !listLength(server.aof_manifest->history_aof_list))
+    {
         return C_OK;
     }
 
@@ -1187,7 +1188,8 @@ void flushAppendOnlyFile(int force) {
          * stop write commands before fsync called in one second,
          * the data in page cache cannot be flushed in time. */
         if (server.aof_fsync == AOF_FSYNC_EVERYSEC && server.aof_last_incr_fsync_offset != server.aof_last_incr_size &&
-            server.mstime - server.aof_last_fsync >= 1000 && !(sync_in_progress = aofFsyncInProgress())) {
+            server.mstime - server.aof_last_fsync >= 1000 && !(sync_in_progress = aofFsyncInProgress()))
+        {
             goto try_fsync;
 
             /* Check if we need to do fsync even the aof buffer is empty,
@@ -1195,7 +1197,8 @@ void flushAppendOnlyFile(int force) {
              * and AOF_FSYNC_ALWAYS is also checked here to handle a case where
              * aof_fsync is changed from everysec to always. */
         } else if (server.aof_fsync == AOF_FSYNC_ALWAYS &&
-                   server.aof_last_incr_fsync_offset != server.aof_last_incr_size) {
+                   server.aof_last_incr_fsync_offset != server.aof_last_incr_size)
+        {
             goto try_fsync;
         } else {
             /* All data is fsync'd already: Update fsynced_reploff_pending just in case.
@@ -1791,7 +1794,8 @@ int loadAppendOnlyFiles(aofManifest *am) {
     if (fileExist(server.aof_filename)) {
         if (!dirExists(server.aof_dirname) || (am->base_aof_info == NULL && listLength(am->incr_aof_list) == 0) ||
             (am->base_aof_info != NULL && listLength(am->incr_aof_list) == 0 &&
-             !strcmp(am->base_aof_info->file_name, server.aof_filename) && !aofFileExist(server.aof_filename))) {
+             !strcmp(am->base_aof_info->file_name, server.aof_filename) && !aofFileExist(server.aof_filename)))
+        {
             aofUpgradePrepare(am);
         }
     }
@@ -1923,7 +1927,8 @@ int rewriteListObject(rio *r, robj *key, robj *o) {
         if (count == 0) {
             int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
             if (!rioWriteBulkCount(r, '*', 2 + cmd_items) || !rioWriteBulkString(r, "RPUSH", 5) ||
-                !rioWriteBulkObject(r, key)) {
+                !rioWriteBulkObject(r, key))
+            {
                 listTypeReleaseIterator(li);
                 return 0;
             }
@@ -1963,7 +1968,8 @@ int rewriteSetObject(rio *r, robj *key, robj *o) {
         if (count == 0) {
             int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
             if (!rioWriteBulkCount(r, '*', 2 + cmd_items) || !rioWriteBulkString(r, "SADD", 4) ||
-                !rioWriteBulkObject(r, key)) {
+                !rioWriteBulkObject(r, key))
+            {
                 setTypeReleaseIterator(si);
                 return 0;
             }
@@ -2006,7 +2012,8 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
 
                 if (!rioWriteBulkCount(r, '*', 2 + cmd_items * 2) || !rioWriteBulkString(r, "ZADD", 4) ||
-                    !rioWriteBulkObject(r, key)) {
+                    !rioWriteBulkObject(r, key))
+                {
                     return 0;
                 }
             }
@@ -2031,7 +2038,8 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
 
                 if (!rioWriteBulkCount(r, '*', 2 + cmd_items * 2) || !rioWriteBulkString(r, "ZADD", 4) ||
-                    !rioWriteBulkObject(r, key)) {
+                    !rioWriteBulkObject(r, key))
+                {
                     hashtableCleanupIterator(&iter);
                     return 0;
                 }
@@ -2114,7 +2122,8 @@ int rewriteHashObject(rio *r, robj *key, robj *o) {
             int cmd_items = (non_volatile_items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : non_volatile_items;
 
             if (!rioWriteBulkCount(r, '*', 2 + cmd_items * 2) || !rioWriteBulkString(r, "HMSET", 5) ||
-                !rioWriteBulkObject(r, key)) {
+                !rioWriteBulkObject(r, key))
+            {
                 hashTypeResetIterator(&hi);
                 return 0;
             }
@@ -2209,7 +2218,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
 
             /* Emit the XADD <key> <id> ...fields... command. */
             if (!rioWriteBulkCount(r, '*', 3 + numfields * 2) || !rioWriteBulkString(r, "XADD", 4) ||
-                !rioWriteBulkObject(r, key) || !rioWriteBulkStreamID(r, &id)) {
+                !rioWriteBulkObject(r, key) || !rioWriteBulkStreamID(r, &id))
+            {
                 streamIteratorStop(&si);
                 return 0;
             }
@@ -2218,7 +2228,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                 int64_t field_len, value_len;
                 streamIteratorGetField(&si, &field, &value, &field_len, &value_len);
                 if (!rioWriteBulkString(r, (char *)field, field_len) ||
-                    !rioWriteBulkString(r, (char *)value, value_len)) {
+                    !rioWriteBulkString(r, (char *)value, value_len))
+                {
                     streamIteratorStop(&si);
                     return 0;
                 }
@@ -2232,7 +2243,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
         id.seq = 1;
         if (!rioWriteBulkCount(r, '*', 7) || !rioWriteBulkString(r, "XADD", 4) || !rioWriteBulkObject(r, key) ||
             !rioWriteBulkString(r, "MAXLEN", 6) || !rioWriteBulkString(r, "0", 1) || !rioWriteBulkStreamID(r, &id) ||
-            !rioWriteBulkString(r, "x", 1) || !rioWriteBulkString(r, "y", 1)) {
+            !rioWriteBulkString(r, "x", 1) || !rioWriteBulkString(r, "y", 1))
+        {
             streamIteratorStop(&si);
             return 0;
         }
@@ -2243,7 +2255,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
     if (!rioWriteBulkCount(r, '*', 7) || !rioWriteBulkString(r, "XSETID", 6) || !rioWriteBulkObject(r, key) ||
         !rioWriteBulkStreamID(r, &s->last_id) || !rioWriteBulkString(r, "ENTRIESADDED", 12) ||
         !rioWriteBulkLongLong(r, s->entries_added) || !rioWriteBulkString(r, "MAXDELETEDID", 12) ||
-        !rioWriteBulkStreamID(r, &s->max_deleted_entry_id)) {
+        !rioWriteBulkStreamID(r, &s->max_deleted_entry_id))
+    {
         streamIteratorStop(&si);
         return 0;
     }
@@ -2260,7 +2273,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
             if (!rioWriteBulkCount(r, '*', 7) || !rioWriteBulkString(r, "XGROUP", 6) ||
                 !rioWriteBulkString(r, "CREATE", 6) || !rioWriteBulkObject(r, key) ||
                 !rioWriteBulkString(r, (char *)ri.key, ri.key_len) || !rioWriteBulkStreamID(r, &group->last_id) ||
-                !rioWriteBulkString(r, "ENTRIESREAD", 11) || !rioWriteBulkLongLong(r, group->entries_read)) {
+                !rioWriteBulkString(r, "ENTRIESREAD", 11) || !rioWriteBulkLongLong(r, group->entries_read))
+            {
                 raxStop(&ri);
                 streamIteratorStop(&si);
                 return 0;
@@ -2292,7 +2306,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                 while (raxNext(&ri_pel)) {
                     streamNACK *nack = ri_pel.data;
                     if (rioWriteStreamPendingEntry(r, key, (char *)ri.key, ri.key_len, consumer, ri_pel.key, nack) ==
-                        0) {
+                        0)
+                    {
                         raxStop(&ri_pel);
                         raxStop(&ri_cons);
                         raxStop(&ri);

--- a/src/bitops.c
+++ b/src/bitops.c
@@ -622,7 +622,8 @@ int getBitfieldTypeFromArgument(client *c, robj *o, int *sign, int *bits) {
     }
 
     if ((string2ll(p + 1, plen - 1, &llbits)) == 0 || llbits < 1 || (*sign == 1 && llbits > 64) ||
-        (*sign == 0 && llbits > 63)) {
+        (*sign == 0 && llbits > 63))
+    {
         addReplyError(c, err);
         return C_ERR;
     }

--- a/src/blocked.c
+++ b/src/blocked.c
@@ -265,7 +265,8 @@ int blockedClientMayTimeout(client *c) {
     if (c->bstate->btype == BLOCKED_LIST ||
         c->bstate->btype == BLOCKED_ZSET ||
         c->bstate->btype == BLOCKED_STREAM ||
-        c->bstate->btype == BLOCKED_WAIT) {
+        c->bstate->btype == BLOCKED_WAIT)
+    {
         return 1;
     }
     return 0;
@@ -345,7 +346,8 @@ void disconnectOrRedirectAllBlockedClients(void) {
                 /* if the client is read-only and blocked by a read command, we do not unblock it */
                 if (c->flag.readonly && !(c->lastcmd->flags & CMD_WRITE)) continue;
                 if (clientSupportStandAloneRedirect(c) && (c->bstate->btype == BLOCKED_LIST || c->bstate->btype == BLOCKED_ZSET ||
-                                                           c->bstate->btype == BLOCKED_STREAM || c->bstate->btype == BLOCKED_MODULE)) {
+                                                           c->bstate->btype == BLOCKED_STREAM || c->bstate->btype == BLOCKED_MODULE))
+                {
                     if (c->bstate->btype == BLOCKED_MODULE && !moduleClientIsBlockedOnKeys(c)) continue;
                     /* Client has redirect capability and blocked on keys */
                     addReplyErrorSds(c, sdscatprintf(sdsempty(), "-REDIRECT %s:%d", server.primary_host, server.primary_port));
@@ -646,7 +648,8 @@ static void handleClientsBlockedOnKey(readyList *rl) {
              * 3. In case of XREADGROUP call we will want to unblock on any change in object type
              *    or in case the key was deleted, since the group is no longer valid. */
             if ((o != NULL && (receiver->bstate->btype == getBlockedTypeByType(o->type))) ||
-                (o != NULL && (receiver->bstate->btype == BLOCKED_MODULE)) || (receiver->bstate->unblock_on_nokey)) {
+                (o != NULL && (receiver->bstate->btype == BLOCKED_MODULE)) || (receiver->bstate->unblock_on_nokey))
+            {
                 if (receiver->bstate->btype != BLOCKED_MODULE)
                     unblockClientOnKey(receiver, rl->key);
                 else

--- a/src/childinfo.c
+++ b/src/childinfo.c
@@ -84,7 +84,8 @@ void sendChildInfoGeneric(childInfoType info_type, size_t keys, size_t repl_outp
 
     monotime now = getMonotonicUs();
     if (info_type != CHILD_INFO_TYPE_CURRENT_INFO || !cow_updated ||
-        now - cow_updated > cow_update_cost * CHILD_COW_DUTY_CYCLE) {
+        now - cow_updated > cow_update_cost * CHILD_COW_DUTY_CYCLE)
+    {
         cow = zmalloc_get_private_dirty(-1);
         cow_updated = getMonotonicUs();
         cow_update_cost = cow_updated - now;

--- a/src/cli_common.c
+++ b/src/cli_common.c
@@ -328,7 +328,8 @@ void parseUri(const char *uri, const char *tool_name, cliConnInfo *connInfo, int
 
     /* URI must start with a valid scheme. */
     if (!strncasecmp(tlsscheme, curr, strlen(tlsscheme)) ||
-        !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme))) {
+        !strncasecmp(redisTlsscheme, curr, strlen(redisTlsscheme)))
+    {
 #ifdef USE_OPENSSL
         *tls_flag = 1;
         const char *del = strstr(curr, "://");

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -488,7 +488,8 @@ void migrateCommand(client *c) {
 
     /* Sanity check */
     if (getLongFromObjectOrReply(c, c->argv[5], &timeout, NULL) != C_OK ||
-        getLongFromObjectOrReply(c, c->argv[4], &dbid, NULL) != C_OK) {
+        getLongFromObjectOrReply(c, c->argv[4], &dbid, NULL) != C_OK)
+    {
         return;
     }
     if (timeout <= 0) timeout = 1000;
@@ -1202,7 +1203,8 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
              * Allowing cross-DB COPY is possible, but it would require looking up the second key in the target DB.
              * The command should only be allowed if the key exists. We may revisit this decision in the future. */
             if (mcmd->proc == copyCommand &&
-                margc >= 4 && !strcasecmp(objectGetVal(margv[3]), "db")) {
+                margc >= 4 && !strcasecmp(objectGetVal(margv[3]), "db"))
+            {
                 long long value;
                 if (getLongLongFromObject(margv[4], &value) != C_OK || value != currentDb->id) {
                     if (error_code) *error_code = CLUSTER_REDIR_UNSTABLE;
@@ -1219,7 +1221,8 @@ clusterNode *getNodeByQuery(client *c, int *error_code) {
              * NODE <node-id>. */
             int flags = LOOKUP_NOTOUCH | LOOKUP_NOSTATS | LOOKUP_NONOTIFY | LOOKUP_NOEXPIRE;
             if (!pubsubshard_included &&
-                (!c->flag.multi || (c->flag.multi && c->cmd->proc == execCommand))) {
+                (!c->flag.multi || (c->flag.multi && c->cmd->proc == execCommand)))
+            {
                 /* Multi/Exec validation happens on exec */
                 if (lookupKeyReadWithFlags(currentDb, thiskey, flags) == NULL)
                     missing_keys++;
@@ -1295,7 +1298,8 @@ after_checking_each_key:
     int is_write_command =
         (cmd_flags & CMD_WRITE) || (c->cmd->proc == execCommand && (c->mstate->cmd_flags & CMD_WRITE));
     if ((c->flag.readonly || pubsubshard_included) && !is_write_command && clusterNodeIsReplica(myself) &&
-        clusterNodeGetPrimary(myself) == n) {
+        clusterNodeGetPrimary(myself) == n)
+    {
         return myself;
     }
 
@@ -1351,7 +1355,8 @@ void clusterRedirectClient(client *c, clusterNode *n, int hashslot, int error_co
 int clusterRedirectBlockedClientIfNeeded(client *c) {
     clusterNode *myself = getMyClusterNode();
     if (c->flag.blocked && (c->bstate->btype == BLOCKED_LIST || c->bstate->btype == BLOCKED_ZSET ||
-                            c->bstate->btype == BLOCKED_STREAM || c->bstate->btype == BLOCKED_MODULE)) {
+                            c->bstate->btype == BLOCKED_STREAM || c->bstate->btype == BLOCKED_MODULE))
+    {
         dictEntry *de;
         dictIterator *di;
 
@@ -1379,7 +1384,8 @@ int clusterRedirectBlockedClientIfNeeded(client *c) {
             /* if the client is read-only and attempting to access key that our
              * replica can handle, allow it. */
             if (c->flag.readonly && !(c->lastcmd->flags & CMD_WRITE) && clusterNodeIsReplica(myself) &&
-                clusterNodeGetPrimary(myself) == node) {
+                clusterNodeGetPrimary(myself) == node)
+            {
                 node = myself;
             }
 
@@ -1431,7 +1437,8 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         length++;
     }
     if (server.cluster_preferred_endpoint_type != CLUSTER_ENDPOINT_TYPE_HOSTNAME && hostname != NULL &&
-        hostname[0] != '\0') {
+        hostname[0] != '\0')
+    {
         length++;
     }
 
@@ -1447,7 +1454,8 @@ void addNodeToNodeReply(client *c, clusterNode *node) {
         length--;
     }
     if (server.cluster_preferred_endpoint_type != CLUSTER_ENDPOINT_TYPE_HOSTNAME && hostname != NULL &&
-        hostname[0] != '\0') {
+        hostname[0] != '\0')
+    {
         addReplyBulkCString(c, "hostname");
         addReplyBulkCString(c, hostname);
         length--;

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -814,7 +814,8 @@ int clusterLoadConfig(char *filename) {
             int field_found = 0;
             for (unsigned j = 0; j < numElements(auxFieldHandlers); j++) {
                 if (sdslen(field_argv[0]) != strlen(auxFieldHandlers[j].field) ||
-                    memcmp(field_argv[0], auxFieldHandlers[j].field, sdslen(field_argv[0])) != 0) {
+                    memcmp(field_argv[0], auxFieldHandlers[j].field, sdslen(field_argv[0])) != 0)
+                {
                     continue;
                 }
                 field_found = 1;
@@ -928,7 +929,8 @@ int clusterLoadConfig(char *filename) {
                 memcpy(n->shard_id, primary->shard_id, CLUSTER_NAMELEN);
                 clusterAddNodeToShard(primary->shard_id, n);
             } else if (clusterGetNodesInMyShard(primary) != NULL &&
-                       memcmp(primary->shard_id, n->shard_id, CLUSTER_NAMELEN) != 0) {
+                       memcmp(primary->shard_id, n->shard_id, CLUSTER_NAMELEN) != 0)
+            {
                 /* If the primary has been added to a shard and this replica has
                  * a different shard id stored in nodes.conf, update it to match
                  * the primary instead of aborting the startup. */
@@ -1370,7 +1372,8 @@ static void updateShardId(clusterNode *node, const char *shard_id) {
      * eventually resolve, if the primary crashes beforehand, it will enter a
      * crash-restart loop due to the mismatch in its nodes.conf. */
     if (shard_id && nodeIsReplica(node) &&
-        memcmp(clusterNodeGetPrimary(node)->shard_id, shard_id, CLUSTER_NAMELEN) != 0) {
+        memcmp(clusterNodeGetPrimary(node)->shard_id, shard_id, CLUSTER_NAMELEN) != 0)
+    {
         serverLog(
             LL_NOTICE,
             "Shard id %.40s update request for node id %.40s diverges from existing primary shard id %.40s, rejecting!",
@@ -1576,7 +1579,8 @@ void clusterAutoFailoverOnShutdown(void) {
         }
         if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE &&
             replica->repl_data->repl_ack_off == server.primary_repl_offset &&
-            replica->repl_data->replica_nodeid && sdslen(replica->repl_data->replica_nodeid) == CLUSTER_NAMELEN) {
+            replica->repl_data->replica_nodeid && sdslen(replica->repl_data->replica_nodeid) == CLUSTER_NAMELEN)
+        {
             best_replica = replica;
         }
     }
@@ -2619,7 +2623,8 @@ void clearNodeFailureIfNeeded(clusterNode *node) {
      * 2) It is yet serving slots from our point of view (not failed over).
      * Apparently no one is going to fix these slots, clear the FAIL flag. */
     if (clusterNodeIsVotingPrimary(node) &&
-        (now - node->fail_time) > (server.cluster_node_timeout * CLUSTER_FAIL_UNDO_TIME_MULT)) {
+        (now - node->fail_time) > (server.cluster_node_timeout * CLUSTER_FAIL_UNDO_TIME_MULT))
+    {
         serverLog(
             LL_NOTICE,
             "Clear FAIL state for node %.40s (%s): is reachable again and nobody is serving its slots after some time.",
@@ -2819,7 +2824,8 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
             if (!(flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_PFAIL)) &&
                 nodeInNormalState(node) &&
                 node->ping_sent == 0 &&
-                clusterNodeFailureReportsCount(node) == 0) {
+                clusterNodeFailureReportsCount(node) == 0)
+            {
                 mstime_t pongtime = ntohl(g->pong_received);
                 pongtime *= 1000; /* Convert back to milliseconds. */
 
@@ -2840,7 +2846,8 @@ void clusterProcessGossipSection(clusterMsg *hdr, clusterLink *link) {
             if (node->flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_PFAIL) && !(flags & CLUSTER_NODE_NOADDR) &&
                 !(flags & (CLUSTER_NODE_FAIL | CLUSTER_NODE_PFAIL)) &&
                 (strcasecmp(node->ip, g->ip) || node->tls_port != msg_tls_port ||
-                 node->tcp_port != msg_tcp_port || node->cport != ntohs(g->cport))) {
+                 node->tcp_port != msg_tcp_port || node->cport != ntohs(g->cport)))
+            {
                 if (node->link) freeClusterLink(node->link);
                 memcpy(node->ip, g->ip, NET_IP_STR_LEN);
                 node->tcp_port = msg_tcp_port;
@@ -3069,7 +3076,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
              * epoch. */
             if (isSlotUnclaimed(j) ||
                 server.cluster->slots[j]->configEpoch < senderConfigEpoch ||
-                clusterSlotFailoverGranted(j)) {
+                clusterSlotFailoverGranted(j))
+            {
                 if (!isSlotUnclaimed(j) && !areInSameShard(server.cluster->slots[j], sender)) {
                     if (first_migrated_slot == -1) {
                         /* Delay-initialize the range of migrated slots. */
@@ -3125,7 +3133,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
                 /* Handle the case where we are importing this slot and the ownership changes */
                 clusterNode *in = getImportingSlotSource(j);
                 if (in != NULL &&
-                    in != sender) {
+                    in != sender)
+                {
                     /* Update importing_slots_from to point to the sender, if it is in the
                      * same shard as the previous slot owner */
                     if (areInSameShard(sender, in)) {
@@ -3169,7 +3178,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
             if (mn != NULL && mn != sender &&
                 (mn->configEpoch < senderConfigEpoch ||
                  nodeIsReplica(mn)) &&
-                areInSameShard(mn, sender)) {
+                areInSameShard(mn, sender))
+            {
                 serverLog(LL_VERBOSE,
                           "Failover occurred in migration target."
                           " Slot %d is now being migrated to node %.40s (%s) in shard %.40s.",
@@ -3239,7 +3249,8 @@ void clusterUpdateSlotsConfigWith(clusterNode *sender, uint64_t senderConfigEpoc
      * the new primary if my current config epoch is lower than the
      * sender's. */
     if (!new_primary && myself->replicaof != sender && sender_slots == 0 && myself->numslots == 0 &&
-        nodeEpoch(myself) < senderConfigEpoch && are_in_same_shard) {
+        nodeEpoch(myself) < senderConfigEpoch && are_in_same_shard)
+    {
         new_primary = sender;
     }
 
@@ -3597,7 +3608,8 @@ static void clusterProcessPublishPacket(clusterMsgDataPublish *publish_data, uin
     /* Don't bother creating useless objects if there are no
      * Pub/Sub subscribers. */
     if ((type == CLUSTERMSG_TYPE_PUBLISH && serverPubsubSubscriptionCount() > 0) ||
-        (type == CLUSTERMSG_TYPE_PUBLISHSHARD && serverPubsubShardSubscriptionCount() > 0)) {
+        (type == CLUSTERMSG_TYPE_PUBLISHSHARD && serverPubsubShardSubscriptionCount() > 0))
+    {
         channel_len = ntohl(publish_data->channel_len);
         message_len = ntohl(publish_data->message_len);
         channel = createStringObject((char *)publish_data->bulk_data, channel_len);
@@ -3763,7 +3775,8 @@ int clusterIsValidPacket(clusterLink *link) {
         explen +=
             sizeof(clusterMsgDataPublish) - 8 + ntohl(publish_data->channel_len) + ntohl(publish_data->message_len);
     } else if (type == CLUSTERMSG_TYPE_FAILOVER_AUTH_REQUEST || type == CLUSTERMSG_TYPE_FAILOVER_AUTH_ACK ||
-               type == CLUSTERMSG_TYPE_MFSTART) {
+               type == CLUSTERMSG_TYPE_MFSTART)
+    {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
     } else if (type == CLUSTERMSG_TYPE_UPDATE) {
         explen = sizeof(clusterMsg) - sizeof(union clusterMsgData);
@@ -3817,7 +3830,8 @@ int clusterProcessPacket(clusterLink *link) {
         clusterMsgHeader *hdr = (clusterMsgHeader *)link->rcvbuf;
         uint16_t type = ntohs(hdr->type);
         if (server.debug_cluster_close_link_on_packet_drop &&
-            (type == server.cluster_drop_packet_filter || server.cluster_drop_packet_filter == -2)) {
+            (type == server.cluster_drop_packet_filter || server.cluster_drop_packet_filter == -2))
+        {
             freeClusterLink(link);
             serverLog(LL_WARNING, "Closing link for matching packet type %s", clusterGetMessageTypeString(type));
             return 0;
@@ -3915,7 +3929,8 @@ int clusterProcessPacket(clusterLink *link) {
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG);
 
             if (server.cluster->failover_auth_time && server.cluster->failover_auth_sent &&
-                sender->configEpoch >= server.cluster->failover_auth_epoch) {
+                sender->configEpoch >= server.cluster->failover_auth_epoch)
+            {
                 /* Another node has claimed an epoch greater than or equal to ours.
                  * If we have an ongoing election, reset it because we cannot win
                  * with an epoch smaller than or equal to the incoming claim. This
@@ -3938,7 +3953,8 @@ int clusterProcessPacket(clusterLink *link) {
         /* If we are a replica performing a manual failover and our primary
          * sent its offset while already paused, populate the MF state. */
         if (server.cluster->mf_end && nodeIsReplica(myself) && myself->replicaof == sender &&
-            msg->mflags[0] & CLUSTERMSG_FLAG0_PAUSED && server.cluster->mf_primary_offset == -1) {
+            msg->mflags[0] & CLUSTERMSG_FLAG0_PAUSED && server.cluster->mf_primary_offset == -1)
+        {
             server.cluster->mf_primary_offset = sender->repl_offset;
             clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_MANUALFAILOVER);
             serverLog(LL_NOTICE,
@@ -4138,7 +4154,8 @@ int clusterProcessPacket(clusterLink *link) {
 
         /* Update the node address if it changed. */
         if (sender && type == CLUSTERMSG_TYPE_PING && !nodeInHandshake(sender) &&
-            nodeUpdateAddressIfNeeded(sender, link, msg)) {
+            nodeUpdateAddressIfNeeded(sender, link, msg))
+        {
             clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
         }
 
@@ -4182,7 +4199,8 @@ int clusterProcessPacket(clusterLink *link) {
                     if (sender_claimed_primary && areInSameShard(sender_claimed_primary, sender)) {
                         /* `sender` was a primary and was in the same shard as its new primary */
                         if (nodeEpoch(sender) > sender_claimed_config_epoch ||
-                            nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch) {
+                            nodeEpoch(sender_claimed_primary) > sender_claimed_config_epoch)
+                        {
                             serverLog(LL_NOTICE,
                                       "Ignore stale message from %.40s (%s) in shard %.40s;"
                                       " gossip config epoch: %llu, current config epoch: %llu",
@@ -4311,7 +4329,8 @@ int clusterProcessPacket(clusterLink *link) {
          * this ASAP to avoid other computational expensive checks later.*/
 
         if (sender && sender_claims_to_be_primary &&
-            (sender_last_reported_as_replica || memcmp(sender->slots, msg->myslots, sizeof(msg->myslots)))) {
+            (sender_last_reported_as_replica || memcmp(sender->slots, msg->myslots, sizeof(msg->myslots))))
+        {
             /* Make sure CLUSTER_NODE_PRIMARY has already been set by now on sender */
             serverAssert(nodeIsPrimary(sender));
 
@@ -4372,7 +4391,8 @@ int clusterProcessPacket(clusterLink *link) {
         /* If our config epoch collides with the sender's try to fix
          * the problem. */
         if (sender && nodeIsPrimary(myself) && nodeIsPrimary(sender) &&
-            sender_claimed_config_epoch == myself->configEpoch) {
+            sender_claimed_config_epoch == myself->configEpoch)
+        {
             clusterHandleConfigEpochCollision(sender);
         }
 
@@ -4909,7 +4929,8 @@ void clusterSendPing(clusterLink *link, int type) {
          * 4) Disconnected nodes if they don't have configured slots.
          */
         if (this->flags & (CLUSTER_NODE_HANDSHAKE | CLUSTER_NODE_NOADDR) ||
-            (this->link == NULL && this->numslots == 0)) {
+            (this->link == NULL && this->numslots == 0))
+        {
             continue;
         }
 
@@ -5409,7 +5430,8 @@ int clusterGetReplicaRank(void) {
         if (primary->replicas[j]->repl_offset > myoffset) {
             rank++;
         } else if (primary->replicas[j]->repl_offset == myoffset &&
-                   memcmp(primary->replicas[j]->name, myself->name, CLUSTER_NAMELEN) < 0) {
+                   memcmp(primary->replicas[j]->name, myself->name, CLUSTER_NAMELEN) < 0)
+        {
             rank++;
         }
     }
@@ -5509,7 +5531,8 @@ void clusterLogCantFailover(int reason) {
 
     /* Special case: If the failure reason is due to data age, log 10 times less frequently. */
     if (reason == server.cluster->cant_failover_reason && reason == CLUSTER_CANT_FAILOVER_DATA_AGE &&
-        now - lastlog_time < 10 * CLUSTER_CANT_FAILOVER_RELOG_PERIOD) {
+        now - lastlog_time < 10 * CLUSTER_CANT_FAILOVER_RELOG_PERIOD)
+    {
         return;
     }
 
@@ -5628,7 +5651,8 @@ void clusterHandleReplicaFailover(void) {
      *    not a manual failover. */
     if (clusterNodeIsPrimary(myself) || myself->replicaof == NULL ||
         (!nodeFailed(myself->replicaof) && !manual_failover) ||
-        (server.cluster_replica_no_failover && !manual_failover)) {
+        (server.cluster_replica_no_failover && !manual_failover))
+    {
         /* There are no reasons to failover, so we set the reason why we
          * are returning without failing over to NONE. */
         server.cluster->cant_failover_reason = CLUSTER_CANT_FAILOVER_NONE;
@@ -5654,7 +5678,8 @@ void clusterHandleReplicaFailover(void) {
      * Check bypassed for manual failovers. */
     if (server.cluster_replica_validity_factor &&
         data_age > (((mstime_t)server.repl_ping_replica_period * 1000) +
-                    (server.cluster_node_timeout * server.cluster_replica_validity_factor))) {
+                    (server.cluster_node_timeout * server.cluster_replica_validity_factor)))
+    {
         if (!manual_failover) {
             clusterLogCantFailover(CLUSTER_CANT_FAILOVER_DATA_AGE);
             return;
@@ -5736,7 +5761,8 @@ void clusterHandleReplicaFailover(void) {
      *
      * Not performed if this is a manual failover. */
     if (server.cluster->failover_auth_sent == 0 && server.cluster->mf_end == 0 &&
-        server.cluster->failover_auth_time != now) {
+        server.cluster->failover_auth_time != now)
+    {
         int newrank = clusterGetReplicaRank();
         if (newrank != server.cluster->failover_auth_rank) {
             long long added_delay = (newrank - server.cluster->failover_auth_rank) * (delay * 2);
@@ -5907,7 +5933,8 @@ void clusterHandleReplicaMigration(int max_replicas) {
      * the natural replicas of this instance to advertise their switch from
      * the old primary to the new one. */
     if (target && candidate == myself && (mstime() - target->orphaned_time) > CLUSTER_REPLICA_MIGRATION_DELAY &&
-        !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) {
+        !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER))
+    {
         serverLog(LL_NOTICE, "Migrating to orphaned primary %.40s (%s) in shard %.40s", target->name,
                   humanNodename(target), target->shard_id);
         /* We are migrating to a different shard that has a completely different
@@ -6054,7 +6081,8 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
     if (nodeInNormalState(node) && node->link != NULL && node->inbound_link == NULL &&
         now - node->inbound_link_freed_time > getHandshakeTimeout() &&
         now - node->meet_sent > getHandshakeTimeout() &&
-        nodeSupportsMultiMeet(node)) {
+        nodeSupportsMultiMeet(node))
+    {
         /* Node has an outbound link, but no inbound link for more than the handshake timeout.
          * This probably means this node does not know us yet, whereas we know it.
          * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view.
@@ -6082,7 +6110,8 @@ static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long 
         link->conn = connCreate(connTypeOfCluster());
         connSetPrivateData(link->conn, link);
         if (connConnect(link->conn, node->ip, node->cport, server.bind_source_addr, 0, clusterLinkConnectHandler) ==
-            C_ERR) {
+            C_ERR)
+        {
             /* We got a synchronous error from connect before
              * clusterSendPing() had a chance to be called.
              * If node->ping_sent is zero, failure detection can't work,
@@ -6241,7 +6270,8 @@ void clusterCron(void) {
             /* and we are waiting for the pong more than timeout/2 */
             ping_delay > server.cluster_node_timeout / 2 &&
             /* and in such interval we are not seeing any traffic at all. */
-            data_delay > server.cluster_node_timeout / 2) {
+            data_delay > server.cluster_node_timeout / 2)
+        {
             /* Disconnect the link, it will be reconnected automatically. */
             freeClusterLink(node->link);
         }
@@ -6260,7 +6290,8 @@ void clusterCron(void) {
         /* If we are a primary and one of the replicas requested a manual
          * failover, ping it continuously. */
         if (server.cluster->mf_end && clusterNodeIsPrimary(myself) && server.cluster->mf_replica == node &&
-            node->link) {
+            node->link)
+        {
             clusterSendPing(node->link, CLUSTERMSG_TYPE_PING);
             continue;
         }
@@ -6350,7 +6381,8 @@ void clusterBeforeSleep(void) {
          * is likely that we can start the election or there is already
          * the quorum from primaries in order to react fast. */
         if (nodeIsReplica(myself) &&
-            !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) {
+            !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER))
+        {
             clusterHandleReplicaFailover();
         }
     }
@@ -6611,7 +6643,8 @@ void clusterUpdateState(void) {
      * to not count the DB loading time. */
     if (first_call_time == 0) first_call_time = mstime();
     if (clusterNodeIsPrimary(myself) && server.cluster->state == CLUSTER_FAIL &&
-        mstime() - first_call_time < CLUSTER_WRITABLE_DELAY) {
+        mstime() - first_call_time < CLUSTER_WRITABLE_DELAY)
+    {
         server.cluster->safe_to_join = 0;
         return;
     } else {
@@ -7976,7 +8009,8 @@ int clusterCommandSpecial(client *c) {
         clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE | CLUSTER_TODO_SAVE_CONFIG);
         addReply(c, shared.ok);
     } else if ((!strcasecmp(objectGetVal(c->argv[1]), "addslotsrange") || !strcasecmp(objectGetVal(c->argv[1]), "delslotsrange")) &&
-               c->argc >= 4) {
+               c->argc >= 4)
+    {
         if (c->argc % 2 == 1) {
             addReplyErrorArity(c);
             return 1;

--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -548,7 +548,8 @@ void clusterCommandSyncSlotsEstablish(client *c) {
     while (i < c->argc) {
         if (!strcasecmp(objectGetVal(c->argv[i]), "source")) {
             if (source_node || i + 1 >= c->argc ||
-                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN) {
+                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN)
+            {
                 addReplyErrorObject(c, shared.syntaxerr);
                 goto cleanup;
             }
@@ -576,7 +577,8 @@ void clusterCommandSyncSlotsEstablish(client *c) {
         }
         if (!strcasecmp(objectGetVal(c->argv[i]), "name")) {
             if (name || i + 1 >= c->argc ||
-                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN) {
+                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN)
+            {
                 addReplyErrorObject(c, shared.syntaxerr);
                 goto cleanup;
             }
@@ -737,7 +739,8 @@ void clusterCommandSyncSlotsFinish(client *c) {
         }
         if (!strcasecmp(objectGetVal(c->argv[i]), "name")) {
             if (name || i + 1 >= c->argc ||
-                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN) {
+                sdslen(objectGetVal(c->argv[i + 1])) != CLUSTER_NAMELEN)
+            {
                 addReplyErrorObject(c, shared.syntaxerr);
                 return;
             }
@@ -1196,7 +1199,8 @@ void clusterCommandMigrateSlots(client *c) {
         }
 
         if (curr_index + 1 >= c->argc ||
-            strcasecmp(objectGetVal(c->argv[curr_index]), "node")) {
+            strcasecmp(objectGetVal(c->argv[curr_index]), "node"))
+        {
             addReplyErrorObject(c, shared.syntaxerr);
             goto cleanup;
         }
@@ -1277,7 +1281,8 @@ void clusterCommandCancelSlotMigrations(client *c) {
     while ((ln = listNext(&li)) != NULL) {
         slotMigrationJob *job = ln->value;
         if (!isSlotMigrationJobInProgress(job) ||
-            job->type == SLOT_MIGRATION_IMPORT) {
+            job->type == SLOT_MIGRATION_IMPORT)
+        {
             continue;
         }
         finishSlotMigrationJob(job, SLOT_MIGRATION_JOB_CANCELLED, NULL);
@@ -1311,7 +1316,8 @@ int connectSlotExportJob(slotMigrationJob *job) {
 
     job->conn = connCreate(connTypeOfReplication());
     if (connConnect(job->conn, n->ip, port, server.bind_source_addr,
-                    0, slotExportConnectHandler) == C_ERR) {
+                    0, slotExportConnectHandler) == C_ERR)
+    {
         return C_ERR;
     }
 
@@ -1444,7 +1450,8 @@ int slotExportTryDoPause(slotMigrationJob *job) {
 
     if (server.debug_slot_migration_prevent_pause ||
         (server.slot_migration_max_failover_repl_bytes >= 0 &&
-         job->client->reply_bytes > (size_t)server.slot_migration_max_failover_repl_bytes)) {
+         job->client->reply_bytes > (size_t)server.slot_migration_max_failover_repl_bytes))
+    {
         return C_ERR;
     }
     serverLog(LL_NOTICE,
@@ -1468,7 +1475,8 @@ void clusterCommandSyncSlotsRequestPause(client *c) {
     serverAssert(isSlotMigrationJobInProgress(c->slot_migration_job));
     /* Child process may not have closed yet, so SNAPSHOTTING is okay here */
     if (c->slot_migration_job->state != SLOT_EXPORT_STREAMING &&
-        c->slot_migration_job->state != SLOT_EXPORT_SNAPSHOTTING) {
+        c->slot_migration_job->state != SLOT_EXPORT_SNAPSHOTTING)
+    {
         serverLog(LL_WARNING,
                   "Received CLUSTER SYNCSLOTS REQUEST-PAUSE for slot migration "
                   "%s, but the client was not streaming incremental updates. "
@@ -1902,7 +1910,8 @@ void slotMigrationJobReadEstablishResponse(connection *conn) {
     }
     if (sdslen(job->response_buf) < 2 ||
         job->response_buf[sdslen(job->response_buf) - 2] != '\r' ||
-        job->response_buf[sdslen(job->response_buf) - 1] != '\n') {
+        job->response_buf[sdslen(job->response_buf) - 1] != '\n')
+    {
         if (sdsavail(job->response_buf) == 0) {
             /* We filled up the buffer, and we still have no response. Only
              * choice is to stop the migration. */
@@ -2448,7 +2457,8 @@ void clusterCleanupSlotMigrationLog(size_t max_len) {
     listIter li;
     listRewindTail(server.cluster->slot_migration_jobs, &li);
     while (server.cluster->slot_migration_jobs->len > max_len &&
-           (ln = listNext(&li)) != NULL) {
+           (ln = listNext(&li)) != NULL)
+    {
         slotMigrationJob *job = ln->value;
         if (isSlotMigrationJobFinished(job)) {
             listDelNode(server.cluster->slot_migration_jobs, ln);
@@ -2488,7 +2498,8 @@ void clusterSlotMigrationCron(void) {
          * connection timeout, since we will use pause timeout. */
         if (isSlotMigrationJobInProgress(job) &&
             job->state != SLOT_EXPORT_FAILOVER_GRANTED &&
-            job->state != SLOT_IMPORT_OCCURRING_ON_PRIMARY) {
+            job->state != SLOT_IMPORT_OCCURRING_ON_PRIMARY)
+        {
             serverAssert(job->type == SLOT_MIGRATION_EXPORT || job->client);
             /* For imports, last interaction will be set to the last
              * incoming command, as replicated clients don't set
@@ -2500,7 +2511,8 @@ void clusterSlotMigrationCron(void) {
                                           : job->client->last_interaction;
 
             if (last_interaction &&
-                (server.unixtime - last_interaction > server.repl_timeout)) {
+                (server.unixtime - last_interaction > server.repl_timeout))
+            {
                 serverLog(LL_WARNING,
                           "Timing out slot migration %s "
                           "after not receiving ack for too long",
@@ -2516,7 +2528,8 @@ void clusterSlotMigrationCron(void) {
 
         if (isSlotMigrationJobInProgress(job) &&
             job->state != SLOT_EXPORT_FAILOVER_GRANTED &&
-            canSlotMigrationJobSendAck(job)) {
+            canSlotMigrationJobSendAck(job))
+        {
             /* For slot exports, the timer is refreshed on any interaction, so we
              * don't need to send an ACK if we wrote this cron loop already. */
             bool timer_already_refreshed = (job->type != SLOT_MIGRATION_IMPORT && job->client->flag.pending_write);
@@ -2619,7 +2632,8 @@ void clusterCommandSyncSlots(client *c) {
         return;
     }
     if (c->slot_migration_job &&
-        isSlotMigrationJobInProgress(c->slot_migration_job)) {
+        isSlotMigrationJobInProgress(c->slot_migration_job))
+    {
         serverLog(LL_WARNING, "Received unknown SYNCSLOTS subcommand from "
                               "slot migration %s. Failing the migration.",
                   c->slot_migration_job->description);

--- a/src/cluster_slot_stats.c
+++ b/src/cluster_slot_stats.c
@@ -263,7 +263,8 @@ void clusterSlotStatsCommand(client *c) {
         /* CLUSTER SLOT-STATS SLOTSRANGE start-slot end-slot */
         int startslot, endslot;
         if ((startslot = getSlotOrReply(c, c->argv[3])) == -1 ||
-            (endslot = getSlotOrReply(c, c->argv[4])) == -1) {
+            (endslot = getSlotOrReply(c, c->argv[4])) == -1)
+        {
             return;
         }
         if (startslot > endslot) {
@@ -299,7 +300,8 @@ void clusterSlotStatsCommand(client *c) {
             if (!strcasecmp(objectGetVal(c->argv[i]), "limit") && moreargs) {
                 if (getRangeLongFromObjectOrReply(
                         c, c->argv[i + 1], 1, CLUSTER_SLOTS, &limit,
-                        "Limit has to lie in between 1 and 16384 (maximum number of slots).") != C_OK) {
+                        "Limit has to lie in between 1 and 16384 (maximum number of slots).") != C_OK)
+                {
                     return;
                 }
                 i++;

--- a/src/commandlog.c
+++ b/src/commandlog.c
@@ -47,7 +47,8 @@ static commandlogEntry *commandlogCreateEntry(client *c, robj **argv, int argc, 
                 ce->argv[j] = shared.redacted;
                 /* Trim too long strings as well... */
             } else if (argv[j]->type == OBJ_STRING && sdsEncodedObject(argv[j]) &&
-                       sdslen(objectGetVal(argv[j])) > COMMANDLOG_ENTRY_MAX_STRING) {
+                       sdslen(objectGetVal(argv[j])) > COMMANDLOG_ENTRY_MAX_STRING)
+            {
                 sds s = sdsnewlen(objectGetVal(argv[j]), COMMANDLOG_ENTRY_MAX_STRING);
 
                 s = sdscatprintf(s, "... (%lu more bytes)",

--- a/src/config.c
+++ b/src/config.c
@@ -847,7 +847,8 @@ void configSetCommand(client *c) {
         if (invalid_args) continue;
 
         if (config->flags & IMMUTABLE_CONFIG ||
-            (config->flags & PROTECTED_CONFIG && !allowProtectedAction(server.enable_protected_configs, c))) {
+            (config->flags & PROTECTED_CONFIG && !allowProtectedAction(server.enable_protected_configs, c)))
+        {
             /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
             errstr = (config->flags & IMMUTABLE_CONFIG) ? "can't set immutable config" : "can't set protected config";
             err_arg_name = objectGetVal(c->argv[2 + i * 2]);
@@ -1183,7 +1184,8 @@ struct rewriteConfigState *rewriteConfigReadOldFile(char *path) {
              /* The following is a list of config features that are only supported in
               * config file parsing and are not recognized by lookupConfig */
              strcasecmp(argv[0], "include") && strcasecmp(argv[0], "rename-command") && strcasecmp(argv[0], "user") &&
-             strcasecmp(argv[0], "loadmodule") && strcasecmp(argv[0], "sentinel"))) {
+             strcasecmp(argv[0], "loadmodule") && strcasecmp(argv[0], "sentinel")))
+        {
             /* The line is either unparsable for some reason, for
              * instance it may have unbalanced quotes, may contain a
              * config that doesn't exist anymore, for instance a module that got
@@ -2132,7 +2134,8 @@ static int numericBoundaryCheck(standardConfig *config, long long ll, const char
     if (config->data.numeric.numeric_type == NUMERIC_TYPE_ULONG_LONG ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_ULONG ||
         config->data.numeric.numeric_type == NUMERIC_TYPE_UINT ||
-        config->data.numeric.numeric_type == NUMERIC_TYPE_SIZE_T) {
+        config->data.numeric.numeric_type == NUMERIC_TYPE_SIZE_T)
+    {
         /* Boundary check for unsigned types */
         unsigned long long ull = ll;
         unsigned long long upper_bound = config->data.numeric.upper_bound;
@@ -2159,7 +2162,8 @@ static int numericBoundaryCheck(standardConfig *config, long long ll, const char
             }
         }
         /* Boundary check for signed types */
-        else if (ll > config->data.numeric.upper_bound || ll < config->data.numeric.lower_bound) {
+        else if (ll > config->data.numeric.upper_bound || ll < config->data.numeric.lower_bound)
+        {
             snprintf(loadbuf, LOADBUF_SIZE, "argument must be between %lld and %lld inclusive",
                      config->data.numeric.lower_bound, config->data.numeric.upper_bound);
             *err = loadbuf;
@@ -2186,7 +2190,8 @@ static int numericParseString(standardConfig *config, sds value, const char **er
 
     /* Attempt to parse as percent */
     if (config->data.numeric.flags & PERCENT_CONFIG && sdslen(value) > 1 && value[sdslen(value) - 1] == '%' &&
-        string2ll(value, sdslen(value) - 1, res) && *res >= 0) {
+        string2ll(value, sdslen(value) - 1, res) && *res >= 0)
+    {
         /* We store percentage as negative value */
         *res = -*res;
         return 1;
@@ -2797,7 +2802,8 @@ static int applyTlsCfg(const char **err) {
 
     /* If TLS is enabled, try to configure OpenSSL. */
     if ((server.tls_port || server.tls_replication || server.tls_cluster) &&
-        connTypeConfigure(connectionTypeTls(), &server.tls_ctx_config, 1) == C_ERR) {
+        connTypeConfigure(connectionTypeTls(), &server.tls_ctx_config, 1) == C_ERR)
+    {
         *err = "Unable to update TLS configuration. Check server logs.";
         return 0;
     }
@@ -2968,7 +2974,8 @@ static int setConfigOOMScoreAdjValuesOption(standardConfig *config, sds *argv, i
      */
 
     if (values[CONFIG_OOM_REPLICA] < values[CONFIG_OOM_PRIMARY] ||
-        values[CONFIG_OOM_BGCHILD] < values[CONFIG_OOM_REPLICA]) {
+        values[CONFIG_OOM_BGCHILD] < values[CONFIG_OOM_REPLICA])
+    {
         serverLog(LL_WARNING, "The oom-score-adj-values configuration may not work for non-privileged processes! "
                               "Please consult the documentation.");
     }

--- a/src/db.c
+++ b/src/db.c
@@ -249,7 +249,8 @@ int getKeySlot(sds key) {
      * so we must always recompute the slot for commands coming from the primary or AOF.
      */
     if (server.current_client && server.current_client->slot >= 0 && server.current_client->flag.executing_command &&
-        !mustObeyClient(server.current_client)) {
+        !mustObeyClient(server.current_client))
+    {
         debugServerAssertWithInfo(server.current_client, NULL,
                                   (int)keyHashSlot(key, (int)sdslen(key)) == server.current_client->slot);
         return server.current_client->slot;
@@ -341,7 +342,8 @@ static void dbSetValue(serverDb *db, robj *key, robj **valref, int overwrite, vo
     }
 
     if ((old->refcount == 1 && old->encoding != OBJ_ENCODING_EMBSTR) &&
-        (val->refcount == 1 && val->encoding != OBJ_ENCODING_EMBSTR)) {
+        (val->refcount == 1 && val->encoding != OBJ_ENCODING_EMBSTR))
+    {
         /* Keep old object in the database. Just swap it's ptr, type and
          * encoding with the content of val. */
         int tmp_type = old->type;
@@ -2951,7 +2953,8 @@ int setGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *
     for (int i = 3; i < argc; i++) {
         char *arg = objectGetVal(argv[i]);
         if ((arg[0] == 'g' || arg[0] == 'G') && (arg[1] == 'e' || arg[1] == 'E') && (arg[2] == 't' || arg[2] == 'T') &&
-            arg[3] == '\0') {
+            arg[3] == '\0')
+        {
             keys[0].flags = CMD_KEY_RW | CMD_KEY_ACCESS | CMD_KEY_UPDATE;
             return 1;
         }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -279,7 +279,8 @@ static void activeDefragZsetNode(void *privdata, void *entry_ref) {
         zskiplistNode *next = x->level[i].forward;
         while (next &&
                (next->score < score ||
-                (next->score == score && sdscmp(zslGetNodeElement(next), ele) < 0))) {
+                (next->score == score && sdscmp(zslGetNodeElement(next), ele) < 0)))
+        {
             x = next;
             next = x->level[i].forward;
         }
@@ -874,7 +875,8 @@ static doneStatus defragLaterStep(monotime endtime, void *privdata) {
         }
 
         if (++iterations > 16 || server.stat_active_defrag_hits > prev_defragged ||
-            server.stat_active_defrag_scanned - prev_scanned > 64) {
+            server.stat_active_defrag_scanned - prev_scanned > 64)
+        {
             if (getMonotonicUs() > endtime) break;
             iterations = 0;
             prev_defragged = server.stat_active_defrag_hits;

--- a/src/evict.c
+++ b/src/evict.c
@@ -445,7 +445,8 @@ int performEvictions(void) {
         robj *valkey;
 
         if (server.maxmemory_policy & (MAXMEMORY_FLAG_LRU | MAXMEMORY_FLAG_LFU) ||
-            server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL) {
+            server.maxmemory_policy == MAXMEMORY_VOLATILE_TTL)
+        {
             struct evictionPoolEntry *pool = EvictionPoolLRU;
             while (bestkey == NULL) {
                 unsigned long total_keys = 0;
@@ -517,7 +518,8 @@ int performEvictions(void) {
 
         /* volatile-random and allkeys-random policy */
         else if (server.maxmemory_policy == MAXMEMORY_ALLKEYS_RANDOM ||
-                 server.maxmemory_policy == MAXMEMORY_VOLATILE_RANDOM) {
+                 server.maxmemory_policy == MAXMEMORY_VOLATILE_RANDOM)
+        {
             /* When evicting a random key, we try to evict a key for
              * each DB, so we use the static 'next_db' variable to
              * incrementally visit all DBs. */

--- a/src/functions.c
+++ b/src/functions.c
@@ -409,7 +409,8 @@ libraryJoin(functionsLibCtx *functions_lib_ctx_dst, functionsLibCtx *functions_l
     while ((entry = dictNext(iter))) {
         functionInfo *fi = dictGetVal(entry);
         if (dictFetchValue(functions_lib_ctx_dst->functions,
-                           objectGetVal(fi->compiled_function->name))) {
+                           objectGetVal(fi->compiled_function->name)))
+        {
             *err = sdscatfmt(sdsempty(),
                              "Function %s already exists",
                              objectGetVal(fi->compiled_function->name));
@@ -825,7 +826,8 @@ void functionRestoreCommand(client *c) {
         functions_lib_ctx = NULL; /* avoid releasing the f_ctx in the end */
     } else {
         if (libraryJoin(curr_functions_lib_ctx, functions_lib_ctx, restore_replicy == restorePolicy_Replace, &err) !=
-            C_OK) {
+            C_OK)
+        {
             goto load_error;
         }
     }
@@ -923,7 +925,8 @@ static int functionsVerifyName(sds name) {
     for (size_t i = 0; i < sdslen(name); ++i) {
         char curr_char = name[i];
         if ((curr_char >= 'a' && curr_char <= 'z') || (curr_char >= 'A' && curr_char <= 'Z') ||
-            (curr_char >= '0' && curr_char <= '9') || (curr_char == '_')) {
+            (curr_char >= '0' && curr_char <= '9') || (curr_char == '_'))
+        {
             continue;
         }
         return C_ERR;
@@ -1085,7 +1088,8 @@ sds functionsCreateWithLibraryCtx(sds code, int replace, sds *err, functionsLibC
     while ((entry = dictNext(iter))) {
         functionInfo *fi = dictGetVal(entry);
         if (dictFetchValue(lib_ctx->functions,
-                           objectGetVal(fi->compiled_function->name))) {
+                           objectGetVal(fi->compiled_function->name)))
+        {
             /* functions name collision, abort. */
             *err = sdscatfmt(sdsempty(), "Function %s already exists",
                              objectGetVal(fi->compiled_function->name));

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -526,7 +526,8 @@ void generateRandomSpecialValue(FuzzerCommand *cmd, ConfigEntry *entry, const ch
         appendArg(cmd, percentiles);
     } else if (strcasecmp(config_name, "rdma-bind") == 0 ||
                strcasecmp(config_name, "bind") == 0 ||
-               strcasecmp(config_name, "dir") == 0) {
+               strcasecmp(config_name, "dir") == 0)
+    {
         /* For these configs, use the current value as we don't want to change them */
         appendArg(cmd, sdsnew(entry->value));
     } else {
@@ -1431,7 +1432,8 @@ static void generateStringArgValue(FuzzerCommand *cmd, const char *argName, Comm
         appendArg(cmd, sdscatprintf(sdsempty(), "\"%s\"", serialized_values[rand() % 2]));
     } else if (strcmp(argName, "member") == 0 ||
                strcmp(argName, "member1") == 0 ||
-               strcmp(argName, "member2") == 0) {
+               strcmp(argName, "member2") == 0)
+    {
         appendArg(cmd, sdscatprintf(sdsempty(), "member:%d", rand() % 50));
     } else if (strcmp(argName, "host") == 0) {
         appendArg(cmd, sdscatprintf(sdsempty(), "host-%d.example.com", rand() % 5));
@@ -1487,13 +1489,15 @@ static void generateStringArgValue(FuzzerCommand *cmd, const char *argName, Comm
     } else if (strcmp(argName, "function-code") == 0) {
         appendArg(cmd, sdscatprintf(sdsempty(), "\"#!lua name=myfunc%d \nserver.register_function('test', function(keys, args) return args[1] end) \"", rand() % 5));
     } else if (strcmp(argName, "library-name") == 0 || strcmp(argName, "library-name-pattern") == 0 ||
-               strcmp(argName, "lib-name") == 0 || strcmp(argName, "libname") == 0) {
+               strcmp(argName, "lib-name") == 0 || strcmp(argName, "libname") == 0)
+    {
         appendArg(cmd, sdscatprintf(sdsempty(), "lib%d", rand() % 5));
     } else if (strcmp(argName, "libver") == 0 || strcmp(argName, "lib-ver") == 0) {
         appendArg(cmd, sdscatprintf(sdsempty(), "%d.%d.%d", rand() % 10, rand() % 10, rand() % 10));
     } else if (strcmp(argName, "node-id") == 0 || strcmp(argName, "nodename") == 0 ||
                strcmp(argName, "importing") == 0 || strcmp(argName, "migrating") == 0 ||
-               strcmp(argName, "node") == 0) {
+               strcmp(argName, "node") == 0)
+    {
         appendArg(cmd, sdscatprintf(sdsempty(), "%08x%08x%08x%08x%08x",
                                     rand(), rand(), rand(), rand(), rand()));
     } else if (strcmp(argName, "encoding") == 0) {
@@ -1510,7 +1514,8 @@ static void generateStringArgValue(FuzzerCommand *cmd, const char *argName, Comm
         appendArg(cmd, sdscatprintf(sdsempty(), "%08x%08x%08x%08x%08x",
                                     rand(), rand(), rand(), rand(), rand()));
     } else if (strcmp(argName, "last-id") == 0 || strcmp(argName, "lastid") == 0 ||
-               strcmp(argName, "max-deleted-id") == 0) {
+               strcmp(argName, "max-deleted-id") == 0)
+    {
         appendArg(cmd, sdscatprintf(sdsempty(), "%d-%d", rand() % 1000, rand() % 1000));
     } else if (strcmp(argName, "min-idle-time") == 0) {
         appendArg(cmd, sdscatprintf(sdsempty(), "%d", rand() % 10000));
@@ -1692,7 +1697,8 @@ static CommandEntry *handlePubSubCommandSelection(void) {
     if ((strcasecmp(selectedCommand->fullname, "UNSUBSCRIBE") == 0 && client_ctx->subscribe_type == 0) ||
         (strcasecmp(selectedCommand->fullname, "PUNSUBSCRIBE") == 0 && client_ctx->subscribe_type == 1) ||
         (strcasecmp(selectedCommand->fullname, "SUNSUBSCRIBE") == 0 && client_ctx->subscribe_type == 2) ||
-        (strcasecmp(selectedCommand->fullname, "RESET") == 0)) {
+        (strcasecmp(selectedCommand->fullname, "RESET") == 0))
+    {
         client_ctx->in_subscribe_mode = 0;
         client_ctx->subscribe_type = 0;
     }

--- a/src/geo.c
+++ b/src/geo.c
@@ -191,7 +191,8 @@ int extractDistanceOrReply(client *c, robj **argv, double *conversion, double *r
 int extractBoxOrReply(client *c, robj **argv, double *conversion, double *width, double *height) {
     double h, w;
     if ((getDoubleFromObjectOrReply(c, argv[0], &w, "need numeric width") != C_OK) ||
-        (getDoubleFromObjectOrReply(c, argv[1], &h, "need numeric height") != C_OK)) {
+        (getDoubleFromObjectOrReply(c, argv[1], &h, "need numeric height") != C_OK))
+    {
         return C_ERR;
     }
 
@@ -416,7 +417,8 @@ int membersOfAllNeighbors(robj *zobj, const GeoHashRadius *n, GeoShape *shape, g
          * elements. Skip every range which is the same as the one
          * processed previously. */
         if (last_processed && neighbors[i].bits == neighbors[last_processed].bits &&
-            neighbors[i].step == neighbors[last_processed].step) {
+            neighbors[i].step == neighbors[last_processed].step)
+        {
             if (debugmsg) D("Skipping processing of %d, same as previous\n", i);
             continue;
         }
@@ -602,12 +604,14 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
                 }
                 i++;
             } else if (!strcasecmp(arg, "store") && (i + 1) < remaining && !(flags & RADIUS_NOSTORE) &&
-                       !(flags & GEOSEARCH)) {
+                       !(flags & GEOSEARCH))
+            {
                 storekey = c->argv[base_args + i + 1];
                 storedist = 0;
                 i++;
             } else if (!strcasecmp(arg, "storedist") && (i + 1) < remaining && !(flags & RADIUS_NOSTORE) &&
-                       !(flags & GEOSEARCH)) {
+                       !(flags & GEOSEARCH))
+            {
                 storekey = c->argv[base_args + i + 1];
                 storedist = 1;
                 i++;

--- a/src/geohash.c
+++ b/src/geohash.c
@@ -134,7 +134,8 @@ int geohashEncode(const GeoHashRange *long_range,
     hash->step = step;
 
     if (latitude < lat_range->min || latitude > lat_range->max || longitude < long_range->min ||
-        longitude > long_range->max) {
+        longitude > long_range->max)
+    {
         return 0;
     }
 

--- a/src/geohash_helper.c
+++ b/src/geohash_helper.c
@@ -357,7 +357,8 @@ int geohashGetDistanceIfInPolygon(double centroidLon, double centroidLat, double
         double *vertexA = vertices[i];
         double *vertexB = vertices[j];
         if (((vertexA[1] > point[1]) != (vertexB[1] > point[1])) &&
-            (point[0] < (vertexB[0] - vertexA[0]) * (point[1] - vertexA[1]) / (vertexB[1] - vertexA[1]) + vertexA[0])) {
+            (point[0] < (vertexB[0] - vertexA[0]) * (point[1] - vertexA[1]) / (vertexB[1] - vertexA[1]) + vertexA[0]))
+        {
             inside = !inside;
         }
     }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2281,7 +2281,8 @@ bool hashtableNext(hashtableIterator *iterator, void **elemptr) {
                      * we can do the compaction now when we're done with a
                      * bucket chain, before we move on to the next index. */
                     if (iter->hashtable->pause_rehash == 1 &&
-                        iter->hashtable->used[iter->table] < iter->last_seen_size) {
+                        iter->hashtable->used[iter->table] < iter->last_seen_size)
+                    {
                         compactBucketChain(iter->hashtable, iter->index, iter->table);
                     }
                     iter->last_seen_size = iter->hashtable->used[iter->table];

--- a/src/hyperloglog.c
+++ b/src/hyperloglog.c
@@ -2040,7 +2040,8 @@ void pfdebugCommand(client *c) {
         }
     }
     /* PFDEBUG DECODE <key> */
-    else if (!strcasecmp(cmd, "decode")) {
+    else if (!strcasecmp(cmd, "decode"))
+    {
         if (c->argc != 3) goto arityerr;
 
         uint8_t *p = objectGetVal(o), *end = p + sdslen(objectGetVal(o));
@@ -2076,14 +2077,16 @@ void pfdebugCommand(client *c) {
         sdsfree(decoded);
     }
     /* PFDEBUG ENCODING <key> */
-    else if (!strcasecmp(cmd, "encoding")) {
+    else if (!strcasecmp(cmd, "encoding"))
+    {
         char *encodingstr[2] = {"dense", "sparse"};
         if (c->argc != 3) goto arityerr;
 
         addReplyStatus(c, encodingstr[hdr->encoding]);
     }
     /* PFDEBUG TODENSE <key> */
-    else if (!strcasecmp(cmd, "todense")) {
+    else if (!strcasecmp(cmd, "todense"))
+    {
         int conv = 0;
         if (c->argc != 3) goto arityerr;
 

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -226,7 +226,8 @@ void IOThreadsAfterSleep(int numevents) {
         serverLog(LL_DEBUG, "IO threads increased from %zu to %zu", active, target);
     }
     /* Scale Down*/
-    else if (target < active) {
+    else if (target < active)
+    {
         int tid = active - 1;
 
         /* Don't suspend if work remains in the specific thread's queue... */

--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -187,7 +187,8 @@ size_t reqresAppendRequest(client *c) {
     if (!strcasecmp(cmd, "debug") || /* because of DEBUG SEGFAULT */
         !strcasecmp(cmd, "sync") || !strcasecmp(cmd, "psync") || !strcasecmp(cmd, "monitor") ||
         !strcasecmp(cmd, "subscribe") || !strcasecmp(cmd, "unsubscribe") || !strcasecmp(cmd, "ssubscribe") ||
-        !strcasecmp(cmd, "sunsubscribe") || !strcasecmp(cmd, "psubscribe") || !strcasecmp(cmd, "punsubscribe")) {
+        !strcasecmp(cmd, "sunsubscribe") || !strcasecmp(cmd, "psubscribe") || !strcasecmp(cmd, "punsubscribe"))
+    {
         return 0;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -2008,7 +2008,8 @@ int VM_SetCommandInfo(ValkeyModuleCommand *command, const ValkeyModuleCommandInf
         !(cmd->key_specs_num == 0 ||
           /* Allow key spec populated from legacy (first,last,step) to exist. */
           (cmd->key_specs_num == 1 && cmd->key_specs[0].begin_search_type == KSPEC_BS_INDEX &&
-           cmd->key_specs[0].find_keys_type == KSPEC_FK_RANGE))) {
+           cmd->key_specs[0].find_keys_type == KSPEC_FK_RANGE)))
+    {
         errno = EEXIST;
         return VALKEYMODULE_ERR;
     }
@@ -4865,11 +4866,13 @@ int VM_ListInsert(ValkeyModuleKey *key, long index, ValkeyModuleString *value) {
         /* Insert in empty key => push. */
         return VM_ListPush(key, VALKEYMODULE_LIST_TAIL, value);
     } else if (key != NULL && key->value != NULL && key->value->type == OBJ_LIST &&
-               (index == (long)listTypeLength(key->value) || index == -1)) {
+               (index == (long)listTypeLength(key->value) || index == -1))
+    {
         /* Insert after the last element => push tail. */
         return VM_ListPush(key, VALKEYMODULE_LIST_TAIL, value);
     } else if (key != NULL && key->value != NULL && key->value->type == OBJ_LIST &&
-               (index == 0 || index == -(long)listTypeLength(key->value) - 1)) {
+               (index == 0 || index == -(long)listTypeLength(key->value) - 1))
+    {
         /* Insert before the first element => push head. */
         return VM_ListPush(key, VALKEYMODULE_LIST_HEAD, value);
     }
@@ -5468,7 +5471,8 @@ int VM_HashHasStringRef(ValkeyModuleKey *key, ValkeyModuleString *field) {
 int VM_HashSet(ValkeyModuleKey *key, int flags, ...) {
     va_list ap;
     if (!key || (flags & ~(VALKEYMODULE_HASH_NX | VALKEYMODULE_HASH_XX | VALKEYMODULE_HASH_CFIELDS |
-                           VALKEYMODULE_HASH_COUNT_ALL))) {
+                           VALKEYMODULE_HASH_COUNT_ALL)))
+    {
         errno = EINVAL;
         return 0;
     } else if (key->value && key->value->type != OBJ_HASH) {
@@ -6832,7 +6836,8 @@ static void moduleCallCommandHelper(ValkeyModuleCtx *ctx, client *c, robj **argv
         /* If the script already made a modification to the dataset, we can't
          * fail it on unpredictable error state. */
         if ((is_running_script && !scriptIsWriteDirty() && cmd_flags & CMD_WRITE) ||
-            (!is_running_script && cmd_flags & CMD_WRITE)) {
+            (!is_running_script && cmd_flags & CMD_WRITE))
+        {
             /* on script mode, if a command is a write command,
              * We will not run it if we encounter disk error
              * or we do not have enough replicas */
@@ -6870,7 +6875,8 @@ static void moduleCallCommandHelper(ValkeyModuleCtx *ctx, client *c, robj **argv
         }
 
         if (server.primary_host && server.repl_state != REPL_STATE_CONNECTED && server.repl_serve_stale_data == 0 &&
-            !(cmd_flags & CMD_STALE)) {
+            !(cmd_flags & CMD_STALE))
+        {
             errno = ESPIPE;
             if (error_as_call_replies) {
                 if (is_running_script) {
@@ -7203,7 +7209,8 @@ moduleType *moduleTypeLookupModuleByNameInternal(const char *name, int ignore_ca
         while ((ln = listNext(&li))) {
             moduleType *mt = ln->value;
             if ((!ignore_case && memcmp(name, mt->name, sizeof(mt->name)) == 0) ||
-                (ignore_case && !strcasecmp(name, mt->name))) {
+                (ignore_case && !strcasecmp(name, mt->name)))
+            {
                 dictReleaseIterator(di);
                 return mt;
             }
@@ -9495,7 +9502,8 @@ void moduleNotifyKeyspaceEvent(int type, const char *event, robj *key, int dbid)
         /* Only notify subscribers on events matching the registration,
          * and avoid subscribers triggering themselves */
         if ((sub->event_mask & type) &&
-            (sub->active == 0 || (sub->module->options & VALKEYMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS))) {
+            (sub->active == 0 || (sub->module->options & VALKEYMODULE_OPTIONS_ALLOW_NESTED_KEYSPACE_NOTIFICATIONS)))
+        {
             ValkeyModuleCtx ctx;
             if (server.executing_client == NULL) {
                 moduleCreateContext(&ctx, sub->module, VALKEYMODULE_CTX_TEMP_CLIENT);
@@ -11044,7 +11052,8 @@ int VM_InfoAddSection(ValkeyModuleInfoCtx *ctx, const char *name) {
      * 3) this specific section was requested. */
     if (ctx->requested_sections) {
         if ((!full_name || !dictFind(ctx->requested_sections, full_name)) &&
-            (!dictFind(ctx->requested_sections, ctx->module->name))) {
+            (!dictFind(ctx->requested_sections, ctx->module->name)))
+        {
             sdsfree(full_name);
             ctx->in_section = 0;
             return VALKEYMODULE_ERR;
@@ -13530,7 +13539,8 @@ int isModuleConfigNameRegistered(ValkeyModule *module, const char *name) {
 int moduleVerifyConfigFlags(unsigned int flags, configType type) {
     if ((flags & ~(VALKEYMODULE_CONFIG_DEFAULT | VALKEYMODULE_CONFIG_IMMUTABLE | VALKEYMODULE_CONFIG_SENSITIVE |
                    VALKEYMODULE_CONFIG_HIDDEN | VALKEYMODULE_CONFIG_PROTECTED | VALKEYMODULE_CONFIG_DENY_LOADING |
-                   VALKEYMODULE_CONFIG_BITFLAGS | VALKEYMODULE_CONFIG_MEMORY | VALKEYMODULE_CONFIG_UNSIGNED))) {
+                   VALKEYMODULE_CONFIG_BITFLAGS | VALKEYMODULE_CONFIG_MEMORY | VALKEYMODULE_CONFIG_UNSIGNED)))
+    {
         serverLogRaw(LL_WARNING, "Invalid flag(s) for configuration");
         return VALKEYMODULE_ERR;
     }
@@ -13555,7 +13565,8 @@ int moduleVerifyResourceName(const char *name) {
     for (size_t i = 0; name[i] != '\0'; i++) {
         char curr_char = name[i];
         if ((curr_char >= 'a' && curr_char <= 'z') || (curr_char >= 'A' && curr_char <= 'Z') ||
-            (curr_char >= '0' && curr_char <= '9') || (curr_char == '_') || (curr_char == '-')) {
+            (curr_char >= '0' && curr_char <= '9') || (curr_char == '_') || (curr_char == '-'))
+        {
             continue;
         }
         serverLog(LL_WARNING, "Invalid character %c in Module resource name %s.", curr_char, name);
@@ -14197,7 +14208,8 @@ int VM_RegisterScriptingEngine(ValkeyModuleCtx *module_ctx,
     if (scriptingEngineManagerRegister(engine_name,
                                        module_ctx->module,
                                        engine_ctx,
-                                       engine_methods) != C_OK) {
+                                       engine_methods) != C_OK)
+    {
         return VALKEYMODULE_ERR;
     }
 

--- a/src/networking.c
+++ b/src/networking.c
@@ -410,7 +410,8 @@ void putClientInPendingWriteQueue(client *c) {
         (!c->repl_data ||
          c->repl_data->repl_state == REPL_STATE_NONE ||
          (isReplicaReadyForReplData(c) && !c->repl_data->repl_start_cmd_stream_on_ack)) &&
-        clusterSlotMigrationShouldInstallWriteHandler(c)) {
+        clusterSlotMigrationShouldInstallWriteHandler(c))
+    {
         /* Here instead of installing the write handler, we just flag the
          * client and put it into a list of clients that have something
          * to write to the socket. This way before re-entering the event
@@ -546,7 +547,8 @@ static size_t upsertPayloadHeader(char *buf,
     /* Try to add payload to last chunk if possible */
     if (*last_header != NULL && (*last_header)->payload_type == type && (*last_header)->slot == slot &&
         (*last_header)->track_bytes == track_bytes &&
-        !atomic_load_explicit(&(*last_header)->tracked_for_cob, memory_order_acquire)) {
+        !atomic_load_explicit(&(*last_header)->tracked_for_cob, memory_order_acquire))
+    {
         (*last_header)->payload_len += allowed_len;
         return allowed_len;
     }
@@ -866,7 +868,8 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
         /* After the errors RAX reaches its limit, instead of tracking
          * custom errors (e.g. LUA), we track the error under `errorstat_ERRORSTATS_OVERFLOW` */
         if (flags & ERR_REPLY_FLAG_CUSTOM && raxSize(server.errors) >= ERRORSTATS_LIMIT &&
-            !raxFind(server.errors, (unsigned char *)err_prefix, prefix_len, NULL)) {
+            !raxFind(server.errors, (unsigned char *)err_prefix, prefix_len, NULL))
+        {
             err_prefix = ERRORSTATS_OVERFLOW_ERR;
             prefix_len = strlen(ERRORSTATS_OVERFLOW_ERR);
         }
@@ -1077,7 +1080,8 @@ void trimReplyUnusedTailSpace(client *c) {
      * Also, to avoid large memmove which happens as part of realloc, we only do
      * that if the used part is small.  */
     if (tail->size - tail->used > tail->size / 4 && tail->used < PROTO_REPLY_CHUNK_BYTES &&
-        c->io_write_state != CLIENT_PENDING_IO && !tail->flag.buf_encoded) {
+        c->io_write_state != CLIENT_PENDING_IO && !tail->flag.buf_encoded)
+    {
         size_t usable_size;
         size_t old_size = tail->size;
         tail = zrealloc_usable(tail, tail->used + sizeof(clientReplyBlock), &usable_size);
@@ -1139,7 +1143,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * - And not too large (avoid large memmove)
      * - And the client is not in a pending I/O state */
     if (ln->prev != NULL && (prev = listNodeValue(ln->prev)) && prev->size > prev->used &&
-        c->io_write_state != CLIENT_PENDING_IO && !prev->flag.buf_encoded) {
+        c->io_write_state != CLIENT_PENDING_IO && !prev->flag.buf_encoded)
+    {
         size_t len_to_copy = prev->size - prev->used;
         if (len_to_copy > length) len_to_copy = length;
         memcpy(prev->buf + prev->used, s, len_to_copy);
@@ -1154,7 +1159,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
     }
 
     if (ln->next != NULL && (next = listNodeValue(ln->next)) && next->size - next->used >= length &&
-        next->used < PROTO_REPLY_CHUNK_BYTES * 4 && c->io_write_state != CLIENT_PENDING_IO && !next->flag.buf_encoded) {
+        next->used < PROTO_REPLY_CHUNK_BYTES * 4 && c->io_write_state != CLIENT_PENDING_IO && !next->flag.buf_encoded)
+    {
         memmove(next->buf + length, next->buf, next->used);
         memcpy(next->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
@@ -1961,7 +1967,8 @@ void unlinkClient(client *c) {
          * snapshot child may take some time to die, during which the migration will continue past
          * the snapshot state. */
         if (c->repl_data && server.rdb_pipe_conns &&
-            ((c->flag.replica && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END))) {
+            ((c->flag.replica && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END)))
+        {
             int i;
             int still_alive = 0;
             for (i = 0; i < server.rdb_pipe_numconns; i++) {
@@ -1979,7 +1986,8 @@ void unlinkClient(client *c) {
         /* Check if this is the slot migration client we are writing to in a
          * child process*/
         if (c->slot_migration_job && !isImportSlotMigrationJob(c->slot_migration_job) &&
-            server.slot_migration_pipe_conn == c->conn) {
+            server.slot_migration_pipe_conn == c->conn)
+        {
             server.slot_migration_pipe_conn = NULL;
             serverLog(LL_NOTICE, "Slot migration target dropped, killing fork child.");
             killSlotMigrationChild();
@@ -2844,7 +2852,8 @@ static void trackBufReferences(char *buf, size_t bufpos, client *c) {
         if (header->payload_type == BULK_STR_REF) {
             uint8_t expected = 0;
             if (atomic_compare_exchange_strong_explicit(&header->tracked_for_cob, &expected, 1,
-                                                        memory_order_acq_rel, memory_order_acquire)) {
+                                                        memory_order_acq_rel, memory_order_acquire))
+            {
                 /* We claimed tracking rights */
                 bulkStrRef *str_ref = (bulkStrRef *)ptr;
                 size_t len = header->payload_len;
@@ -3544,7 +3553,8 @@ void parseMultibulkBuffer(client *c) {
     serverAssert(queue->len == 0);
     while ((flag & READ_FLAGS_PARSING_COMPLETED) &&
            sdslen(c->querybuf) > c->qb_pos &&
-           c->querybuf[c->qb_pos] == '*') {
+           c->querybuf[c->qb_pos] == '*')
+    {
         c->reqtype = PROTO_REQ_MULTIBULK;
         /* Push a new parser state to the command queue */
         if (queue->len == queue->cap) {
@@ -3754,7 +3764,8 @@ static int parseMultibulk(client *c,
 
             /* Check that what follows argv is a real \r\n */
             if (unlikely(c->querybuf[c->qb_pos + c->bulklen] != '\r' ||
-                         c->querybuf[c->qb_pos + c->bulklen + 1] != '\n')) {
+                         c->querybuf[c->qb_pos + c->bulklen + 1] != '\n'))
+            {
                 return READ_FLAGS_ERROR_INVALID_CRLF;
             }
 
@@ -3762,7 +3773,8 @@ static int parseMultibulk(client *c,
              * instead of creating a new object by *copying* the sds we
              * just use the current sds string. */
             if (!is_replicated && c->qb_pos == 0 && c->bulklen >= PROTO_MBULK_BIG_ARG &&
-                sdslen(c->querybuf) == (size_t)(c->bulklen + 2)) {
+                sdslen(c->querybuf) == (size_t)(c->bulklen + 2))
+            {
                 (*argv)[(*argc)++] = createObject(OBJ_STRING, c->querybuf);
                 *argv_len_sum += c->bulklen;
                 sdsIncrLen(c->querybuf, -2); /* remove CRLF */
@@ -4113,7 +4125,8 @@ static void prefetchCommandQueueKeys(client *c) {
 int processInputBuffer(client *c) {
     /* Parse the query buffer and/or execute already parsed commands. */
     while ((c->querybuf && c->qb_pos < sdslen(c->querybuf)) ||
-           c->cmd_queue.off < c->cmd_queue.len) {
+           c->cmd_queue.off < c->cmd_queue.len)
+    {
         if (!canParseCommand(c)) {
             break;
         }
@@ -4204,7 +4217,8 @@ static bool readToQueryBuf(client *c) {
      * thread_shared_qb, we still add this check for code robustness. */
     int use_thread_shared_qb = (c->querybuf == thread_shared_qb) ? 1 : 0;
     if (!is_replicated && // replicated clients' querybuf can grow greedy.
-        (big_arg || sdsalloc(c->querybuf) < PROTO_IOBUF_LEN)) {
+        (big_arg || sdsalloc(c->querybuf) < PROTO_IOBUF_LEN))
+    {
         /* When reading a BIG_ARG we won't be reading more than that one arg
          * into the query buffer, so we don't need to pre-allocate more than we
          * need, so using the non-greedy growing. For an initial allocation of
@@ -4237,7 +4251,8 @@ static bool readToQueryBuf(client *c) {
          * For unauthenticated clients, the query buffer cannot exceed 1MB at most. */
         size_t qb_memory = sdslen(c->querybuf) + (c->mstate ? c->mstate->argv_len_sums : 0);
         if (qb_memory > server.client_max_querybuf_len ||
-            (qb_memory > 1024 * 1024 && (c->read_flags & READ_FLAGS_AUTH_REQUIRED))) {
+            (qb_memory > 1024 * 1024 && (c->read_flags & READ_FLAGS_AUTH_REQUIRED)))
+        {
             c->read_flags |= READ_FLAGS_QB_LIMIT_REACHED;
         }
     }
@@ -5055,7 +5070,8 @@ static int clientMatchesFlagFilter(client *c, sds flag_filter) {
                 c->flag.unblocked || c->flag.close_asap ||
                 c->flag.unix_socket || c->flag.readonly ||
                 c->flag.no_evict || c->flag.no_touch ||
-                c->flag.import_source || c->slot_migration_job) {
+                c->flag.import_source || c->slot_migration_job)
+            {
                 return 0;
             }
             break;
@@ -5534,7 +5550,8 @@ void clientTrackingCommand(client *c) {
         }
 
         if ((options.tracking_optin && c->flag.tracking_optout) ||
-            (options.tracking_optout && c->flag.tracking_optin)) {
+            (options.tracking_optout && c->flag.tracking_optin))
+        {
             addReplyError(c, "You can't switch OPTIN/OPTOUT mode before disabling "
                              "tracking for this client, and then re-enabling it with "
                              "a different mode.");
@@ -5716,7 +5733,8 @@ void helloCommand(client *c) {
 
     if (c->argc >= 2) {
         if (getLongLongFromObjectOrReply(c, c->argv[next_arg++], &ver,
-                                         "Protocol version is not an integer or out of range") != C_OK) {
+                                         "Protocol version is not an integer or out of range") != C_OK)
+        {
             return;
         }
 
@@ -6201,7 +6219,8 @@ void flushReplicasOutputBuffers(void) {
          * 3. Obviously if the replica is not ONLINE.
          */
         if (isReplicaReadyForReplData(replica) && !(replica->flag.close_asap) && can_receive_writes &&
-            !replica->repl_data->repl_start_cmd_stream_on_ack && clientHasPendingReplies(replica)) {
+            !replica->repl_data->repl_start_cmd_stream_on_ack && clientHasPendingReplies(replica))
+        {
             writeToClient(replica);
         }
     }
@@ -6498,7 +6517,8 @@ void evictClients(void) {
     while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
                server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] -
                pending_freed >
-           client_eviction_limit) {
+           client_eviction_limit)
+    {
         listNode *ln = listNext(&bucket_iter);
         if (ln) {
             client *c = ln->value;

--- a/src/object.c
+++ b/src/object.c
@@ -854,7 +854,8 @@ void trimStringObjectIfNeeded(robj *o, int trim_small_values) {
      * 3. When calling from RM_TrimStringAllocation (trim_small_values is true). */
     size_t len = sdslen(o->val_ptr);
     if (len >= PROTO_MBULK_BIG_ARG || trim_small_values ||
-        (server.executing_client && server.executing_client->flag.script && len < LUA_CMD_OBJCACHE_MAX_LEN)) {
+        (server.executing_client && server.executing_client->flag.script && len < LUA_CMD_OBJCACHE_MAX_LEN))
+    {
         if (sdsavail(o->val_ptr) > len / 10) {
             o->val_ptr = sdsRemoveFreeSpace(o->val_ptr, 0);
         }
@@ -1007,7 +1008,8 @@ int equalStringObjects(robj *a, robj *b) {
         return objectGetVal(a) == objectGetVal(b);
     } else if (a->encoding != OBJ_ENCODING_INT &&
                b->encoding != OBJ_ENCODING_INT &&
-               sdslen(objectGetVal(a)) != sdslen(objectGetVal(b))) {
+               sdslen(objectGetVal(a)) != sdslen(objectGetVal(b)))
+    {
         return 0;
     } else {
         return compareStringObjects(a, b) == 0;

--- a/src/queues.c
+++ b/src/queues.c
@@ -178,7 +178,8 @@ inline void *spmcDequeue(spmcQueue *q) {
             /* Slot has data. Attempt to claim via CAS on head. */
             if (atomic_compare_exchange_weak_explicit(&q->head, &head, head + 1,
                                                       memory_order_relaxed,
-                                                      memory_order_relaxed)) {
+                                                      memory_order_relaxed))
+            {
                 data = cell->data;
 
                 /* Mark slot empty for next generation (pos + size) */

--- a/src/quicklist.c
+++ b/src/quicklist.c
@@ -225,7 +225,8 @@ static int __quicklistCompressNode(quicklistNode *node) {
 
     /* Cancel if compression fails or doesn't compress small enough */
     if (((lzf->sz = lzf_compress(node->entry, node->sz, lzf->compressed, node->sz)) == 0) ||
-        lzf->sz + MIN_COMPRESS_IMPROVE >= node->sz) {
+        lzf->sz + MIN_COMPRESS_IMPROVE >= node->sz)
+    {
         /* lzf_compress aborts/rejects compression if value not compressible. */
         zfree(lzf);
         return 0;
@@ -730,7 +731,8 @@ void quicklistReplaceEntry(quicklistIter *iter, quicklistEntry *entry, void *dat
     unsigned char *newentry;
 
     if (likely(!QL_NODE_IS_PLAIN(entry->node) && !isLargeElement(sz, quicklist->fill) &&
-               (newentry = lpReplace(entry->node->entry, &entry->zi, data, sz)) != NULL)) {
+               (newentry = lpReplace(entry->node->entry, &entry->zi, data, sz)) != NULL))
+    {
         entry->node->entry = newentry;
         quicklistNodeUpdateSz(entry->node);
         /* quicklistNext() and quicklistGetIteratorEntryAtIdx() provide an uncompressed node */

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2014,7 +2014,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
                         return NULL;
                     }
                 } else if (setTypeSize(o) < server.set_max_listpack_entries &&
-                           maxelelen <= server.set_max_listpack_value && lpSafeToAdd(NULL, sumelelen)) {
+                           maxelelen <= server.set_max_listpack_value && lpSafeToAdd(NULL, sumelelen))
+                {
                     /* We checked if it's safe to add one large element instead
                      * of many small ones. It's OK since lpSafeToAdd doesn't
                      * care about individual elements, only the total size. */
@@ -2031,7 +2032,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
              * to a listpack encoded set. */
             if (o->encoding == OBJ_ENCODING_LISTPACK) {
                 if (setTypeSize(o) < server.set_max_listpack_entries && elelen <= server.set_max_listpack_value &&
-                    lpSafeToAdd(objectGetVal(o), elelen)) {
+                    lpSafeToAdd(objectGetVal(o), elelen))
+                {
                     unsigned char *p = lpFirst(objectGetVal(o));
                     if (p && lpFind(objectGetVal(o), p, (unsigned char *)sdsele, elelen, 0)) {
                         rdbReportCorruptRDB("Duplicate set members detected");
@@ -2127,7 +2129,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
         /* Convert *after* loading, since sorted sets are not stored ordered. */
         if (zsetLength(o) <= server.zset_max_listpack_entries && maxelelen <= server.zset_max_listpack_value &&
-            lpSafeToAdd(NULL, totelelen)) {
+            lpSafeToAdd(NULL, totelelen))
+        {
             zsetConvert(o, OBJ_ENCODING_LISTPACK);
         }
     } else if (rdbtype == RDB_TYPE_HASH || rdbtype == RDB_TYPE_HASH_2) {
@@ -2185,7 +2188,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             /* Convert to hash table if size threshold is exceeded */
             if (o->encoding != OBJ_ENCODING_HASHTABLE &&
                 (sdslen(field) > server.hash_max_listpack_value || sdslen(value) > server.hash_max_listpack_value ||
-                 !lpSafeToAdd(objectGetVal(o), sdslen(field) + sdslen(value)))) {
+                 !lpSafeToAdd(objectGetVal(o), sdslen(field) + sdslen(value))))
+            {
                 hashTypeConvert(o, OBJ_ENCODING_HASHTABLE);
                 entry *entry = entryCreate(field, value, EXPIRY_NONE);
                 sdsfree(field);
@@ -2252,7 +2256,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             /* If this is a non-preamble RDB being loaded on the primary, and this
              * field is already expired relative to 'now', skip it. */
             if (iAmPrimary() && !(rdbflags & RDBFLAGS_AOF_PREAMBLE) && now != 0 &&
-                itemexpiry != EXPIRY_NONE && itemexpiry < now) {
+                itemexpiry != EXPIRY_NONE && itemexpiry < now)
+            {
                 /* Emit HDEL to replicas. */
                 if ((rdbflags & RDBFLAGS_FEED_REPL) && server.repl_backlog) {
                     robj keyobj, fieldobj;
@@ -2368,7 +2373,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
     } else if (rdbtype == RDB_TYPE_HASH_ZIPMAP || rdbtype == RDB_TYPE_LIST_ZIPLIST || rdbtype == RDB_TYPE_SET_INTSET ||
                rdbtype == RDB_TYPE_SET_LISTPACK || rdbtype == RDB_TYPE_ZSET_ZIPLIST ||
                rdbtype == RDB_TYPE_ZSET_LISTPACK || rdbtype == RDB_TYPE_HASH_ZIPLIST ||
-               rdbtype == RDB_TYPE_HASH_LISTPACK) {
+               rdbtype == RDB_TYPE_HASH_LISTPACK)
+    {
         size_t encoded_len;
         unsigned char *encoded = rdbGenericLoadStringObject(rdb, RDB_LOAD_PLAIN, &encoded_len);
         if (encoded == NULL) return NULL;
@@ -2588,7 +2594,8 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             break;
         }
     } else if (rdbtype == RDB_TYPE_STREAM_LISTPACKS || rdbtype == RDB_TYPE_STREAM_LISTPACKS_2 ||
-               rdbtype == RDB_TYPE_STREAM_LISTPACKS_3) {
+               rdbtype == RDB_TYPE_STREAM_LISTPACKS_3)
+    {
         o = createStreamObject();
         stream *s = objectGetVal(o);
         uint64_t listpacks = rdbLoadLen(rdb, NULL);
@@ -3054,7 +3061,8 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
     if (server.rdb_checksum) rioGenericUpdateChecksum(r, buf, len);
     if (server.loading_process_events_interval_bytes &&
         (r->processed_bytes + len) / server.loading_process_events_interval_bytes >
-            r->processed_bytes / server.loading_process_events_interval_bytes) {
+            r->processed_bytes / server.loading_process_events_interval_bytes)
+    {
         if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER) replicationSendNewlineToPrimary();
         loadingAbsProgress(r->processed_bytes);
         processEventsWhileBlocked();
@@ -3085,7 +3093,8 @@ int rdbFunctionLoad(rio *rdb, int ver, functionsLibCtx *lib_ctx, int rdbflags, s
     if (lib_ctx) {
         sds library_name = NULL;
         if (!(library_name =
-                  functionsCreateWithLibraryCtx(final_payload, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx, 0))) {
+                  functionsCreateWithLibraryCtx(final_payload, rdbflags & RDBFLAGS_ALLOW_DUP, &error, lib_ctx, 0)))
+        {
             if (!error) {
                 error = sdsnew("Failed creating the library");
             }
@@ -3329,7 +3338,8 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                  * which are the slot number, number of keys in slot and the number of volatile keys. */
                 if (sscanf(objectGetVal(auxval), "%i,%lu,%lu,%lu",
                            &slot_id, &slot_size, &expires_slot_size,
-                           &keys_with_volatile_items_slot_size) < 3) {
+                           &keys_with_volatile_items_slot_size) < 3)
+                {
                     decrRefCount(auxkey);
                     decrRefCount(auxval);
                     goto eoferr;
@@ -3889,7 +3899,8 @@ int rdbSaveToReplicasSockets(int req, int rdbver, rdbSaveInfo *rsi) {
             } else {
                 close(rdb_pipe_write); /* close write in parent so that it can detect the close on the child. */
                 if (aeCreateFileEvent(server.el, server.rdb_pipe_read, AE_READABLE, rdbPipeReadHandler, NULL) ==
-                    AE_ERR) {
+                    AE_ERR)
+                {
                     serverPanic("Unrecoverable error creating server.rdb_pipe_read file event.");
                 }
             }

--- a/src/replication.c
+++ b/src/replication.c
@@ -864,7 +864,8 @@ int primaryTryPartialResynchronization(client *c, long long psync_offset) {
      * Note that there are two potentially valid replication IDs: the ID1
      * and the ID2. The ID2 however is only valid up to a specific offset. */
     if (strcasecmp(primary_replid, server.replid) &&
-        (strcasecmp(primary_replid, server.replid2) || psync_offset > server.second_replid_offset)) {
+        (strcasecmp(primary_replid, server.replid2) || psync_offset > server.second_replid_offset))
+    {
         /* Replid "?" is used by replicas that want to force a full resync. */
         if (primary_replid[0] != '?') {
             if (strcasecmp(primary_replid, server.replid) && strcasecmp(primary_replid, server.replid2)) {
@@ -888,7 +889,8 @@ int primaryTryPartialResynchronization(client *c, long long psync_offset) {
 
     /* We still have the data our replica is asking for? */
     if (!server.repl_backlog || psync_offset < server.repl_backlog->offset ||
-        psync_offset > (server.repl_backlog->offset + server.repl_backlog->histlen)) {
+        psync_offset > (server.repl_backlog->offset + server.repl_backlog->histlen))
+    {
         if (!server.repl_backlog) {
             serverLog(LL_NOTICE,
                       "Unable to partial resync with replica %s for lack of backlog (Replica request was: %s:%lld).",
@@ -1234,7 +1236,8 @@ void syncCommand(client *c) {
          * capabilities of the replica that triggered the current BGSAVE
          * and its exact requirements. */
         if (ln && ((c->repl_data->replica_capa & replica->repl_data->replica_capa) == replica->repl_data->replica_capa) &&
-            c->repl_data->replica_req == replica->repl_data->replica_req) {
+            c->repl_data->replica_req == replica->repl_data->replica_req)
+        {
             /* Perfect, the server is already registering differences for
              * another replica. Set the right state, and copy the buffer.
              * We don't copy buffer if clients don't want. */
@@ -1314,7 +1317,8 @@ void freeClientReplicationData(client *c) {
          * to keep data safe and we may delay configured 'save' for full sync. */
         if (server.saveparamslen == 0 && c->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END &&
             server.child_type == CHILD_TYPE_RDB && server.rdb_child_type == RDB_CHILD_TYPE_DISK &&
-            anyOtherReplicaWaitRdb(c) == 0) {
+            anyOtherReplicaWaitRdb(c) == 0)
+        {
             serverLog(LL_NOTICE, "Background saving, persistence disabled, last replica dropped, killing fork child.");
             killRDBChild();
         }
@@ -1648,7 +1652,8 @@ void removeRDBUsedToSyncReplicas(void) {
             replica = ln->value;
             if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_START ||
                 replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END ||
-                replica->repl_data->repl_state == REPLICA_STATE_SEND_BULK) {
+                replica->repl_data->repl_state == REPLICA_STATE_SEND_BULK)
+            {
                 delrdb = 0;
                 break; /* No need to check the other replicas. */
             }
@@ -1766,7 +1771,8 @@ void rdbPipeWriteHandler(struct connection *conn) {
     client *replica = connGetPrivateData(conn);
     ssize_t nwritten;
     if ((nwritten = connWrite(conn, server.rdb_pipe_buff + replica->repl_data->repldboff,
-                              server.rdb_pipe_bufflen - replica->repl_data->repldboff)) == -1) {
+                              server.rdb_pipe_bufflen - replica->repl_data->repldboff)) == -1)
+    {
         if (connGetState(conn) == CONN_STATE_CONNECTED) return; /* equivalent to EAGAIN */
         serverLog(LL_WARNING, "Write error sending DB to replica: %s", connGetLastError(conn));
         freeClient(replica);
@@ -1873,7 +1879,8 @@ void slotMigrationPipeWriteHandler(struct connection *conn) {
     client *target = connGetPrivateData(conn);
     ssize_t nwritten;
     if ((nwritten = connWrite(conn, server.slot_migration_pipe_buff + target->repl_data->repldboff,
-                              server.slot_migration_pipe_bufflen - target->repl_data->repldboff)) == -1) {
+                              server.slot_migration_pipe_bufflen - target->repl_data->repldboff)) == -1)
+    {
         if (connGetState(conn) == CONN_STATE_CONNECTED) return; /* equivalent to EAGAIN */
         serverLog(LL_WARNING, "Write error sending slot migration snapshot to target: %s", connGetLastError(conn));
         freeClient(target);
@@ -2200,7 +2207,8 @@ static int useDisklessLoad(void) {
             enabled = 0;
         }
         /* Check all modules handle async replication, otherwise it's not safe to use diskless load. */
-        else if (server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB && !moduleAllModulesHandleReplAsyncLoad()) {
+        else if (server.repl_diskless_load == REPL_DISKLESS_LOAD_SWAPDB && !moduleAllModulesHandleReplAsyncLoad())
+        {
             serverLog(LL_NOTICE,
                       "Skipping diskless-load because there are modules that are not aware of async replication.");
             enabled = 0;
@@ -2598,7 +2606,8 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
      * RDB file so it can be reused as the AOF base file, avoiding a redundant
      * bgrewriteaof that would produce an almost identical snapshot. */
     if (!(server.aof_enabled && server.aof_use_rdb_preamble) &&
-        server.rdb_del_sync_files && allPersistenceDisabled()) {
+        server.rdb_del_sync_files && allPersistenceDisabled())
+    {
         serverLog(LL_NOTICE, "Removing the RDB file obtained from "
                              "the primary. This replica has persistence "
                              "disabled");
@@ -3252,7 +3261,8 @@ void replStreamProgressCallback(size_t offset, int readlen, time_t *last_progres
     if (server.loading_process_events_interval_bytes &&
         ((offset + readlen) / server.loading_process_events_interval_bytes >
          offset / server.loading_process_events_interval_bytes) &&
-        (now - *last_progress_callback > server.loading_process_events_interval_ms)) {
+        (now - *last_progress_callback > server.loading_process_events_interval_ms))
+    {
         replicationSendNewlineToPrimary();
         processEventsWhileBlocked();
         *last_progress_callback = now;
@@ -3303,7 +3313,8 @@ void bufferReplData(connection *conn) {
         }
         if (readlen && remaining_bytes == 0) {
             if (server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes &&
-                server.pending_repl_data.len > server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes) {
+                server.pending_repl_data.len > server.client_obuf_limits[CLIENT_TYPE_REPLICA].hard_limit_bytes)
+            {
                 dualChannelServerLog(LL_NOTICE,
                                      "Replication buffer limit reached (%llu bytes), stopping buffering. "
                                      "Further accumulation will occur on primary side.",
@@ -3792,7 +3803,8 @@ int syncWithPrimaryHandleReceivePingReplyState(connection *conn) {
      * permitted" instead of using a proper error code, so we test
      * both. */
     if (err[0] != '+' && strncmp(err, "-NOAUTH", 7) != 0 && strncmp(err, "-NOPERM", 7) != 0 &&
-        strncmp(err, "-ERR operation not permitted", 28) != 0) {
+        strncmp(err, "-ERR operation not permitted", 28) != 0)
+    {
         serverLog(LL_WARNING, "Error reply to PING from primary: '%s'", err);
         sdsfree(err);
         return C_ERR;
@@ -4204,7 +4216,8 @@ void syncWithPrimary(connection *conn) {
      * could happen in edge cases. */
     if (server.failover_state == FAILOVER_IN_PROGRESS) {
         if (psync_result == PSYNC_CONTINUE || psync_result == PSYNC_FULLRESYNC ||
-            psync_result == PSYNC_FULLRESYNC_DUAL_CHANNEL) {
+            psync_result == PSYNC_FULLRESYNC_DUAL_CHANNEL)
+        {
             clearFailoverState(true);
         } else {
             abortFailover("Failover target rejected psync request");
@@ -4274,7 +4287,8 @@ void syncWithPrimary(connection *conn) {
         /* Create RDB connection */
         server.repl_rdb_transfer_s = connCreate(connTypeOfReplication());
         if (connConnect(server.repl_rdb_transfer_s, server.primary_host, server.primary_port, server.bind_source_addr,
-                        server.repl_mptcp, dualChannelFullSyncWithPrimary) == C_ERR) {
+                        server.repl_mptcp, dualChannelFullSyncWithPrimary) == C_ERR)
+        {
             dualChannelServerLog(LL_WARNING, "Unable to connect to Primary: %s",
                                  connGetLastError(server.repl_rdb_transfer_s));
             connClose(server.repl_rdb_transfer_s);
@@ -4324,7 +4338,8 @@ void syncWithPrimary(connection *conn) {
 int connectWithPrimary(void) {
     server.repl_transfer_s = connCreate(connTypeOfReplication());
     if (connConnect(server.repl_transfer_s, server.primary_host, server.primary_port, server.bind_source_addr,
-                    server.repl_mptcp, syncWithPrimary) == C_ERR) {
+                    server.repl_mptcp, syncWithPrimary) == C_ERR)
+    {
         serverLog(LL_WARNING, "Unable to connect to PRIMARY: %s", connGetLastError(server.repl_transfer_s));
         connClose(server.repl_transfer_s);
         server.repl_transfer_s = NULL;
@@ -5109,10 +5124,12 @@ void processClientsWaitingReplicas(void) {
          * or calling replicationCountAOFAcksByOffset()
          * if the requested offset / replicas were equal or less. */
         if (!is_wait_aof && last_offset && last_offset >= c->bstate->reploffset &&
-            last_numreplicas >= c->bstate->numreplicas) {
+            last_numreplicas >= c->bstate->numreplicas)
+        {
             numreplicas = last_numreplicas;
         } else if (is_wait_aof && last_aof_offset && last_aof_offset >= c->bstate->reploffset &&
-                   last_aof_numreplicas >= c->bstate->numreplicas) {
+                   last_aof_numreplicas >= c->bstate->numreplicas)
+        {
             numreplicas = last_aof_numreplicas;
         } else {
             numreplicas = is_wait_aof ? replicationCountAOFAcksByOffset(c->bstate->reploffset)
@@ -5233,14 +5250,16 @@ void replicationCron(void) {
 
     /* Non blocking connection timeout? */
     if (server.primary_host && (server.repl_state == REPL_STATE_CONNECTING || replicaIsInHandshakeState()) &&
-        (time(NULL) - server.repl_transfer_lastio) > server.repl_timeout) {
+        (time(NULL) - server.repl_transfer_lastio) > server.repl_timeout)
+    {
         serverLog(LL_WARNING, "Timeout connecting to the PRIMARY...");
         cancelReplicationHandshake(1);
     }
 
     /* Bulk transfer I/O timeout? */
     if (server.primary_host && server.repl_state == REPL_STATE_TRANSFER &&
-        (time(NULL) - server.repl_transfer_lastio) > server.repl_timeout) {
+        (time(NULL) - server.repl_transfer_lastio) > server.repl_timeout)
+    {
         serverLog(LL_WARNING, "Timeout receiving bulk data from PRIMARY... If the problem persists try to set the "
                               "'repl-timeout' parameter in valkey.conf to a larger value.");
         cancelReplicationHandshake(1);
@@ -5248,7 +5267,8 @@ void replicationCron(void) {
 
     /* Timed out primary when we are an already connected replica? */
     if (server.primary_host && server.repl_state == REPL_STATE_CONNECTED &&
-        (time(NULL) - server.primary->last_interaction) > server.repl_timeout) {
+        (time(NULL) - server.primary->last_interaction) > server.repl_timeout)
+    {
         serverLog(LL_WARNING, "PRIMARY timeout: no data nor PING received...");
         freeClient(server.primary);
     }
@@ -5337,9 +5357,11 @@ void replicationCron(void) {
              * by the fork child so if a disk-based replica is stuck it doesn't prevent the fork child
              * from terminating. */
             if (replica->repl_data->repl_state == REPLICA_STATE_WAIT_BGSAVE_END &&
-                server.rdb_child_type == RDB_CHILD_TYPE_SOCKET) {
+                server.rdb_child_type == RDB_CHILD_TYPE_SOCKET)
+            {
                 if (replica->repl_data->repl_last_partial_write != 0 &&
-                    (server.unixtime - replica->repl_data->repl_last_partial_write) > server.repl_timeout) {
+                    (server.unixtime - replica->repl_data->repl_last_partial_write) > server.repl_timeout)
+                {
                     serverLog(LL_WARNING, "Disconnecting timedout replica (full sync): %s",
                               replicationGetReplicaName(replica));
                     freeClient(replica);
@@ -5356,7 +5378,8 @@ void replicationCron(void) {
      * backlog, in order to reply to PSYNC queries if they are turned into
      * primaries after a failover. */
     if (listLength(server.replicas) == 0 && server.repl_backlog_time_limit && server.repl_backlog &&
-        server.primary_host == NULL) {
+        server.primary_host == NULL)
+    {
         time_t idle = server.unixtime - server.repl_no_replicas_since;
 
         if (idle > server.repl_backlog_time_limit) {
@@ -5435,7 +5458,8 @@ int shouldStartChildReplication(int *mincapa_out, int *req_out, int *rdbver_out)
                     req = replica->repl_data->replica_req;
                     rdbver = replicaRdbVersion(replica);
                 } else if (req != replica->repl_data->replica_req ||
-                           rdbver != replicaRdbVersion(replica)) {
+                           rdbver != replicaRdbVersion(replica))
+                {
                     /* Skip replicas that don't match */
                     continue;
                 }
@@ -5450,7 +5474,8 @@ int shouldStartChildReplication(int *mincapa_out, int *req_out, int *rdbver_out)
         if (replicas_waiting && (!server.repl_diskless_sync ||
                                  (server.repl_diskless_sync_max_replicas > 0 &&
                                   replicas_waiting >= server.repl_diskless_sync_max_replicas) ||
-                                 max_idle >= server.repl_diskless_sync_delay)) {
+                                 max_idle >= server.repl_diskless_sync_delay))
+        {
             if (mincapa_out) *mincapa_out = mincapa;
             if (req_out) *req_out = req;
             if (rdbver_out) *rdbver_out = rdbver;

--- a/src/script.c
+++ b/src/script.c
@@ -196,7 +196,8 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx,
         /* Check OOM state. the no-writes flag imply allow-oom. we tested it
          * after the no-write error, so no need to mention it in the error reply. */
         if (!client_allow_oom && server.pre_command_oom_state && server.maxmemory &&
-            !(script_flags & (SCRIPT_FLAG_ALLOW_OOM | SCRIPT_FLAG_NO_WRITES))) {
+            !(script_flags & (SCRIPT_FLAG_ALLOW_OOM | SCRIPT_FLAG_NO_WRITES)))
+        {
             addReplyError(caller, "-OOM allow-oom flag is not set on the script, "
                                   "can not run it when used memory > 'maxmemory'");
             return C_ERR;
@@ -228,7 +229,8 @@ int scriptPrepareForRun(scriptRunCtx *run_ctx,
         run_ctx->flags |= SCRIPT_READ_ONLY;
     }
     if (client_allow_oom ||
-        (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_ALLOW_OOM))) {
+        (!(script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) && (script_flags & SCRIPT_FLAG_ALLOW_OOM)))
+    {
         /* Note: we don't need to test the no-writes flag here and set this run_ctx flag,
          * since only write commands can deny-oom. */
         run_ctx->flags |= SCRIPT_ALLOW_OOM;

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -430,7 +430,8 @@ debuggerEnableRet scriptingEngineCallDebuggerEnable(scriptingEngine *engine,
     if (engine->impl.methods.debugger_enable == NULL ||
         engine->impl.methods.debugger_disable == NULL ||
         engine->impl.methods.debugger_start == NULL ||
-        engine->impl.methods.debugger_end == NULL) {
+        engine->impl.methods.debugger_end == NULL)
+    {
         return VMSE_DEBUG_NOT_SUPPORTED;
     }
 
@@ -1012,7 +1013,8 @@ static const debuggerCommand *findCommand(robj **argv, size_t argc) {
         const debuggerCommand *cmd = &builtins[i];
         if ((sdslen(objectGetVal(argv[0])) == cmd->prefix_len &&
              strncasecmp(cmd->name, objectGetVal(argv[0]), cmd->prefix_len) == 0) ||
-            strcasecmp(cmd->name, objectGetVal(argv[0])) == 0) {
+            strcasecmp(cmd->name, objectGetVal(argv[0])) == 0)
+        {
             if (checkCommandParameters(cmd, argc)) {
                 return cmd;
             }
@@ -1024,7 +1026,8 @@ static const debuggerCommand *findCommand(robj **argv, size_t argc) {
         const debuggerCommand *cmd = &ds.commands[i];
         if ((sdslen(objectGetVal(argv[0])) == cmd->prefix_len &&
              strncasecmp(cmd->name, objectGetVal(argv[0]), cmd->prefix_len) == 0) ||
-            strcasecmp(cmd->name, objectGetVal(argv[0])) == 0) {
+            strcasecmp(cmd->name, objectGetVal(argv[0])) == 0)
+        {
             if (checkCommandParameters(cmd, argc)) {
                 return cmd;
             }

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -578,7 +578,8 @@ sentinelAddr *createSentinelAddr(char *hostname, int port, int is_accept_unresol
         return NULL;
     }
     if (anetResolve(NULL, hostname, ip, sizeof(ip), sentinel.resolve_hostnames ? ANET_NONE : ANET_IP_ONLY) ==
-        ANET_ERR) {
+        ANET_ERR)
+    {
         serverLog(LL_WARNING, "Failed to resolve hostname '%s'", hostname);
         if (sentinel.resolve_hostnames && is_accept_unresolved) {
             ip[0] = '\0';
@@ -625,7 +626,8 @@ int sentinelAddrEqualsHostname(sentinelAddr *a, char *hostname) {
 
     /* Try resolve the hostname and compare it to the address */
     if (anetResolve(NULL, hostname, ip, sizeof(ip), sentinel.resolve_hostnames ? ANET_NONE : ANET_IP_ONLY) ==
-        ANET_ERR) {
+        ANET_ERR)
+    {
         /* If failed resolve then compare based on hostnames. That is our best effort as
          * long as the server is unavailable for some reason. It is fine since an
          * instance cannot have multiple hostnames for a given setup */
@@ -1493,7 +1495,8 @@ sentinelValkeyInstance *getSentinelValkeyInstanceByAddrAndRunID(dict *instances,
 
         if (runid && !ri->runid) continue;
         if ((runid == NULL || strcmp(ri->runid, runid) == 0) &&
-            (addr == NULL || sentinelAddrOrHostnameEqual(ri->addr, ri_addr))) {
+            (addr == NULL || sentinelAddrOrHostnameEqual(ri->addr, ri_addr)))
+        {
             instance = ri;
             break;
         }
@@ -1663,7 +1666,8 @@ sentinelAddr *sentinelGetCurrentPrimaryAddress(sentinelValkeyInstance *primary) 
      * replica acknowledged the configuration switch. Advertise the new
      * address. */
     if ((primary->flags & SRI_FAILOVER_IN_PROGRESS) && primary->promoted_replica &&
-        primary->failover_state >= SENTINEL_FAILOVER_STATE_RECONF_REPLICAS) {
+        primary->failover_state >= SENTINEL_FAILOVER_STATE_RECONF_REPLICAS)
+    {
         return primary->promoted_replica->addr;
     } else {
         return primary->addr;
@@ -1915,7 +1919,8 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         ri = sentinelGetPrimaryByName(argv[1]);
         if (!ri) return "No such master with specified name.";
         if ((replica = createSentinelValkeyInstance(NULL, SRI_REPLICA, argv[2], atoi(argv[3]), ri->quorum, ri)) ==
-            NULL) {
+            NULL)
+        {
             return sentinelCheckCreateInstanceErrors(SRI_REPLICA);
         }
     } else if (!strcasecmp(argv[0], "known-sentinel") && (argc == 4 || argc == 5)) {
@@ -1926,7 +1931,8 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
             ri = sentinelGetPrimaryByName(argv[1]);
             if (!ri) return "No such master with specified name.";
             if ((si = createSentinelValkeyInstance(argv[4], SRI_SENTINEL, argv[2], atoi(argv[3]), ri->quorum, ri)) ==
-                NULL) {
+                NULL)
+            {
                 return sentinelCheckCreateInstanceErrors(SRI_SENTINEL);
             }
             si->runid = sdsnew(argv[4]);
@@ -1973,7 +1979,8 @@ const char *sentinelHandleConfiguration(char **argv, int argc) {
         }
     } else if ((!strcasecmp(argv[0], "primary-reboot-down-after-period") ||
                 !strcasecmp(argv[0], "master-reboot-down-after-period")) &&
-               argc == 3) {
+               argc == 3)
+    {
         /* primary-reboot-down-after-period <name> <milliseconds> */
         ri = sentinelGetPrimaryByName(argv[1]);
         if (!ri) return "No such master with specified name.";
@@ -2308,7 +2315,8 @@ void sentinelSetClientName(sentinelValkeyInstance *ri, valkeyAsyncContext *c, ch
 
     snprintf(name, sizeof(name), "sentinel-%.8s-%s", sentinel.myid, type);
     if (valkeyAsyncCommand(c, sentinelDiscardReplyCallback, ri, "%s SETNAME %s",
-                           sentinelInstanceMapCommand(ri, "CLIENT"), name) == C_OK) {
+                           sentinelInstanceMapCommand(ri, "CLIENT"), name) == C_OK)
+    {
         ri->link->pending_commands++;
     }
 }
@@ -2504,7 +2512,8 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
              * otherwise add it. */
             if (sentinelValkeyInstanceLookupReplica(ri, ip, atoi(port)) == NULL) {
                 if ((replica = createSentinelValkeyInstance(NULL, SRI_REPLICA, ip, atoi(port), ri->quorum, ri)) !=
-                    NULL) {
+                    NULL)
+                {
                     sentinelEvent(LL_NOTICE, "+slave", replica, "%@");
                     sentinelFlushConfig();
                 }
@@ -2602,7 +2611,8 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
         /* If this is a promoted replica we can change state to the
          * failover state machine. */
         if ((ri->flags & SRI_PROMOTED) && (ri->primary->flags & SRI_FAILOVER_IN_PROGRESS) &&
-            (ri->primary->failover_state == SENTINEL_FAILOVER_STATE_WAIT_PROMOTION)) {
+            (ri->primary->failover_state == SENTINEL_FAILOVER_STATE_WAIT_PROMOTION))
+        {
             /* Now that we are sure the replica was reconfigured as a primary
              * set the primary configuration epoch to the epoch we won the
              * election to perform this failover. This will force the other
@@ -2628,7 +2638,8 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
             mstime_t wait_time = sentinel_publish_period * 4;
 
             if (!(ri->flags & SRI_PROMOTED) && sentinelPrimaryLooksSane(ri->primary) &&
-                sentinelValkeyInstanceNoDownFor(ri, wait_time) && mstime() - ri->role_reported_time > wait_time) {
+                sentinelValkeyInstanceNoDownFor(ri, wait_time) && mstime() - ri->role_reported_time > wait_time)
+            {
                 int retval = sentinelSendReplicaOf(ri, ri->primary->addr);
                 if (retval == C_OK) sentinelEvent(LL_NOTICE, "+convert-to-slave", ri, "%@");
             }
@@ -2641,7 +2652,8 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
 
         /* Make sure the primary is sane before reconfiguring this instance */
         if (sentinelPrimaryLooksSane(ri->primary) && sentinelValkeyInstanceNoDownFor(ri, wait_time) &&
-            mstime() - ri->monitored_instance_failover_change_time > wait_time) {
+            mstime() - ri->monitored_instance_failover_change_time > wait_time)
+        {
             int retval = sentinelSendReplicaOf(ri, ri->primary->addr);
             if (retval == C_OK) sentinelEvent(LL_NOTICE, "+fix-slave-config", ri, "%@");
         }
@@ -2650,13 +2662,15 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
     /* Handle replicas replicating to a different primary address. */
     if ((ri->flags & SRI_REPLICA) && role == SRI_REPLICA &&
         (ri->replica_primary_port != ri->primary->addr->port ||
-         !sentinelAddrEqualsHostname(ri->primary->addr, ri->replica_primary_host))) {
+         !sentinelAddrEqualsHostname(ri->primary->addr, ri->replica_primary_host)))
+    {
         mstime_t wait_time = ri->primary->failover_timeout;
 
         /* Make sure the primary is sane before reconfiguring this instance
          * into a replica. */
         if (sentinelPrimaryLooksSane(ri->primary) && sentinelValkeyInstanceNoDownFor(ri, wait_time) &&
-            mstime() - ri->replica_conf_change_time > wait_time) {
+            mstime() - ri->replica_conf_change_time > wait_time)
+        {
             int retval = sentinelSendReplicaOf(ri, ri->primary->addr);
             if (retval == C_OK) sentinelEvent(LL_NOTICE, "+fix-slave-config", ri, "%@");
         }
@@ -2668,7 +2682,8 @@ void sentinelRefreshInstanceInfo(sentinelValkeyInstance *ri, const char *info) {
         /* SRI_RECONF_SENT -> SRI_RECONF_INPROG. */
         if ((ri->flags & SRI_RECONF_SENT) && ri->replica_primary_host &&
             sentinelAddrEqualsHostname(ri->primary->promoted_replica->addr, ri->replica_primary_host) &&
-            ri->replica_primary_port == ri->primary->promoted_replica->addr->port) {
+            ri->replica_primary_port == ri->primary->promoted_replica->addr->port)
+        {
             ri->flags &= ~SRI_RECONF_SENT;
             ri->flags |= SRI_RECONF_INPROG;
             sentinelEvent(LL_NOTICE, "+slave-reconf-inprog", ri, "%@");
@@ -2720,7 +2735,8 @@ void sentinelPingReplyCallback(valkeyAsyncContext *c, void *reply, void *privdat
         /* Update the "instance available" field only if this is an
          * acceptable reply. */
         if (strncmp(r->str, "PONG", 4) == 0 || strncmp(r->str, "LOADING", 7) == 0 ||
-            strncmp(r->str, "MASTERDOWN", 10) == 0) {
+            strncmp(r->str, "MASTERDOWN", 10) == 0)
+        {
             link->last_avail_time = mstime();
             link->act_ping_time = 0; /* Flag the pong as received. */
 
@@ -2731,7 +2747,8 @@ void sentinelPingReplyCallback(valkeyAsyncContext *c, void *reply, void *privdat
              * down because of a busy script. */
             if (strncmp(r->str, "BUSY", 4) == 0 && (ri->flags & SRI_S_DOWN) && !(ri->flags & SRI_SCRIPT_KILL_SENT)) {
                 if (valkeyAsyncCommand(ri->link->cc, sentinelDiscardReplyCallback, ri, "%s KILL",
-                                       sentinelInstanceMapCommand(ri, "SCRIPT")) == C_OK) {
+                                       sentinelInstanceMapCommand(ri, "SCRIPT")) == C_OK)
+                {
                     ri->link->pending_commands++;
                 }
                 ri->flags |= SRI_SCRIPT_KILL_SENT;
@@ -3028,7 +3045,8 @@ void sentinelSendPeriodicCommands(sentinelValkeyInstance *ri) {
      * to be disconnected from the primary, so that we can have a fresh
      * disconnection time figure. */
     if ((ri->flags & SRI_REPLICA) &&
-        ((ri->primary->flags & (SRI_O_DOWN | SRI_FAILOVER_IN_PROGRESS)) || (ri->primary_link_down_time != 0))) {
+        ((ri->primary->flags & (SRI_O_DOWN | SRI_FAILOVER_IN_PROGRESS)) || (ri->primary_link_down_time != 0)))
+    {
         info_period = 1000;
     } else {
         info_period = sentinel_info_period;
@@ -3058,7 +3076,8 @@ void sentinelSendPeriodicCommands(sentinelValkeyInstance *ri) {
            - during coordinated failover
            - during Valkey failover (this may be a failover that is stuck) */
         if (((ri->flags & SRI_COORD_FAILOVER) == 0 || ri->failover_state > SENTINEL_FAILOVER_STATE_WAIT_PROMOTION) &&
-            ri->monitored_instance_failover_state != SENTINEL_MONITORED_INSTANCE_FAILOVER) {
+            ri->monitored_instance_failover_state != SENTINEL_MONITORED_INSTANCE_FAILOVER)
+        {
             sentinelSendHello(ri);
         }
     }
@@ -3819,7 +3838,8 @@ void sentinelCommand(client *c) {
         /* SENTINEL MYID */
         addReplyBulkCBuffer(c, sentinel.myid, CONFIG_RUN_ID_SIZE);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "is-primary-down-by-addr") ||
-               !strcasecmp(objectGetVal(c->argv[1]), "is-master-down-by-addr")) {
+               !strcasecmp(objectGetVal(c->argv[1]), "is-master-down-by-addr"))
+    {
         /* SENTINEL IS-PRIMARY-DOWN-BY-ADDR <ip> <port> <current-epoch> <runid>
          *
          * Arguments:
@@ -3872,7 +3892,8 @@ void sentinelCommand(client *c) {
         if (c->argc != 3) goto numargserr;
         addReplyLongLong(c, sentinelResetPrimariesByPattern(objectGetVal(c->argv[2]), SENTINEL_GENERATE_EVENT));
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "get-primary-addr-by-name") ||
-               !strcasecmp(objectGetVal(c->argv[1]), "get-master-addr-by-name")) {
+               !strcasecmp(objectGetVal(c->argv[1]), "get-master-addr-by-name"))
+    {
         /* SENTINEL GET-PRIMARY-ADDR-BY-NAME <primary-name> */
         sentinelValkeyInstance *ri;
 
@@ -3954,7 +3975,8 @@ void sentinelCommand(client *c) {
          * Otherwise just validate address.
          */
         if (anetResolve(NULL, objectGetVal(c->argv[3]), ip, sizeof(ip), sentinel.resolve_hostnames ? ANET_NONE : ANET_IP_ONLY) ==
-            ANET_ERR) {
+            ANET_ERR)
+        {
             addReplyError(c, "Invalid IP address or hostname specified");
             return;
         }
@@ -4345,7 +4367,8 @@ void sentinelSetCommand(client *c) {
             changes++;
         } else if ((!strcasecmp(option, "primary-reboot-down-after-period") ||
                     !strcasecmp(option, "master-reboot-down-after-period")) &&
-                   moreargs > 0) {
+                   moreargs > 0)
+        {
             /* primary-reboot-down-after-period <milliseconds> */
             robj *o = c->argv[++j];
             if (getLongLongFromObject(o, &ll) == C_ERR || ll < 0) {
@@ -4424,7 +4447,8 @@ void sentinelCheckSubjectivelyDown(sentinelValkeyInstance *ri) {
         /* The pending ping is delayed, and we did not receive
          * error replies as well. */
         (mstime() - ri->link->act_ping_time) > (ri->down_after_period / 2) &&
-        (mstime() - ri->link->last_pong_time) > (ri->down_after_period / 2)) {
+        (mstime() - ri->link->last_pong_time) > (ri->down_after_period / 2))
+    {
         instanceLinkCloseConnection(ri->link, ri->link->cc);
     }
 
@@ -4434,7 +4458,8 @@ void sentinelCheckSubjectivelyDown(sentinelValkeyInstance *ri) {
      *    SENTINEL_PUBLISH_PERIOD * 3.
      */
     if (ri->link->pc && (mstime() - ri->link->pc_conn_time) > sentinel_min_link_reconnect_period &&
-        (mstime() - ri->link->pc_last_activity) > (sentinel_publish_period * 3)) {
+        (mstime() - ri->link->pc_last_activity) > (sentinel_publish_period * 3))
+    {
         instanceLinkCloseConnection(ri->link, ri->link->pc);
     }
 
@@ -4448,7 +4473,8 @@ void sentinelCheckSubjectivelyDown(sentinelValkeyInstance *ri) {
         (ri->flags & SRI_PRIMARY && ri->role_reported == SRI_REPLICA &&
          mstime() - ri->role_reported_time > (ri->down_after_period + sentinel_info_period * 2)) ||
         (ri->flags & SRI_PRIMARY_REBOOT &&
-         mstime() - ri->primary_reboot_since_time > ri->primary_reboot_down_after_period)) {
+         mstime() - ri->primary_reboot_since_time > ri->primary_reboot_down_after_period))
+    {
         /* Is subjectively down */
         if ((ri->flags & SRI_S_DOWN) == 0) {
             sentinelEvent(LL_WARNING, "+sdown", ri, "%@");
@@ -4519,7 +4545,8 @@ void sentinelReceiveIsPrimaryDownReply(valkeyAsyncContext *c, void *reply, void 
      * Note that if the command returns an error for any reason we'll
      * end clearing the SRI_PRIMARY_DOWN flag for timeout anyway. */
     if (r->type == VALKEY_REPLY_ARRAY && r->elements == 3 && r->element[0]->type == VALKEY_REPLY_INTEGER &&
-        r->element[1]->type == VALKEY_REPLY_STRING && r->element[2]->type == VALKEY_REPLY_INTEGER) {
+        r->element[1]->type == VALKEY_REPLY_STRING && r->element[2]->type == VALKEY_REPLY_INTEGER)
+    {
         ri->last_primary_down_reply_time = mstime();
         if (r->element[0]->integer == 1) {
             ri->flags |= SRI_PRIMARY_DOWN;
@@ -5255,7 +5282,8 @@ void sentinelFailoverReconfNextReplica(sentinelValkeyInstance *primary) {
          * Sentinels will detect the replica as misconfigured and fix its
          * configuration later. */
         if ((replica->flags & SRI_RECONF_SENT) &&
-            (mstime() - replica->replica_reconf_sent_time) > sentinel_replica_reconf_timeout) {
+            (mstime() - replica->replica_reconf_sent_time) > sentinel_replica_reconf_timeout)
+        {
             sentinelEvent(LL_NOTICE, "-slave-reconf-sent-timeout", replica, "%@");
             replica->flags &= ~SRI_RECONF_SENT;
             replica->flags |= SRI_RECONF_DONE;

--- a/src/server.c
+++ b/src/server.c
@@ -645,7 +645,8 @@ const void *hashtableObjectGetKey(const void *entry) {
 void hashtableObjectPrefetchValue(const void *entry) {
     const robj *obj = entry;
     if (obj->encoding != OBJ_ENCODING_EMBSTR &&
-        obj->encoding != OBJ_ENCODING_INT) {
+        obj->encoding != OBJ_ENCODING_INT)
+    {
         valkey_prefetch(objectGetVal(obj));
     }
 }
@@ -1017,7 +1018,8 @@ int clientsCronResizeOutputBuffer(client *c, mstime_t now_ms) {
      * it will start to shrink.
      */
     if (server.reply_buffer_peak_reset_time >= 0 &&
-        now_ms - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time) {
+        now_ms - c->buf_peak_last_reset_time >= server.reply_buffer_peak_reset_time)
+    {
         c->buf_peak = c->bufpos;
         c->buf_peak_last_reset_time = now_ms;
     }
@@ -1639,7 +1641,8 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
              * CONFIG_BGSAVE_RETRY_DELAY seconds already elapsed. */
             if (server.dirty >= sp->changes && server.unixtime - server.lastsave > sp->seconds &&
                 (server.unixtime - server.lastbgsave_try > CONFIG_BGSAVE_RETRY_DELAY ||
-                 server.lastbgsave_status == C_OK)) {
+                 server.lastbgsave_status == C_OK))
+            {
                 serverLog(LL_NOTICE, "%d changes in %d seconds. Saving...", sp->changes, (int)sp->seconds);
                 rdbSaveInfo rsi, *rsiptr;
                 rsiptr = rdbPopulateSaveInfo(&rsi);
@@ -1650,7 +1653,8 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
 
         /* Trigger an AOF rewrite if needed. */
         if (server.aof_state == AOF_ON && !hasActiveChildProcess() && server.aof_rewrite_perc &&
-            server.aof_current_size > server.aof_rewrite_min_size) {
+            server.aof_current_size > server.aof_rewrite_min_size)
+        {
             long long base = server.aof_rewrite_base_size ? server.aof_rewrite_base_size : 1;
             long long growth = (server.aof_current_size * 100 / base) - 100;
             if (growth >= server.aof_rewrite_perc && !aofRewriteLimited()) {
@@ -1675,7 +1679,8 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
      * a higher frequency. */
     run_with_period(1000) {
         if ((server.aof_state == AOF_ON || server.aof_state == AOF_WAIT_REWRITE) &&
-            server.aof_last_write_status == C_ERR) {
+            server.aof_last_write_status == C_ERR)
+        {
             flushAppendOnlyFile(0);
         }
     }
@@ -1721,7 +1726,8 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
      * make sure when refactoring this file to keep this order. This is useful
      * because we want to give priority to RDB savings for replication. */
     if (!hasActiveChildProcess() && server.rdb_bgsave_scheduled &&
-        (server.unixtime - server.lastbgsave_try > CONFIG_BGSAVE_RETRY_DELAY || server.lastbgsave_status == C_OK)) {
+        (server.unixtime - server.lastbgsave_try > CONFIG_BGSAVE_RETRY_DELAY || server.lastbgsave_status == C_OK))
+    {
         rdbSaveInfo rsi, *rsiptr;
         rsiptr = rdbPopulateSaveInfo(&rsi);
         if (rdbSaveBackground(REPLICA_REQ_NONE, server.rdb_filename, rsiptr, RDBFLAGS_NONE) == C_OK)
@@ -1731,7 +1737,8 @@ long long serverCron(struct aeEventLoop *eventLoop, long long id, void *clientDa
     /* TLS auto-reload if enabled (only when TLS is built-in). */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */
     if ((server.tls_port || server.tls_replication || server.tls_cluster) &&
-        server.tls_ctx_config.auto_reload_interval > 0) {
+        server.tls_ctx_config.auto_reload_interval > 0)
+    {
         run_with_period(1000) {
             tlsReconfigureIfNeeded();
             tlsApplyPendingReload();
@@ -3270,7 +3277,8 @@ void populateCommandLegacyRangeSpec(struct serverCommand *c) {
     }
 
     if (c->key_specs_num == 1 && c->key_specs[0].begin_search_type == KSPEC_BS_INDEX &&
-        c->key_specs[0].find_keys_type == KSPEC_FK_RANGE) {
+        c->key_specs[0].find_keys_type == KSPEC_FK_RANGE)
+    {
         /* Quick win, exactly one range spec. */
         c->legacy_range_key_spec = c->key_specs[0];
         /* If it has the incomplete flag, set the movablekeys flag on the command. */
@@ -3287,7 +3295,8 @@ void populateCommandLegacyRangeSpec(struct serverCommand *c) {
             continue;
         }
         if (c->key_specs[i].fk.range.keystep != 1 ||
-            (prev_lastkey && prev_lastkey != c->key_specs[i].bs.index.pos - 1)) {
+            (prev_lastkey && prev_lastkey != c->key_specs[i].bs.index.pos - 1))
+        {
             /* Found a range spec that's not plain (step of 1) or not consecutive to the previous one.
              * Skip it, and we set the movablekeys flag. */
             c->flags |= CMD_MOVABLE_KEYS;
@@ -3741,7 +3750,8 @@ static void propagatePendingCommands(void) {
      * (i.e. not from within a script, MULTI/EXEC, RM_Call, etc.) we want
      * to avoid using a transaction (much like active-expire) */
     if (server.current_client && server.current_client->cmd &&
-        server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS) {
+        server.current_client->cmd->flags & CMD_TOUCHES_ARBITRARY_KEYS)
+    {
         transaction = 0;
     }
 
@@ -4036,7 +4046,8 @@ void call(client *c, int flags) {
      * propagated if needed (see propagatePendingCommands).
      * Also, module commands take care of themselves */
     if (flags & CMD_CALL_PROPAGATE && !c->flag.prevent_prop && c->cmd->proc != execCommand &&
-        !(c->cmd->flags & CMD_MODULE)) {
+        !(c->cmd->flags & CMD_MODULE))
+    {
         int propagate_flags = PROPAGATE_NONE;
 
         /* Check if the command operated changes in the data set. If so
@@ -4071,12 +4082,14 @@ void call(client *c, int flags) {
      * make sure to remember the keys it fetched via this command. For read-only
      * scripts, don't process the script, only the commands it executes. */
     if ((c->cmd->flags & CMD_READONLY) && (c->cmd->proc != evalRoCommand) && (c->cmd->proc != evalShaRoCommand) &&
-        (c->cmd->proc != fcallroCommand)) {
+        (c->cmd->proc != fcallroCommand))
+    {
         /* We use the tracking flag of the original external client that
          * triggered the command, but we take the keys from the actual command
          * being executed. */
         if (server.current_client && (server.current_client->flag.tracking) &&
-            !(server.current_client->flag.tracking_bcast)) {
+            !(server.current_client->flag.tracking_bcast))
+        {
             trackingRememberKeys(server.current_client, c);
         }
     }
@@ -4222,7 +4235,8 @@ uint64_t getCommandFlags(client *c) {
     if (c->cmd->proc == fcallCommand || c->cmd->proc == fcallroCommand) {
         cmd_flags = fcallGetCommandFlags(c, cmd_flags);
     } else if (c->cmd->proc == evalCommand || c->cmd->proc == evalRoCommand || c->cmd->proc == evalShaCommand ||
-               c->cmd->proc == evalShaRoCommand) {
+               c->cmd->proc == evalShaRoCommand)
+    {
         cmd_flags = evalGetCommandFlags(c, cmd_flags);
     }
 
@@ -4308,7 +4322,8 @@ int processCommand(client *c) {
     /* If we're inside a module blocked context yielding that wants to avoid
      * processing clients, postpone the command. */
     if (server.busy_module_yield_flags != BUSY_MODULE_YIELD_NONE &&
-        !(server.busy_module_yield_flags & BUSY_MODULE_YIELD_CLIENTS)) {
+        !(server.busy_module_yield_flags & BUSY_MODULE_YIELD_CLIENTS))
+    {
         blockPostponeClient(c);
         return C_OK;
     }
@@ -4357,7 +4372,8 @@ int processCommand(client *c) {
         /* Check if the command is marked as protected and the relevant configuration allows it */
         if (c->cmd->flags & CMD_PROTECTED) {
             if ((c->cmd->proc == debugCommand && !allowProtectedAction(server.enable_debug_cmd, c)) ||
-                (c->cmd->proc == moduleCommand && !allowProtectedAction(server.enable_module_cmd, c))) {
+                (c->cmd->proc == moduleCommand && !allowProtectedAction(server.enable_module_cmd, c)))
+            {
                 rejectCommandFormat(c,
                                     "%s command not allowed. If the %s option is set to \"local\", "
                                     "you can run it from a local connection, otherwise you need to set this option "
@@ -4410,7 +4426,8 @@ int processCommand(client *c) {
      * 1) The sender of this command is our primary.
      * 2) The command has no key arguments. */
     if (server.cluster_enabled && !obey_client &&
-        !(!(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand)) {
+        !(!(c->cmd->flags & CMD_MOVABLE_KEYS) && c->cmd->key_specs_num == 0 && c->cmd->proc != execCommand))
+    {
         int error_code;
         clusterNode *n = getNodeByQuery(c, &error_code);
         if (n == NULL || !clusterNodeIsMyself(n)) {
@@ -4427,7 +4444,8 @@ int processCommand(client *c) {
     }
 
     if (clientSupportStandAloneRedirect(c) && !obey_client &&
-        (is_write_command || (is_read_command && !c->flag.readonly))) {
+        (is_write_command || (is_read_command && !c->flag.readonly)))
+    {
         if (server.failover_state == FAILOVER_IN_PROGRESS) {
             /* During the FAILOVER process, when conditions are met (such as
              * when the force time is reached or the primary and replica offsets
@@ -4557,7 +4575,8 @@ int processCommand(client *c) {
     if ((c->flag.pubsub && c->resp == 2) && c->cmd->proc != pingCommand && c->cmd->proc != subscribeCommand &&
         c->cmd->proc != ssubscribeCommand && c->cmd->proc != unsubscribeCommand &&
         c->cmd->proc != sunsubscribeCommand && c->cmd->proc != psubscribeCommand &&
-        c->cmd->proc != punsubscribeCommand && c->cmd->proc != quitCommand && c->cmd->proc != resetCommand) {
+        c->cmd->proc != punsubscribeCommand && c->cmd->proc != quitCommand && c->cmd->proc != resetCommand)
+    {
         rejectCommandFormat(c,
                             "Can't execute '%s': only (P|S)SUBSCRIBE / "
                             "(P|S)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context",
@@ -4569,7 +4588,8 @@ int processCommand(client *c) {
      * when replica-serve-stale-data is no and we are a replica with a broken
      * link with primary. */
     if (server.primary_host && server.repl_state != REPL_STATE_CONNECTED && server.repl_serve_stale_data == 0 &&
-        is_denystale_command) {
+        is_denystale_command)
+    {
         rejectCommand(c, shared.primarydownerr);
         return C_OK;
     }
@@ -4618,7 +4638,8 @@ int processCommand(client *c) {
     /* If the server is paused, block the client until the pause has ended. Replicas and slot
      * export clients are never paused to allow failover/slot migration to succeed. */
     if (!c->flag.replica && (!c->slot_migration_job || isImportSlotMigrationJob(c->slot_migration_job)) &&
-        ((isPausedActions(PAUSE_ACTION_CLIENT_ALL)) || ((isPausedActions(PAUSE_ACTION_CLIENT_WRITE)) && is_may_replicate_command))) {
+        ((isPausedActions(PAUSE_ACTION_CLIENT_ALL)) || ((isPausedActions(PAUSE_ACTION_CLIENT_WRITE)) && is_may_replicate_command)))
+    {
         blockPostponeClient(c);
         return C_OK;
     }
@@ -4626,7 +4647,8 @@ int processCommand(client *c) {
     /* Exec the command */
     if (c->flag.multi && c->cmd->proc != execCommand && c->cmd->proc != discardCommand &&
         c->cmd->proc != quitCommand &&
-        c->cmd->proc != resetCommand) {
+        c->cmd->proc != resetCommand)
+    {
         queueMultiCommand(c, cmd_flags);
         addReply(c, shared.queued);
     } else {
@@ -6654,7 +6676,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
 
     /* Modules */
     if (all_sections || (dictFind(section_dict, "module_list") != NULL) ||
-        (dictFind(section_dict, "modules") != NULL)) {
+        (dictFind(section_dict, "modules") != NULL))
+    {
         if (sections++) info = sdscat(info, "\r\n");
         info = sdscatprintf(info, "# Modules\r\n");
         info = genModulesInfoString(info);
@@ -6742,7 +6765,8 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
      * so we proceed if there's a requested section name that's not found yet, or when the user asked
      * for "all" with any additional section names. */
     if (everything || dictFind(section_dict, "modules") != NULL || sections < (int)dictSize(section_dict) ||
-        (all_sections && dictSize(section_dict))) {
+        (all_sections && dictSize(section_dict)))
+    {
         info = modulesCollectInfo(info, everything || dictFind(section_dict, "modules") != NULL ? NULL : section_dict,
                                   0, /* not a crash report */
                                   sections);
@@ -7240,7 +7264,8 @@ void loadDataFromDisk(void) {
                 /* Note that older implementations may save a repl_stream_db
                  * of -1 inside the RDB file in a wrong way, see more
                  * information in function rdbPopulateSaveInfo. */
-                rsi.repl_stream_db != -1) {
+                rsi.repl_stream_db != -1)
+            {
                 rsi_is_valid = 1;
                 if (!iAmPrimary()) {
                     memcpy(server.replid, rsi.repl_id, sizeof(server.replid));
@@ -7553,7 +7578,8 @@ __attribute__((weak)) int main(int argc, char **argv) {
              * string "port 6380\n" to be parsed after the actual config file
              * and stdin input are parsed (if they exist).
              * Only consider that if the last config has at least one argument. */
-            else if (handled_last_config_arg && argv[j][0] == '-' && argv[j][1] == '-') {
+            else if (handled_last_config_arg && argv[j][0] == '-' && argv[j][1] == '-')
+            {
                 /* Option name */
                 if (sdslen(options)) options = sdscat(options, "\n");
                 /* argv[j]+2 for removing the preceding `--` */
@@ -7566,7 +7592,8 @@ __attribute__((weak)) int main(int argc, char **argv) {
                     handled_last_config_arg = 0;
 
                     if ((j != argc - 1) && argv[j + 1][0] == '-' && argv[j + 1][1] == '-' &&
-                        !strcasecmp(argv[j], "--save")) {
+                        !strcasecmp(argv[j], "--save"))
+                    {
                         /* Special case: handle some things like `--save --config value`.
                          * In this case, if next argument starts with `--`, we will reset
                          * handled_last_config_arg flag and append an empty "" config value
@@ -7582,7 +7609,8 @@ __attribute__((weak)) int main(int argc, char **argv) {
                          * so it will become `--save ""` and will follow the same reset thing. */
                         options = sdscat(options, "\"\"");
                     } else if ((j != argc - 1) && argv[j + 1][0] == '-' && argv[j + 1][1] == '-' &&
-                               !strcasecmp(argv[j], "--sentinel")) {
+                               !strcasecmp(argv[j], "--sentinel"))
+                    {
                         /* Special case: handle some things like `--sentinel --config value`.
                          * It is a pseudo config option with no value. In this case, if next
                          * argument starts with `--`, we will reset handled_last_config_arg flag.

--- a/src/sort.c
+++ b/src/sort.c
@@ -227,7 +227,8 @@ void sortCommandGeneric(client *c, int readonly) {
             alpha = 1;
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "limit") && leftargs >= 2) {
             if ((getLongFromObjectOrReply(c, c->argv[j + 1], &limit_start, NULL) != C_OK) ||
-                (getLongFromObjectOrReply(c, c->argv[j + 2], &limit_count, NULL) != C_OK)) {
+                (getLongFromObjectOrReply(c, c->argv[j + 2], &limit_count, NULL) != C_OK))
+            {
                 syntax_error++;
                 break;
             }
@@ -246,7 +247,8 @@ void sortCommandGeneric(client *c, int readonly) {
                  * unless we can make sure the keys formed by the pattern are in the same slot
                  * as the key to sort. */
                 if (server.cluster_enabled &&
-                    patternHashSlot(objectGetVal(sortby), sdslen(objectGetVal(sortby))) != getKeySlot(objectGetVal(c->argv[1]))) {
+                    patternHashSlot(objectGetVal(sortby), sdslen(objectGetVal(sortby))) != getKeySlot(objectGetVal(c->argv[1])))
+                {
                     addReplyError(c, "BY option of SORT denied in Cluster mode when "
                                      "keys formed by the pattern may be in different slots.");
                     syntax_error++;
@@ -267,7 +269,8 @@ void sortCommandGeneric(client *c, int readonly) {
              * as the key to sort. */
             if (server.cluster_enabled &&
                 !isReturnSubstPattern(objectGetVal(c->argv[j + 1])) &&
-                patternHashSlot(objectGetVal(c->argv[j + 1]), sdslen(objectGetVal(c->argv[j + 1]))) != getKeySlot(objectGetVal(c->argv[1]))) {
+                patternHashSlot(objectGetVal(c->argv[j + 1]), sdslen(objectGetVal(c->argv[j + 1]))) != getKeySlot(objectGetVal(c->argv[1])))
+            {
                 addReplyError(c, "GET option of SORT denied in Cluster mode when "
                                  "keys formed by the pattern may be in different slots.");
                 syntax_error++;

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -938,7 +938,8 @@ void hincrbyCommand(client *c) {
 
     oldvalue = value;
     if ((incr < 0 && oldvalue < 0 && incr < (LLONG_MIN - oldvalue)) ||
-        (incr > 0 && oldvalue > 0 && incr > (LLONG_MAX - oldvalue))) {
+        (incr > 0 && oldvalue > 0 && incr > (LLONG_MAX - oldvalue)))
+    {
         addReplyError(c, "increment or decrement would overflow");
         return;
     }
@@ -1396,7 +1397,8 @@ void hsetexCommand(client *c) {
 
     /* Check NX/XX key-level conditions before creating a new object */
     if (((flags & ARGS_SET_NX) && o != NULL) ||
-        ((flags & ARGS_SET_XX) && o == NULL)) {
+        ((flags & ARGS_SET_XX) && o == NULL))
+    {
         addReply(c, shared.czero);
         return;
     }
@@ -1422,7 +1424,8 @@ void hsetexCommand(client *c) {
             /* Key exists: check fields normally */
             for (i = fields_index; i < c->argc; i += 2) {
                 if (((flags & ARGS_SET_FNX) && hashTypeExists(o, objectGetVal(c->argv[i]))) ||
-                    ((flags & ARGS_SET_FXX) && !hashTypeExists(o, objectGetVal(c->argv[i])))) {
+                    ((flags & ARGS_SET_FXX) && !hashTypeExists(o, objectGetVal(c->argv[i]))))
+                {
                     addReply(c, shared.czero);
                     return;
                 }
@@ -1462,7 +1465,8 @@ void hsetexCommand(client *c) {
             if (strcasecmp(objectGetVal(c->argv[i]), "NX") &&
                 strcasecmp(objectGetVal(c->argv[i]), "XX") &&
                 strcasecmp(objectGetVal(c->argv[i]), "FNX") &&
-                strcasecmp(objectGetVal(c->argv[i]), "FXX")) {
+                strcasecmp(objectGetVal(c->argv[i]), "FXX"))
+            {
                 /* Propagate as HSETEX Key Value PXAT millisecond-timestamp if there is
                  * EX/PX/EXAT flag. */
                 if (expire && !(flags & ARGS_PXAT) && c->argv[i + 1] == expire) {
@@ -2291,7 +2295,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * In this case we can simply get random elements from the hash and add
      * to the temporary hash, trying to eventually get enough unique elements
      * to reach the specified count. */
-    else {
+    else
+    {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
         listpackEntry field, value;

--- a/src/t_list.c
+++ b/src/t_list.c
@@ -54,7 +54,8 @@ static void listTypeTryConvertListpack(robj *o, robj **argv, int start, int end,
     }
 
     if (quicklistNodeExceedsLimit(server.list_max_listpack_size, lpBytes(objectGetVal(o)) + add_bytes,
-                                  lpLength(objectGetVal(o)) + add_length)) {
+                                  lpLength(objectGetVal(o)) + add_length))
+    {
         /* Invoke callback before conversion. */
         if (fn) fn(data);
 

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -64,7 +64,8 @@ robj *setTypeCreate(sds value, size_t size_hint) {
  * the size hint. */
 void setTypeMaybeConvert(robj *set, size_t size_hint) {
     if ((set->encoding == OBJ_ENCODING_LISTPACK && size_hint > server.set_max_listpack_entries) ||
-        (set->encoding == OBJ_ENCODING_INTSET && size_hint > server.set_max_intset_entries)) {
+        (set->encoding == OBJ_ENCODING_INTSET && size_hint > server.set_max_intset_entries))
+    {
         setTypeConvertAndExpand(set, OBJ_ENCODING_HASHTABLE, size_hint, 1);
     }
 }
@@ -162,7 +163,8 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
         if (p == NULL) {
             /* Not found.  */
             if (lpLength(lp) < server.set_max_listpack_entries && len <= server.set_max_listpack_value &&
-                lpSafeToAdd(lp, len)) {
+                lpSafeToAdd(lp, len))
+            {
                 if (str == tmpbuf) {
                     /* This came in as integer so we can avoid parsing it again.
                      * TODO: Create and use lpFindInteger; don't go via string. */
@@ -201,7 +203,8 @@ int setTypeAddAux(robj *set, char *str, size_t len, int64_t llval, int str_is_sd
             }
             if (intsetLen((const intset *)objectGetVal(set)) < server.set_max_listpack_entries &&
                 len <= server.set_max_listpack_value && maxelelen <= server.set_max_listpack_value &&
-                lpSafeToAdd(NULL, totsize + len)) {
+                lpSafeToAdd(NULL, totsize + len))
+            {
                 /* In the "safe to add" check above we assumed all elements in
                  * the intset are of size maxelelen. This is an upper bound. */
                 setTypeConvertAndExpand(set, OBJ_ENCODING_LISTPACK, intsetLen(objectGetVal(set)) + 1, 1);
@@ -1161,7 +1164,8 @@ void srandmemberWithCountCommand(client *c) {
      * In this case we can simply get random elements from the set and add
      * to the temporary set, trying to eventually get enough unique elements
      * to reach the specified count. */
-    else {
+    else
+    {
         unsigned long added = 0;
         sds sdsele;
 
@@ -1483,7 +1487,8 @@ void sunionDiffGenericCommand(client *c, robj **setkeys, int setnum, robj *dstke
          * the hashtable is more efficient when find and compare than the listpack. The corresponding
          * time complexity are O(1) vs O(n). */
         if (!dstkey && dstset_encoding == OBJ_ENCODING_INTSET &&
-            (setobj->encoding == OBJ_ENCODING_LISTPACK || setobj->encoding == OBJ_ENCODING_HASHTABLE)) {
+            (setobj->encoding == OBJ_ENCODING_LISTPACK || setobj->encoding == OBJ_ENCODING_HASHTABLE))
+        {
             dstset_encoding = OBJ_ENCODING_HASHTABLE;
         }
         sets[j] = setobj;

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -1184,7 +1184,8 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
              * deleted or tombstones are included, emit it. */
             if (!si->rev) {
                 if (streamCompareID(id, &si->start_id) >= 0 &&
-                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
+                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED)))
+                {
                     if (streamCompareID(id, &si->end_id) > 0) return 0; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
@@ -1192,7 +1193,8 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                 }
             } else {
                 if (streamCompareID(id, &si->end_id) <= 0 &&
-                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
+                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED)))
+                {
                     if (streamCompareID(id, &si->start_id) < 0) return 0; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
@@ -1427,7 +1429,8 @@ int streamRangeHasTombstones(stream *s, streamID *start, streamID *end) {
     }
 
     if (streamCompareID(&start_id, &s->max_deleted_entry_id) <= 0 &&
-        streamCompareID(&s->max_deleted_entry_id, &end_id) <= 0) {
+        streamCompareID(&s->max_deleted_entry_id, &end_id) <= 0)
+    {
         /* start_id <= max_deleted_entry_id <= end_id: The range does include a tombstone. */
         return 1;
     }
@@ -1700,7 +1703,8 @@ size_t streamReplyWithRange(client *c,
         if (group && streamCompareID(&id, &group->last_id) > 0) {
             if (group->entries_read != SCG_INVALID_ENTRIES_READ &&
                 streamCompareID(&group->last_id, &s->first_id) >= 0 &&
-                !streamRangeHasTombstones(s, &group->last_id, NULL)) {
+                !streamRangeHasTombstones(s, &group->last_id, NULL))
+            {
                 /* A valid counter and no tombstones in the group's last-delivered-id and the stream's last-generated-id,
                  * we can increment the read counter to keep tracking the group's progress. */
                 group->entries_read++;
@@ -2039,7 +2043,8 @@ void xaddCommand(client *c) {
     errno = 0;
     streamID id;
     if (streamAppendItem(s, c->argv + field_pos, (c->argc - field_pos) / 2, &id,
-                         parsed_args.id_given ? &parsed_args.id : NULL, parsed_args.seq_given) == C_ERR) {
+                         parsed_args.id_given ? &parsed_args.id : NULL, parsed_args.seq_given) == C_ERR)
+    {
         serverAssert(errno != 0);
         if (errno == EDOM)
             addReplyError(c, "The ID specified in XADD is equal or smaller than "
@@ -2599,7 +2604,8 @@ void xgroupCommand(client *c) {
                 mkstream = 1;
                 i++;
             } else if ((create_subcmd || setid_subcmd) && !strcasecmp(objectGetVal(c->argv[i]), "ENTRIESREAD") &&
-                       i + 1 < c->argc) {
+                       i + 1 < c->argc)
+            {
                 if (getLongLongFromObjectOrReply(c, c->argv[i + 1], &entries_read, NULL) != C_OK) return;
                 if (entries_read < 0 && entries_read != SCG_INVALID_ENTRIES_READ) {
                     addReplyError(c, "value for ENTRIESREAD must be positive or -1");
@@ -2632,7 +2638,8 @@ void xgroupCommand(client *c) {
 
         /* Certain subcommands require the group to exist. */
         if ((cg = streamLookupCG(s, grpname)) == NULL &&
-            (!strcasecmp(opt, "SETID") || !strcasecmp(opt, "CREATECONSUMER") || !strcasecmp(opt, "DELCONSUMER"))) {
+            (!strcasecmp(opt, "SETID") || !strcasecmp(opt, "CREATECONSUMER") || !strcasecmp(opt, "DELCONSUMER")))
+        {
             addReplyErrorFormat(c,
                                 "-NOGROUP No such consumer group '%s' "
                                 "for key name '%s'",

--- a/src/t_string.c
+++ b/src/t_string.c
@@ -612,7 +612,8 @@ void msetexCommand(client *c) {
 
     /* Parse the numkeys. */
     if (getRangeLongFromObjectOrReply(c, c->argv[1], 1, INT_MAX, &numkeys,
-                                      "invalid numkeys value or out of range") != C_OK) {
+                                      "invalid numkeys value or out of range") != C_OK)
+    {
         return;
     }
 
@@ -624,7 +625,8 @@ void msetexCommand(client *c) {
         return;
     }
     if (parseExtendedCommandArgumentsOrReply(c, COMMAND_MSET, (int)args_start_idx, c->argc,
-                                             &flags, &unit, &expire_idx, &expire, NULL) != C_OK) {
+                                             &flags, &unit, &expire_idx, &expire, NULL) != C_OK)
+    {
         return;
     }
 
@@ -645,7 +647,8 @@ void msetexCommand(client *c) {
         for (int j = 2; j < args_start_idx; j += 2) {
             robj *o = lookupKeyWrite(c->db, c->argv[j]);
             if (((flags & ARGS_SET_NX) && o != NULL) ||
-                ((flags & ARGS_SET_XX) && o == NULL)) {
+                ((flags & ARGS_SET_XX) && o == NULL))
+            {
                 addReply(c, shared.czero);
                 return;
             }
@@ -704,14 +707,16 @@ void incrDecrCommand(client *c, long long incr) {
 
     oldvalue = value;
     if ((incr < 0 && oldvalue < 0 && incr < (LLONG_MIN - oldvalue)) ||
-        (incr > 0 && oldvalue > 0 && incr > (LLONG_MAX - oldvalue))) {
+        (incr > 0 && oldvalue > 0 && incr > (LLONG_MAX - oldvalue)))
+    {
         addReplyError(c, "increment or decrement would overflow");
         return;
     }
     value += incr;
 
     if (o && o->refcount == 1 && o->encoding == OBJ_ENCODING_INT &&
-        value >= LONG_MIN && value <= LONG_MAX) {
+        value >= LONG_MIN && value <= LONG_MAX)
+    {
         new = o;
         objectSetVal(o, (void *)((long)value));
     } else {
@@ -849,7 +854,8 @@ void lcsCommand(client *c) {
     obja = lookupKeyRead(c->db, c->argv[1]);
     objb = lookupKeyRead(c->db, c->argv[2]);
     if ((obja && obja->type != OBJ_STRING) ||
-        (objb && objb->type != OBJ_STRING)) {
+        (objb && objb->type != OBJ_STRING))
+    {
         addReplyError(c,
                       "The specified keys must contain string values");
         /* Don't cleanup the objects, we need to do that

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -367,7 +367,8 @@ static zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double
      * at the same position, we can just update the score without
      * actually removing and re-inserting the element in the skiplist. */
     if ((node->backward == NULL || node->backward->score < newscore) &&
-        (node->level[0].forward == NULL || node->level[0].forward->score > newscore)) {
+        (node->level[0].forward == NULL || node->level[0].forward->score > newscore))
+    {
         node->score = newscore;
         return NULL;
     }
@@ -530,7 +531,8 @@ static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, h
     x = zslGetHeader(zsl);
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
         while (x->level[i].forward &&
-               !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), range)) {
+               !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), range))
+        {
             x = x->level[i].forward;
         }
         update[i] = x;
@@ -720,7 +722,8 @@ int zsetParseLexRange(robj *min, robj *max, zlexrangespec *spec) {
 
     spec->min = spec->max = NULL;
     if (zslParseLexRangeItem(min, &spec->min, &spec->minex) == C_ERR ||
-        zslParseLexRangeItem(max, &spec->max, &spec->maxex) == C_ERR) {
+        zslParseLexRangeItem(max, &spec->max, &spec->maxex) == C_ERR)
+    {
         zsetFreeLexRange(spec);
         return C_ERR;
     } else {
@@ -1295,7 +1298,8 @@ robj *zsetTypeCreate(size_t size_hint, size_t val_len_hint) {
  * the size hint. */
 void zsetTypeMaybeConvert(robj *zobj, size_t size_hint, size_t value_len_hint) {
     if (zobj->encoding == OBJ_ENCODING_LISTPACK &&
-        (size_hint > server.zset_max_listpack_entries || value_len_hint > server.zset_max_listpack_value)) {
+        (size_hint > server.zset_max_listpack_entries || value_len_hint > server.zset_max_listpack_value))
+    {
         zsetConvertAndExpand(zobj, OBJ_ENCODING_SKIPLIST, size_hint);
     }
 }
@@ -1390,7 +1394,8 @@ void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelele
     zset *zset = objectGetVal(zobj);
 
     if (zslGetLength(zset->zsl) <= server.zset_max_listpack_entries &&
-        maxelelen <= server.zset_max_listpack_value && lpSafeToAdd(NULL, totelelen)) {
+        maxelelen <= server.zset_max_listpack_value && lpSafeToAdd(NULL, totelelen))
+    {
         zsetConvert(zobj, OBJ_ENCODING_LISTPACK);
     }
 }
@@ -1516,7 +1521,8 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
             /* check if the element is too large or the list
              * becomes too long *before* executing zzlInsert. */
             if (zzlLength(objectGetVal(zobj)) + 1 > server.zset_max_listpack_entries ||
-                sdslen(ele) > server.zset_max_listpack_value || !lpSafeToAdd(objectGetVal(zobj), sdslen(ele))) {
+                sdslen(ele) > server.zset_max_listpack_value || !lpSafeToAdd(objectGetVal(zobj), sdslen(ele)))
+            {
                 zsetConvertAndExpand(zobj, OBJ_ENCODING_SKIPLIST, zsetLength(zobj) + 1);
             } else {
                 objectSetVal(zobj, zzlInsert(objectGetVal(zobj), ele, score));
@@ -2650,18 +2656,21 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
 
         while (remaining) {
             if (op != SET_OP_DIFF && !cardinality_only && remaining >= (setnum + 1) &&
-                !strcasecmp(objectGetVal(c->argv[j]), "weights")) {
+                !strcasecmp(objectGetVal(c->argv[j]), "weights"))
+            {
                 j++;
                 remaining--;
                 for (i = 0; i < setnum; i++, j++, remaining--) {
                     if (getDoubleFromObjectOrReply(c, c->argv[j], &src[i].weight, "weight value is not a float") !=
-                        C_OK) {
+                        C_OK)
+                    {
                         zfree(src);
                         return;
                     }
                 }
             } else if (op != SET_OP_DIFF && !cardinality_only && remaining >= 2 &&
-                       !strcasecmp(objectGetVal(c->argv[j]), "aggregate")) {
+                       !strcasecmp(objectGetVal(c->argv[j]), "aggregate"))
+            {
                 j++;
                 remaining--;
                 if (!strcasecmp(objectGetVal(c->argv[j]), "sum")) {
@@ -3621,7 +3630,8 @@ void zrangeGenericCommand(zrange_result_handler *handler,
             opt_withscores = 1;
         } else if (!strcasecmp(objectGetVal(c->argv[j]), "limit") && leftargs >= 2) {
             if ((getLongFromObjectOrReply(c, c->argv[j + 1], &opt_offset, NULL) != C_OK) ||
-                (getLongFromObjectOrReply(c, c->argv[j + 2], &opt_limit, NULL) != C_OK)) {
+                (getLongFromObjectOrReply(c, c->argv[j + 2], &opt_limit, NULL) != C_OK))
+            {
                 return;
             }
             j += 2;
@@ -3664,7 +3674,8 @@ void zrangeGenericCommand(zrange_result_handler *handler,
     case ZRANGE_RANK:
         /* Z[REV]RANGE, ZRANGESTORE [REV]RANGE */
         if ((getLongFromObjectOrReply(c, c->argv[minidx], &opt_start, NULL) != C_OK) ||
-            (getLongFromObjectOrReply(c, c->argv[maxidx], &opt_end, NULL) != C_OK)) {
+            (getLongFromObjectOrReply(c, c->argv[maxidx], &opt_end, NULL) != C_OK))
+        {
             return;
         }
         break;
@@ -4291,7 +4302,8 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * In this case we can simply get random elements from the zset and add
      * to the temporary set, trying to eventually get enough unique elements
      * to reach the specified count. */
-    else {
+    else
+    {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
         hashtable *ht = hashtableCreate(&setHashtableType);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -59,7 +59,8 @@ int clientsCronHandleTimeout(client *c, mstime_t now_ms) {
         !mustObeyClient(c) && /* No timeout for primaries and AOF */
         !c->flag.blocked &&   /* No timeout for BLPOP */
         !c->flag.pubsub &&    /* No timeout for Pub/Sub clients */
-        (now - c->last_interaction > server.maxidletime)) {
+        (now - c->last_interaction > server.maxidletime))
+    {
         serverLog(LL_VERBOSE, "Closing idle client");
         freeClient(c);
         return 1;

--- a/src/tls.c
+++ b/src/tls.c
@@ -400,7 +400,8 @@ static int tlsUpdateCertInfoFromDir(const char *path, long long *expiry, sds *se
 
 static void tlsRefreshServerCertInfo(void) {
     if (!(server.tls_port || server.tls_replication || server.tls_cluster) || !valkey_tls_ctx ||
-        tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_cert_expire_time, &server.tls_server_cert_serial) == C_ERR) {
+        tlsUpdateCertInfoFromCtx(valkey_tls_ctx, &server.tls_server_cert_expire_time, &server.tls_server_cert_serial) == C_ERR)
+    {
         tlsClearCertInfo(&server.tls_server_cert_expire_time, &server.tls_server_cert_serial);
     }
 }
@@ -470,7 +471,8 @@ static bool isCertValid(X509 *cert) {
     const ASN1_TIME *not_after = X509_get0_notAfter(cert);
     if (!not_before || !not_after) return false;
     if (X509_cmp_current_time(not_before) > 0 ||
-        X509_cmp_current_time(not_after) < 0) {
+        X509_cmp_current_time(not_after) < 0)
+    {
         return false;
     }
     return true;
@@ -658,7 +660,8 @@ static int tlsCreateContexts(serverTLSContextConfig *ctx_config, SSL_CTX **out_c
     }
 
     if (((server.tls_auth_clients != TLS_CLIENT_AUTH_NO) || server.tls_cluster || server.tls_replication) &&
-        !ctx_config->ca_cert_file && !ctx_config->ca_cert_dir) {
+        !ctx_config->ca_cert_file && !ctx_config->ca_cert_dir)
+    {
         serverLog(LL_WARNING, "Either tls-ca-cert-file or tls-ca-cert-dir must be specified when tls-cluster, "
                               "tls-replication or tls-auth-clients are enabled!");
         goto error;
@@ -849,17 +852,20 @@ static void captureMetadata(serverTLSContextConfig *ctx_config, tlsMaterialsMeta
 static int metadataChanged(const tlsMaterialsMetadata *old, const tlsMaterialsMetadata *new) {
     /* Check certificate fingerprints */
     if (old->cert_fingerprint_len != new->cert_fingerprint_len ||
-        (new->cert_fingerprint_len > 0 && memcmp(old->cert_fingerprint, new->cert_fingerprint, new->cert_fingerprint_len) != 0)) {
+        (new->cert_fingerprint_len > 0 && memcmp(old->cert_fingerprint, new->cert_fingerprint, new->cert_fingerprint_len) != 0))
+    {
         return 1;
     }
 
     if (old->client_cert_fingerprint_len != new->client_cert_fingerprint_len ||
-        (new->client_cert_fingerprint_len > 0 && memcmp(old->client_cert_fingerprint, new->client_cert_fingerprint, new->client_cert_fingerprint_len) != 0)) {
+        (new->client_cert_fingerprint_len > 0 && memcmp(old->client_cert_fingerprint, new->client_cert_fingerprint, new->client_cert_fingerprint_len) != 0))
+    {
         return 1;
     }
 
     if (old->ca_cert_fingerprint_len != new->ca_cert_fingerprint_len ||
-        (new->ca_cert_fingerprint_len > 0 && memcmp(old->ca_cert_fingerprint, new->ca_cert_fingerprint, new->ca_cert_fingerprint_len) != 0)) {
+        (new->ca_cert_fingerprint_len > 0 && memcmp(old->ca_cert_fingerprint, new->ca_cert_fingerprint, new->ca_cert_fingerprint_len) != 0))
+    {
         return 1;
     }
 
@@ -1011,7 +1017,8 @@ void tlsReconfigureIfNeeded(void) {
     const long long configAgeMicros = server.ustime - lastConfigureTime;
     const long long configAgeSeconds = (configAgeMicros / 1000) / 1000;
     if (server.tls_ctx_config.auto_reload_interval == 0 ||
-        configAgeSeconds < server.tls_ctx_config.auto_reload_interval) {
+        configAgeSeconds < server.tls_ctx_config.auto_reload_interval)
+    {
         return;
     }
     bioCreateTlsReloadJob();

--- a/src/tracking.c
+++ b/src/tracking.c
@@ -138,7 +138,8 @@ int checkPrefixCollisionsOrReply(client *c, robj **prefixes, size_t numprefix) {
         /* Check input has no overlap with itself. */
         for (size_t j = i + 1; j < numprefix; j++) {
             if (stringCheckPrefix(objectGetVal(prefixes[i]), sdslen(objectGetVal(prefixes[i])), objectGetVal(prefixes[j]),
-                                  sdslen(objectGetVal(prefixes[j])))) {
+                                  sdslen(objectGetVal(prefixes[j]))))
+            {
                 addReplyErrorFormat(c,
                                     "Prefix '%s' overlaps with another provided prefix '%s'. "
                                     "Prefixes for a single client must not overlap.",

--- a/src/util.c
+++ b/src/util.c
@@ -768,7 +768,8 @@ int string2d(const char *s, size_t slen, double *dp) {
     char *eptr;
     *dp = valkey_strtod_n(s, slen, &eptr);
     if (slen == 0 || isspace(((const char *)s)[0]) || (size_t)(eptr - (char *)s) != slen ||
-        (errno == ERANGE && (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) || isnan(*dp) || errno == EINVAL) {
+        (errno == ERANGE && (*dp == HUGE_VAL || *dp == -HUGE_VAL || fpclassify(*dp) == FP_ZERO)) || isnan(*dp) || errno == EINVAL)
+    {
         errno = 0;
         return 0;
     }

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -641,7 +641,8 @@ static long long acquireTokenOrWait(int tokens) {
                 &old_last_time_ns,
                 last_time_ns,
                 memory_order_release,
-                memory_order_relaxed)) {
+                memory_order_relaxed))
+        {
             break;
         }
     }
@@ -2517,7 +2518,8 @@ int main(int argc, char **argv) {
         }
 
         if (test_is_selected("lrange") || test_is_selected("lrange_100") || test_is_selected("lrange_300") ||
-            test_is_selected("lrange_500") || test_is_selected("lrange_600")) {
+            test_is_selected("lrange_500") || test_is_selected("lrange_600"))
+        {
             len = valkeyFormatCommand(&cmd, "LPUSH mylist%s %s", tag, data);
             benchmark("LPUSH (needed to benchmark LRANGE)", cmd, len);
             free(cmd);

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -629,7 +629,8 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
     rdbver = atoi(buf + 6);
     if (rdbver < 1 ||
         (rdbver < RDB_FOREIGN_VERSION_MIN && !is_redis_magic) ||
-        (rdbver > RDB_FOREIGN_VERSION_MAX && !is_valkey_magic)) {
+        (rdbver > RDB_FOREIGN_VERSION_MAX && !is_valkey_magic))
+    {
         rdbCheckError("Can't handle RDB format version %d", rdbver);
         goto err;
     } else if (rdbver > RDB_VERSION) {
@@ -767,7 +768,8 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             continue;
         } else if (rdbIsForeignVersion(rdbver) &&
                    type >= RDB_FOREIGN_TYPE_MIN &&
-                   type <= RDB_FOREIGN_TYPE_MAX) {
+                   type <= RDB_FOREIGN_TYPE_MAX)
+        {
             rdbCheckError("Unknown object type %d in RDB file with foreign version %d", type, rdbver);
             goto err;
         } else if (!rdbIsObjectType(type)) {

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1876,7 +1876,8 @@ static sds cliFormatReplyTTY(valkeyReply *r, char *prefix) {
 /* Returns 1 if the reply is a pubsub pushed reply. */
 int isPubsubPush(valkeyReply *r) {
     if (r == NULL || r->type != (config.current_resp3 ? VALKEY_REPLY_PUSH : VALKEY_REPLY_ARRAY) || r->elements < 3 ||
-        r->element[0]->type != VALKEY_REPLY_STRING) {
+        r->element[0]->type != VALKEY_REPLY_STRING)
+    {
         return 0;
     }
     char *str = r->element[0]->str;
@@ -2095,7 +2096,8 @@ static sds cliFormatReplyJson(sds out, valkeyReply *r, int mode) {
         for (i = 0; i < r->elements; i += 2) {
             valkeyReply *key = r->element[i];
             if (key->type == VALKEY_REPLY_ERROR || key->type == VALKEY_REPLY_STATUS || key->type == VALKEY_REPLY_STRING ||
-                key->type == VALKEY_REPLY_VERB) {
+                key->type == VALKEY_REPLY_VERB)
+            {
                 out = cliFormatReplyJson(out, key, mode);
             } else {
                 /* According to JSON spec, JSON map keys must be strings,
@@ -2204,7 +2206,8 @@ static int cliReadReply(int output_raw_strings) {
     /* Check if we need to connect to a different node and reissue the
      * request. */
     if (config.cluster_mode && reply->type == VALKEY_REPLY_ERROR &&
-        (!strncmp(reply->str, "MOVED ", 6) || !strncmp(reply->str, "ASK ", 4))) {
+        (!strncmp(reply->str, "MOVED ", 6) || !strncmp(reply->str, "ASK ", 4)))
+    {
         char *p = reply->str, *s;
         int slot;
 
@@ -2366,7 +2369,8 @@ static int cliSendCommand(int argc, char **argv, long repeat) {
         (argc == 2 && !strcasecmp(command, "latency") && !strcasecmp(argv[1], "doctor")) ||
         /* Format PROXY INFO command for Cluster Proxy:
          * https://github.com/artix75/redis-cluster-proxy */
-        (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info"))) {
+        (argc >= 2 && !strcasecmp(command, "proxy") && !strcasecmp(argv[1], "info")))
+    {
         output_raw = 1;
     }
 
@@ -2799,12 +2803,14 @@ static int parseOptions(int argc, char **argv) {
         } else if (!strcmp(argv[i], "--cluster-slave") || !strcmp(argv[i], "--cluster-replica")) {
             config.cluster_manager_command.flags |= CLUSTER_MANAGER_CMD_FLAG_REPLICA;
         } else if (!strcmp(argv[i], "--cluster-use-empty-masters") ||
-                   !strcmp(argv[i], "--cluster-use-empty-primaries")) {
+                   !strcmp(argv[i], "--cluster-use-empty-primaries"))
+        {
             config.cluster_manager_command.flags |= CLUSTER_MANAGER_CMD_FLAG_EMPTY_PRIMARY;
         } else if (!strcmp(argv[i], "--cluster-search-multiple-owners")) {
             config.cluster_manager_command.flags |= CLUSTER_MANAGER_CMD_FLAG_CHECK_OWNERS;
         } else if (!strcmp(argv[i], "--cluster-fix-with-unreachable-masters") ||
-                   !strcmp(argv[i], "--cluster-fix-with-unreachable-primaries")) {
+                   !strcmp(argv[i], "--cluster-fix-with-unreachable-primaries"))
+        {
             config.cluster_manager_command.flags |= CLUSTER_MANAGER_CMD_FLAG_FIX_WITH_UNREACHABLE_PRIMARIES;
         } else if (!strcmp(argv[i], "--cluster-use-atomic-slot-migration")) {
             config.cluster_manager_command.flags |= CLUSTER_MANAGER_CMD_FLAG_USE_ATOMIC_SLOT_MIGRATION;
@@ -3151,7 +3157,8 @@ static int issueCommandRepeat(int argc, char **argv, long repeat) {
 
     while (1) {
         if (config.cluster_reissue_command || context == NULL || context->err == VALKEY_ERR_IO ||
-            context->err == VALKEY_ERR_EOF) {
+            context->err == VALKEY_ERR_EOF)
+        {
             if (cliConnect(CC_FORCE) != VALKEY_OK) {
                 cliPrintContextError();
                 config.cluster_reissue_command = 0;
@@ -3264,14 +3271,16 @@ static int isSensitiveCommand(int argc, char **argv) {
         return 1;
     } else if (argc > 1 && !strcasecmp(argv[0], "acl") &&
                (!strcasecmp(argv[1], "deluser") || !strcasecmp(argv[1], "setuser") ||
-                !strcasecmp(argv[1], "getuser"))) {
+                !strcasecmp(argv[1], "getuser")))
+    {
         return 1;
     } else if (argc > 2 && !strcasecmp(argv[0], "config") && !strcasecmp(argv[1], "set")) {
         for (int j = 2; j < argc; j = j + 2) {
             if (!strcasecmp(argv[j], "masterauth") || !strcasecmp(argv[j], "masteruser") ||
                 !strcasecmp(argv[j], "primaryuser") || !strcasecmp(argv[j], "primaryauth") ||
                 !strcasecmp(argv[j], "tls-key-file-pass") || !strcasecmp(argv[j], "tls-client-key-file-pass") ||
-                !strcasecmp(argv[j], "requirepass")) {
+                !strcasecmp(argv[j], "requirepass"))
+            {
                 return 1;
             }
         }
@@ -3305,7 +3314,8 @@ static int isSensitiveCommand(int argc, char **argv) {
         /* SENTINEL CONFIG SET sentinel-pass password
          * SENTINEL CONFIG SET sentinel-user username */
         if (!strcasecmp(argv[1], "config") && !strcasecmp(argv[2], "set") &&
-            (!strcasecmp(argv[3], "sentinel-pass") || !strcasecmp(argv[3], "sentinel-user"))) {
+            (!strcasecmp(argv[3], "sentinel-pass") || !strcasecmp(argv[3], "sentinel-user")))
+        {
             return 1;
         }
         /* SENTINEL SET <primaryname> auth-pass password
@@ -5302,7 +5312,8 @@ static int clusterManagerMigrateKeysInSlot(clusterManagerNode *source,
                             clusterManagerLogErr("*** Value check failed!\n");
                             const char *debug_not_allowed = "ERR DEBUG command not allowed.";
                             if ((source_err && !strncmp(source_err, debug_not_allowed, 30)) ||
-                                (target_err && !strncmp(target_err, debug_not_allowed, 30))) {
+                                (target_err && !strncmp(target_err, debug_not_allowed, 30)))
+                            {
                                 clusterManagerLogErr("DEBUG command is not allowed.\n"
                                                      "You can turn on the enable-debug-command option.\n"
                                                      "Or you can relaunch the command with --cluster-replace "
@@ -5829,7 +5840,8 @@ static int clusterManagerLoadInfoCommon(clusterManagerNode *node, int include_un
             e = NULL;
             if (clusterManagerNodeLoadInfo(friend, 0, &e)) {
                 if (friend->flags &
-                    (CLUSTER_MANAGER_FLAG_NOADDR | CLUSTER_MANAGER_FLAG_DISCONNECT | CLUSTER_MANAGER_FLAG_FAIL)) {
+                    (CLUSTER_MANAGER_FLAG_NOADDR | CLUSTER_MANAGER_FLAG_DISCONNECT | CLUSTER_MANAGER_FLAG_FAIL))
+                {
                     goto invalid_friend;
                 }
                 listAddNodeTail(cluster_manager.nodes, friend);
@@ -6367,7 +6379,8 @@ static int clusterManagerFixSlotsCoverage(char *all_slots) {
         clusterManagerPrintSlotsList(multi);
         if (confirmWithYes("Fix these slots by moving keys "
                            "into a single node?",
-                           ignore_force)) {
+                           ignore_force))
+        {
             listIter li;
             listNode *ln;
             listRewind(multi, &li);
@@ -6615,7 +6628,8 @@ static int clusterManagerFixOpenSlot(int slot) {
      * they probably got keys about the slot after a restart so opened
      * the slot. In this case we just move all the keys to the owner
      * according to the configuration. */
-    else if (listLength(migrating) == 0 && listLength(importing) > 0) {
+    else if (listLength(migrating) == 0 && listLength(importing) > 0)
+    {
         clusterManagerLogInfo(">>> Case 2: Moving all the %d slot keys to its "
                               "owner %s:%d\n",
                               slot, owner->ip, owner->port);
@@ -6653,7 +6667,8 @@ static int clusterManagerFixOpenSlot(int slot) {
      * If no importing node has the same ID as the destination node of the
      * migrating node, the slot's state is closed on both the migrating node
      * and the importing nodes. */
-    else if (listLength(migrating) == 1 && listLength(importing) > 1) {
+    else if (listLength(migrating) == 1 && listLength(importing) > 1)
+    {
         int try_to_fix = 1;
         clusterManagerNode *src = listFirst(migrating)->value;
         clusterManagerNode *dst = NULL;
@@ -9350,7 +9365,8 @@ static void sendReadOnly(void) {
         fprintf(stderr, "\nI/O error\n");
         exit(1);
     } else if (read_reply->type == VALKEY_REPLY_ERROR &&
-               strcmp(read_reply->str, "ERR This instance has cluster support disabled") != 0) {
+               strcmp(read_reply->str, "ERR This instance has cluster support disabled") != 0)
+    {
         fprintf(stderr, "Error: %s\n", read_reply->str);
         exit(1);
     }

--- a/src/vset.c
+++ b/src/vset.c
@@ -1417,7 +1417,8 @@ static inline bool shrinkRaxBucketIfPossible(vsetBucket **target, vsetGetExpiryF
         /* We will not convert hashtable to our only bucket since we will lose the ability to scan the items in a sorted way.
          * We will also not shrink when we have a full vector, since it might immediately be repopulated.  */
         if (bucket_type == VSET_BUCKET_SINGLE ||
-            (bucket_type == VSET_BUCKET_VECTOR && pvLen(vsetBucketVector(bucket)) < VOLATILESET_VECTOR_BUCKET_MAX_SIZE)) {
+            (bucket_type == VSET_BUCKET_VECTOR && pvLen(vsetBucketVector(bucket)) < VOLATILESET_VECTOR_BUCKET_MAX_SIZE))
+        {
             if (bucket_type == VSET_BUCKET_VECTOR) {
                 pVector *pv = vsetBucketVector(bucket);
                 /* first lets sort the vector. we cannot set the target bucket as unsorted vector bucket */


### PR DESCRIPTION
So when we merged the [original clang format](https://github.com/valkey-io/valkey/pull/323#discussion_r1600265975), we merged something I think a few of us had an issue with which was indentation on multi-line control statements made it hard to see when if ended and when the code began, example:

```
            if (!rioWriteBulkCount(r, '*', 2 + cmd_items) || !rioWriteBulkString(r, "RPUSH", 5) ||
                !rioWriteBulkObject(r, key)) {
                listTypeReleaseIterator(li);
                return 0;
            }
```

listTypeReleaseIterator is not part of the conditional, but it looks like it is. The current code formatter forces this. Without a column limit, there is not way to force the multi-line, but the provided configuration makes it "allowed". 

```
            if (!rioWriteBulkCount(r, '*', 2 + cmd_items) || !rioWriteBulkString(r, "RPUSH", 5) ||
                !rioWriteBulkObject(r, key))
            {
                listTypeReleaseIterator(li);
                return 0;
            }
```
Also, the original Redis style did this. 