### PR TITLE
Fix FD leak in connSocketBlockingConnect on timeout

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -374,13 +374,14 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
         return C_ERR;
     }
 
+    conn->fd = fd;
+
     if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
         return C_ERR;
     }
 
-    conn->fd = fd;
     conn->state = CONN_STATE_CONNECTED;
     return C_OK;
 }


### PR DESCRIPTION
## Summary

Fix a file descriptor leak in `connSocketBlockingConnect()` when `aeWait()` times out.

## Bug

When `anetTcpNonBlockConnect()` succeeds but `aeWait()` times out (e.g., MIGRATE to an unreachable host), the fd is leaked because it was never assigned to `conn->fd`. The caller's `connClose()` checks `conn->fd != -1` and skips cleanup.

## Fix

Assign `conn->fd = fd` immediately after `anetTcpNonBlockConnect()` succeeds, before `aeWait()`. This way the caller's normal `connClose()` cleanup path handles the fd on any error, which is consistent with how the rest of the connection lifecycle works.

TLS connections also benefit since `connTLSBlockingConnect` delegates to this function for the TCP layer.

## Reproducer

```
valkey-cli SET key hello
# Repeat against unreachable host:
for i in $(seq 1 30); do valkey-cli MIGRATE 192.0.2.1 6379 key 0 500; done
# Check: /proc/<pid>/fd shows 30 leaked socket fds
```

---

*This issue was generated by AI but verified, with love, by a human.*