### PR TITLE
hashtable iterator safety: invalidate on exhaustion

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2320,6 +2320,11 @@ bool hashtableNext(hashtableIterator *iterator, void **elemptr) {
         }
         return true;
     }
+    /* Clean up eagerly so repeated hashtableNext calls return false and
+     * safe iterators don't keep rehashing paused. The caller's own
+     * hashtableCleanupIterator call becomes a no-op (hashtable == NULL). */
+    hashtableCleanupIterator(iterator);
+    iter->hashtable = NULL;
     return false;
 }
 

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1300,3 +1300,64 @@ TEST_F(HashtableTest, hashtable_retarget_iterator) {
 
     hashtableCleanupIterator(&iter);
 }
+
+TEST_F(HashtableTest, iterator_next_after_exhaustion) {
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    for (int i = 0; i < 100; i++) {
+        ASSERT_TRUE(hashtableAdd(ht, (void *)(long)i));
+    }
+
+    /* Exhaust the iterator. */
+    hashtableIterator iter;
+    void *entry;
+    hashtableInitIterator(&iter, ht, 0);
+
+    size_t count = 0;
+    while (hashtableNext(&iter, &entry)) count++;
+    ASSERT_EQ(count, 100u);
+
+    /* Repeated calls after exhaustion should return false. */
+    ASSERT_FALSE(hashtableNext(&iter, &entry));
+    ASSERT_FALSE(hashtableNext(&iter, &entry));
+
+    /* Cleanup should still be safe (no-op). */
+    hashtableCleanupIterator(&iter);
+    hashtableRelease(ht);
+}
+
+TEST_F(HashtableTest, safe_iterator_cleanup_on_exhaustion) {
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    /* Add entries until rehashing starts so we can observe pause/resume. */
+    long j = 0;
+    while (!hashtableIsRehashing(ht)) {
+        j++;
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+    }
+
+    hashtableIterator iter;
+    void *entry;
+    hashtableInitIterator(&iter, ht, HASHTABLE_ITER_SAFE);
+
+    /* First call pauses rehashing. */
+    ASSERT_TRUE(hashtableNext(&iter, &entry));
+    ASSERT_TRUE(hashtableIsRehashingPaused(ht));
+
+    /* Exhaust the iterator. */
+    while (hashtableNext(&iter, &entry)) {
+    }
+
+    /* Rehashing should already be resumed by the exhaustion path,
+     * before the caller's explicit cleanup call. */
+    ASSERT_FALSE(hashtableIsRehashingPaused(ht));
+
+    /* Repeated calls should return false safely. */
+    ASSERT_FALSE(hashtableNext(&iter, &entry));
+
+    /* Cleanup is a no-op but must not crash. */
+    hashtableCleanupIterator(&iter);
+    hashtableRelease(ht);
+}

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1361,3 +1361,30 @@ TEST_F(HashtableTest, safe_iterator_cleanup_on_exhaustion) {
     hashtableCleanupIterator(&iter);
     hashtableRelease(ht);
 }
+
+TEST_F(HashtableTest, safe_iterator_release_before_cleanup) {
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    /* Add entries until rehashing starts. */
+    long j = 0;
+    while (!hashtableIsRehashing(ht)) {
+        j++;
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+    }
+
+    hashtableIterator iter;
+    void *entry;
+    hashtableInitIterator(&iter, ht, HASHTABLE_ITER_SAFE);
+
+    /* Exhaust the iterator. */
+    while (hashtableNext(&iter, &entry)) {
+    }
+
+    /* Release the hashtable before calling cleanup. The iterator was already
+     * untracked by exhaustion, so this should not access freed memory. */
+    hashtableRelease(ht);
+
+    /* Cleanup should be a no-op (hashtable == NULL). */
+    hashtableCleanupIterator(&iter);
+}


### PR DESCRIPTION
PR #2611 is abandoned, so I'm raising this PR to guard against the same potential issue.

If anyone called hashtableNext after it has returned false, it may re-enter the loop with stale table/index values. If the hashtable has been resized/rehashed since the first exhaustion so this may result in out of bounds access.

It also somewhat guards against the caller forgetting to clean up the iterator and leaving rehash disabled indefinitely resulting in accumulating performance degradation, but of course relying on this to automatically clean up should be avoided.