### PR TITLE
tls: prevent stale auto-reload from overriding CONFIG SET

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -787,6 +787,7 @@ typedef struct {
     SSL_CTX *ctx;
     SSL_CTX *client_ctx;
     tlsMaterialsMetadata metadata;
+    unsigned long long generation;
 } tlsPendingReload;
 
 /* Last known (active) TLS materials metadata */
@@ -880,8 +881,26 @@ static int metadataChanged(const tlsMaterialsMetadata *old, const tlsMaterialsMe
 
 /* TLS background reload state */
 static _Atomic long long lastTlsConfigureTime = 0;
+static _Atomic unsigned long long tls_config_generation = 1;
 static tlsPendingReload pending_reload = {0};
 static pthread_mutex_t pending_reload_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Caller must hold pending_reload_mutex. Use the unlocked wrapper unless the
+ * lock is already held by the current code path. */
+static void tlsDiscardPendingReloadLocked(const char *reason) {
+    if (pending_reload.ctx) {
+        SSL_CTX_free(pending_reload.ctx);
+        SSL_CTX_free(pending_reload.client_ctx);
+        memset(&pending_reload, 0, sizeof(pending_reload));
+        if (reason) serverLog(LL_DEBUG, "%s", reason);
+    }
+}
+
+static void tlsDiscardPendingReload(const char *reason) {
+    pthread_mutex_lock(&pending_reload_mutex);
+    tlsDiscardPendingReloadLocked(reason);
+    pthread_mutex_unlock(&pending_reload_mutex);
+}
 
 /* Attempt to configure/reconfigure TLS. This operation is atomic and will
  * leave the SSL_CTX unchanged if it fails.
@@ -909,6 +928,7 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
 
     if (background && reconfigure) {
         tlsMaterialsMetadata new_metadata;
+        unsigned long long generation = atomic_load_explicit(&tls_config_generation, memory_order_acquire);
         captureMetadata(ctx_config, &new_metadata);
 
         if (!metadataChanged(&active_metadata, &new_metadata)) {
@@ -932,6 +952,7 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
         pending_reload.ctx = ctx;
         pending_reload.client_ctx = client_ctx;
         pending_reload.metadata = new_metadata;
+        pending_reload.generation = generation;
         pthread_mutex_unlock(&pending_reload_mutex);
 
         serverLog(LL_DEBUG, "Background TLS reload parsed TLS materials successfully");
@@ -939,6 +960,10 @@ static int tlsConfigure(void *priv, int reconfigure, bool background) {
         if (tlsCreateContexts(ctx_config, &ctx, &client_ctx) == C_ERR) {
             return C_ERR;
         }
+
+        /* Synchronous reconfiguration wins over any staged background reloads. */
+        atomic_fetch_add_explicit(&tls_config_generation, 1, memory_order_acq_rel);
+        tlsDiscardPendingReload("Discarding stale pending TLS reload after synchronous reconfiguration");
 
         SSL_CTX_free(valkey_tls_ctx);
         SSL_CTX_free(valkey_tls_client_ctx);
@@ -970,18 +995,22 @@ void tlsConfigureAsync(void) {
  * that just swaps pointers, updates metadata, and frees old contexts. */
 void tlsApplyPendingReload(void) {
     tlsPendingReload local_pending;
+    unsigned long long current_generation = atomic_load_explicit(&tls_config_generation, memory_order_acquire);
     pthread_mutex_lock(&pending_reload_mutex);
     if (!pending_reload.ctx) {
         pthread_mutex_unlock(&pending_reload_mutex);
         return;
     }
 
-    if (!metadataChanged(&active_metadata, &pending_reload.metadata)) {
-        SSL_CTX_free(pending_reload.ctx);
-        SSL_CTX_free(pending_reload.client_ctx);
-        memset(&pending_reload, 0, sizeof(pending_reload));
+    if (pending_reload.generation != current_generation) {
+        tlsDiscardPendingReloadLocked("Discarding stale pending TLS reload");
         pthread_mutex_unlock(&pending_reload_mutex);
-        serverLog(LL_DEBUG, "Discarding pending TLS reload with unchanged materials");
+        return;
+    }
+
+    if (!metadataChanged(&active_metadata, &pending_reload.metadata)) {
+        tlsDiscardPendingReloadLocked("Discarding pending TLS reload with unchanged materials");
+        pthread_mutex_unlock(&pending_reload_mutex);
         return;
     }
 

--- a/tests/unit/tls.tcl
+++ b/tests/unit/tls.tcl
@@ -348,6 +348,67 @@ start_server {tags {"tls"}} {
             }
         }
 
+        test {TLS: CONFIG SET discards staged auto-reload results} {
+            if {$::tls_module} {
+                skip "Not supported with TLS built as a module"
+            }
+
+            set orig_server_crt [lindex [r config get tls-cert-file] 1]
+            set orig_server_key [lindex [r config get tls-key-file] 1]
+            set orig_loglevel [lindex [r config get loglevel] 1]
+            set orig_hz [lindex [r config get hz] 1]
+            set temp_crt "$orig_server_crt.temp"
+            set temp_key "$orig_server_key.temp"
+            file copy -force $orig_server_crt $temp_crt
+            file copy -force $orig_server_key $temp_key
+
+            try {
+                set valkey_crt [format "%s/tests/tls/valkey.crt" [pwd]]
+                set valkey_key [format "%s/tests/tls/valkey.key" [pwd]]
+
+                r CONFIG SET loglevel debug
+                r CONFIG SET hz 1
+                r CONFIG SET tls-cert-file $temp_crt tls-key-file $temp_key
+                r CONFIG SET tls-auto-reload-interval 1
+
+                set info1 [r info tls]
+                if {![regexp {tls_server_cert_serial:([^\r\n]+)} $info1 -> serial1]} {
+                    fail "INFO tls missing tls_server_cert_serial before staged reload"
+                }
+                assert {$serial1 ne "none"}
+
+                after 1100
+
+                set parsed_from_line [count_log_lines 0]
+                file copy -force $valkey_crt $temp_crt
+                file copy -force $valkey_key $temp_key
+                wait_for_log_messages 0 {"*Background TLS reload parsed TLS materials successfully*"} $parsed_from_line 200 10
+
+                # Replace the active TLS configuration after the background job staged a reload.
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
+                assert_equal [list tls-cert-file $orig_server_crt] [r CONFIG GET tls-cert-file]
+                assert_equal [list tls-key-file $orig_server_key] [r CONFIG GET tls-key-file]
+
+                # Wait past the next cron cycle. The stale staged reload used to be applied here.
+                after 1200
+
+                set s [valkey_client]
+                assert_equal "PONG" [$s PING]
+                $s close
+
+                set info2 [r info tls]
+                if {![regexp {tls_server_cert_serial:([^\r\n]+)} $info2 -> serial2]} {
+                    fail "INFO tls missing tls_server_cert_serial after synchronous reconfiguration"
+                }
+                assert_equal $serial1 $serial2
+            } finally {
+                r CONFIG SET tls-auto-reload-interval 0
+                r CONFIG SET tls-cert-file $orig_server_crt tls-key-file $orig_server_key
+                r CONFIG SET hz $orig_hz loglevel $orig_loglevel
+                file delete -force $temp_crt $temp_key
+            }
+        }
+
         test {TLS: Auto-reload interval validation} {
             if {$::tls_module} {
                 # Auto-reload requires built-in TLS


### PR DESCRIPTION
If TLS auto-reload stages an older context in the background, it can still be applied after a user changes TLS settings with CONFIG SET.

This can leave CONFIG GET showing the new paths while the active TLS context still uses the older certificate state.

Prevent stale staged reloads from overriding a newer synchronous TLS reconfiguration, and strengthen the regression test to verify both CONFIG GET and INFO tls.