### PR TITLE
Fix: reject bare '(' and empty string as score in ZRANGEBYSCORE

### DIFF
--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -634,10 +634,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(min);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len <= 1) return C_ERR;
             spec->min = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
             spec->minex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->min = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->min)) return C_ERR;
         }
@@ -648,10 +650,12 @@ static int zslParseRange(robj *min, robj *max, zrangespec *spec) {
         char *s = objectGetVal(max);
         size_t len = sdslen(s);
         if (s[0] == '(') {
+            if (len <= 1) return C_ERR;
             spec->max = valkey_strtod_n(s + 1, len - 1, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
             spec->maxex = 1;
         } else {
+            if (len == 0) return C_ERR;
             spec->max = valkey_strtod_n(s, len, &eptr);
             if (eptr[0] != '\0' || isnan(spec->max)) return C_ERR;
         }

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2948,4 +2948,17 @@ start_server [list overrides [list save ""] tags {"zset needs:debug external:ski
         }
         assert_equal 1 $can_break
     }
+
+    test {ZRANGEBYSCORE with bare "(" or empty string returns an error} {
+        r zadd zset_test 1 "a"
+        
+        # Check that a bare "(" as min score results in an error
+        assert_error "*min or max is not a float*" {r zrangebyscore zset_test ( +inf}
+        
+        # Check that an empty string as min score results in an error
+        assert_error "*min or max is not a float*" {r zrangebyscore zset_test "" +inf}
+        
+        # Check that a bare "(" as max score results in an error
+        assert_error "*min or max is not a float*" {r zrangebyscore zset_test -inf (}
+    }
 }


### PR DESCRIPTION
Note there also a same pending fix in #3493

### Description
Fixed a bug where `ZRANGEBYSCORE` and related commands (including `ZCOUNT`, `ZRANGESTORE`, etc.) incorrectly accepted a bare `(` character or an empty string as a valid score of `0.0`.

According to the documentation, `(` should be a prefix for an exclusive score (e.g., `(1.5`). A bare `(` without any following number is malformed and should return a parsing error.

**Changes:**
- Added a length check in `zslParseRange` to ensure that `(` is followed by a numeric value.
- Added a check to reject empty strings `""` which were previously parsed as `0.0`.
- Added regression tests to verify the fix and prevent future regressions.

### Fixes
Fixes #3483

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the [development guidelines](https://github.com/valkey-io/valkey/blob/unstable/DEVELOPMENT_GUIDE.md)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests passed (Ran `tests/unit/type/zset`)
- [x] I have signed my commits with DCO (Signed-off-by)

### Test Results
Passed `tclsh tests/test_helper.tcl --single unit/type/zset`:

~~~[ok]: ZRANGEBYSCORE with bare "(" or empty string returns an error
Test Summary: 327 passed, 0 failed
~~~