### PR TITLE
Pin clang to version 17 in sanitizer CI jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -950,7 +950,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang-17]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1017,7 +1017,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang-17]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1088,7 +1088,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang-17]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1155,7 +1155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang-17]
     env:
       CC: ${{ matrix.compiler }}
     steps:


### PR DESCRIPTION
### Analysis
The daily CI sanitizer jobs with clang are failing during the build step.

The `ubuntu-latest` runner now has clang 18, but the LLVM gold plugin
is still version 17. When the static Lua module is built with `-flto`,
the `.o` files contain LLVM 18 bitcode that the gold plugin (v17) cannot
read:
`bfd plugin: LLVM gold plugin has failed to create LTO module: Unknown attribute kind (91) (Producer: 'LLVM18.1.3' Reader: 'LLVM 17.0.6')
`
Example failure: https://github.com/valkey-io/valkey/actions/runs/24753491944/job/72421581512

### Fix
Pin the sanitizer jobs to `clang-17` so the compiler and gold plugin
versions match.
Tested(successfully built): https://github.com/hanxizh9910/valkey/actions/runs/24859845008

### Note
If `clang-17` is removed from the `ubuntu-latest` image in the future,
we may need to either add an explicit install step
