### PR TITLE
[Draft] ZSET (ordered index) interface and UTs for zskiplist - preparation to replace zskiplist with fbtree

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -33,6 +33,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/t_list.c
     ${CMAKE_SOURCE_DIR}/src/t_set.c
     ${CMAKE_SOURCE_DIR}/src/t_zset.c
+    ${CMAKE_SOURCE_DIR}/src/skiplist_ordered_index.c
     ${CMAKE_SOURCE_DIR}/src/t_hash.c
     ${CMAKE_SOURCE_DIR}/src/config.c
     ${CMAKE_SOURCE_DIR}/src/aof.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -555,6 +555,7 @@ ENGINE_SERVER_OBJ = \
     sha1.o \
     sha256.o \
     siphash.o \
+    skiplist_ordered_index.o \
     socket.o \
     sort.o \
     sparkline.o \

--- a/src/aof.c
+++ b/src/aof.c
@@ -32,6 +32,7 @@
 #include "rio.h"
 #include "functions.h"
 #include "module.h"
+#include "ordered_index.h"
 
 #include <signal.h>
 #include <fcntl.h>
@@ -2026,7 +2027,7 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
         hashtableInitIterator(&iter, zs->ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {
-            zskiplistNode *node = next;
+            OrderedIndexItem *item = next;
             if (count == 0) {
                 int cmd_items = (items > AOF_REWRITE_ITEMS_PER_CMD) ? AOF_REWRITE_ITEMS_PER_CMD : items;
 
@@ -2036,8 +2037,10 @@ int rewriteSortedSetObject(rio *r, robj *key, robj *o) {
                     return 0;
                 }
             }
-            sds ele = zslGetNodeElement(node);
-            if (!rioWriteBulkDouble(r, node->score) || !rioWriteBulkString(r, ele, sdslen(ele))) {
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+            if (!rioWriteBulkDouble(r, orderedIndexGetScore(item)) || !rioWriteBulkString(r, ele_ptr, ele_len)) {
                 hashtableCleanupIterator(&iter);
                 return 0;
             }

--- a/src/db.c
+++ b/src/db.c
@@ -1085,12 +1085,15 @@ void hashtableScanCallback(void *privdata, void *entry) {
         }
     }
 
-    /* zset data must be copied. Do this after filtering to avoid unneeded
-     * allocations. */
+    /* zset data: the score value must always be copied (it's formatted from a
+     * double into a stack buffer). The element key points directly into the
+     * node and doesn't need copying when only_keys is set. When values are
+     * included, we must copy the key too since free_callback applies to all
+     * items uniformly. */
     if (o->type == OBJ_ZSET) {
-        OrderedIndexItem *node = (OrderedIndexItem *)entry;
-        key = sdsnewlen(key, key_len);
         if (!data->only_keys) {
+            OrderedIndexItem *node = (OrderedIndexItem *)entry;
+            key = sdsnewlen(key, key_len);
             char buf[MAX_LONG_DOUBLE_CHARS];
             int len = ld2string(buf, sizeof(buf), orderedIndexGetScore(node), LD_STR_AUTO);
             sds tmp = sdsnewlen(buf, len);
@@ -1260,8 +1263,10 @@ void scanGenericCommand(client *c, robj *o, unsigned long long cursor, int slot,
     } else if (o->type == OBJ_ZSET && o->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(o);
         ht = zs->ht;
-        /* scanning ZSET allocates temporary strings even though it's a dict */
-        free_callback = sdsfree;
+        /* When returning scores, both element and score strings are allocated
+         * copies. When only_keys, element pointers reference the live data
+         * structure directly — no freeing needed. */
+        free_callback = only_keys ? NULL : sdsfree;
     }
     vectorInit(&result, SCAN_VECTOR_INITIAL_ALLOC, sizeof(stringRef));
 

--- a/src/db.c
+++ b/src/db.c
@@ -30,6 +30,7 @@
 #include "server.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
+#include "ordered_index.h"
 #include "latency.h"
 #include "script.h"
 #include "functions.h"
@@ -1049,7 +1050,8 @@ void keysScanCallback(void *privdata, void *entry, int didx) {
 void hashtableScanCallback(void *privdata, void *entry) {
     scanData *data = (scanData *)privdata;
     stringRef val = {NULL, 0};
-    sds key = NULL;
+    const char *key = NULL;
+    size_t key_len = 0;
 
     robj *o = data->o;
     data->sampled++;
@@ -1060,13 +1062,15 @@ void hashtableScanCallback(void *privdata, void *entry) {
 
     /* get key, value */
     if (o->type == OBJ_SET) {
-        key = (sds)entry;
+        key = (const char *)entry;
+        key_len = sdslen((sds)entry);
     } else if (o->type == OBJ_ZSET) {
-        zskiplistNode *node = (zskiplistNode *)entry;
-        key = zslGetNodeElement(node);
+        OrderedIndexItem *node = (OrderedIndexItem *)entry;
+        orderedIndexGetElementRaw(node, &key, &key_len);
         /* zset data is copied after filtering by key */
     } else if (o->type == OBJ_HASH) {
         key = entryGetField(entry);
+        key_len = sdslen((sds)key);
         if (!data->only_keys) {
             val.buf = entryGetValue(entry, &val.len);
         }
@@ -1076,7 +1080,7 @@ void hashtableScanCallback(void *privdata, void *entry) {
 
     /* Filter element if it does not match the pattern. */
     if (data->pattern) {
-        if (!stringmatchlen(data->pattern, sdslen(data->pattern), key, sdslen(key), 0)) {
+        if (!stringmatchlen(data->pattern, sdslen(data->pattern), key, key_len, 0)) {
             return;
         }
     }
@@ -1084,19 +1088,18 @@ void hashtableScanCallback(void *privdata, void *entry) {
     /* zset data must be copied. Do this after filtering to avoid unneeded
      * allocations. */
     if (o->type == OBJ_ZSET) {
-        /* zset data is copied */
-        zskiplistNode *node = (zskiplistNode *)entry;
-        key = sdsdup(zslGetNodeElement(node));
+        OrderedIndexItem *node = (OrderedIndexItem *)entry;
+        key = sdsnewlen(key, key_len);
         if (!data->only_keys) {
             char buf[MAX_LONG_DOUBLE_CHARS];
-            int len = ld2string(buf, sizeof(buf), node->score, LD_STR_AUTO);
+            int len = ld2string(buf, sizeof(buf), orderedIndexGetScore(node), LD_STR_AUTO);
             sds tmp = sdsnewlen(buf, len);
             val.buf = (const char *)tmp;
             val.len = sdslen(tmp);
         }
     }
 
-    addScanDataItem(data->result, (const char *)key, sdslen(key));
+    addScanDataItem(data->result, key, key_len);
     if (val.buf) {
         addScanDataItem(data->result, val.buf, val.len);
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -40,6 +40,7 @@
 #include "sds.h"
 #include "module.h"
 #include "ordered_index.h"
+#include "skiplist_internal.h"
 
 #include <arpa/inet.h>
 #include <signal.h>

--- a/src/debug.c
+++ b/src/debug.c
@@ -40,7 +40,6 @@
 #include "sds.h"
 #include "module.h"
 #include "ordered_index.h"
-#include "skiplist_internal.h"
 
 #include <arpa/inet.h>
 #include <signal.h>
@@ -1166,7 +1165,7 @@ void serverLogObjectDebugInfo(const robj *o) {
     } else if (o->type == OBJ_ZSET) {
         serverLog(LL_WARNING, "Sorted set size: %d", (int)zsetLength(o));
         if (o->encoding == OBJ_ENCODING_SKIPLIST)
-            serverLog(LL_WARNING, "Skiplist level: %d", (int)zslGetHeight((const zskiplist *)((const zset *)o->ptr)->zidx));
+            serverLog(LL_WARNING, "Skiplist level: %d", orderedIndexGetHeight(((const zset *)o->ptr)->zidx));
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING, "Stream size: %d", (int)streamLength(o));
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -39,6 +39,7 @@
 #include "io_threads.h"
 #include "sds.h"
 #include "module.h"
+#include "ordered_index.h"
 
 #include <arpa/inet.h>
 #include <signal.h>
@@ -216,12 +217,14 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
 
             void *next;
             while (hashtableNext(&iter, &next)) {
-                zskiplistNode *node = next;
-                const int len = fpconv_dtoa(node->score, buf);
+                OrderedIndexItem *item = next;
+                const int len = fpconv_dtoa(orderedIndexGetScore(item), buf);
                 buf[len] = '\0';
                 memset(eledigest, 0, 20);
-                sds ele = zslGetNodeElement(node);
-                mixDigest(eledigest, ele, sdslen(ele));
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+                mixDigest(eledigest, ele_ptr, ele_len);
                 mixDigest(eledigest, buf, strlen(buf));
                 xorDigest(digest, eledigest, 20);
             }
@@ -1162,7 +1165,7 @@ void serverLogObjectDebugInfo(const robj *o) {
     } else if (o->type == OBJ_ZSET) {
         serverLog(LL_WARNING, "Sorted set size: %d", (int)zsetLength(o));
         if (o->encoding == OBJ_ENCODING_SKIPLIST)
-            serverLog(LL_WARNING, "Skiplist level: %d", (int)((const zset *)o->ptr)->zsl->level);
+            serverLog(LL_WARNING, "Skiplist level: %d", (int)zslGetHeight((const zskiplist *)((const zset *)o->ptr)->zidx));
     } else if (o->type == OBJ_STREAM) {
         serverLog(LL_WARNING, "Stream size: %d", (int)streamLength(o));
     }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -40,6 +40,7 @@
 
 #include "server.h"
 #include "hashtable.h"
+#include "ordered_index.h"
 #include "eval.h"
 #include "script.h"
 #include "module.h"
@@ -236,63 +237,6 @@ robj *activeDefragStringOb(robj *ob) {
     return new_robj;
 }
 
-/* Internal function used by zslDefrag */
-static void zslUpdateNode(zskiplist *zsl, zskiplistNode *oldnode, zskiplistNode *newnode, zskiplistNode **update) {
-    int i;
-    for (i = 0; i < zslGetHeight(zsl); i++) {
-        if (update[i]->level[i].forward == oldnode) update[i]->level[i].forward = newnode;
-    }
-    serverAssert(zslGetHeader(zsl) != oldnode);
-    if (newnode->level[0].forward) {
-        serverAssert(newnode->level[0].forward->backward == oldnode);
-        newnode->level[0].forward->backward = newnode;
-    } else {
-        serverAssert(zslGetTail(zsl) == oldnode);
-        zslSetTail(zsl, newnode);
-    }
-}
-
-/* Hashtable scan callback for sorted set. It defragments a single skiplist
- * node, updates skiplist pointers, and updates the hashtable pointer to the
- * node. */
-static void activeDefragZsetNode(void *privdata, void *entry_ref) {
-    zskiplist *zsl = privdata;
-    zskiplistNode **node_ref = (zskiplistNode **)entry_ref;
-    zskiplistNode *node = *node_ref;
-
-    size_t allocation_size;
-    zskiplistNode *newnode = activeDefragAllocWithoutFree(node, &allocation_size);
-    if (newnode == NULL) return;
-
-    const double score = node->score;
-
-    /* find skiplist pointers that need to be updated if we end up moving the
-     * skiplist node. */
-    sds ele = zslGetNodeElement(node);
-    zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
-    zskiplistNode *x = zslGetHeader(zsl);
-    for (int i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        /* stop when we've reached the end of this level or the next node comes
-         * after our target in sorted order. Even though defrag replacements does not impact the skip list order,
-         * when scores are equal, we MUST compare elements lexicographically to maintain correct skip list ordering.
-         * Otherwise we might miss locating the entry. */
-        zskiplistNode *next = x->level[i].forward;
-        while (next &&
-               (next->score < score ||
-                (next->score == score && sdscmp(zslGetNodeElement(next), ele) < 0))) {
-            x = next;
-            next = x->level[i].forward;
-        }
-        update[i] = x;
-    }
-    /* should have arrived at intended node */
-    serverAssert(x->level[0].forward == node);
-
-    zslUpdateNode(zsl, node, newnode, update);
-    *node_ref = newnode; /* update hashtable pointer */
-    allocatorDefragFree(node, allocation_size);
-}
-
 #define DEFRAG_SDS_DICT_NO_VAL 0
 #define DEFRAG_SDS_DICT_VAL_IS_SDS 1
 #define DEFRAG_SDS_DICT_VAL_IS_STROB 2
@@ -433,15 +377,16 @@ static long scanLaterList(robj *ob, unsigned long *cursor, monotime endtime) {
     return 0;
 }
 
-static void scanLaterZsetCallback(void *privdata, void *element_ref) {
-    activeDefragZsetNode(privdata, element_ref);
+static void defragZsetItemMoved(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx) {
+    hashtable *ht = ctx;
+    hashtableReplaceReallocatedEntry(ht, old_item, new_item);
     server.stat_active_defrag_scanned++;
 }
 
 static void scanLaterZset(robj *ob, unsigned long *cursor) {
     serverAssert(ob->type == OBJ_ZSET && ob->encoding == OBJ_ENCODING_SKIPLIST);
     zset *zs = (zset *)objectGetVal(ob);
-    *cursor = hashtableScanDefrag(zs->ht, *cursor, scanLaterZsetCallback, zs->zsl, activeDefragAlloc, HASHTABLE_SCAN_EMIT_REF);
+    *cursor = orderedIndexScanDefrag(zs->zidx, *cursor, defragZsetItemMoved, zs->ht, activeDefragAlloc);
 }
 
 /* Used as hashtable scan callback when all we need is to defrag the hashtable
@@ -481,12 +426,13 @@ static void defragZsetSkiplist(robj *ob) {
     zset *zs = (zset *)objectGetVal(ob);
 
     zset *newzs;
-    zskiplist *newzsl;
     if ((newzs = activeDefragAlloc(zs))) {
         objectSetVal(ob, newzs);
         zs = newzs;
     }
-    if ((newzsl = activeDefragAlloc(zs->zsl))) zs->zsl = newzsl;
+
+    OrderedIndex *newidx = orderedIndexDefragInternals(zs->zidx, activeDefragAlloc);
+    if (newidx) zs->zidx = newidx;
 
     hashtable *newtable;
     if ((newtable = hashtableDefragTables(zs->ht, activeDefragAlloc))) zs->ht = newtable;
@@ -496,7 +442,7 @@ static void defragZsetSkiplist(robj *ob) {
     else {
         unsigned long cursor = 0;
         do {
-            cursor = hashtableScanDefrag(zs->ht, cursor, activeDefragZsetNode, zs->zsl, activeDefragAlloc, HASHTABLE_SCAN_EMIT_REF);
+            cursor = orderedIndexScanDefrag(zs->zidx, cursor, defragZsetItemMoved, zs->ht, activeDefragAlloc);
         } while (cursor != 0);
     }
 }

--- a/src/geo.c
+++ b/src/geo.c
@@ -32,11 +32,11 @@
 #include "geohash_helper.h"
 #include "debugmacro.h"
 #include "pqsort.h"
+#include "ordered_index.h"
 
 /* Things exported from t_zset.c only for geo.c, since it is the only other
  * part of the server that requires close zset introspection. */
 unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
-int zslValueLteMax(double value, zrangespec *spec);
 
 /* ====================================================================
  * This file implements the following commands:
@@ -294,7 +294,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             score = zzlGetScore(sptr);
 
             /* If we fell out of range, break. */
-            if (!zslValueLteMax(score, &range)) break;
+            if (!zsetScoreLteMax(score, range.max, range.maxex)) break;
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
             if (geoWithinShape(shape, score, xy, &distance) == C_OK) {
@@ -307,27 +307,27 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *node;
 
-        if ((ln = zslNthInRange(zsl, &range, 0, NULL)) == NULL) {
-            /* Nothing exists starting at our min.  No results. */
-            return 0;
-        }
-
-        while (ln) {
+        orderedIndexInitIterator(&iter, zs->zidx);
+        orderedIndexSeekToScoreRange(&iter, range.min, range.max, range.minex, range.maxex, 0);
+        while (orderedIndexNext(&iter, &node)) {
             double xy[2];
             double distance = 0;
+            double score = orderedIndexGetScore(node);
             /* Abort when the node is no longer in range. */
-            if (!zslValueLteMax(ln->score, &range)) break;
-            if (geoWithinShape(shape, ln->score, xy, &distance) == C_OK) {
+            if (!zsetScoreLteMax(score, range.max, range.maxex)) break;
+            if (geoWithinShape(shape, score, xy, &distance) == C_OK) {
                 /* Append the new element. */
-                sds ele = zslGetNodeElement(ln);
-                geoArrayAppend(ga, xy, distance, ln->score, sdsdup(ele));
+                const char *ptr;
+                size_t len;
+                orderedIndexGetElementRaw(node, &ptr, &len);
+                geoArrayAppend(ga, xy, distance, score, sdsnewlen(ptr, len));
             }
             if (ga->used && limit && ga->used >= limit) break;
-            ln = ln->level[0].forward;
         }
+        orderedIndexResetIterator(&iter);
     }
     return ga->used - origincount;
 }
@@ -816,7 +816,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
         }
 
         for (i = 0; i < returned_items; i++) {
-            zskiplistNode *znode;
+            OrderedIndexItem *znode;
             geoPoint *gp = ga.array + i;
             gp->dist /= shape.conversion; /* Fix according to unit. */
             double score = storedist ? gp->dist : gp->score;
@@ -824,7 +824,7 @@ void georadiusGeneric(client *c, int srcKeyIndex, int flags) {
 
             if (maxelelen < elelen) maxelelen = elelen;
             totelelen += elelen;
-            znode = zslInsert(zs->zsl, score, gp->member);
+            znode = orderedIndexInsert(zs->zidx, score, gp->member);
             serverAssert(hashtableAdd(zs->ht, znode));
             sdsfree(gp->member);
             gp->member = NULL;

--- a/src/geo.c
+++ b/src/geo.c
@@ -294,7 +294,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             score = zzlGetScore(sptr);
 
             /* If we fell out of range, break. */
-            if (!zsetScoreLteMax(score, range.max, range.maxex)) break;
+            if (!zsetScoreLte(score, range.max, range.maxex)) break;
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
             if (geoWithinShape(shape, score, xy, &distance) == C_OK) {
@@ -317,7 +317,7 @@ int geoGetPointsInRange(robj *zobj, double min, double max, GeoShape *shape, geo
             double distance = 0;
             double score = orderedIndexGetScore(node);
             /* Abort when the node is no longer in range. */
-            if (!zsetScoreLteMax(score, range.max, range.maxex)) break;
+            if (!zsetScoreLte(score, range.max, range.maxex)) break;
             if (geoWithinShape(shape, score, xy, &distance) == C_OK) {
                 /* Append the new element. */
                 const char *ptr;

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -3,6 +3,7 @@
 #include "functions.h"
 #include "cluster.h"
 #include "module.h"
+#include "ordered_index.h"
 
 #include <stdatomic.h>
 
@@ -143,7 +144,7 @@ size_t lazyfreeGetFreeEffort(robj *key, robj *obj, int dbid) {
         return hashtableSize(ht);
     } else if (obj->type == OBJ_ZSET && obj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(obj);
-        return zslGetLength(zs->zsl);
+        return orderedIndexLength(zs->zidx);
     } else if (obj->type == OBJ_HASH && obj->encoding == OBJ_ENCODING_HASHTABLE) {
         hashtable *ht = objectGetVal(obj);
         return hashtableSize(ht);

--- a/src/module.c
+++ b/src/module.c
@@ -220,15 +220,15 @@ struct ValkeyModuleKey {
         } list;
         struct {
             /* Zset iterator, use only if value->type == OBJ_ZSET */
-            uint32_t type;     /* VALKEYMODULE_ZSET_RANGE_* */
-            zrangespec rs;     /* Score range. */
-            zlexrangespec lrs; /* Lex range. */
-            uint32_t start;    /* Start pos for positional ranges. */
-            uint32_t end;      /* End pos for positional ranges. */
-            void *current;     /* Zset iterator current node (listpack pointer or OrderedIndexItem). */
+            uint32_t type;           /* VALKEYMODULE_ZSET_RANGE_* */
+            zrangespec rs;           /* Score range. */
+            zlexrangespec lrs;       /* Lex range. */
+            uint32_t start;          /* Start pos for positional ranges. */
+            uint32_t end;            /* End pos for positional ranges. */
+            void *current;           /* Zset iterator current node (listpack pointer or OrderedIndexItem). */
             OrderedIndexIterator oi; /* OrderedIndex iterator for skiplist encoding. */
-            int er;            /* Zset iterator end reached flag
-                                   (true if end was reached). */
+            int er;                  /* Zset iterator end reached flag
+                                         (true if end was reached). */
         } zset;
         struct {
             /* Stream, use only if value->type == OBJ_STREAM */

--- a/src/module.c
+++ b/src/module.c
@@ -225,7 +225,8 @@ struct ValkeyModuleKey {
             zlexrangespec lrs; /* Lex range. */
             uint32_t start;    /* Start pos for positional ranges. */
             uint32_t end;      /* End pos for positional ranges. */
-            void *current;     /* Zset iterator current node. */
+            void *current;     /* Zset iterator current node (listpack pointer or OrderedIndexItem). */
+            OrderedIndexIterator oi; /* OrderedIndex iterator for skiplist encoding. */
             int er;            /* Zset iterator end reached flag
                                    (true if end was reached). */
         } zset;
@@ -5129,8 +5130,15 @@ int zsetInitScoreRange(ValkeyModuleKey *key, double min, double max, int minex, 
         key->u.zset.current = first ? zzlFirstInRange(objectGetVal(key->value), zrs) : zzlLastInRange(objectGetVal(key->value), zrs);
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
-        zskiplist *zsl = (zskiplist *)zs->zidx;
-        key->u.zset.current = first ? zslNthInRange(zsl, zrs, 0, NULL) : zslNthInRange(zsl, zrs, -1, NULL);
+        orderedIndexInitIterator(&key->u.zset.oi, zs->zidx);
+        orderedIndexSeekToScoreRange(&key->u.zset.oi, zrs->min, zrs->max, zrs->minex, zrs->maxex, first ? 0 : -1);
+        OrderedIndexItem *item;
+        if (first) {
+            orderedIndexNext(&key->u.zset.oi, &item);
+        } else {
+            orderedIndexPrev(&key->u.zset.oi, &item);
+        }
+        key->u.zset.current = item;
     } else {
         serverPanic("Unsupported zset encoding");
     }
@@ -5192,8 +5200,15 @@ int zsetInitLexRange(ValkeyModuleKey *key, ValkeyModuleString *min, ValkeyModule
             first ? zzlFirstInLexRange(objectGetVal(key->value), zlrs) : zzlLastInLexRange(objectGetVal(key->value), zlrs);
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
-        zskiplist *zsl = (zskiplist *)zs->zidx;
-        key->u.zset.current = first ? zslNthInLexRange(zsl, zlrs, 0) : zslNthInLexRange(zsl, zlrs, -1);
+        orderedIndexInitIterator(&key->u.zset.oi, zs->zidx);
+        orderedIndexSeekToLexRange(&key->u.zset.oi, zlrs->min, zlrs->max, zlrs->minex, zlrs->maxex, first ? 0 : -1);
+        OrderedIndexItem *item;
+        if (first) {
+            orderedIndexNext(&key->u.zset.oi, &item);
+        } else {
+            orderedIndexPrev(&key->u.zset.oi, &item);
+        }
+        key->u.zset.current = item;
     } else {
         serverPanic("Unsupported zset encoding");
     }
@@ -5242,10 +5257,12 @@ ValkeyModuleString *VM_ZsetRangeCurrentElement(ValkeyModuleKey *key, double *sco
         }
         str = createObject(OBJ_STRING, ele);
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
-        zskiplistNode *ln = key->u.zset.current;
-        if (score) *score = ln->score;
-        sds ele = zslGetNodeElement(ln);
-        str = createStringObject(ele, sdslen(ele));
+        OrderedIndexItem *ln = key->u.zset.current;
+        if (score) *score = orderedIndexGetScore(ln);
+        const char *ptr;
+        size_t len;
+        orderedIndexGetElementRaw(ln, &ptr, &len);
+        str = createStringObject(ptr, len);
     } else {
         serverPanic("Unsupported zset encoding");
     }
@@ -5292,17 +5309,20 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
             return 1;
         }
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
-        zskiplistNode *ln = key->u.zset.current, *next = ln->level[0].forward;
-        if (next == NULL) {
+        OrderedIndexItem *next;
+        if (!orderedIndexNext(&key->u.zset.oi, &next)) {
             key->u.zset.er = 1;
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueLteMax(next->score, &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueLteMax(orderedIndexGetScore(next), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
-                if (!zslLexValueLteMax(zslGetNodeElement(next), &key->u.zset.lrs)) {
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(next, &ele_ptr, &ele_len);
+                if (!zslLexValueLteMax(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5354,17 +5374,20 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
             return 1;
         }
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
-        zskiplistNode *ln = key->u.zset.current, *prev = ln->backward;
-        if (prev == NULL) {
+        OrderedIndexItem *prev;
+        if (!orderedIndexPrev(&key->u.zset.oi, &prev)) {
             key->u.zset.er = 1;
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueGteMin(prev->score, &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueGteMin(orderedIndexGetScore(prev), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
-                if (!zslLexValueGteMin(zslGetNodeElement(prev), &key->u.zset.lrs)) {
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(prev, &ele_ptr, &ele_len);
+                if (!zslLexValueGteMin(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }

--- a/src/module.c
+++ b/src/module.c
@@ -5294,7 +5294,7 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
                 unsigned char *saved_next = next;
                 next = lpNext(zl, next);          /* Skip next element. */
                 double score = zzlGetScore(next); /* Obtain the next score. */
-                if (!zslValueLteMax(score, &key->u.zset.rs)) {
+                if (!zsetValueLteMax(score, &key->u.zset.rs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5315,14 +5315,14 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueLteMax(orderedIndexGetScore(next), &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetValueLteMax(orderedIndexGetScore(next), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(next, &ele_ptr, &ele_len);
-                if (!zslLexValueLteMax(ele_ptr, ele_len, &key->u.zset.lrs)) {
+                if (!zsetLexValueLteMax(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5359,7 +5359,7 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
                 unsigned char *saved_prev = prev;
                 prev = lpNext(zl, prev);          /* Skip element to get the score.*/
                 double score = zzlGetScore(prev); /* Obtain the prev score. */
-                if (!zslValueGteMin(score, &key->u.zset.rs)) {
+                if (!zsetValueGteMin(score, &key->u.zset.rs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5380,14 +5380,14 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zslValueGteMin(orderedIndexGetScore(prev), &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetValueGteMin(orderedIndexGetScore(prev), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(prev, &ele_ptr, &ele_len);
-                if (!zslLexValueGteMin(ele_ptr, ele_len, &key->u.zset.lrs)) {
+                if (!zsetLexValueGteMin(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }

--- a/src/module.c
+++ b/src/module.c
@@ -5093,6 +5093,11 @@ void VM_ZsetRangeStop(ValkeyModuleKey *key) {
     if (!key->value || key->value->type != OBJ_ZSET) return;
     /* Free resources if needed. */
     if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) zsetFreeLexRange(&key->u.zset.lrs);
+    /* Release the ordered index iterator if one was active. */
+    if (key->value->encoding == OBJ_ENCODING_SKIPLIST &&
+        key->u.zset.type != VALKEYMODULE_ZSET_RANGE_NONE) {
+        orderedIndexResetIterator(&key->u.zset.oi);
+    }
     /* Setup sensible values so that misused iteration API calls when an
      * iterator is not active will result into something more sensible
      * than crashing. */
@@ -5294,7 +5299,7 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
                 unsigned char *saved_next = next;
                 next = lpNext(zl, next);          /* Skip next element. */
                 double score = zzlGetScore(next); /* Obtain the next score. */
-                if (!zsetValueLteMax(score, &key->u.zset.rs)) {
+                if (!zsetScoreLteMax(score, &key->u.zset.rs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5315,14 +5320,14 @@ int VM_ZsetRangeNext(ValkeyModuleKey *key) {
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetValueLteMax(orderedIndexGetScore(next), &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetScoreLteMax(orderedIndexGetScore(next), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(next, &ele_ptr, &ele_len);
-                if (!zsetLexValueLteMax(ele_ptr, ele_len, &key->u.zset.lrs)) {
+                if (!zsetLexLteMax(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5359,7 +5364,7 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
                 unsigned char *saved_prev = prev;
                 prev = lpNext(zl, prev);          /* Skip element to get the score.*/
                 double score = zzlGetScore(prev); /* Obtain the prev score. */
-                if (!zsetValueGteMin(score, &key->u.zset.rs)) {
+                if (!zsetScoreGteMin(score, &key->u.zset.rs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }
@@ -5380,14 +5385,14 @@ int VM_ZsetRangePrev(ValkeyModuleKey *key) {
             return 0;
         } else {
             /* Are we still within the range? */
-            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetValueGteMin(orderedIndexGetScore(prev), &key->u.zset.rs)) {
+            if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_SCORE && !zsetScoreGteMin(orderedIndexGetScore(prev), &key->u.zset.rs)) {
                 key->u.zset.er = 1;
                 return 0;
             } else if (key->u.zset.type == VALKEYMODULE_ZSET_RANGE_LEX) {
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(prev, &ele_ptr, &ele_len);
-                if (!zsetLexValueGteMin(ele_ptr, ele_len, &key->u.zset.lrs)) {
+                if (!zsetLexGteMin(ele_ptr, ele_len, &key->u.zset.lrs)) {
                     key->u.zset.er = 1;
                     return 0;
                 }

--- a/src/module.c
+++ b/src/module.c
@@ -69,6 +69,7 @@
 #include "io_threads.h"
 #include "scripting_engine.h"
 #include "cluster_migrateslots.h"
+#include "ordered_index.h"
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -5128,7 +5129,7 @@ int zsetInitScoreRange(ValkeyModuleKey *key, double min, double max, int minex, 
         key->u.zset.current = first ? zzlFirstInRange(objectGetVal(key->value), zrs) : zzlLastInRange(objectGetVal(key->value), zrs);
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
-        zskiplist *zsl = zs->zsl;
+        zskiplist *zsl = (zskiplist *)zs->zidx;
         key->u.zset.current = first ? zslNthInRange(zsl, zrs, 0, NULL) : zslNthInRange(zsl, zrs, -1, NULL);
     } else {
         serverPanic("Unsupported zset encoding");
@@ -5191,7 +5192,7 @@ int zsetInitLexRange(ValkeyModuleKey *key, ValkeyModuleString *min, ValkeyModule
             first ? zzlFirstInLexRange(objectGetVal(key->value), zlrs) : zzlLastInLexRange(objectGetVal(key->value), zlrs);
     } else if (key->value->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(key->value);
-        zskiplist *zsl = zs->zsl;
+        zskiplist *zsl = (zskiplist *)zs->zidx;
         key->u.zset.current = first ? zslNthInLexRange(zsl, zlrs, 0) : zslNthInLexRange(zsl, zlrs, -1);
     } else {
         serverPanic("Unsupported zset encoding");
@@ -12004,9 +12005,12 @@ static void moduleScanKeyHashtableCallback(void *privdata, void *entry) {
         key = entry;
         /* no value */
     } else if (o->type == OBJ_ZSET) {
-        zskiplistNode *node = (zskiplistNode *)entry;
-        key = zslGetNodeElement(node);
-        value = createStringObjectFromLongDouble(node->score, 0);
+        OrderedIndexItem *node = (OrderedIndexItem *)entry;
+        const char *ele_ptr;
+        size_t ele_len;
+        orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+        key = (sds)ele_ptr;
+        value = createStringObjectFromLongDouble(orderedIndexGetScore(node), 0);
     } else if (o->type == OBJ_HASH) {
         key = entryGetField(entry);
         size_t val_len;

--- a/src/object.c
+++ b/src/object.c
@@ -33,6 +33,7 @@
 #include "serverassert.h"
 #include "functions.h"
 #include "intset.h" /* Compact integer set structure */
+#include "ordered_index.h"
 #include "util.h"
 #include "vset.h"
 #include "zmalloc.h"
@@ -521,12 +522,7 @@ robj *createHashObject(void) {
 }
 
 robj *createZsetObject(void) {
-    zset *zs = zmalloc(sizeof(*zs));
-    robj *o;
-
-    zs->ht = hashtableCreate(&zsetHashtableType);
-    zs->zsl = zslCreate();
-    o = createObject(OBJ_ZSET, zs);
+    robj *o = createObject(OBJ_ZSET, zsetCreate());
     o->encoding = OBJ_ENCODING_SKIPLIST;
     return o;
 }
@@ -583,7 +579,7 @@ void freeZsetObject(robj *o) {
     case OBJ_ENCODING_SKIPLIST:
         zs = objectGetVal(o);
         hashtableRelease(zs->ht);
-        zslFree(zs->zsl);
+        orderedIndexFree(zs->zidx);
         zfree(zs);
         break;
     case OBJ_ENCODING_LISTPACK: zfree(objectGetVal(o)); break;
@@ -719,17 +715,11 @@ void dismissSetObject(robj *o, size_t size_hint) {
 void dismissZsetObject(robj *o, size_t size_hint) {
     if (o->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(o);
-        zskiplist *zsl = zs->zsl;
-        serverAssert(zslGetLength(zsl) != 0);
+        serverAssert(orderedIndexLength(zs->zidx) != 0);
         /* We iterate all nodes only when average member size is bigger than a
          * page size, and there's a high chance we'll actually dismiss something. */
-        if (size_hint / zslGetLength(zsl) >= server.page_size) {
-            zskiplistNode *zn = zslGetTail(zsl);
-            while (zn != NULL) {
-                zskiplistNode *next = zn->backward;
-                dismissMemory(zn, 0);
-                zn = next;
-            }
+        if (size_hint / orderedIndexLength(zs->zidx) >= server.page_size) {
+            orderedIndexDismissMemory(zs->zidx);
         }
 
         dismissHashtable(zs->ht);
@@ -1243,16 +1233,8 @@ size_t objectComputeSize(robj *key, robj *o, size_t sample_size, int dbid) {
             asize += zmalloc_size(objectGetVal(o));
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
             hashtable *ht = ((zset *)objectGetVal(o))->ht;
-            zskiplist *zsl = ((zset *)objectGetVal(o))->zsl;
-            zskiplistNode *zheader = zslGetHeader(zsl);
-            zskiplistNode *znode = zheader->level[0].forward;
-            asize += sizeof(zset) + zslGetAllocSize() + hashtableMemUsage(ht);
-            while (znode != NULL && samples < sample_size) {
-                elesize += zmalloc_size(znode);
-                samples++;
-                znode = znode->level[0].forward;
-            }
-            if (samples) asize += (double)elesize / samples * hashtableSize(ht);
+            OrderedIndex *idx = ((zset *)objectGetVal(o))->zidx;
+            asize += sizeof(zset) + orderedIndexEstimateMemory(idx, sample_size) + hashtableMemUsage(ht);
         } else {
             serverPanic("Unknown sorted set encoding");
         }

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -56,6 +56,20 @@ static inline void orderedIndexFreeItem(OrderedIndexItem *item) {
     skiplistFreeItem(item);
 }
 
+static inline OrderedIndexItem *orderedIndexCreateDetached(double score, const char *ele, size_t len) {
+    return skiplistCreateDetached(score, ele, len);
+}
+
+/* Set the score on a detached item (not yet inserted into an index).
+ * Do not use on inserted items — use orderedIndexUpdateScore instead. */
+static inline void orderedIndexDetachedSetScore(OrderedIndexItem *item, double score) {
+    skiplistDetachedSetScore(item, score);
+}
+
+static inline OrderedIndexItem *orderedIndexInsertDetached(OrderedIndex *idx, OrderedIndexItem *item) {
+    return skiplistInsertDetached(idx, item);
+}
+
 static inline unsigned long orderedIndexDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) {
     return skiplistDeleteRangeByScore(idx, min, max, min_ex, max_ex, on_delete, ctx);
 }

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -6,7 +6,7 @@
 /* Opaque types for ordered index, positions, and iterators */
 typedef struct OrderedIndex OrderedIndex;
 typedef struct OrderedIndexItem OrderedIndexItem;
-typedef uint64_t OrderedIndexIterator[3];
+typedef uint64_t OrderedIndexIterator[2];
 
 /* Callback invoked for each item removed during a range-delete operation. */
 typedef void (*OrderedIndexOnDelete)(OrderedIndexItem *item, void *ctx);
@@ -60,8 +60,13 @@ static inline OrderedIndexItem *orderedIndexCreateDetached(double score, const c
     return skiplistCreateDetached(score, ele, len);
 }
 
-/* Set the score on a detached item (not yet inserted into an index).
- * Do not use on inserted items — use orderedIndexUpdateScore instead. */
+/* Set the score on a detached item — one created via orderedIndexCreateDetached
+ * but not yet inserted into an ordered index.  Items that live only in a
+ * hashtable (e.g. during ZUNIONSTORE score accumulation) are still considered
+ * "detached" for this purpose because they are not part of any ordered index.
+ *
+ * Do NOT use on items that have been inserted into an ordered index — doing so
+ * would silently corrupt the sort order.  Use orderedIndexUpdateScore instead. */
 static inline void orderedIndexDetachedSetScore(OrderedIndexItem *item, double score) {
     skiplistDetachedSetScore(item, score);
 }
@@ -103,9 +108,12 @@ static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
     return skiplistGetScore(pos);
 }
 
-/* Return the length of an element string. The pointer may come from
+/* Return the length of an element string.  The pointer may come from
  * orderedIndexGetElementRaw (pointing into an index item) or be a plain
- * sds used as a lookup key. The implementation knows how to handle both. */
+ * SDS used as a lookup key — both are valid.  This dual-use is intentional:
+ * the zset hashtable callbacks receive plain SDS keys during lookups and
+ * OrderedIndexItem element pointers for stored entries, and both must be
+ * measurable through the same function. */
 static inline size_t orderedIndexElementLen(const char *ptr) {
     return skiplistElementLen(ptr);
 }
@@ -163,12 +171,18 @@ static inline size_t orderedIndexEstimateMemory(OrderedIndex *idx, size_t sample
 }
 
 /* Defrag */
+
+/* Defrag */
 typedef void (*OrderedIndexDefragCallback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx);
 
 static inline OrderedIndex *orderedIndexDefragInternals(OrderedIndex *idx, void *(*defragfn)(void *)) {
     return skiplistDefragInternals(idx, defragfn);
 }
 
+/* Cursor-based incremental defrag.  Walks the ordered index in batches,
+ * calling defragfn on each item.  When an item is reallocated, the callback
+ * is invoked so the caller can update external references (e.g. hashtable).
+ * Returns the next cursor, or 0 when the scan is complete. */
 static inline unsigned long orderedIndexScanDefrag(OrderedIndex *idx, unsigned long cursor, OrderedIndexDefragCallback callback, void *ctx, void *(*defragfn)(void *)) {
     return skiplistScanDefrag(idx, cursor, callback, ctx, defragfn);
 }

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -103,6 +103,13 @@ static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
     return skiplistGetScore(pos);
 }
 
+/* Return the length of an element string. The pointer may come from
+ * orderedIndexGetElementRaw (pointing into an index item) or be a plain
+ * sds used as a lookup key. The implementation knows how to handle both. */
+static inline size_t orderedIndexElementLen(const char *ptr) {
+    return skiplistElementLen(ptr);
+}
+
 static inline unsigned long orderedIndexCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
     return skiplistCountScoreRange(idx, min, max, min_ex, max_ex);
 }

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -8,139 +8,142 @@ typedef struct OrderedIndex OrderedIndex;
 typedef struct OrderedIndexItem OrderedIndexItem;
 typedef uint64_t OrderedIndexIterator[3];
 
-/* Operations interface for ordered index implementations */
-typedef struct OrderedIndexOps {
-    /* Lifecycle */
-    OrderedIndex *(*create)(void);
-    void (*free)(OrderedIndex *idx);
+/* Callback invoked for each item removed during a range-delete operation. */
+typedef void (*OrderedIndexOnDelete)(OrderedIndexItem *item, void *ctx);
 
-    /* Modification */
-    OrderedIndexItem *(*insert)(OrderedIndex *idx, double score, const_sds ele);
-    void (*delete_item)(OrderedIndex *idx, OrderedIndexItem *pos);
-    OrderedIndexItem *(*update_score)(OrderedIndex *idx, OrderedIndexItem *pos, double newscore);
-    OrderedIndexItem *(*pop_first)(OrderedIndex *idx);
-    OrderedIndexItem *(*pop_last)(OrderedIndex *idx);
-    void (*free_item)(OrderedIndexItem *item);
-    unsigned long (*delete_range_by_score)(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
-    unsigned long (*delete_range_by_rank)(OrderedIndex *idx, unsigned long start, unsigned long end);
-    unsigned long (*delete_range_by_lex)(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex);
+/* ---- Production inline wrappers ----
+ *
+ * Currently hardcoded to the skiplist implementation. When additional ordered
+ * index backends are added (e.g. B-tree), a compile-time switch can select
+ * the implementation here without changing any call sites. */
+#include "skiplist_ordered_index.h"
 
-    /* Query */
-    unsigned long (*length)(OrderedIndex *idx);
-    OrderedIndexItem *(*get_by_rank)(OrderedIndex *idx, unsigned long rank);
-    unsigned long (*get_rank)(OrderedIndex *idx, const OrderedIndexItem *pos);
-    void (*get_element_raw)(const OrderedIndexItem *pos, const char **ptr, size_t *len);
-    double (*get_score)(const OrderedIndexItem *pos);
-
-    /* Iterator */
-    void (*init_iterator)(OrderedIndexIterator *iter, OrderedIndex *idx);
-    void (*reset_iterator)(OrderedIndexIterator *iter);
-    bool (*next)(OrderedIndexIterator *iter, OrderedIndexItem **pos);
-    bool (*prev)(OrderedIndexIterator *iter, OrderedIndexItem **pos);
-    void (*seek_to_rank)(OrderedIndexIterator *iter, unsigned long rank);
-    void (*seek_to_score_range)(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset);
-    void (*seek_to_lex_range)(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
-
-    /* TODO: Add interface methods for memory management:
-     * - Memory dismiss (for CoW optimization during fork/snapshot)
-     * - Memory defrag (for active defragmentation when nodes are relocated)
-     * These will eliminate direct access to forward/backward pointers in defrag.c and object.c */
-} OrderedIndexOps;
-
-/* Inline wrappers for performance (compiler can inline these) */
-static inline OrderedIndex *orderedIndexCreate(const OrderedIndexOps *ops) {
-    return ops->create();
+/* Lifecycle */
+static inline OrderedIndex *orderedIndexCreate(void) {
+    return skiplistCreate();
 }
 
-static inline void orderedIndexFree(const OrderedIndexOps *ops, OrderedIndex *idx) {
-    ops->free(idx);
+static inline void orderedIndexFree(OrderedIndex *idx) {
+    skiplistFree(idx);
 }
 
-static inline OrderedIndexItem *orderedIndexInsert(const OrderedIndexOps *ops, OrderedIndex *idx, double score, const_sds ele) {
-    return ops->insert(idx, score, ele);
+/* Modification */
+static inline OrderedIndexItem *orderedIndexInsertRaw(OrderedIndex *idx, double score, const char *ele, size_t len) {
+    return skiplistInsert(idx, score, ele, len);
 }
 
-static inline void orderedIndexDelete(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos) {
-    ops->delete_item(idx, pos);
+static inline OrderedIndexItem *orderedIndexInsert(OrderedIndex *idx, double score, const_sds ele) {
+    return skiplistInsert(idx, score, ele, sdslen(ele));
 }
 
-static inline OrderedIndexItem *orderedIndexUpdateScore(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos, double newscore) {
-    return ops->update_score(idx, pos, newscore);
+static inline void orderedIndexDelete(OrderedIndex *idx, OrderedIndexItem *pos) {
+    skiplistDelete(idx, pos);
 }
 
-static inline OrderedIndexItem *orderedIndexPopFirst(const OrderedIndexOps *ops, OrderedIndex *idx) {
-    return ops->pop_first(idx);
+static inline OrderedIndexItem *orderedIndexUpdateScore(OrderedIndex *idx, OrderedIndexItem *pos, double newscore) {
+    return skiplistUpdateScore(idx, pos, newscore);
 }
 
-static inline OrderedIndexItem *orderedIndexPopLast(const OrderedIndexOps *ops, OrderedIndex *idx) {
-    return ops->pop_last(idx);
+static inline OrderedIndexItem *orderedIndexPopFirst(OrderedIndex *idx) {
+    return skiplistPopFirst(idx);
 }
 
-static inline void orderedIndexFreeItem(const OrderedIndexOps *ops, OrderedIndexItem *item) {
-    ops->free_item(item);
+static inline OrderedIndexItem *orderedIndexPopLast(OrderedIndex *idx) {
+    return skiplistPopLast(idx);
 }
 
-static inline unsigned long orderedIndexDeleteRangeByScore(const OrderedIndexOps *ops, OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
-    return ops->delete_range_by_score(idx, min, max, min_ex, max_ex);
+static inline void orderedIndexFreeItem(OrderedIndexItem *item) {
+    skiplistFreeItem(item);
 }
 
-static inline unsigned long orderedIndexDeleteRangeByRank(const OrderedIndexOps *ops, OrderedIndex *idx, unsigned long start, unsigned long end) {
-    return ops->delete_range_by_rank(idx, start, end);
+static inline unsigned long orderedIndexDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) {
+    return skiplistDeleteRangeByScore(idx, min, max, min_ex, max_ex, on_delete, ctx);
 }
 
-static inline unsigned long orderedIndexDeleteRangeByLex(const OrderedIndexOps *ops, OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
-    return ops->delete_range_by_lex(idx, min, max, min_ex, max_ex);
+static inline unsigned long orderedIndexDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end, OrderedIndexOnDelete on_delete, void *ctx) {
+    return skiplistDeleteRangeByRank(idx, start, end, on_delete, ctx);
 }
 
-static inline unsigned long orderedIndexLength(const OrderedIndexOps *ops, OrderedIndex *idx) {
-    return ops->length(idx);
+static inline unsigned long orderedIndexDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) {
+    return skiplistDeleteRangeByLex(idx, min, max, min_ex, max_ex, on_delete, ctx);
 }
 
-static inline OrderedIndexItem *orderedIndexGetByRank(const OrderedIndexOps *ops, OrderedIndex *idx, unsigned long rank) {
-    return ops->get_by_rank(idx, rank);
+/* Query */
+static inline unsigned long orderedIndexLength(OrderedIndex *idx) {
+    return skiplistLength(idx);
 }
 
-static inline unsigned long orderedIndexGetRank(const OrderedIndexOps *ops, OrderedIndex *idx, const OrderedIndexItem *pos) {
-    return ops->get_rank(idx, pos);
+static inline OrderedIndexItem *orderedIndexGetByRank(OrderedIndex *idx, unsigned long rank) {
+    return skiplistGetByRank(idx, rank);
 }
 
-static inline void orderedIndexGetElementRaw(const OrderedIndexOps *ops, const OrderedIndexItem *pos, const char **ptr, size_t *len) {
-    ops->get_element_raw(pos, ptr, len);
+static inline unsigned long orderedIndexGetRank(OrderedIndex *idx, const OrderedIndexItem *pos) {
+    return skiplistGetRank(idx, pos);
 }
 
-static inline double orderedIndexGetScore(const OrderedIndexOps *ops, const OrderedIndexItem *pos) {
-    return ops->get_score(pos);
+static inline void orderedIndexGetElementRaw(const OrderedIndexItem *pos, const char **ptr, size_t *len) {
+    skiplistGetElementRaw(pos, ptr, len);
 }
 
-static inline void orderedIndexInitIterator(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndex *idx) {
-    ops->init_iterator(iter, idx);
+static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
+    return skiplistGetScore(pos);
 }
 
-static inline void orderedIndexResetIterator(const OrderedIndexOps *ops, OrderedIndexIterator *iter) {
-    ops->reset_iterator(iter);
+/* Memory */
+static inline void orderedIndexDismissMemory(OrderedIndex *idx) {
+    skiplistDismissMemory(idx);
 }
 
-static inline bool orderedIndexNext(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndexItem **pos) {
-    return ops->next(iter, pos);
+static inline size_t orderedIndexEstimateMemory(OrderedIndex *idx, size_t sample_size) {
+    return skiplistEstimateMemory(idx, sample_size);
 }
 
-static inline bool orderedIndexPrev(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndexItem **pos) {
-    return ops->prev(iter, pos);
+/* Iterator */
+static inline void orderedIndexInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
+    skiplistInitIterator(iter, idx);
 }
 
-static inline void orderedIndexSeekToRank(const OrderedIndexOps *ops, OrderedIndexIterator *iter, unsigned long rank) {
-    ops->seek_to_rank(iter, rank);
+static inline void orderedIndexResetIterator(OrderedIndexIterator *iter) {
+    skiplistResetIterator(iter);
 }
 
-static inline void orderedIndexSeekToScoreRange(const OrderedIndexOps *ops, OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
-    ops->seek_to_score_range(iter, min, max, min_ex, max_ex, offset);
+static inline bool orderedIndexNext(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return skiplistNext(iter, pos);
 }
 
-static inline void orderedIndexSeekToLexRange(const OrderedIndexOps *ops, OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
-    ops->seek_to_lex_range(iter, min, max, min_ex, max_ex, offset);
+static inline bool orderedIndexPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return skiplistPrev(iter, pos);
 }
 
-/* Available implementations */
-extern const OrderedIndexOps skiplistOrderedIndexOps;
+static inline void orderedIndexSeekToRank(OrderedIndexIterator *iter, unsigned long rank) {
+    skiplistSeekToRank(iter, rank);
+}
+
+/* Seek to a position within a score/lex range.
+ *
+ * offset >= 0: positions for forward iteration (next() returns the element).
+ *   offset 0 = first element in range, 1 = second, etc.
+ * offset < 0:  positions for reverse iteration (prev() returns the element).
+ *   offset -1 = last element in range, -2 = second-to-last, etc. */
+static inline void orderedIndexSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
+    skiplistSeekToScoreRange(iter, min, max, min_ex, max_ex, offset);
+}
+
+static inline void orderedIndexSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
+    skiplistSeekToLexRange(iter, min, max, min_ex, max_ex, offset);
+}
+
+/* Defrag */
+typedef void (*OrderedIndexDefragCallback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx);
+
+static inline OrderedIndex *orderedIndexDefragInternals(OrderedIndex *idx, void *(*defragfn)(void *)) {
+    return skiplistDefragInternals(idx, defragfn);
+}
+
+static inline unsigned long orderedIndexScanDefrag(OrderedIndex *idx, unsigned long cursor,
+                                                   OrderedIndexDefragCallback callback, void *ctx,
+                                                   void *(*defragfn)(void *)) {
+    return skiplistScanDefrag(idx, cursor, callback, ctx, defragfn);
+}
 
 #endif /* ORDERED_INDEX_H */

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -89,6 +89,11 @@ static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
     return skiplistGetScore(pos);
 }
 
+/* Debug */
+static inline int orderedIndexGetHeight(OrderedIndex *idx) {
+    return skiplistGetHeight(idx);
+}
+
 /* Memory */
 static inline void orderedIndexDismissMemory(OrderedIndex *idx) {
     skiplistDismissMemory(idx);

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -108,16 +108,6 @@ static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
     return skiplistGetScore(pos);
 }
 
-/* Return the length of an element string.  The pointer may come from
- * orderedIndexGetElementRaw (pointing into an index item) or be a plain
- * SDS used as a lookup key — both are valid.  This dual-use is intentional:
- * the zset hashtable callbacks receive plain SDS keys during lookups and
- * OrderedIndexItem element pointers for stored entries, and both must be
- * measurable through the same function. */
-static inline size_t orderedIndexElementLen(const char *ptr) {
-    return skiplistElementLen(ptr);
-}
-
 static inline unsigned long orderedIndexCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
     return skiplistCountScoreRange(idx, min, max, min_ex, max_ex);
 }
@@ -169,8 +159,6 @@ static inline void orderedIndexDismissMemory(OrderedIndex *idx) {
 static inline size_t orderedIndexEstimateMemory(OrderedIndex *idx, size_t sample_size) {
     return skiplistEstimateMemory(idx, sample_size);
 }
-
-/* Defrag */
 
 /* Defrag */
 typedef void (*OrderedIndexDefragCallback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx);

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -162,9 +162,7 @@ static inline OrderedIndex *orderedIndexDefragInternals(OrderedIndex *idx, void 
     return skiplistDefragInternals(idx, defragfn);
 }
 
-static inline unsigned long orderedIndexScanDefrag(OrderedIndex *idx, unsigned long cursor,
-                                                   OrderedIndexDefragCallback callback, void *ctx,
-                                                   void *(*defragfn)(void *)) {
+static inline unsigned long orderedIndexScanDefrag(OrderedIndex *idx, unsigned long cursor, OrderedIndexDefragCallback callback, void *ctx, void *(*defragfn)(void *)) {
     return skiplistScanDefrag(idx, cursor, callback, ctx, defragfn);
 }
 

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -89,18 +89,12 @@ static inline double orderedIndexGetScore(const OrderedIndexItem *pos) {
     return skiplistGetScore(pos);
 }
 
-/* Debug */
-static inline int orderedIndexGetHeight(OrderedIndex *idx) {
-    return skiplistGetHeight(idx);
+static inline unsigned long orderedIndexCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
+    return skiplistCountScoreRange(idx, min, max, min_ex, max_ex);
 }
 
-/* Memory */
-static inline void orderedIndexDismissMemory(OrderedIndex *idx) {
-    skiplistDismissMemory(idx);
-}
-
-static inline size_t orderedIndexEstimateMemory(OrderedIndex *idx, size_t sample_size) {
-    return skiplistEstimateMemory(idx, sample_size);
+static inline unsigned long orderedIndexCountLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
+    return skiplistCountLexRange(idx, min, max, min_ex, max_ex);
 }
 
 /* Iterator */
@@ -138,6 +132,15 @@ static inline void orderedIndexSeekToLexRange(OrderedIndexIterator *iter, const_
     skiplistSeekToLexRange(iter, min, max, min_ex, max_ex, offset);
 }
 
+/* Memory */
+static inline void orderedIndexDismissMemory(OrderedIndex *idx) {
+    skiplistDismissMemory(idx);
+}
+
+static inline size_t orderedIndexEstimateMemory(OrderedIndex *idx, size_t sample_size) {
+    return skiplistEstimateMemory(idx, sample_size);
+}
+
 /* Defrag */
 typedef void (*OrderedIndexDefragCallback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx);
 
@@ -149,6 +152,15 @@ static inline unsigned long orderedIndexScanDefrag(OrderedIndex *idx, unsigned l
                                                    OrderedIndexDefragCallback callback, void *ctx,
                                                    void *(*defragfn)(void *)) {
     return skiplistScanDefrag(idx, cursor, callback, ctx, defragfn);
+}
+
+/* Debug */
+static inline int orderedIndexGetHeight(OrderedIndex *idx) {
+    return skiplistGetHeight(idx);
+}
+
+static inline int orderedIndexVerifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) {
+    return skiplistVerifyIntegrity(idx, errmsg, errmsg_len);
 }
 
 #endif /* ORDERED_INDEX_H */

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -1,0 +1,141 @@
+#ifndef ORDERED_INDEX_H
+#define ORDERED_INDEX_H
+
+#include "sds.h"
+
+/* Opaque types for ordered index, positions, and iterators */
+typedef struct OrderedIndex OrderedIndex;
+typedef struct OrderedIndexItem OrderedIndexItem;
+typedef uint64_t OrderedIndexIterator[3];
+
+/* Operations interface for ordered index implementations */
+typedef struct OrderedIndexOps {
+    /* Lifecycle */
+    OrderedIndex *(*create)(void);
+    void (*free)(OrderedIndex *idx);
+
+    /* Modification */
+    OrderedIndexItem *(*insert)(OrderedIndex *idx, double score, const_sds ele);
+    void (*deleteItem)(OrderedIndex *idx, OrderedIndexItem *pos);
+    OrderedIndexItem *(*update_score)(OrderedIndex *idx, OrderedIndexItem *pos, double newscore);
+    OrderedIndexItem *(*pop_first)(OrderedIndex *idx);
+    OrderedIndexItem *(*pop_last)(OrderedIndex *idx);
+    void (*free_item)(OrderedIndexItem *item);
+    unsigned long (*delete_range_by_score)(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
+    unsigned long (*delete_range_by_rank)(OrderedIndex *idx, unsigned long start, unsigned long end);
+
+    /* Query */
+    unsigned long (*length)(OrderedIndex *idx);
+    OrderedIndexItem *(*get_by_rank)(OrderedIndex *idx, unsigned long rank);
+    long (*get_rank)(OrderedIndex *idx, const OrderedIndexItem *pos);
+    void (*get_element_raw)(const OrderedIndexItem *pos, const char **ptr, size_t *len);
+    double (*get_score)(const OrderedIndexItem *pos);
+
+    /* Iterator */
+    void (*init_iterator)(OrderedIndexIterator *iter, OrderedIndex *idx);
+    void (*reset_iterator)(OrderedIndexIterator *iter);
+    bool (*next)(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+    bool (*prev)(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+    void (*seek_to_rank)(OrderedIndexIterator *iter, unsigned long rank);
+    void (*seek_to_score_range)(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset);
+    void (*seek_to_lex_range)(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
+
+    /* TODO: Add interface methods for memory management:
+     * - Memory dismiss (for CoW optimization during fork/snapshot)
+     * - Memory defrag (for active defragmentation when nodes are relocated)
+     * These will eliminate direct access to forward/backward pointers in defrag.c and object.c */
+} OrderedIndexOps;
+
+/* Inline wrappers for performance (compiler can inline these) */
+static inline OrderedIndex *orderedIndexCreate(const OrderedIndexOps *ops) {
+    return ops->create();
+}
+
+static inline void orderedIndexFree(const OrderedIndexOps *ops, OrderedIndex *idx) {
+    ops->free(idx);
+}
+
+static inline OrderedIndexItem *orderedIndexInsert(const OrderedIndexOps *ops, OrderedIndex *idx, double score, const_sds ele) {
+    return ops->insert(idx, score, ele);
+}
+
+static inline void orderedIndexDelete(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos) {
+    ops->deleteItem(idx, pos);
+}
+
+static inline OrderedIndexItem *orderedIndexUpdateScore(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos, double newscore) {
+    return ops->update_score(idx, pos, newscore);
+}
+
+static inline OrderedIndexItem *orderedIndexPopFirst(const OrderedIndexOps *ops, OrderedIndex *idx) {
+    return ops->pop_first(idx);
+}
+
+static inline OrderedIndexItem *orderedIndexPopLast(const OrderedIndexOps *ops, OrderedIndex *idx) {
+    return ops->pop_last(idx);
+}
+
+static inline void orderedIndexFreeItem(const OrderedIndexOps *ops, OrderedIndexItem *item) {
+    ops->free_item(item);
+}
+
+static inline unsigned long orderedIndexDeleteRangeByScore(const OrderedIndexOps *ops, OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
+    return ops->delete_range_by_score(idx, min, max, min_ex, max_ex);
+}
+
+static inline unsigned long orderedIndexDeleteRangeByRank(const OrderedIndexOps *ops, OrderedIndex *idx, unsigned long start, unsigned long end) {
+    return ops->delete_range_by_rank(idx, start, end);
+}
+
+static inline unsigned long orderedIndexLength(const OrderedIndexOps *ops, OrderedIndex *idx) {
+    return ops->length(idx);
+}
+
+static inline OrderedIndexItem *orderedIndexGetByRank(const OrderedIndexOps *ops, OrderedIndex *idx, unsigned long rank) {
+    return ops->get_by_rank(idx, rank);
+}
+
+static inline long orderedIndexGetRank(const OrderedIndexOps *ops, OrderedIndex *idx, const OrderedIndexItem *pos) {
+    return ops->get_rank(idx, pos);
+}
+
+static inline void orderedIndexGetElementRaw(const OrderedIndexOps *ops, const OrderedIndexItem *pos, const char **ptr, size_t *len) {
+    ops->get_element_raw(pos, ptr, len);
+}
+
+static inline double orderedIndexGetScore(const OrderedIndexOps *ops, const OrderedIndexItem *pos) {
+    return ops->get_score(pos);
+}
+
+static inline void orderedIndexInitIterator(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndex *idx) {
+    ops->init_iterator(iter, idx);
+}
+
+static inline void orderedIndexResetIterator(const OrderedIndexOps *ops, OrderedIndexIterator *iter) {
+    ops->reset_iterator(iter);
+}
+
+static inline bool orderedIndexNext(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return ops->next(iter, pos);
+}
+
+static inline bool orderedIndexPrev(const OrderedIndexOps *ops, OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return ops->prev(iter, pos);
+}
+
+static inline void orderedIndexSeekToRank(const OrderedIndexOps *ops, OrderedIndexIterator *iter, unsigned long rank) {
+    ops->seek_to_rank(iter, rank);
+}
+
+static inline void orderedIndexSeekToScoreRange(const OrderedIndexOps *ops, OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
+    ops->seek_to_score_range(iter, min, max, min_ex, max_ex, offset);
+}
+
+static inline void orderedIndexSeekToLexRange(const OrderedIndexOps *ops, OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
+    ops->seek_to_lex_range(iter, min, max, min_ex, max_ex, offset);
+}
+
+/* Available implementations */
+extern const OrderedIndexOps skiplistOrderedIndexOps;
+
+#endif /* ORDERED_INDEX_H */

--- a/src/ordered_index.h
+++ b/src/ordered_index.h
@@ -16,18 +16,19 @@ typedef struct OrderedIndexOps {
 
     /* Modification */
     OrderedIndexItem *(*insert)(OrderedIndex *idx, double score, const_sds ele);
-    void (*deleteItem)(OrderedIndex *idx, OrderedIndexItem *pos);
+    void (*delete_item)(OrderedIndex *idx, OrderedIndexItem *pos);
     OrderedIndexItem *(*update_score)(OrderedIndex *idx, OrderedIndexItem *pos, double newscore);
     OrderedIndexItem *(*pop_first)(OrderedIndex *idx);
     OrderedIndexItem *(*pop_last)(OrderedIndex *idx);
     void (*free_item)(OrderedIndexItem *item);
     unsigned long (*delete_range_by_score)(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
     unsigned long (*delete_range_by_rank)(OrderedIndex *idx, unsigned long start, unsigned long end);
+    unsigned long (*delete_range_by_lex)(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex);
 
     /* Query */
     unsigned long (*length)(OrderedIndex *idx);
     OrderedIndexItem *(*get_by_rank)(OrderedIndex *idx, unsigned long rank);
-    long (*get_rank)(OrderedIndex *idx, const OrderedIndexItem *pos);
+    unsigned long (*get_rank)(OrderedIndex *idx, const OrderedIndexItem *pos);
     void (*get_element_raw)(const OrderedIndexItem *pos, const char **ptr, size_t *len);
     double (*get_score)(const OrderedIndexItem *pos);
 
@@ -60,7 +61,7 @@ static inline OrderedIndexItem *orderedIndexInsert(const OrderedIndexOps *ops, O
 }
 
 static inline void orderedIndexDelete(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos) {
-    ops->deleteItem(idx, pos);
+    ops->delete_item(idx, pos);
 }
 
 static inline OrderedIndexItem *orderedIndexUpdateScore(const OrderedIndexOps *ops, OrderedIndex *idx, OrderedIndexItem *pos, double newscore) {
@@ -87,6 +88,10 @@ static inline unsigned long orderedIndexDeleteRangeByRank(const OrderedIndexOps 
     return ops->delete_range_by_rank(idx, start, end);
 }
 
+static inline unsigned long orderedIndexDeleteRangeByLex(const OrderedIndexOps *ops, OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
+    return ops->delete_range_by_lex(idx, min, max, min_ex, max_ex);
+}
+
 static inline unsigned long orderedIndexLength(const OrderedIndexOps *ops, OrderedIndex *idx) {
     return ops->length(idx);
 }
@@ -95,7 +100,7 @@ static inline OrderedIndexItem *orderedIndexGetByRank(const OrderedIndexOps *ops
     return ops->get_by_rank(idx, rank);
 }
 
-static inline long orderedIndexGetRank(const OrderedIndexOps *ops, OrderedIndex *idx, const OrderedIndexItem *pos) {
+static inline unsigned long orderedIndexGetRank(const OrderedIndexOps *ops, OrderedIndex *idx, const OrderedIndexItem *pos) {
     return ops->get_rank(idx, pos);
 }
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -44,6 +44,7 @@
 #include "bio.h"
 #include "zmalloc.h"
 #include "module.h"
+#include "ordered_index.h"
 #include "cluster.h"
 #include "cluster_migrateslots.h"
 
@@ -956,28 +957,31 @@ ssize_t rdbSaveObject(rio *rdb, robj *o, robj *key, int dbid, unsigned char rdbt
             nwritten += n;
         } else if (o->encoding == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(o);
-            zskiplist *zsl = zs->zsl;
 
-            if ((n = rdbSaveLen(rdb, zslGetLength(zsl))) == -1) return -1;
+            if ((n = rdbSaveLen(rdb, orderedIndexLength(zs->zidx))) == -1) return -1;
             nwritten += n;
 
             /* We save the skiplist elements from the greatest to the smallest
-             * (that's trivial since the elements are already ordered in the
-             * skiplist): this improves the load process, since the next loaded
-             * element will always be the smaller, so adding to the skiplist
-             * will always immediately stop at the head, making the insertion
-             * O(1) instead of O(log(N)). */
-            zskiplistNode *zn = zslGetTail(zsl);
-            while (zn != NULL) {
-                sds ele = zslGetNodeElement(zn);
-                if ((n = rdbSaveRawString(rdb, (unsigned char *)ele, sdslen(ele))) == -1) {
+             * because on load prepending will be O(1) instead of O(log(N)). */
+            OrderedIndexIterator iter;
+            OrderedIndexItem *item;
+            orderedIndexInitIterator(&iter, zs->zidx);
+            while (orderedIndexPrev(&iter, &item)) {
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+                if ((n = rdbSaveRawString(rdb, (unsigned char *)ele_ptr, ele_len)) == -1) {
+                    orderedIndexResetIterator(&iter);
                     return -1;
                 }
                 nwritten += n;
-                if ((n = rdbSaveBinaryDoubleValue(rdb, zn->score)) == -1) return -1;
+                if ((n = rdbSaveBinaryDoubleValue(rdb, orderedIndexGetScore(item))) == -1) {
+                    orderedIndexResetIterator(&iter);
+                    return -1;
+                }
                 nwritten += n;
-                zn = zn->backward;
             }
+            orderedIndexResetIterator(&iter);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2083,7 +2087,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
         while (zsetlen--) {
             sds sdsele;
             double score;
-            zskiplistNode *znode;
 
             if ((sdsele = rdbGenericLoadStringObject(rdb, RDB_LOAD_SDS, NULL)) == NULL) {
                 decrRefCount(o);
@@ -2115,9 +2118,9 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
             if (sdslen(sdsele) > maxelelen) maxelelen = sdslen(sdsele);
             totelelen += sdslen(sdsele);
 
-            znode = zslInsert(zs->zsl, score, sdsele);
+            OrderedIndexItem *zitem = orderedIndexInsert(zs->zidx, score, sdsele);
             sdsfree(sdsele);
-            if (!hashtableAdd(zs->ht, znode)) {
+            if (!hashtableAdd(zs->ht, zitem)) {
                 rdbReportCorruptRDB("Duplicate zset fields detected");
                 decrRefCount(o);
                 /* no need to free 'sdsele', will be released by zslFree together with 'o' */

--- a/src/server.c
+++ b/src/server.c
@@ -621,18 +621,6 @@ hashtableType setHashtableType = {
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictSdsDestructor};
 
-const void *zsetHashtableGetKey(const void *element) {
-    const zskiplistNode *node = element;
-    return zslGetNodeElement(node);
-}
-
-/* Sorted sets hash (note: a skiplist is used in addition to the hash table) */
-hashtableType zsetHashtableType = {
-    .hashFunction = sdsHashConfigurableSeed,
-    .entryGetKey = zsetHashtableGetKey,
-    .keyCompare = dictSdsKeyCompare,
-};
-
 uint64_t hashtableSdsHash(const void *key) {
     return hashtableGenHashFunction((const char *)key, sdslen((char *)key));
 }

--- a/src/server.h
+++ b/src/server.h
@@ -497,9 +497,6 @@ typedef enum {
 #define SUPERVISED_SYSTEMD 2
 #define SUPERVISED_UPSTART 3
 
-#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
-#define ZSKIPLIST_MAX_SEARCH 10
-
 /* Append only defines */
 #define REPL_MAX_WRITTEN_BEFORE_FSYNC (1024 * 1024 * 8) /* 8 MB */
 #define AOF_FSYNC_NO 0
@@ -1489,38 +1486,6 @@ struct sharedObjectsStruct {
         *sethdr[OBJ_SHARED_BULKHDR_LEN];
     sds minstring, maxstring;
 };
-
-/* ZSETs use a specialized version of Skiplists */
-typedef struct zskiplistNode {
-    union {
-        double score;         /* Sorting score for node ordering. */
-        unsigned long length; /* Number of elements in the skiplist. */
-    };
-    union {
-        struct zskiplistNode *backward; /* Pointer to previous node for reverse traversal. */
-        struct zskiplistNode *tail;     /* Tail element of the skiplist. */
-    };
-    struct zskiplistLevel {
-        struct zskiplistNode *forward;
-        /* At each level we keep the span, which is the number of elements which are on the "subtree"
-         * from this node at this level to the next node at the same level.
-         * One exception is the value at level 0. In level 0 the span can only be 1 or 0 (in case the last elements in the list)
-         * So we use it in order to hold the height of the node, which is the number of levels. */
-        unsigned long span;
-    } level[1]; /* Flexible array member - actual levels determined at node creation. */
-    /* For non-header nodes, after the level[], sds header length (1 byte) and an embedded sds element are stored. */
-} zskiplistNode;
-
-/* The header node does not store actual data (no score, no backward pointer,
- * and its node height is fixed at ZSKIPLIST_MAXLEVEL).
- * To save memory, we reuse the memory space of these fields in the header node to store:
- *   - skiplist length (number of elements)
- *   - tail pointer to the last element
- *   - maximum current level of the skiplist
- * For detailed memory layout, refer to the zskiplistNode struct definition. */
-typedef struct zskiplist {
-    zskiplistNode header;
-} zskiplist;
 
 /* Forward declaration — full definition in ordered_index.h */
 typedef struct OrderedIndex OrderedIndex;
@@ -3381,34 +3346,27 @@ typedef struct {
     int minex, maxex; /* are min or max exclusive? */
 } zlexrangespec;
 
-/* flags for incrCommandFailedCalls */
-#define ERROR_COMMAND_REJECTED (1 << 0) /* Indicate to update the command rejected stats */
-#define ERROR_COMMAND_FAILED (1 << 1)   /* Indicate to update the command failed stats */
-
-/* TODO: migrate debug.c and module.c to use OrderedIndex interface, then move
- * remaining zsl* declarations to skiplist_internal.h. */
-int zslGetHeight(const zskiplist *zsl);
-zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
-sds zslGetNodeElement(const zskiplistNode *x);
-double zslGetScore(const zskiplistNode *node);
-
-/* Skiplist iterator - opaque type that can be stack allocated.
- * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */
-typedef uint64_t zskiplistIterator[2];
-
-double zzlGetScore(unsigned char *sptr);
-void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
-void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
-unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
-unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
-/* Score range comparison helpers */
+/* Score/lex range comparison helpers */
 static inline bool zsetScoreGteMin(double score, double min, int min_ex) {
     return min_ex ? (score > min) : (score >= min);
 }
 static inline bool zsetScoreLteMax(double score, double max, int max_ex) {
     return max_ex ? (score < max) : (score <= max);
 }
+int zslValueGteMin(double value, zrangespec *spec);
+int zslValueLteMax(double value, zrangespec *spec);
+int zslLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec);
+int zslLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec);
 
+/* flags for incrCommandFailedCalls */
+#define ERROR_COMMAND_REJECTED (1 << 0) /* Indicate to update the command rejected stats */
+#define ERROR_COMMAND_FAILED (1 << 1)   /* Indicate to update the command failed stats */
+
+double zzlGetScore(unsigned char *sptr);
+void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
+void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
+unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
+unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
 unsigned long zsetLength(const robj *zobj);
 zset *zsetCreate(void);
 void zsetConvert(robj *zobj, int encoding);
@@ -3427,17 +3385,12 @@ void genericZpopCommand(client *c,
                         int reply_nil_when_empty,
                         int *deleted);
 sds lpGetObject(unsigned char *sptr);
-int zslValueGteMin(double value, zrangespec *spec);
-int zslValueLteMax(double value, zrangespec *spec);
 void zsetFreeLexRange(zlexrangespec *spec);
 int zsetParseLexRange(robj *min, robj *max, zlexrangespec *spec);
 unsigned char *zzlFirstInLexRange(unsigned char *zl, zlexrangespec *range);
 unsigned char *zzlLastInLexRange(unsigned char *zl, zlexrangespec *range);
-zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n);
 int zzlLexValueGteMin(unsigned char *p, zlexrangespec *spec);
 int zzlLexValueLteMax(unsigned char *p, zlexrangespec *spec);
-int zslLexValueGteMin(sds value, zlexrangespec *spec);
-int zslLexValueLteMax(sds value, zlexrangespec *spec);
 
 /* Core functions */
 int getMaxmemoryState(size_t *total, size_t *logical, size_t *tofree, float *level);

--- a/src/server.h
+++ b/src/server.h
@@ -3391,8 +3391,30 @@ zskiplistNode *zslGetHeader(zskiplist *zsl);
 size_t zslGetAllocSize(void);
 void zslFree(zskiplist *zsl);
 zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele);
+void zslDelete(zskiplist *zsl, zskiplistNode *node);
+zskiplistNode *zslDetachNode(zskiplist *zsl, zskiplistNode *node);
+void zslFreeNode(zskiplistNode *node);
+zskiplistNode *zslGetFirst(const zskiplist *zsl);
+zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
+unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node);
+unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht);
+unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned int end, hashtable *ht);
 zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
+zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore);
 sds zslGetNodeElement(const zskiplistNode *x);
+
+/* Skiplist iterator - opaque type that can be stack allocated.
+ * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */
+typedef uint64_t zskiplistIterator[2];
+void zslInitIterator(zskiplistIterator *iter, zskiplist *zsl);
+void zslResetIterator(zskiplistIterator *iter);
+zskiplistIterator *zslCreateIterator(zskiplist *zsl);
+void zslReleaseIterator(zskiplistIterator *iter);
+bool zslNext(zskiplistIterator *iter, zskiplistNode **nodeptr);
+bool zslPrev(zskiplistIterator *iter, zskiplistNode **nodeptr);
+void zslSeekToRank(zskiplistIterator *iter, unsigned long rank);
+void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset);
+void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
 double zzlGetScore(unsigned char *sptr);
 void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);

--- a/src/server.h
+++ b/src/server.h
@@ -2774,7 +2774,6 @@ extern dictType objectKeyPointerValueDictType;
 extern hashtableType objectHashtableType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern hashtableType setHashtableType;
-extern dictType BenchmarkDictType;
 extern hashtableType kvstoreKeysHashtableType;
 extern hashtableType kvstoreExpiresHashtableType;
 extern double R_Zero, R_PosInf, R_NegInf, R_Nan;
@@ -3353,10 +3352,10 @@ static inline bool zsetScoreGteMin(double score, double min, int min_ex) {
 static inline bool zsetScoreLteMax(double score, double max, int max_ex) {
     return max_ex ? (score < max) : (score <= max);
 }
-int zslValueGteMin(double value, zrangespec *spec);
-int zslValueLteMax(double value, zrangespec *spec);
-int zslLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec);
-int zslLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec);
+int zsetValueGteMin(double value, zrangespec *spec);
+int zsetValueLteMax(double value, zrangespec *spec);
+int zsetLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec);
+int zsetLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec);
 
 /* flags for incrCommandFailedCalls */
 #define ERROR_COMMAND_REJECTED (1 << 0) /* Indicate to update the command rejected stats */

--- a/src/server.h
+++ b/src/server.h
@@ -3345,17 +3345,21 @@ typedef struct {
     int minex, maxex; /* are min or max exclusive? */
 } zlexrangespec;
 
-/* Score/lex range comparison helpers */
-static inline bool zsetScoreGteMin(double score, double min, int min_ex) {
+/* Score/lex range comparison helpers.
+ *
+ * zsetScoreGte / zsetScoreLte — compare a score against explicit bounds.
+ * zsetScoreGteMin / zsetScoreLteMax — compare against a zrangespec.
+ * zsetLexGteMin / zsetLexLteMax — compare against a zlexrangespec. */
+static inline bool zsetScoreGte(double score, double min, int min_ex) {
     return min_ex ? (score > min) : (score >= min);
 }
-static inline bool zsetScoreLteMax(double score, double max, int max_ex) {
+static inline bool zsetScoreLte(double score, double max, int max_ex) {
     return max_ex ? (score < max) : (score <= max);
 }
-int zsetValueGteMin(double value, zrangespec *spec);
-int zsetValueLteMax(double value, zrangespec *spec);
-int zsetLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec);
-int zsetLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec);
+int zsetScoreGteMin(double value, zrangespec *spec);
+int zsetScoreLteMax(double value, zrangespec *spec);
+int zsetLexGteMin(const char *value, size_t value_len, zlexrangespec *spec);
+int zsetLexLteMax(const char *value, size_t value_len, zlexrangespec *spec);
 
 /* flags for incrCommandFailedCalls */
 #define ERROR_COMMAND_REJECTED (1 << 0) /* Indicate to update the command rejected stats */
@@ -3855,6 +3859,7 @@ void startEvictionTimeProc(void);
 /* Keys hashing/comparison functions for dict.c and hashtable.c hash tables. */
 uint64_t dictSdsHash(const void *key);
 uint64_t dictSdsCaseHash(const void *key);
+uint64_t genHashFunctionConfigurableSeed(const char *buf, size_t len);
 uint64_t dictCStrHash(const void *key);
 uint64_t dictCStrCaseHash(const void *key);
 uint64_t dictEncObjHash(const void *key);

--- a/src/server.h
+++ b/src/server.h
@@ -1522,9 +1522,12 @@ typedef struct zskiplist {
     zskiplistNode header;
 } zskiplist;
 
+/* Forward declaration — full definition in ordered_index.h */
+typedef struct OrderedIndex OrderedIndex;
+
 typedef struct zset {
     hashtable *ht;
-    zskiplist *zsl;
+    OrderedIndex *zidx;
 } zset;
 
 typedef struct clientBufferLimitsConfig {
@@ -2806,7 +2809,7 @@ extern dictType objectKeyPointerValueDictType;
 extern hashtableType objectHashtableType;
 extern dictType objectKeyHeapPointerValueDictType;
 extern hashtableType setHashtableType;
-extern hashtableType zsetHashtableType;
+extern dictType BenchmarkDictType;
 extern hashtableType kvstoreKeysHashtableType;
 extern hashtableType kvstoreExpiresHashtableType;
 extern double R_Zero, R_PosInf, R_NegInf, R_Nan;
@@ -3382,47 +3385,32 @@ typedef struct {
 #define ERROR_COMMAND_REJECTED (1 << 0) /* Indicate to update the command rejected stats */
 #define ERROR_COMMAND_FAILED (1 << 1)   /* Indicate to update the command failed stats */
 
-zskiplist *zslCreate(void);
+/* TODO: migrate debug.c and module.c to use OrderedIndex interface, then move
+ * remaining zsl* declarations to skiplist_internal.h. */
 int zslGetHeight(const zskiplist *zsl);
-zskiplistNode *zslGetTail(const zskiplist *zsl);
-void zslSetTail(zskiplist *zsl, zskiplistNode *tail);
-unsigned long zslGetLength(const zskiplist *zsl);
-zskiplistNode *zslGetHeader(zskiplist *zsl);
-size_t zslGetAllocSize(void);
-void zslFree(zskiplist *zsl);
-zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele);
-void zslDelete(zskiplist *zsl, zskiplistNode *node);
-zskiplistNode *zslDetachNode(zskiplist *zsl, zskiplistNode *node);
-void zslFreeNode(zskiplistNode *node);
-zskiplistNode *zslGetFirst(const zskiplist *zsl);
-zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
-unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node);
-unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht);
-unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned long start, unsigned long end, hashtable *ht);
-unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, hashtable *ht);
 zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
-zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore);
 sds zslGetNodeElement(const zskiplistNode *x);
 double zslGetScore(const zskiplistNode *node);
 
 /* Skiplist iterator - opaque type that can be stack allocated.
  * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */
 typedef uint64_t zskiplistIterator[2];
-void zslInitIterator(zskiplistIterator *iter, zskiplist *zsl);
-void zslResetIterator(zskiplistIterator *iter);
-zskiplistIterator *zslCreateIterator(zskiplist *zsl);
-void zslReleaseIterator(zskiplistIterator *iter);
-bool zslNext(zskiplistIterator *iter, zskiplistNode **nodeptr);
-bool zslPrev(zskiplistIterator *iter, zskiplistNode **nodeptr);
-void zslSeekToRank(zskiplistIterator *iter, unsigned long rank);
-void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset);
-void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
+
 double zzlGetScore(unsigned char *sptr);
 void zzlNext(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 void zzlPrev(unsigned char *zl, unsigned char **eptr, unsigned char **sptr);
 unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range);
 unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range);
+/* Score range comparison helpers */
+static inline bool zsetScoreGteMin(double score, double min, int min_ex) {
+    return min_ex ? (score > min) : (score >= min);
+}
+static inline bool zsetScoreLteMax(double score, double max, int max_ex) {
+    return max_ex ? (score < max) : (score <= max);
+}
+
 unsigned long zsetLength(const robj *zobj);
+zset *zsetCreate(void);
 void zsetConvert(robj *zobj, int encoding);
 void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelelen);
 int zsetScore(robj *zobj, sds member, double *score);

--- a/src/server.h
+++ b/src/server.h
@@ -3398,10 +3398,12 @@ zskiplistNode *zslGetFirst(const zskiplist *zsl);
 zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
 unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node);
 unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht);
-unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned int end, hashtable *ht);
+unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned long start, unsigned long end, hashtable *ht);
+unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, hashtable *ht);
 zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
 zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore);
 sds zslGetNodeElement(const zskiplistNode *x);
+double zslGetScore(const zskiplistNode *node);
 
 /* Skiplist iterator - opaque type that can be stack allocated.
  * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -1,0 +1,66 @@
+#ifndef SKIPLIST_INTERNAL_H
+#define SKIPLIST_INTERNAL_H
+
+/* Internal skiplist node helpers shared between t_zset.c and
+ * skiplist_ordered_index.c.  Not for use outside the skiplist
+ * implementation. */
+
+#include "server.h"
+
+/* Lifecycle */
+zskiplist *zslCreate(void);
+void zslFree(zskiplist *zsl);
+size_t zslGetAllocSize(void);
+
+/* Skiplist structure accessors */
+unsigned long zslGetLength(const zskiplist *zsl);
+zskiplistNode *zslGetHeader(zskiplist *zsl);
+zskiplistNode *zslGetTail(const zskiplist *zsl);
+void zslSetTail(zskiplist *zsl, zskiplistNode *tail);
+zskiplistNode *zslGetFirst(const zskiplist *zsl);
+
+/* Modification */
+zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele);
+void zslDelete(zskiplist *zsl, zskiplistNode *node);
+zskiplistNode *zslDetachNode(zskiplist *zsl, zskiplistNode *node);
+void zslFreeNode(zskiplistNode *node);
+zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore);
+
+/* Query */
+zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
+unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node);
+
+/* Iterator */
+void zslInitIterator(zskiplistIterator *iter, zskiplist *zsl);
+void zslResetIterator(zskiplistIterator *iter);
+zskiplistIterator *zslCreateIterator(zskiplist *zsl);
+void zslReleaseIterator(zskiplistIterator *iter);
+bool zslNext(zskiplistIterator *iter, zskiplistNode **nodeptr);
+bool zslPrev(zskiplistIterator *iter, zskiplistNode **nodeptr);
+void zslSeekToRank(zskiplistIterator *iter, unsigned long rank);
+void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset);
+void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
+
+/* Level-0 span stores the node height, so span accessors treat it specially. */
+static inline unsigned long zslGetNodeSpanAtLevel(const zskiplistNode *x, int level) {
+    if (level > 0) return x->level[level].span;
+    return x->level[level].forward ? 1 : 0;
+}
+
+static inline void zslSetNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long span) {
+    if (level > 0) x->level[level].span = span;
+}
+
+static inline void zslIncrNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long incr) {
+    if (level > 0) x->level[level].span += incr;
+}
+
+static inline void zslDecrNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long decr) {
+    if (level > 0) x->level[level].span -= decr;
+}
+
+static inline unsigned long zslGetNodeHeight(const zskiplistNode *x) {
+    return x->level[0].span;
+}
+
+#endif /* SKIPLIST_INTERNAL_H */

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -3,9 +3,16 @@
 
 /* Internal skiplist node helpers shared between t_zset.c and
  * skiplist_ordered_index.c.  Not for use outside the skiplist
- * implementation. */
+ * implementation.
+ *
+ * Callers must include server.h before this header for the full
+ * definitions of zrangespec and zlexrangespec. */
 
-#include "server.h"
+#include "sds.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
 #define ZSKIPLIST_MAX_SEARCH 10

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -90,6 +90,9 @@ zskiplistNode *zslCreateNode(int height, double score, const_sds ele);
 int zslRandomLevel(void);
 zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node);
 
+/* Internal unlink helper (used by skiplist_ordered_index.c for range deletion) */
+void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update);
+
 /* Level-0 span stores the node height, so span accessors treat it specially. */
 static inline unsigned long zslGetNodeSpanAtLevel(const zskiplistNode *x, int level) {
     if (level > 0) return x->level[level].span;

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -85,6 +85,11 @@ void zslSeekToRank(zskiplistIterator *iter, unsigned long rank);
 void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset);
 void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
 
+/* Node creation and insertion (used by skiplist_ordered_index.c for detached items) */
+zskiplistNode *zslCreateNode(int height, double score, const_sds ele);
+int zslRandomLevel(void);
+zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node);
+
 /* Level-0 span stores the node height, so span accessors treat it specially. */
 static inline unsigned long zslGetNodeSpanAtLevel(const zskiplistNode *x, int level) {
     if (level > 0) return x->level[level].span;

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -86,7 +86,7 @@ void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, in
 void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
 
 /* Node creation and insertion (used by skiplist_ordered_index.c for detached items) */
-zskiplistNode *zslCreateNode(int height, double score, const_sds ele);
+zskiplistNode *zslCreateNode(int height, double score, const char *ele, size_t ele_len);
 int zslRandomLevel(void);
 zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node);
 

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -7,12 +7,52 @@
 
 #include "server.h"
 
+#define ZSKIPLIST_MAXLEVEL 32 /* Should be enough for 2^64 elements */
+#define ZSKIPLIST_MAX_SEARCH 10
+
+/* ZSETs use a specialized version of Skiplists */
+typedef struct zskiplistNode {
+    union {
+        double score;         /* Sorting score for node ordering. */
+        unsigned long length; /* Number of elements in the skiplist. */
+    };
+    union {
+        struct zskiplistNode *backward; /* Pointer to previous node for reverse traversal. */
+        struct zskiplistNode *tail;     /* Tail element of the skiplist. */
+    };
+    struct zskiplistLevel {
+        struct zskiplistNode *forward;
+        /* At each level we keep the span, which is the number of elements which are on the "subtree"
+         * from this node at this level to the next node at the same level.
+         * One exception is the value at level 0. In level 0 the span can only be 1 or 0 (in case the last elements in the list)
+         * So we use it in order to hold the height of the node, which is the number of levels. */
+        unsigned long span;
+    } level[1]; /* Flexible array member - actual levels determined at node creation. */
+    /* For non-header nodes, after the level[], sds header length (1 byte) and an embedded sds element are stored. */
+} zskiplistNode;
+
+/* The header node does not store actual data (no score, no backward pointer,
+ * and its node height is fixed at ZSKIPLIST_MAXLEVEL).
+ * To save memory, we reuse the memory space of these fields in the header node to store:
+ *   - skiplist length (number of elements)
+ *   - tail pointer to the last element
+ *   - maximum current level of the skiplist
+ * For detailed memory layout, refer to the zskiplistNode struct definition. */
+typedef struct zskiplist {
+    zskiplistNode header;
+} zskiplist;
+
+/* Skiplist iterator - opaque type that can be stack allocated.
+ * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */
+typedef uint64_t zskiplistIterator[2];
+
 /* Lifecycle */
 zskiplist *zslCreate(void);
 void zslFree(zskiplist *zsl);
 size_t zslGetAllocSize(void);
 
 /* Skiplist structure accessors */
+int zslGetHeight(const zskiplist *zsl);
 unsigned long zslGetLength(const zskiplist *zsl);
 zskiplistNode *zslGetHeader(zskiplist *zsl);
 zskiplistNode *zslGetTail(const zskiplist *zsl);
@@ -29,6 +69,10 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newsco
 /* Query */
 zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
 unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node);
+sds zslGetNodeElement(const zskiplistNode *x);
+double zslGetScore(const zskiplistNode *node);
+zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *rank);
+zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n);
 
 /* Iterator */
 void zslInitIterator(zskiplistIterator *iter, zskiplist *zsl);

--- a/src/skiplist_internal.h
+++ b/src/skiplist_internal.h
@@ -49,9 +49,12 @@ typedef struct zskiplist {
     zskiplistNode header;
 } zskiplist;
 
-/* Skiplist iterator - opaque type that can be stack allocated.
- * Size: 2 x uint64_t = 16 bytes (zsl pointer + node pointer) */
-typedef uint64_t zskiplistIterator[2];
+/* Skiplist iterator — used directly by the skiplist implementation and
+ * cast from OrderedIndexIterator in skiplist_ordered_index.c. */
+typedef struct {
+    zskiplist *zsl;      /* The skiplist being iterated */
+    zskiplistNode *node; /* Current node (NULL before first call) */
+} zslIter;
 
 /* Lifecycle */
 zskiplist *zslCreate(void);
@@ -82,15 +85,15 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
 zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n);
 
 /* Iterator */
-void zslInitIterator(zskiplistIterator *iter, zskiplist *zsl);
-void zslResetIterator(zskiplistIterator *iter);
-zskiplistIterator *zslCreateIterator(zskiplist *zsl);
-void zslReleaseIterator(zskiplistIterator *iter);
-bool zslNext(zskiplistIterator *iter, zskiplistNode **nodeptr);
-bool zslPrev(zskiplistIterator *iter, zskiplistNode **nodeptr);
-void zslSeekToRank(zskiplistIterator *iter, unsigned long rank);
-void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset);
-void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
+void zslInitIterator(zslIter *iter, zskiplist *zsl);
+void zslResetIterator(zslIter *iter);
+zslIter *zslCreateIterator(zskiplist *zsl);
+void zslReleaseIterator(zslIter *iter);
+bool zslNext(zslIter *iter, zskiplistNode **nodeptr);
+bool zslPrev(zslIter *iter, zskiplistNode **nodeptr);
+void zslSeekToRank(zslIter *iter, unsigned long rank);
+void zslSeekToScoreRange(zslIter *iter, double min, double max, int min_ex, int max_ex, long offset);
+void zslSeekToLexRange(zslIter *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
 
 /* Node creation and insertion (used by skiplist_ordered_index.c for detached items) */
 zskiplistNode *zslCreateNode(int height, double score, const char *ele, size_t ele_len);

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -85,6 +85,26 @@ void skiplistFreeItem(OrderedIndexItem *item) {
     zslFreeNode((zskiplistNode *)item);
 }
 
+OrderedIndexItem *skiplistCreateDetached(double score, const char *ele, size_t len) {
+    sds tmp = sdsnewlen(ele, len);
+    zskiplistNode *node = zslCreateNode(zslRandomLevel(), score, tmp);
+    sdsfree(tmp);
+    return (OrderedIndexItem *)node;
+}
+
+/* Set the score on a detached item (created by skiplistCreateDetached but not
+ * yet inserted). Must NOT be used on items that are already in an index —
+ * doing so would silently corrupt the sort order. Use skiplistUpdateScore
+ * (orderedIndexUpdateScore) to change the score of an inserted item. */
+void skiplistDetachedSetScore(OrderedIndexItem *item, double score) {
+    ((zskiplistNode *)item)->score = score;
+}
+
+OrderedIndexItem *skiplistInsertDetached(OrderedIndex *idx, OrderedIndexItem *item) {
+    zskiplistNode *node = zslInsertNode((zskiplist *)idx, (zskiplistNode *)item);
+    return (OrderedIndexItem *)node;
+}
+
 unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
                                          int min_ex, int max_ex,
                                          OrderedIndexOnDelete on_delete, void *ctx) {

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -213,6 +213,39 @@ double skiplistGetScore(const OrderedIndexItem *node) {
     return zslGetScore((const zskiplistNode *)node);
 }
 
+unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
+    long first_rank, last_rank;
+
+    /* Find first element in range and its rank. */
+    zskiplistNode *first = zslNthInRange(zsl, &range, 0, &first_rank);
+    if (first == NULL) return 0;
+
+    /* Find last element in range and its rank. */
+    zskiplistNode *last_node = zslNthInRange(zsl, &range, -1, &last_rank);
+    if (last_node == NULL) return 0;
+
+    return (unsigned long)(last_rank - first_rank + 1);
+}
+
+unsigned long skiplistCountLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
+
+    /* Find first element in range. */
+    zskiplistNode *first = zslNthInLexRange(zsl, &range, 0);
+    if (first == NULL) return 0;
+    unsigned long first_rank = zslGetRank(zsl, first);
+
+    /* Find last element in range. */
+    zskiplistNode *last_node = zslNthInLexRange(zsl, &range, -1);
+    if (last_node == NULL) return 0;
+    unsigned long last_rank = zslGetRank(zsl, last_node);
+
+    return last_rank - first_rank + 1;
+}
+
 /* Iterator */
 
 void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
@@ -241,12 +274,6 @@ void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max
 
 void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
     zslSeekToLexRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
-}
-
-/* Debug */
-
-int skiplistGetHeight(OrderedIndex *idx) {
-    return zslGetHeight((zskiplist *)idx);
 }
 
 /* Memory */
@@ -359,5 +386,140 @@ unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
     }
 
     return node ? rank : 0; /* 0 = done */
+}
+
+/* Debug */
+
+int skiplistGetHeight(OrderedIndex *idx) {
+    return zslGetHeight((zskiplist *)idx);
+}
+
+/* Verify the structural integrity of the skiplist.
+ * Returns 1 if valid, 0 if corrupt (with a description in errmsg). */
+int skiplistVerifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *header = zslGetHeader(zsl);
+    int height = zslGetHeight(zsl);
+    unsigned long length = zslGetLength(zsl);
+
+#define FAIL(...)                              \
+    do {                                       \
+        snprintf(errmsg, errmsg_len, __VA_ARGS__); \
+        return 0;                              \
+    } while (0)
+
+    /* 1. Height must be in [1, ZSKIPLIST_MAXLEVEL]. */
+    if (height < 1 || height > ZSKIPLIST_MAXLEVEL)
+        FAIL("height %d out of range [1, %d]", height, ZSKIPLIST_MAXLEVEL);
+
+    /* 2. All levels above height must have NULL forward from header. */
+    for (int i = height; i < ZSKIPLIST_MAXLEVEL; i++) {
+        if (header->level[i].forward != NULL)
+            FAIL("header level %d forward is non-NULL above height %d", i, height);
+    }
+
+    /* 3. Walk level 0 to count nodes, verify ordering, backward pointers, and tail. */
+    unsigned long count = 0;
+    zskiplistNode *prev = NULL;
+    zskiplistNode *node = header->level[0].forward;
+    zskiplistNode *last = NULL;
+
+    while (node != NULL) {
+        count++;
+
+        /* Verify backward pointer. */
+        if (node->backward != prev)
+            FAIL("node at rank %lu: backward pointer mismatch", count);
+
+        /* Verify sort order (score, then element). */
+        if (prev != NULL) {
+            if (node->score < prev->score)
+                FAIL("node at rank %lu: score %.17g < previous %.17g", count, node->score, prev->score);
+            if (node->score == prev->score) {
+                sds prev_ele = zslGetNodeElement(prev);
+                sds node_ele = zslGetNodeElement(node);
+                if (sdscmp(node_ele, prev_ele) <= 0)
+                    FAIL("node at rank %lu: element not lexicographically after previous at same score", count);
+            }
+        }
+
+        /* Verify node height is in valid range. */
+        unsigned long node_height = zslGetNodeHeight(node);
+        if (node_height < 1 || node_height > (unsigned long)ZSKIPLIST_MAXLEVEL)
+            FAIL("node at rank %lu: height %lu out of range", count, node_height);
+
+        /* Node height should not exceed skiplist height. */
+        if (node_height > (unsigned long)height)
+            FAIL("node at rank %lu: height %lu exceeds skiplist height %d", count, node_height, height);
+
+        last = node;
+        prev = node;
+        node = node->level[0].forward;
+    }
+
+    /* 4. Verify length. */
+    if (count != length)
+        FAIL("length mismatch: stored %lu, counted %lu", length, count);
+
+    /* 5. Verify tail pointer. */
+    zskiplistNode *tail = zslGetTail(zsl);
+    if (length == 0) {
+        if (tail != NULL)
+            FAIL("tail should be NULL for empty skiplist");
+    } else {
+        if (tail != last)
+            FAIL("tail pointer does not point to last node");
+    }
+
+    /* 6. Verify the highest non-empty level matches height. */
+    if (length > 0) {
+        if (header->level[height - 1].forward == NULL)
+            FAIL("highest level %d has NULL forward but skiplist is non-empty", height - 1);
+    }
+
+    /* 7. Verify spans at each level. */
+    for (int i = 1; i < height; i++) {
+        unsigned long rank = 0;
+        zskiplistNode *x = header;
+
+        while (x != NULL) {
+            zskiplistNode *next_at_level = x->level[i].forward;
+            unsigned long span = zslGetNodeSpanAtLevel(x, i);
+
+            if (next_at_level == NULL) {
+                unsigned long remaining = length - rank;
+                if (span != remaining)
+                    FAIL("level %d: node at rank %lu has span %lu but %lu nodes remain",
+                         i, rank, span, remaining);
+                break;
+            }
+
+            if (zslGetNodeHeight(next_at_level) <= (unsigned long)i)
+                FAIL("level %d: forward node has height %lu, expected > %d",
+                     i, zslGetNodeHeight(next_at_level), i);
+
+            unsigned long actual_span = 0;
+            zskiplistNode *walk_next = (x == header) ? header->level[0].forward : x->level[0].forward;
+            while (walk_next != NULL && walk_next != next_at_level) {
+                actual_span++;
+                walk_next = walk_next->level[0].forward;
+            }
+            actual_span++;
+
+            if (walk_next != next_at_level)
+                FAIL("level %d: forward pointer from rank %lu does not appear in level-0 chain", i, rank);
+
+            if (span != actual_span)
+                FAIL("level %d: node at rank %lu has span %lu but actual distance is %lu",
+                     i, rank, span, actual_span);
+
+            rank += span;
+            x = next_at_level;
+        }
+    }
+
+#undef FAIL
+    errmsg[0] = '\0';
+    return 1;
 }
 

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -79,9 +79,7 @@ OrderedIndexItem *skiplistInsertDetached(OrderedIndex *idx, OrderedIndexItem *it
     return (OrderedIndexItem *)node;
 }
 
-unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
-                                         int min_ex, int max_ex,
-                                         OrderedIndexOnDelete on_delete, void *ctx) {
+unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) {
     zskiplist *zsl = (zskiplist *)idx;
     zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
@@ -112,8 +110,7 @@ unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double m
     return removed;
 }
 
-unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
-                                        OrderedIndexOnDelete on_delete, void *ctx) {
+unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end, OrderedIndexOnDelete on_delete, void *ctx) {
     zskiplist *zsl = (zskiplist *)idx;
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
     unsigned long traversed = 0, removed = 0;
@@ -144,9 +141,7 @@ unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, 
     return removed;
 }
 
-unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max,
-                                       int min_ex, int max_ex,
-                                       OrderedIndexOnDelete on_delete, void *ctx) {
+unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) {
     zskiplist *zsl = (zskiplist *)idx;
     zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
@@ -310,8 +305,7 @@ OrderedIndex *skiplistDefragInternals(OrderedIndex *idx, void *(*defragfn)(void 
 
 /* Patch skiplist pointers after a node has been reallocated to a new address.
  * update[] contains the predecessor at each level. */
-static void skiplistPatchNodePointers(zskiplist *zsl, zskiplistNode *oldnode,
-                                      zskiplistNode *newnode, zskiplistNode **update) {
+static void skiplistPatchNodePointers(zskiplist *zsl, zskiplistNode *oldnode, zskiplistNode *newnode, zskiplistNode **update) {
     for (int i = 0; i < zslGetHeight(zsl); i++) {
         if (update[i]->level[i].forward == oldnode)
             update[i]->level[i].forward = newnode;
@@ -331,10 +325,7 @@ static void skiplistPatchNodePointers(zskiplist *zsl, zskiplistNode *oldnode,
  *
  * Processes up to 16 nodes per call to bound latency, returning the
  * next cursor position (or 0 when complete). */
-unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
-                                 void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx),
-                                 void *ctx,
-                                 void *(*defragfn)(void *)) {
+unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor, void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx), void *ctx, void *(*defragfn)(void *)) {
     zskiplist *zsl = (zskiplist *)idx;
     zskiplistNode *header = zslGetHeader(zsl);
 
@@ -396,10 +387,10 @@ int skiplistVerifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) 
     int height = zslGetHeight(zsl);
     unsigned long length = zslGetLength(zsl);
 
-#define FAIL(...)                              \
-    do {                                       \
+#define FAIL(...)                                  \
+    do {                                           \
         snprintf(errmsg, errmsg_len, __VA_ARGS__); \
-        return 0;                              \
+        return 0;                                  \
     } while (0)
 
     /* 1. Height must be in [1, ZSKIPLIST_MAXLEVEL]. */
@@ -516,4 +507,3 @@ int skiplistVerifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) 
     errmsg[0] = '\0';
     return 1;
 }
-

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -243,6 +243,12 @@ void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds
     zslSeekToLexRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
 }
 
+/* Debug */
+
+int skiplistGetHeight(OrderedIndex *idx) {
+    return zslGetHeight((zskiplist *)idx);
+}
+
 /* Memory */
 
 void skiplistDismissMemory(OrderedIndex *idx) {

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -85,7 +85,7 @@ unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double m
 
     x = zslGetHeader(zsl);
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, &range))
+        while (x->level[i].forward && !zsetScoreGteMin(x->level[i].forward->score, &range))
             x = x->level[i].forward;
         update[i] = x;
     }
@@ -94,7 +94,7 @@ unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double m
     x = x->level[0].forward;
 
     /* Delete nodes while in range. */
-    while (x && zsetValueLteMax(x->score, &range)) {
+    while (x && zsetScoreLteMax(x->score, &range)) {
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
         if (on_delete) {
@@ -149,7 +149,7 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
         while (x->level[i].forward) {
             sds fwd_ele = zslGetNodeElement(x->level[i].forward);
-            if (zsetLexValueGteMin(fwd_ele, sdslen(fwd_ele), &range)) break;
+            if (zsetLexGteMin(fwd_ele, sdslen(fwd_ele), &range)) break;
             x = x->level[i].forward;
         }
         update[i] = x;
@@ -161,7 +161,7 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
     /* Delete nodes while in range. */
     while (x) {
         sds ele = zslGetNodeElement(x);
-        if (!zsetLexValueLteMax(ele, sdslen(ele), &range)) break;
+        if (!zsetLexLteMax(ele, sdslen(ele), &range)) break;
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
         if (on_delete) {

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -1,0 +1,143 @@
+#include "server.h"
+#include "ordered_index.h"
+
+/* Skiplist implementation of OrderedIndex interface */
+
+/* Lifecycle */
+
+static OrderedIndex *skiplistCreate(void) {
+    return (OrderedIndex *)zslCreate();
+}
+
+static void skiplistFree(OrderedIndex *idx) {
+    zslFree((zskiplist *)idx);
+}
+
+/* Modification */
+
+static OrderedIndexItem *skiplistInsert(OrderedIndex *idx, double score, const_sds ele) {
+    return (OrderedIndexItem *)zslInsert((zskiplist *)idx, score, ele);
+}
+
+static void skiplistDelete(OrderedIndex *idx, OrderedIndexItem *node) {
+    zslDelete((zskiplist *)idx, (zskiplistNode *)node);
+}
+
+static OrderedIndexItem *skiplistUpdateScore(OrderedIndex *idx, OrderedIndexItem *node, double newscore) {
+    zskiplistNode *result = zslUpdateScore((zskiplist *)idx, (zskiplistNode *)node, newscore);
+    return result ? (OrderedIndexItem *)result : (OrderedIndexItem *)node;
+}
+
+static OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *first = zslGetFirst(zsl);
+    if (!first) return NULL;
+    zslDetachNode(zsl, first);
+    return (OrderedIndexItem *)first;
+}
+
+static OrderedIndexItem *skiplistPopLast(OrderedIndex *idx) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *last = zslGetTail(zsl);
+    if (!last) return NULL;
+    zslDetachNode(zsl, last);
+    return (OrderedIndexItem *)last;
+}
+
+static void skiplistFreeItem(OrderedIndexItem *item) {
+    zslFreeNode((zskiplistNode *)item);
+}
+
+static unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
+    zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
+    return zslDeleteRangeByScore((zskiplist *)idx, &range, NULL);
+}
+
+static unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end) {
+    return zslDeleteRangeByRank((zskiplist *)idx, start, end, NULL);
+}
+
+/* Query */
+
+static unsigned long skiplistLength(OrderedIndex *idx) {
+    return zslGetLength((zskiplist *)idx);
+}
+
+static OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank) {
+    return (OrderedIndexItem *)zslGetElementByRank((zskiplist *)idx, rank);
+}
+
+static long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node) {
+    return (long)zslGetRank((zskiplist *)idx, (const zskiplistNode *)node);
+}
+
+static void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len) {
+    const zskiplistNode *znode = (const zskiplistNode *)node;
+    sds ele = zslGetNodeElement(znode);
+    *ptr = ele;
+    *len = sdslen(ele);
+}
+
+static double skiplistGetScore(const OrderedIndexItem *node) {
+    return ((const zskiplistNode *)node)->score;
+}
+
+/* Iterator */
+
+static void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
+    zslInitIterator((zskiplistIterator *)iter, (zskiplist *)idx);
+}
+
+static void skiplistResetIterator(OrderedIndexIterator *iter) {
+    zslResetIterator((zskiplistIterator *)iter);
+}
+
+static bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return zslNext((zskiplistIterator *)iter, (zskiplistNode **)pos);
+}
+
+static bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+    return zslPrev((zskiplistIterator *)iter, (zskiplistNode **)pos);
+}
+
+static void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank) {
+    zslSeekToRank((zskiplistIterator *)iter, rank);
+}
+
+static void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
+    zslSeekToScoreRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
+}
+
+static void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
+    zslSeekToLexRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
+}
+
+/* Skiplist implementation ops table */
+const OrderedIndexOps skiplistOrderedIndexOps = {
+    /* Lifecycle */
+    .create = skiplistCreate,
+    .free = skiplistFree,
+    /* Modification */
+    .insert = skiplistInsert,
+    .deleteItem = skiplistDelete,
+    .update_score = skiplistUpdateScore,
+    .pop_first = skiplistPopFirst,
+    .pop_last = skiplistPopLast,
+    .free_item = skiplistFreeItem,
+    .delete_range_by_score = skiplistDeleteRangeByScore,
+    .delete_range_by_rank = skiplistDeleteRangeByRank,
+    /* Query */
+    .length = skiplistLength,
+    .get_by_rank = skiplistGetByRank,
+    .get_rank = skiplistGetRank,
+    .get_element_raw = skiplistGetElementRaw,
+    .get_score = skiplistGetScore,
+    /* Iterator */
+    .init_iterator = skiplistInitIterator,
+    .reset_iterator = skiplistResetIterator,
+    .next = skiplistNext,
+    .prev = skiplistPrev,
+    .seek_to_rank = skiplistSeekToRank,
+    .seek_to_score_range = skiplistSeekToScoreRange,
+    .seek_to_lex_range = skiplistSeekToLexRange,
+};

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -2,8 +2,8 @@
 #include "ordered_index.h"
 #include "skiplist_internal.h"
 
-static_assert(sizeof(OrderedIndexIterator) >= sizeof(zskiplistIterator),
-              "OrderedIndexIterator must be large enough to hold zskiplistIterator");
+static_assert(sizeof(OrderedIndexIterator) >= sizeof(zslIter),
+              "OrderedIndexIterator must be large enough to hold zslIter");
 
 /* Skiplist implementation of OrderedIndex interface */
 
@@ -199,10 +199,6 @@ double skiplistGetScore(const OrderedIndexItem *node) {
     return zslGetScore((const zskiplistNode *)node);
 }
 
-size_t skiplistElementLen(const char *ptr) {
-    return sdslen((const_sds)ptr);
-}
-
 unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
     zskiplist *zsl = (zskiplist *)idx;
     zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
@@ -239,31 +235,31 @@ unsigned long skiplistCountLexRange(OrderedIndex *idx, const_sds min, const_sds 
 /* Iterator */
 
 void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
-    zslInitIterator((zskiplistIterator *)iter, (zskiplist *)idx);
+    zslInitIterator((zslIter *)iter, (zskiplist *)idx);
 }
 
 void skiplistResetIterator(OrderedIndexIterator *iter) {
-    zslResetIterator((zskiplistIterator *)iter);
+    zslResetIterator((zslIter *)iter);
 }
 
 bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
-    return zslNext((zskiplistIterator *)iter, (zskiplistNode **)pos);
+    return zslNext((zslIter *)iter, (zskiplistNode **)pos);
 }
 
 bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
-    return zslPrev((zskiplistIterator *)iter, (zskiplistNode **)pos);
+    return zslPrev((zslIter *)iter, (zskiplistNode **)pos);
 }
 
 void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank) {
-    zslSeekToRank((zskiplistIterator *)iter, rank);
+    zslSeekToRank((zslIter *)iter, rank);
 }
 
 void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
-    zslSeekToScoreRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
+    zslSeekToScoreRange((zslIter *)iter, min, max, min_ex, max_ex, offset);
 }
 
 void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
-    zslSeekToLexRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
+    zslSeekToLexRange((zslIter *)iter, min, max, min_ex, max_ex, offset);
 }
 
 /* Memory */

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -1,6 +1,9 @@
 #include "server.h"
 #include "ordered_index.h"
 
+static_assert(sizeof(OrderedIndexIterator) >= sizeof(zskiplistIterator),
+              "OrderedIndexIterator must be large enough to hold zskiplistIterator");
+
 /* Skiplist implementation of OrderedIndex interface */
 
 /* Lifecycle */
@@ -57,6 +60,11 @@ static unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long 
     return zslDeleteRangeByRank((zskiplist *)idx, start, end, NULL);
 }
 
+static unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
+    zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
+    return zslDeleteRangeByLex((zskiplist *)idx, &range, NULL);
+}
+
 /* Query */
 
 static unsigned long skiplistLength(OrderedIndex *idx) {
@@ -67,8 +75,8 @@ static OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank
     return (OrderedIndexItem *)zslGetElementByRank((zskiplist *)idx, rank);
 }
 
-static long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node) {
-    return (long)zslGetRank((zskiplist *)idx, (const zskiplistNode *)node);
+static unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node) {
+    return zslGetRank((zskiplist *)idx, (const zskiplistNode *)node);
 }
 
 static void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len) {
@@ -79,7 +87,7 @@ static void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr
 }
 
 static double skiplistGetScore(const OrderedIndexItem *node) {
-    return ((const zskiplistNode *)node)->score;
+    return zslGetScore((const zskiplistNode *)node);
 }
 
 /* Iterator */
@@ -119,13 +127,14 @@ const OrderedIndexOps skiplistOrderedIndexOps = {
     .free = skiplistFree,
     /* Modification */
     .insert = skiplistInsert,
-    .deleteItem = skiplistDelete,
+    .delete_item = skiplistDelete,
     .update_score = skiplistUpdateScore,
     .pop_first = skiplistPopFirst,
     .pop_last = skiplistPopLast,
     .free_item = skiplistFreeItem,
     .delete_range_by_score = skiplistDeleteRangeByScore,
     .delete_range_by_rank = skiplistDeleteRangeByRank,
+    .delete_range_by_lex = skiplistDeleteRangeByLex,
     /* Query */
     .length = skiplistLength,
     .get_by_rank = skiplistGetByRank,

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -11,32 +11,6 @@ static_assert(sizeof(OrderedIndexIterator) >= sizeof(zskiplistIterator),
  * Internal skiplist helpers
  *---------------------------------------------------------------------------*/
 
-/* Internal function to unlink a node from the skiplist (does not free it). */
-static void skiplistUnlinkNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
-    int i;
-    for (i = 0; i < zslGetHeight(zsl); i++) {
-        if (update[i]->level[i].forward == x) {
-            zslIncrNodeSpanAtLevel(update[i], i, zslGetNodeSpanAtLevel(x, i) - 1);
-            update[i]->level[i].forward = x->level[i].forward;
-        } else {
-            zslDecrNodeSpanAtLevel(update[i], i, 1);
-        }
-    }
-    if (x->level[0].forward) {
-        x->level[0].forward->backward = x->backward;
-    } else {
-        zslSetTail(zsl, x->backward);
-    }
-
-    int level;
-    zskiplistNode *zheader = zslGetHeader(zsl);
-    while ((level = zslGetHeight(zsl)) > 1 && zheader->level[level - 1].forward == NULL) {
-        /* zslSetHeight is static in t_zset.c, replicate inline: header level[0].span = height */
-        zheader->level[0].span = level - 1;
-    }
-    zsl->header.length--;
-}
-
 /* Lifecycle */
 
 OrderedIndex *skiplistCreate(void) {
@@ -116,7 +90,7 @@ unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double m
 
     x = zslGetHeader(zsl);
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, &range))
+        while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, &range))
             x = x->level[i].forward;
         update[i] = x;
     }
@@ -125,9 +99,9 @@ unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double m
     x = x->level[0].forward;
 
     /* Delete nodes while in range. */
-    while (x && zslValueLteMax(x->score, &range)) {
+    while (x && zsetValueLteMax(x->score, &range)) {
         zskiplistNode *next = x->level[0].forward;
-        skiplistUnlinkNode(zsl, x, update);
+        zslDeleteNode(zsl, x, update);
         if (on_delete) {
             on_delete((OrderedIndexItem *)x, ctx);
         }
@@ -158,7 +132,7 @@ unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, 
     x = x->level[0].forward;
     while (x && traversed <= end) {
         zskiplistNode *next = x->level[0].forward;
-        skiplistUnlinkNode(zsl, x, update);
+        zslDeleteNode(zsl, x, update);
         if (on_delete) {
             on_delete((OrderedIndexItem *)x, ctx);
         }
@@ -183,7 +157,7 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
         while (x->level[i].forward) {
             sds fwd_ele = zslGetNodeElement(x->level[i].forward);
-            if (zslLexValueGteMin(fwd_ele, sdslen(fwd_ele), &range)) break;
+            if (zsetLexValueGteMin(fwd_ele, sdslen(fwd_ele), &range)) break;
             x = x->level[i].forward;
         }
         update[i] = x;
@@ -195,9 +169,9 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
     /* Delete nodes while in range. */
     while (x) {
         sds ele = zslGetNodeElement(x);
-        if (!zslLexValueLteMax(ele, sdslen(ele), &range)) break;
+        if (!zsetLexValueLteMax(ele, sdslen(ele), &range)) break;
         zskiplistNode *next = x->level[0].forward;
-        skiplistUnlinkNode(zsl, x, update);
+        zslDeleteNode(zsl, x, update);
         if (on_delete) {
             on_delete((OrderedIndexItem *)x, ctx);
         }
@@ -355,7 +329,7 @@ static void skiplistPatchNodePointers(zskiplist *zsl, zskiplistNode *oldnode,
  * goes via defragfn. When an item is reallocated there is a callback
  * for any other pointer updates needed.
  *
- * Processes up to 64 nodes per call to bound latency, returning the
+ * Processes up to 16 nodes per call to bound latency, returning the
  * next cursor position (or 0 when complete). */
 unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
                                  void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx),

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -161,8 +161,9 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
 
     x = zslGetHeader(zsl);
     for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward &&
-               !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), &range)) {
+        while (x->level[i].forward) {
+            sds fwd_ele = zslGetNodeElement(x->level[i].forward);
+            if (zslLexValueGteMin(fwd_ele, sdslen(fwd_ele), &range)) break;
             x = x->level[i].forward;
         }
         update[i] = x;
@@ -172,7 +173,9 @@ unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_s
     x = x->level[0].forward;
 
     /* Delete nodes while in range. */
-    while (x && zslLexValueLteMax(zslGetNodeElement(x), &range)) {
+    while (x) {
+        sds ele = zslGetNodeElement(x);
+        if (!zslLexValueLteMax(ele, sdslen(ele), &range)) break;
         zskiplistNode *next = x->level[0].forward;
         skiplistUnlinkNode(zsl, x, update);
         if (on_delete) {

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -24,10 +24,9 @@ void skiplistFree(OrderedIndex *idx) {
 /* Modification */
 
 OrderedIndexItem *skiplistInsert(OrderedIndex *idx, double score, const char *ele, size_t len) {
-    sds tmp = sdsnewlen(ele, len);
-    OrderedIndexItem *node = (OrderedIndexItem *)zslInsert((zskiplist *)idx, score, tmp);
-    sdsfree(tmp);
-    return node;
+    zskiplistNode *node = zslCreateNode(zslRandomLevel(), score, ele, len);
+    zslInsertNode((zskiplist *)idx, node);
+    return (OrderedIndexItem *)node;
 }
 
 void skiplistDelete(OrderedIndex *idx, OrderedIndexItem *node) {
@@ -60,9 +59,7 @@ void skiplistFreeItem(OrderedIndexItem *item) {
 }
 
 OrderedIndexItem *skiplistCreateDetached(double score, const char *ele, size_t len) {
-    sds tmp = sdsnewlen(ele, len);
-    zskiplistNode *node = zslCreateNode(zslRandomLevel(), score, tmp);
-    sdsfree(tmp);
+    zskiplistNode *node = zslCreateNode(zslRandomLevel(), score, ele, len);
     return (OrderedIndexItem *)node;
 }
 
@@ -200,6 +197,10 @@ void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_
 
 double skiplistGetScore(const OrderedIndexItem *node) {
     return zslGetScore((const zskiplistNode *)node);
+}
+
+size_t skiplistElementLen(const char *ptr) {
+    return sdslen((const_sds)ptr);
 }
 
 unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {

--- a/src/skiplist_ordered_index.c
+++ b/src/skiplist_ordered_index.c
@@ -1,37 +1,71 @@
 #include "server.h"
 #include "ordered_index.h"
+#include "skiplist_internal.h"
 
 static_assert(sizeof(OrderedIndexIterator) >= sizeof(zskiplistIterator),
               "OrderedIndexIterator must be large enough to hold zskiplistIterator");
 
 /* Skiplist implementation of OrderedIndex interface */
 
+/*-----------------------------------------------------------------------------
+ * Internal skiplist helpers
+ *---------------------------------------------------------------------------*/
+
+/* Internal function to unlink a node from the skiplist (does not free it). */
+static void skiplistUnlinkNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
+    int i;
+    for (i = 0; i < zslGetHeight(zsl); i++) {
+        if (update[i]->level[i].forward == x) {
+            zslIncrNodeSpanAtLevel(update[i], i, zslGetNodeSpanAtLevel(x, i) - 1);
+            update[i]->level[i].forward = x->level[i].forward;
+        } else {
+            zslDecrNodeSpanAtLevel(update[i], i, 1);
+        }
+    }
+    if (x->level[0].forward) {
+        x->level[0].forward->backward = x->backward;
+    } else {
+        zslSetTail(zsl, x->backward);
+    }
+
+    int level;
+    zskiplistNode *zheader = zslGetHeader(zsl);
+    while ((level = zslGetHeight(zsl)) > 1 && zheader->level[level - 1].forward == NULL) {
+        /* zslSetHeight is static in t_zset.c, replicate inline: header level[0].span = height */
+        zheader->level[0].span = level - 1;
+    }
+    zsl->header.length--;
+}
+
 /* Lifecycle */
 
-static OrderedIndex *skiplistCreate(void) {
+OrderedIndex *skiplistCreate(void) {
     return (OrderedIndex *)zslCreate();
 }
 
-static void skiplistFree(OrderedIndex *idx) {
+void skiplistFree(OrderedIndex *idx) {
     zslFree((zskiplist *)idx);
 }
 
 /* Modification */
 
-static OrderedIndexItem *skiplistInsert(OrderedIndex *idx, double score, const_sds ele) {
-    return (OrderedIndexItem *)zslInsert((zskiplist *)idx, score, ele);
+OrderedIndexItem *skiplistInsert(OrderedIndex *idx, double score, const char *ele, size_t len) {
+    sds tmp = sdsnewlen(ele, len);
+    OrderedIndexItem *node = (OrderedIndexItem *)zslInsert((zskiplist *)idx, score, tmp);
+    sdsfree(tmp);
+    return node;
 }
 
-static void skiplistDelete(OrderedIndex *idx, OrderedIndexItem *node) {
+void skiplistDelete(OrderedIndex *idx, OrderedIndexItem *node) {
     zslDelete((zskiplist *)idx, (zskiplistNode *)node);
 }
 
-static OrderedIndexItem *skiplistUpdateScore(OrderedIndex *idx, OrderedIndexItem *node, double newscore) {
+OrderedIndexItem *skiplistUpdateScore(OrderedIndex *idx, OrderedIndexItem *node, double newscore) {
     zskiplistNode *result = zslUpdateScore((zskiplist *)idx, (zskiplistNode *)node, newscore);
     return result ? (OrderedIndexItem *)result : (OrderedIndexItem *)node;
 }
 
-static OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx) {
+OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx) {
     zskiplist *zsl = (zskiplist *)idx;
     zskiplistNode *first = zslGetFirst(zsl);
     if (!first) return NULL;
@@ -39,7 +73,7 @@ static OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx) {
     return (OrderedIndexItem *)first;
 }
 
-static OrderedIndexItem *skiplistPopLast(OrderedIndex *idx) {
+OrderedIndexItem *skiplistPopLast(OrderedIndex *idx) {
     zskiplist *zsl = (zskiplist *)idx;
     zskiplistNode *last = zslGetTail(zsl);
     if (!last) return NULL;
@@ -47,106 +81,274 @@ static OrderedIndexItem *skiplistPopLast(OrderedIndex *idx) {
     return (OrderedIndexItem *)last;
 }
 
-static void skiplistFreeItem(OrderedIndexItem *item) {
+void skiplistFreeItem(OrderedIndexItem *item) {
     zslFreeNode((zskiplistNode *)item);
 }
 
-static unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) {
+unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
+                                         int min_ex, int max_ex,
+                                         OrderedIndexOnDelete on_delete, void *ctx) {
+    zskiplist *zsl = (zskiplist *)idx;
     zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
-    return zslDeleteRangeByScore((zskiplist *)idx, &range, NULL);
+    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
+    unsigned long removed = 0;
+    int i;
+
+    x = zslGetHeader(zsl);
+    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
+        while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, &range))
+            x = x->level[i].forward;
+        update[i] = x;
+    }
+
+    /* Current node is the last with score < or <= min. */
+    x = x->level[0].forward;
+
+    /* Delete nodes while in range. */
+    while (x && zslValueLteMax(x->score, &range)) {
+        zskiplistNode *next = x->level[0].forward;
+        skiplistUnlinkNode(zsl, x, update);
+        if (on_delete) {
+            on_delete((OrderedIndexItem *)x, ctx);
+        }
+        zslFreeNode(x);
+        removed++;
+        x = next;
+    }
+    return removed;
 }
 
-static unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end) {
-    return zslDeleteRangeByRank((zskiplist *)idx, start, end, NULL);
+unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
+                                        OrderedIndexOnDelete on_delete, void *ctx) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
+    unsigned long traversed = 0, removed = 0;
+    int i;
+
+    x = zslGetHeader(zsl);
+    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
+        while (x->level[i].forward && (traversed + zslGetNodeSpanAtLevel(x, i)) < start) {
+            traversed += zslGetNodeSpanAtLevel(x, i);
+            x = x->level[i].forward;
+        }
+        update[i] = x;
+    }
+
+    traversed++;
+    x = x->level[0].forward;
+    while (x && traversed <= end) {
+        zskiplistNode *next = x->level[0].forward;
+        skiplistUnlinkNode(zsl, x, update);
+        if (on_delete) {
+            on_delete((OrderedIndexItem *)x, ctx);
+        }
+        zslFreeNode(x);
+        removed++;
+        traversed++;
+        x = next;
+    }
+    return removed;
 }
 
-static unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) {
+unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max,
+                                       int min_ex, int max_ex,
+                                       OrderedIndexOnDelete on_delete, void *ctx) {
+    zskiplist *zsl = (zskiplist *)idx;
     zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
-    return zslDeleteRangeByLex((zskiplist *)idx, &range, NULL);
+    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
+    unsigned long removed = 0;
+    int i;
+
+    x = zslGetHeader(zsl);
+    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
+        while (x->level[i].forward &&
+               !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), &range)) {
+            x = x->level[i].forward;
+        }
+        update[i] = x;
+    }
+
+    /* Current node is the last with element < or <= min. */
+    x = x->level[0].forward;
+
+    /* Delete nodes while in range. */
+    while (x && zslLexValueLteMax(zslGetNodeElement(x), &range)) {
+        zskiplistNode *next = x->level[0].forward;
+        skiplistUnlinkNode(zsl, x, update);
+        if (on_delete) {
+            on_delete((OrderedIndexItem *)x, ctx);
+        }
+        zslFreeNode(x);
+        removed++;
+        x = next;
+    }
+    return removed;
 }
 
 /* Query */
 
-static unsigned long skiplistLength(OrderedIndex *idx) {
+unsigned long skiplistLength(OrderedIndex *idx) {
     return zslGetLength((zskiplist *)idx);
 }
 
-static OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank) {
+OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank) {
     return (OrderedIndexItem *)zslGetElementByRank((zskiplist *)idx, rank);
 }
 
-static unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node) {
+unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node) {
     return zslGetRank((zskiplist *)idx, (const zskiplistNode *)node);
 }
 
-static void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len) {
+void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len) {
     const zskiplistNode *znode = (const zskiplistNode *)node;
     sds ele = zslGetNodeElement(znode);
     *ptr = ele;
     *len = sdslen(ele);
 }
 
-static double skiplistGetScore(const OrderedIndexItem *node) {
+double skiplistGetScore(const OrderedIndexItem *node) {
     return zslGetScore((const zskiplistNode *)node);
 }
 
 /* Iterator */
 
-static void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
+void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx) {
     zslInitIterator((zskiplistIterator *)iter, (zskiplist *)idx);
 }
 
-static void skiplistResetIterator(OrderedIndexIterator *iter) {
+void skiplistResetIterator(OrderedIndexIterator *iter) {
     zslResetIterator((zskiplistIterator *)iter);
 }
 
-static bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
     return zslNext((zskiplistIterator *)iter, (zskiplistNode **)pos);
 }
 
-static bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
+bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos) {
     return zslPrev((zskiplistIterator *)iter, (zskiplistNode **)pos);
 }
 
-static void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank) {
+void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank) {
     zslSeekToRank((zskiplistIterator *)iter, rank);
 }
 
-static void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
+void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) {
     zslSeekToScoreRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
 }
 
-static void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
+void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
     zslSeekToLexRange((zskiplistIterator *)iter, min, max, min_ex, max_ex, offset);
 }
 
-/* Skiplist implementation ops table */
-const OrderedIndexOps skiplistOrderedIndexOps = {
-    /* Lifecycle */
-    .create = skiplistCreate,
-    .free = skiplistFree,
-    /* Modification */
-    .insert = skiplistInsert,
-    .delete_item = skiplistDelete,
-    .update_score = skiplistUpdateScore,
-    .pop_first = skiplistPopFirst,
-    .pop_last = skiplistPopLast,
-    .free_item = skiplistFreeItem,
-    .delete_range_by_score = skiplistDeleteRangeByScore,
-    .delete_range_by_rank = skiplistDeleteRangeByRank,
-    .delete_range_by_lex = skiplistDeleteRangeByLex,
-    /* Query */
-    .length = skiplistLength,
-    .get_by_rank = skiplistGetByRank,
-    .get_rank = skiplistGetRank,
-    .get_element_raw = skiplistGetElementRaw,
-    .get_score = skiplistGetScore,
-    /* Iterator */
-    .init_iterator = skiplistInitIterator,
-    .reset_iterator = skiplistResetIterator,
-    .next = skiplistNext,
-    .prev = skiplistPrev,
-    .seek_to_rank = skiplistSeekToRank,
-    .seek_to_score_range = skiplistSeekToScoreRange,
-    .seek_to_lex_range = skiplistSeekToLexRange,
-};
+/* Memory */
+
+void skiplistDismissMemory(OrderedIndex *idx) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *zn = zslGetTail(zsl);
+    while (zn != NULL) {
+        zskiplistNode *prev = zn->backward;
+        dismissMemory(zn, 0);
+        zn = prev;
+    }
+}
+
+size_t skiplistEstimateMemory(OrderedIndex *idx, size_t sample_size) {
+    zskiplist *zsl = (zskiplist *)idx;
+    unsigned long length = zslGetLength(zsl);
+    size_t asize = zslGetAllocSize();
+
+    if (length == 0) return asize;
+
+    size_t elesize = 0;
+    size_t samples = 0;
+    zskiplistNode *znode = zslGetHeader(zsl)->level[0].forward;
+    while (znode != NULL && samples < sample_size) {
+        elesize += zmalloc_size(znode);
+        samples++;
+        znode = znode->level[0].forward;
+    }
+    if (samples) asize += (double)elesize / samples * length;
+    return asize;
+}
+
+/* Defrag */
+
+OrderedIndex *skiplistDefragInternals(OrderedIndex *idx, void *(*defragfn)(void *)) {
+    OrderedIndex *newidx = defragfn(idx);
+    return newidx; /* NULL if no move needed */
+}
+
+/* Patch skiplist pointers after a node has been reallocated to a new address.
+ * update[] contains the predecessor at each level. */
+static void skiplistPatchNodePointers(zskiplist *zsl, zskiplistNode *oldnode,
+                                      zskiplistNode *newnode, zskiplistNode **update) {
+    for (int i = 0; i < zslGetHeight(zsl); i++) {
+        if (update[i]->level[i].forward == oldnode)
+            update[i]->level[i].forward = newnode;
+    }
+    if (newnode->level[0].forward) {
+        newnode->level[0].forward->backward = newnode;
+    } else {
+        zslSetTail(zsl, newnode);
+    }
+}
+
+/* Cursor-based incremental defrag of skiplist nodes.
+ *
+ * Walks nodes forward from cursor position (a rank), defragging as it
+ * goes via defragfn. When an item is reallocated there is a callback
+ * for any other pointer updates needed.
+ *
+ * Processes up to 64 nodes per call to bound latency, returning the
+ * next cursor position (or 0 when complete). */
+unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
+                                 void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx),
+                                 void *ctx,
+                                 void *(*defragfn)(void *)) {
+    zskiplist *zsl = (zskiplist *)idx;
+    zskiplistNode *header = zslGetHeader(zsl);
+
+    /* cursor is the 1-based rank of the next node to process, 0 means start */
+    zskiplistNode *prev = header;
+    if (cursor > 0) {
+        /* Seek to the node just before cursor position */
+        zskiplistNode *target = zslGetElementByRank(zsl, cursor);
+        if (target == NULL) return 0; /* past end */
+        prev = target->backward ? target->backward : header;
+    }
+
+    zskiplistNode *node = prev->level[0].forward;
+    unsigned long count = 0;
+    unsigned long rank = cursor > 0 ? cursor : 1;
+
+    while (node != NULL && count < 16) {
+        zskiplistNode *next = node->level[0].forward;
+        zskiplistNode *newnode = defragfn(node);
+
+        if (newnode) {
+            /* Node was reallocated. Find predecessors and patch pointers. */
+            zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
+            zskiplistNode *x = header;
+            double score = newnode->score;
+            sds ele = zslGetNodeElement(newnode);
+            for (int i = zslGetHeight(zsl) - 1; i >= 0; i--) {
+                while (x->level[i].forward &&
+                       (x->level[i].forward->score < score ||
+                        (x->level[i].forward->score == score &&
+                         sdscmp(zslGetNodeElement(x->level[i].forward), ele) < 0))) {
+                    x = x->level[i].forward;
+                }
+                update[i] = x;
+            }
+            skiplistPatchNodePointers(zsl, node, newnode, update);
+            callback((OrderedIndexItem *)node, (OrderedIndexItem *)newnode, ctx);
+        }
+
+        node = next;
+        rank++;
+        count++;
+    }
+
+    return node ? rank : 0; /* 0 = done */
+}
+

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -3,11 +3,6 @@
 
 #include "sds.h"
 
-typedef struct OrderedIndex OrderedIndex;
-typedef struct OrderedIndexItem OrderedIndexItem;
-typedef uint64_t OrderedIndexIterator[3];
-typedef void (*OrderedIndexOnDelete)(OrderedIndexItem *item, void *ctx);
-
 /* Lifecycle */
 OrderedIndex *skiplistCreate(void);
 void skiplistFree(OrderedIndex *idx);

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -35,6 +35,9 @@ unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node);
 void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len);
 double skiplistGetScore(const OrderedIndexItem *node);
 
+/* Debug */
+int skiplistGetHeight(OrderedIndex *idx);
+
 /* Memory */
 void skiplistDismissMemory(OrderedIndex *idx);
 size_t skiplistEstimateMemory(OrderedIndex *idx, size_t sample_size);

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -32,6 +32,7 @@ OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank);
 unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node);
 void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len);
 double skiplistGetScore(const OrderedIndexItem *node);
+size_t skiplistElementLen(const char *ptr);
 unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
 unsigned long skiplistCountLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex);
 

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -1,0 +1,60 @@
+#ifndef SKIPLIST_ORDERED_INDEX_H
+#define SKIPLIST_ORDERED_INDEX_H
+
+#include "sds.h"
+
+typedef struct OrderedIndex OrderedIndex;
+typedef struct OrderedIndexItem OrderedIndexItem;
+typedef uint64_t OrderedIndexIterator[3];
+typedef void (*OrderedIndexOnDelete)(OrderedIndexItem *item, void *ctx);
+
+/* Lifecycle */
+OrderedIndex *skiplistCreate(void);
+void skiplistFree(OrderedIndex *idx);
+
+/* Modification */
+OrderedIndexItem *skiplistInsert(OrderedIndex *idx, double score, const char *ele, size_t len);
+void skiplistDelete(OrderedIndex *idx, OrderedIndexItem *node);
+OrderedIndexItem *skiplistUpdateScore(OrderedIndex *idx, OrderedIndexItem *node, double newscore);
+OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx);
+OrderedIndexItem *skiplistPopLast(OrderedIndex *idx);
+void skiplistFreeItem(OrderedIndexItem *item);
+unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
+                                         int min_ex, int max_ex,
+                                         OrderedIndexOnDelete on_delete, void *ctx);
+unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
+                                        OrderedIndexOnDelete on_delete, void *ctx);
+unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max,
+                                       int min_ex, int max_ex,
+                                       OrderedIndexOnDelete on_delete, void *ctx);
+
+/* Query */
+unsigned long skiplistLength(OrderedIndex *idx);
+OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank);
+unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node);
+void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len);
+double skiplistGetScore(const OrderedIndexItem *node);
+
+/* Memory */
+void skiplistDismissMemory(OrderedIndex *idx);
+size_t skiplistEstimateMemory(OrderedIndex *idx, size_t sample_size);
+
+/* Defrag */
+OrderedIndex *skiplistDefragInternals(OrderedIndex *idx, void *(*defragfn)(void *));
+unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
+                                 void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx),
+                                 void *ctx,
+                                 void *(*defragfn)(void *));
+
+/* Iterator */
+void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx);
+void skiplistResetIterator(OrderedIndexIterator *iter);
+bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank);
+void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max,
+                               int min_ex, int max_ex, long offset);
+void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max,
+                             int min_ex, int max_ex, long offset);
+
+#endif /* SKIPLIST_ORDERED_INDEX_H */

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -22,14 +22,9 @@ void skiplistFreeItem(OrderedIndexItem *item);
 OrderedIndexItem *skiplistCreateDetached(double score, const char *ele, size_t len);
 void skiplistDetachedSetScore(OrderedIndexItem *item, double score);
 OrderedIndexItem *skiplistInsertDetached(OrderedIndex *idx, OrderedIndexItem *item);
-unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
-                                         int min_ex, int max_ex,
-                                         OrderedIndexOnDelete on_delete, void *ctx);
-unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
-                                        OrderedIndexOnDelete on_delete, void *ctx);
-unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max,
-                                       int min_ex, int max_ex,
-                                       OrderedIndexOnDelete on_delete, void *ctx);
+unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx);
+unsigned long skiplistDeleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end, OrderedIndexOnDelete on_delete, void *ctx);
+unsigned long skiplistDeleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx);
 
 /* Query */
 unsigned long skiplistLength(OrderedIndex *idx);
@@ -46,10 +41,8 @@ void skiplistResetIterator(OrderedIndexIterator *iter);
 bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos);
 bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos);
 void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank);
-void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max,
-                               int min_ex, int max_ex, long offset);
-void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max,
-                             int min_ex, int max_ex, long offset);
+void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset);
+void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset);
 
 /* Memory */
 void skiplistDismissMemory(OrderedIndex *idx);
@@ -57,10 +50,7 @@ size_t skiplistEstimateMemory(OrderedIndex *idx, size_t sample_size);
 
 /* Defrag */
 OrderedIndex *skiplistDefragInternals(OrderedIndex *idx, void *(*defragfn)(void *));
-unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
-                                 void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx),
-                                 void *ctx,
-                                 void *(*defragfn)(void *));
+unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor, void (*callback)(OrderedIndexItem *old_item, OrderedIndexItem *new_item, void *ctx), void *ctx, void *(*defragfn)(void *));
 
 /* Debug */
 int skiplistGetHeight(OrderedIndex *idx);

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -19,6 +19,9 @@ OrderedIndexItem *skiplistUpdateScore(OrderedIndex *idx, OrderedIndexItem *node,
 OrderedIndexItem *skiplistPopFirst(OrderedIndex *idx);
 OrderedIndexItem *skiplistPopLast(OrderedIndex *idx);
 void skiplistFreeItem(OrderedIndexItem *item);
+OrderedIndexItem *skiplistCreateDetached(double score, const char *ele, size_t len);
+void skiplistDetachedSetScore(OrderedIndexItem *item, double score);
+OrderedIndexItem *skiplistInsertDetached(OrderedIndex *idx, OrderedIndexItem *item);
 unsigned long skiplistDeleteRangeByScore(OrderedIndex *idx, double min, double max,
                                          int min_ex, int max_ex,
                                          OrderedIndexOnDelete on_delete, void *ctx);

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -34,9 +34,19 @@ OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank);
 unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node);
 void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len);
 double skiplistGetScore(const OrderedIndexItem *node);
+unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
+unsigned long skiplistCountLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex);
 
-/* Debug */
-int skiplistGetHeight(OrderedIndex *idx);
+/* Iterator */
+void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx);
+void skiplistResetIterator(OrderedIndexIterator *iter);
+bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos);
+void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank);
+void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max,
+                               int min_ex, int max_ex, long offset);
+void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max,
+                             int min_ex, int max_ex, long offset);
 
 /* Memory */
 void skiplistDismissMemory(OrderedIndex *idx);
@@ -49,15 +59,8 @@ unsigned long skiplistScanDefrag(OrderedIndex *idx, unsigned long cursor,
                                  void *ctx,
                                  void *(*defragfn)(void *));
 
-/* Iterator */
-void skiplistInitIterator(OrderedIndexIterator *iter, OrderedIndex *idx);
-void skiplistResetIterator(OrderedIndexIterator *iter);
-bool skiplistNext(OrderedIndexIterator *iter, OrderedIndexItem **pos);
-bool skiplistPrev(OrderedIndexIterator *iter, OrderedIndexItem **pos);
-void skiplistSeekToRank(OrderedIndexIterator *iter, unsigned long rank);
-void skiplistSeekToScoreRange(OrderedIndexIterator *iter, double min, double max,
-                               int min_ex, int max_ex, long offset);
-void skiplistSeekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max,
-                             int min_ex, int max_ex, long offset);
+/* Debug */
+int skiplistGetHeight(OrderedIndex *idx);
+int skiplistVerifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len);
 
 #endif /* SKIPLIST_ORDERED_INDEX_H */

--- a/src/skiplist_ordered_index.h
+++ b/src/skiplist_ordered_index.h
@@ -27,7 +27,6 @@ OrderedIndexItem *skiplistGetByRank(OrderedIndex *idx, unsigned long rank);
 unsigned long skiplistGetRank(OrderedIndex *idx, const OrderedIndexItem *node);
 void skiplistGetElementRaw(const OrderedIndexItem *node, const char **ptr, size_t *len);
 double skiplistGetScore(const OrderedIndexItem *node);
-size_t skiplistElementLen(const char *ptr);
 unsigned long skiplistCountScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex);
 unsigned long skiplistCountLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex);
 

--- a/src/sort.c
+++ b/src/sort.c
@@ -430,9 +430,11 @@ void sortCommandGeneric(client *c, int readonly) {
             /* Seek so that prev() returns the element at startrank */
             orderedIndexSeekToRank(&oiiter, startrank);
         } else {
-            unsigned long startrank = (start > 0) ? (unsigned long)(start + 1) : 1;
-            /* Seek so that next() returns the element at startrank */
-            orderedIndexSeekToRank(&oiiter, startrank - 1);
+            /* start is 0-based; seekToRank uses 1-based ranks and positions
+             * the iterator so that next() returns rank N+1.  Seeking to rank
+             * 'start' makes next() return rank start+1, i.e. the element at
+             * 0-based index 'start'. */
+            orderedIndexSeekToRank(&oiiter, (unsigned long)start);
         }
 
         while (rangelen--) {

--- a/src/sort.c
+++ b/src/sort.c
@@ -33,10 +33,9 @@
 #include "pqsort.h" /* Partial qsort for SORT+LIMIT */
 #include <math.h>   /* isnan() */
 #include "cluster.h"
+#include "ordered_index.h"
 
 #include "valkey_strtod.h"
-
-zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
 
 serverSortOperation *createSortOperation(int type, robj *pattern) {
     serverSortOperation *so = zmalloc(sizeof(*so));
@@ -417,32 +416,40 @@ void sortCommandGeneric(client *c, int readonly) {
          * way, just getting the required range, as an optimization. */
 
         zset *zs = objectGetVal(sortval);
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
-        sds sdsele;
+        OrderedIndex *idx = zs->zidx;
+        OrderedIndexItem *ln;
         int rangelen = vectorlen;
+
+        OrderedIndexIterator oiiter;
+        orderedIndexInitIterator(&oiiter, idx);
 
         /* Check if starting point is trivial, before doing log(N) lookup. */
         if (desc) {
             long zsetlen = hashtableSize(((zset *)objectGetVal(sortval))->ht);
-
-            ln = zslGetTail(zsl);
-            if (start > 0) ln = zslGetElementByRank(zsl, zsetlen - start);
+            unsigned long startrank = (start > 0) ? (unsigned long)(zsetlen - start) : orderedIndexLength(idx);
+            /* Seek so that prev() returns the element at startrank */
+            orderedIndexSeekToRank(&oiiter, startrank);
         } else {
-            zskiplistNode *zheader = zslGetHeader(zsl);
-            ln = zheader->level[0].forward;
-            if (start > 0) ln = zslGetElementByRank(zsl, start + 1);
+            unsigned long startrank = (start > 0) ? (unsigned long)(start + 1) : 1;
+            /* Seek so that next() returns the element at startrank */
+            orderedIndexSeekToRank(&oiiter, startrank - 1);
         }
 
         while (rangelen--) {
+            if (desc)
+                orderedIndexPrev(&oiiter, &ln);
+            else
+                orderedIndexNext(&oiiter, &ln);
             serverAssertWithInfo(c, sortval, ln != NULL);
-            sdsele = zslGetNodeElement(ln);
-            vector[j].obj = createStringObject(sdsele, sdslen(sdsele));
+            const char *ptr;
+            size_t len;
+            orderedIndexGetElementRaw(ln, &ptr, &len);
+            vector[j].obj = createStringObject(ptr, len);
             vector[j].u.score = 0;
             vector[j].u.cmpobj = NULL;
             j++;
-            ln = desc ? ln->backward : ln->level[0].forward;
         }
+        orderedIndexResetIterator(&oiiter);
         /* Fix start/end: output code is not aware of this optimization. */
         end -= start;
         start = 0;
@@ -452,9 +459,11 @@ void sortCommandGeneric(client *c, int readonly) {
         hashtableInitIterator(&iter, ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {
-            zskiplistNode *node = next;
-            sds sdsele = zslGetNodeElement(node);
-            vector[j].obj = createStringObject(sdsele, sdslen(sdsele));
+            OrderedIndexItem *node = (OrderedIndexItem *)next;
+            const char *ptr;
+            size_t len;
+            orderedIndexGetElementRaw(node, &ptr, &len);
+            vector[j].obj = createStringObject(ptr, len);
             vector[j].u.score = 0;
             vector[j].u.cmpobj = NULL;
             j++;

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -84,13 +84,19 @@ static const void *zsetHashtableGetKey(const void *element) {
     return ptr;
 }
 
+/* The zset hashtable callbacks operate on SDS element strings returned by
+ * entryGetKey.  When the ordered index backend changes (e.g. to a B+ tree),
+ * the hash/compare callbacks and entryGetKey will need to be revisited so
+ * they can distinguish between stored OrderedIndexItem pointers and plain
+ * SDS lookup keys. */
+
 static uint64_t zsetHashtableHash(const void *key) {
-    return genHashFunctionConfigurableSeed(key, orderedIndexElementLen(key));
+    return genHashFunctionConfigurableSeed(key, sdslen((const_sds)key));
 }
 
 static int zsetHashtableKeyCompare(const void *key1, const void *key2) {
-    size_t l1 = orderedIndexElementLen(key1);
-    size_t l2 = orderedIndexElementLen(key2);
+    size_t l1 = sdslen((const_sds)key1);
+    size_t l2 = sdslen((const_sds)key2);
     if (l1 != l2) return 0;
     return memcmp(key1, key2, l1) == 0;
 }
@@ -559,44 +565,28 @@ zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank) {
  * Skiplist iterator
  *----------------------------------------------------------------------------*/
 
-/* Internal iterator structure */
-typedef struct {
-    zskiplist *zsl;      /* The skiplist being iterated */
-    zskiplistNode *node; /* Current node (NULL before first call) */
-} zslIter;
-
-static_assert(sizeof(zskiplistIterator) >= sizeof(zslIter), "zskiplistIterator must be large enough to hold zslIter");
-
-/* Helper macros to convert between opaque and internal types */
-#define zslIterFromOpaque(iter) ((zslIter *)(iter))
-#define zslIterToOpaque(iter) ((zskiplistIterator *)(iter))
-
 /* Initialize a stack-allocated iterator */
-void zslInitIterator(zskiplistIterator *iterator, zskiplist *zsl) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslInitIterator(zslIter *iter, zskiplist *zsl) {
     iter->zsl = zsl;
     iter->node = NULL;
 }
 
 /* Reset a stack-allocated iterator */
-void zslResetIterator(zskiplistIterator *iterator) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslResetIterator(zslIter *iter) {
     iter->zsl = NULL;
     iter->node = NULL;
 }
 
 /* Allocate and initialize an iterator (heap-allocated) */
-zskiplistIterator *zslCreateIterator(zskiplist *zsl) {
+zslIter *zslCreateIterator(zskiplist *zsl) {
     zslIter *iter = zmalloc(sizeof(*iter));
-    zskiplistIterator *opaque = zslIterToOpaque(iter);
-    zslInitIterator(opaque, zsl);
-    return opaque;
+    zslInitIterator(iter, zsl);
+    return iter;
 }
 
 /* Reset and free a heap-allocated iterator */
-void zslReleaseIterator(zskiplistIterator *iterator) {
-    zslResetIterator(iterator);
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslReleaseIterator(zslIter *iter) {
+    zslResetIterator(iter);
     zfree(iter);
 }
 
@@ -604,8 +594,7 @@ void zslReleaseIterator(zskiplistIterator *iterator) {
  * Returns the node at the current iterator position and advances the iterator.
  * For the "between items" mental model: if positioned between N and N+1,
  * this returns N+1 and positions between N+1 and N+2. */
-bool zslNext(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+bool zslNext(zslIter *iter, zskiplistNode **nodeptr) {
     if (iter->zsl == NULL) return false;
 
     if (iter->node == NULL) {
@@ -627,8 +616,7 @@ bool zslNext(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
  * Returns the node at the current iterator position and moves backward.
  * For the "between items" mental model: if positioned between N and N+1,
  * this returns N and positions between N-1 and N. */
-bool zslPrev(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+bool zslPrev(zslIter *iter, zskiplistNode **nodeptr) {
     if (iter->zsl == NULL) return false;
     if (iter->node == zslGetHeader(iter->zsl)) {
         iter->zsl = NULL;
@@ -651,8 +639,7 @@ bool zslPrev(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
  * - next() will return rank N+1
  * - prev() will return rank N
  * Rank is 1-based. */
-void zslSeekToRank(zskiplistIterator *iterator, unsigned long rank) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslSeekToRank(zslIter *iter, unsigned long rank) {
     if (iter->zsl == NULL) return;
     if (rank == 0)
         iter->node = zslGetHeader(iter->zsl);
@@ -667,8 +654,7 @@ void zslSeekToRank(zskiplistIterator *iterator, unsigned long rank) {
  * min_ex/max_ex: 1 for exclusive bounds, 0 for inclusive
  * offset >= 0: positions for forward iteration via next(). 0 = first in range.
  * offset < 0:  positions for reverse iteration via prev(). -1 = last in range. */
-void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslSeekToScoreRange(zslIter *iter, double min, double max, int min_ex, int max_ex, long offset) {
     if (iter->zsl == NULL) return;
     zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
     zskiplistNode *node = zslNthInRange(iter->zsl, &range, offset, NULL);
@@ -682,8 +668,7 @@ void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, in
     iter->node = (offset < 0) ? node : node->backward;
 }
 
-void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
-    zslIter *iter = zslIterFromOpaque(iterator);
+void zslSeekToLexRange(zslIter *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
     if (iter->zsl == NULL) return;
     zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
     zskiplistNode *node = zslNthInLexRange(iter->zsl, &range, offset);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -84,14 +84,22 @@ static const void *zsetHashtableGetKey(const void *element) {
     return ptr;
 }
 
-/* Defined in server.c */
-extern uint64_t sdsHashConfigurableSeed(const void *key);
+static uint64_t zsetHashtableHash(const void *key) {
+    return genHashFunctionConfigurableSeed(key, orderedIndexElementLen(key));
+}
+
+static int zsetHashtableKeyCompare(const void *key1, const void *key2) {
+    size_t l1 = orderedIndexElementLen(key1);
+    size_t l2 = orderedIndexElementLen(key2);
+    if (l1 != l2) return 0;
+    return memcmp(key1, key2, l1) == 0;
+}
 
 /* Sorted sets hashtable (note: a skiplist is used in addition to the hash table) */
 static hashtableType zsetHashtableType = {
-    .hashFunction = sdsHashConfigurableSeed,
+    .hashFunction = zsetHashtableHash,
     .entryGetKey = zsetHashtableGetKey,
-    .keyCompare = dictSdsKeyCompare,
+    .keyCompare = zsetHashtableKeyCompare,
 };
 
 /* Allocate and initialize a new zset (skiplist + hashtable). */
@@ -133,10 +141,9 @@ static inline size_t zslGetNodeAllocSize(int level) {
  *
  *   sds-header-size and element-sds are only valid for non-header nodes.
  */
-zskiplistNode *zslCreateNode(int height, double score, const_sds ele) {
-    size_t ele_sds_len = sdslen(ele);
-    char ele_sds_type = sdsReqType(ele_sds_len);
-    size_t ele_sds_size = sdsReqSize(ele_sds_len, ele_sds_type);
+zskiplistNode *zslCreateNode(int height, double score, const char *ele, size_t ele_len) {
+    char ele_sds_type = sdsReqType(ele_len);
+    size_t ele_sds_size = sdsReqSize(ele_len, ele_sds_type);
     /* Allocate enough space for the node, levels, and the element sds.
      * We include one extra byte representing the sds header size,
      * which is the offset into the embedded sds data where the
@@ -147,7 +154,7 @@ zskiplistNode *zslCreateNode(int height, double score, const_sds ele) {
     zslSetNodeHeight(zn, height);
     char *data = ((char *)zn) + node_size;
     *data++ = sdsHdrSize(ele_sds_type);
-    sdswrite(data, ele_sds_size, ele_sds_type, ele, ele_sds_len);
+    sdswrite(data, ele_sds_size, ele_sds_type, ele, ele_len);
     return zn;
 }
 
@@ -318,7 +325,7 @@ zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node) {
  * exist (up to the caller to enforce that). The string 'ele' is copied. */
 zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele) {
     const int level = zslRandomLevel();
-    zskiplistNode *node = zslCreateNode(level, score, ele);
+    zskiplistNode *node = zslCreateNode(level, score, ele, sdslen(ele));
     zslInsertNode(zsl, node);
     return node;
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -411,11 +411,11 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newsco
     return node;
 }
 
-int zsetValueGteMin(double value, zrangespec *spec) {
+int zsetScoreGteMin(double value, zrangespec *spec) {
     return spec->minex ? (value > spec->min) : (value >= spec->min);
 }
 
-int zsetValueLteMax(double value, zrangespec *spec) {
+int zsetScoreLteMax(double value, zrangespec *spec) {
     return spec->maxex ? (value < spec->max) : (value <= spec->max);
 }
 
@@ -426,10 +426,10 @@ int zslIsInRange(zskiplist *zsl, zrangespec *range) {
     /* Test for ranges that will always be empty. */
     if (range->min > range->max || (range->min == range->max && (range->minex || range->maxex))) return 0;
     x = zslGetTail(zsl);
-    if (x == NULL || !zsetValueGteMin(x->score, range)) return 0;
+    if (x == NULL || !zsetScoreGteMin(x->score, range)) return 0;
     zskiplistNode *zheader = zslGetHeader(zsl);
     x = zheader->level[0].forward;
-    if (x == NULL || !zsetValueLteMax(x->score, range)) return 0;
+    if (x == NULL || !zsetScoreLteMax(x->score, range)) return 0;
     return 1;
 }
 
@@ -445,7 +445,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
     zskiplistNode *x = zslGetHeader(zsl);
     int i = zslGetHeight(zsl) - 1;
     long last_highest_level_rank = 0;
-    while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, range)) {
+    while (x->level[i].forward && !zsetScoreGteMin(x->level[i].forward->score, range)) {
         last_highest_level_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
@@ -456,7 +456,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         long start_rank = last_highest_level_rank;
         for (i = zslGetHeight(zsl) - 2; i >= 0; i--) {
             /* Go forward while *OUT* of range. */
-            while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, range)) {
+            while (x->level[i].forward && !zsetScoreGteMin(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element smaller than the range. */
                 start_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -476,13 +476,13 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score <= max. */
-        if (x && !zsetValueLteMax(x->score, range)) return NULL;
+        if (x && !zsetScoreLteMax(x->score, range)) return NULL;
         if (rank) *rank = start_rank + n;
     } else {
         long end_rank = last_highest_level_rank;
         for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
-            while (x->level[i].forward && zsetValueLteMax(x->level[i].forward->score, range)) {
+            while (x->level[i].forward && zsetScoreLteMax(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element in range. */
                 end_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -503,7 +503,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score >= min. */
-        if (x && !zsetValueGteMin(x->score, range)) return NULL;
+        if (x && !zsetScoreGteMin(x->score, range)) return NULL;
         if (rank) *rank = end_rank + n;
     }
 
@@ -820,11 +820,11 @@ static int sdscmplex(const char *a, size_t alen, sds b) {
     return cmp;
 }
 
-int zsetLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec) {
+int zsetLexGteMin(const char *value, size_t value_len, zlexrangespec *spec) {
     return spec->minex ? (sdscmplex(value, value_len, spec->min) > 0) : (sdscmplex(value, value_len, spec->min) >= 0);
 }
 
-int zsetLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec) {
+int zsetLexLteMax(const char *value, size_t value_len, zlexrangespec *spec) {
     return spec->maxex ? (sdscmplex(value, value_len, spec->max) < 0) : (sdscmplex(value, value_len, spec->max) <= 0);
 }
 
@@ -838,12 +838,12 @@ static int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
     x = zslGetTail(zsl);
     if (x == NULL) return 0;
     sds ele = zslGetNodeElement(x);
-    if (!zsetLexValueGteMin(ele, sdslen(ele), range)) return 0;
+    if (!zsetLexGteMin(ele, sdslen(ele), range)) return 0;
     zskiplistNode *zheader = zslGetHeader(zsl);
     x = zheader->level[0].forward;
     if (x == NULL) return 0;
     ele = zslGetNodeElement(x);
-    if (!zsetLexValueLteMax(ele, sdslen(ele), range)) return 0;
+    if (!zsetLexLteMax(ele, sdslen(ele), range)) return 0;
     return 1;
 }
 
@@ -867,7 +867,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
     i = zslGetHeight(zsl) - 1;
     while (x->level[i].forward) {
         ele = zslGetNodeElement(x->level[i].forward);
-        if (zsetLexValueGteMin(ele, sdslen(ele), range)) break;
+        if (zsetLexGteMin(ele, sdslen(ele), range)) break;
         edge_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
@@ -880,7 +880,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
             /* Go forward while *OUT* of range. */
             while (x->level[i].forward) {
                 ele = zslGetNodeElement(x->level[i].forward);
-                if (zsetLexValueGteMin(ele, sdslen(ele), range)) break;
+                if (zsetLexGteMin(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element smaller than the range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -902,14 +902,14 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
         /* Check if score <= max. */
         if (x) {
             ele = zslGetNodeElement(x);
-            if (!zsetLexValueLteMax(ele, sdslen(ele), range)) return NULL;
+            if (!zsetLexLteMax(ele, sdslen(ele), range)) return NULL;
         }
     } else {
         for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
             while (x->level[i].forward) {
                 ele = zslGetNodeElement(x->level[i].forward);
-                if (!zsetLexValueLteMax(ele, sdslen(ele), range)) break;
+                if (!zsetLexLteMax(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element in range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -931,7 +931,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
         /* Check if score >= min. */
         if (x) {
             ele = zslGetNodeElement(x);
-            if (!zsetLexValueGteMin(ele, sdslen(ele), range)) return NULL;
+            if (!zsetLexGteMin(ele, sdslen(ele), range)) return NULL;
         }
     }
 
@@ -1055,12 +1055,12 @@ int zzlIsInRange(unsigned char *zl, zrangespec *range) {
     p = lpSeek(zl, -1);      /* Last score. */
     if (p == NULL) return 0; /* Empty sorted set */
     score = zzlGetScore(p);
-    if (!zsetValueGteMin(score, range)) return 0;
+    if (!zsetScoreGteMin(score, range)) return 0;
 
     p = lpSeek(zl, 1); /* First score. */
     serverAssert(p != NULL);
     score = zzlGetScore(p);
-    if (!zsetValueLteMax(score, range)) return 0;
+    if (!zsetScoreLteMax(score, range)) return 0;
 
     return 1;
 }
@@ -1079,9 +1079,9 @@ unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range) {
         serverAssert(sptr != NULL);
 
         score = zzlGetScore(sptr);
-        if (zsetValueGteMin(score, range)) {
+        if (zsetScoreGteMin(score, range)) {
             /* Check if score <= max. */
-            if (zsetValueLteMax(score, range)) return eptr;
+            if (zsetScoreLteMax(score, range)) return eptr;
             return NULL;
         }
 
@@ -1106,9 +1106,9 @@ unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range) {
         serverAssert(sptr != NULL);
 
         score = zzlGetScore(sptr);
-        if (zsetValueLteMax(score, range)) {
+        if (zsetScoreLteMax(score, range)) {
             /* Check if score >= min. */
-            if (zsetValueGteMin(score, range)) return eptr;
+            if (zsetScoreGteMin(score, range)) return eptr;
             return NULL;
         }
 
@@ -1126,14 +1126,14 @@ unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range) {
 
 int zzlLexValueGteMin(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zsetLexValueGteMin(value, sdslen(value), spec);
+    int res = zsetLexGteMin(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
 
 int zzlLexValueLteMax(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zsetLexValueLteMax(value, sdslen(value), spec);
+    int res = zsetLexLteMax(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
@@ -1305,7 +1305,7 @@ static unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl, eptr)) != NULL) {
         score = zzlGetScore(sptr);
-        if (zsetValueLteMax(score, range)) {
+        if (zsetScoreLteMax(score, range)) {
             /* Delete both the element and the score. */
             zl = lpDeleteRangeWithEntry(zl, &eptr, 2);
             num++;
@@ -3333,9 +3333,9 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
 
             /* Abort when the node is no longer in range. */
             if (reverse) {
-                if (!zsetValueGteMin(score, range)) break;
+                if (!zsetScoreGteMin(score, range)) break;
             } else {
-                if (!zsetValueLteMax(score, range)) break;
+                if (!zsetScoreLteMax(score, range)) break;
             }
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
@@ -3363,7 +3363,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
         if (reverse) {
             orderedIndexSeekToScoreRange(&iter, range->min, range->max, range->minex, range->maxex, -offset - 1);
             while (orderedIndexPrev(&iter, &item) && limit--) {
-                if (!zsetScoreGteMin(orderedIndexGetScore(item), range->min, range->minex)) break;
+                if (!zsetScoreGte(orderedIndexGetScore(item), range->min, range->minex)) break;
                 rangelen++;
                 const char *ele_ptr;
                 size_t ele_len;
@@ -3373,7 +3373,7 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
         } else {
             orderedIndexSeekToScoreRange(&iter, range->min, range->max, range->minex, range->maxex, offset);
             while (orderedIndexNext(&iter, &item) && limit--) {
-                if (!zsetScoreLteMax(orderedIndexGetScore(item), range->max, range->maxex)) break;
+                if (!zsetScoreLte(orderedIndexGetScore(item), range->max, range->maxex)) break;
                 rangelen++;
                 const char *ele_ptr;
                 size_t ele_len;
@@ -3435,14 +3435,14 @@ void zcountCommand(client *c) {
         /* First element is in range */
         sptr = lpNext(zl, eptr);
         score = zzlGetScore(sptr);
-        serverAssertWithInfo(c, zobj, zsetValueLteMax(score, &range));
+        serverAssertWithInfo(c, zobj, zsetScoreLteMax(score, &range));
 
         /* Iterate over elements in range */
         while (eptr) {
             score = zzlGetScore(sptr);
 
             /* Abort when the node is no longer in range. */
-            if (!zsetValueLteMax(score, &range)) {
+            if (!zsetScoreLteMax(score, &range)) {
                 break;
             } else {
                 count++;
@@ -3594,7 +3594,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zsetLexValueGteMin(ele_ptr, ele_len, range)) break;
+                if (!zsetLexGteMin(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }
@@ -3604,7 +3604,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zsetLexValueLteMax(ele_ptr, ele_len, range)) break;
+                if (!zsetLexLteMax(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }
@@ -3932,7 +3932,7 @@ void genericZpopCommand(client *c,
     int idx;
     robj *key = NULL;
     robj *zobj = NULL;
-    sds ele;
+    sds ele = NULL;
     double score;
 
     if (deleted) *deleted = 0;
@@ -3973,6 +3973,10 @@ void genericZpopCommand(client *c,
 
     /* Remove the element. */
     do {
+        const char *reply_ptr;
+        size_t reply_len;
+        OrderedIndexItem *popped_item = NULL; /* non-NULL only for skiplist */
+
         if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
             unsigned char *zl = objectGetVal(zobj);
             unsigned char *eptr, *sptr;
@@ -3996,59 +4000,47 @@ void genericZpopCommand(client *c,
 
             /* Delete from listpack. */
             serverAssertWithInfo(c, zobj, zsetDel(zobj, ele));
-
-            server.dirty++;
-
-            if (result_count == 0) { /* Do this only for the first iteration. */
-                char *events[2] = {"zpopmin", "zpopmax"};
-                notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
-                addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
-            }
-
-            if (use_nested_array) {
-                addReplyArrayLen(c, 2);
-            }
-            addReplyBulkCBuffer(c, ele, sdslen(ele));
-            addReplyDouble(c, score);
-            sdsfree(ele);
-            ++result_count;
+            reply_ptr = ele;
+            reply_len = sdslen(ele);
         } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(zobj);
 
             /* Pop the first or last element from the ordered index. */
-            OrderedIndexItem *item = (where == ZSET_MAX
-                                          ? orderedIndexPopLast(zs->zidx)
-                                          : orderedIndexPopFirst(zs->zidx));
+            popped_item = (where == ZSET_MAX
+                               ? orderedIndexPopLast(zs->zidx)
+                               : orderedIndexPopFirst(zs->zidx));
 
             /* There must be an element in the sorted set. */
-            serverAssertWithInfo(c, zobj, item != NULL);
-            const char *ele_ptr;
-            size_t ele_len;
-            orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
-            score = orderedIndexGetScore(item);
+            serverAssertWithInfo(c, zobj, popped_item != NULL);
+            orderedIndexGetElementRaw(popped_item, &reply_ptr, &reply_len);
+            score = orderedIndexGetScore(popped_item);
 
             /* Remove from hashtable. */
-            hashtablePop(zs->ht, (sds)ele_ptr, NULL);
-
-            server.dirty++;
-
-            if (result_count == 0) { /* Do this only for the first iteration. */
-                char *events[2] = {"zpopmin", "zpopmax"};
-                notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
-                addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
-            }
-
-            if (use_nested_array) {
-                addReplyArrayLen(c, 2);
-            }
-            /* Reply directly from the item's buffer, then free. */
-            addReplyBulkCBuffer(c, ele_ptr, ele_len);
-            addReplyDouble(c, score);
-            orderedIndexFreeItem(item);
-            ++result_count;
+            hashtablePop(zs->ht, (sds)reply_ptr, NULL);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
+
+        server.dirty++;
+
+        if (result_count == 0) { /* Do this only for the first iteration. */
+            char *events[2] = {"zpopmin", "zpopmax"};
+            notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
+            addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
+        }
+
+        if (use_nested_array) {
+            addReplyArrayLen(c, 2);
+        }
+        addReplyBulkCBuffer(c, reply_ptr, reply_len);
+        addReplyDouble(c, score);
+
+        /* Free encoding-specific resources. */
+        if (popped_item)
+            orderedIndexFreeItem(popped_item);
+        else
+            sdsfree(ele);
+        ++result_count;
     } while (--rangelen);
 
     /* Remove the key, if indeed needed. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -133,7 +133,7 @@ static inline size_t zslGetNodeAllocSize(int level) {
  *
  *   sds-header-size and element-sds are only valid for non-header nodes.
  */
-static zskiplistNode *zslCreateNode(int height, double score, const_sds ele) {
+zskiplistNode *zslCreateNode(int height, double score, const_sds ele) {
     size_t ele_sds_len = sdslen(ele);
     char ele_sds_type = sdsReqType(ele_sds_len);
     size_t ele_sds_size = sdsReqSize(ele_sds_len, ele_sds_type);
@@ -232,7 +232,7 @@ void zslFree(zskiplist *zsl) {
  * The return value of this function is between 1 and ZSKIPLIST_MAXLEVEL
  * (both inclusive), with a powerlaw-alike distribution where higher
  * levels are less likely to be returned. */
-static int zslRandomLevel(void) {
+int zslRandomLevel(void) {
     uint64_t rand = genrand64_int64();
 
     /* The probability of gaining 2 additional leading zeros is 0.25.
@@ -263,7 +263,7 @@ static int zslCompareNodes(const zskiplistNode *a, const zskiplistNode *b) {
 /* Insert a node in the skiplist. Assumes the element does not already exist in
  * the skiplist (up to the caller to enforce that). The skiplist takes ownership
  * of the passed node. */
-static zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node) {
+zskiplistNode *zslInsertNode(zskiplist *zsl, zskiplistNode *node) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
     unsigned long rank[ZSKIPLIST_MAXLEVEL];
     const int level = zslGetNodeHeight(node);
@@ -2861,41 +2861,38 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                 void *existing;
                 if (hashtableFindPositionForInsert(dstzset->ht, sdsval, &position, &existing)) {
                     sds tmp_ele = zuiNewSdsFromValue(&zval);
-                    /* TODO: migrate to OrderedIndex when interface supports deferred insertion.
-                     * This creates a node without inserting it into the skiplist. */
-                    zskiplistNode *new_node = zslCreateNode(zslRandomLevel(), score, tmp_ele);
+                    OrderedIndexItem *new_item = orderedIndexCreateDetached(score, tmp_ele, sdslen(tmp_ele));
                     sdsfree(tmp_ele);
-                    hashtableInsertAtPosition(dstzset->ht, new_node, &position);
+                    hashtableInsertAtPosition(dstzset->ht, new_item, &position);
                     /* Remember the longest single element encountered,
                      * to understand if it's possible to convert to listpack
                      * at the end. */
                     const char *ele_ptr;
                     size_t ele_len;
-                    orderedIndexGetElementRaw((OrderedIndexItem *)new_node, &ele_ptr, &ele_len);
+                    orderedIndexGetElementRaw(new_item, &ele_ptr, &ele_len);
                     totelelen += ele_len;
                     if (ele_len > maxelelen) {
                         maxelelen = ele_len;
                     }
                 } else {
                     /* Update the score with the score of the new instance
-                     * of the element found in the current sorted set.
-                     * TODO: migrate to OrderedIndex when interface supports in-place score mutation. */
-                    zskiplistNode *node = existing;
-                    zunionInterAggregate(&node->score, score, aggregate);
+                     * of the element found in the current sorted set. */
+                    OrderedIndexItem *item = existing;
+                    double cur = orderedIndexGetScore(item);
+                    zunionInterAggregate(&cur, score, aggregate);
+                    orderedIndexDetachedSetScore(item, cur);
                 }
             }
             zuiClearIterator(&src[i]);
         }
 
-        /* Step 2: Create the skiplist using final score ordering
-         * TODO: migrate to OrderedIndex when interface supports deferred insertion. */
+        /* Step 2: Insert all detached items into the ordered index. */
         hashtableIterator iter;
         hashtableInitIterator(&iter, dstzset->ht, 0);
 
         void *next;
         while (hashtableNext(&iter, &next)) {
-            zskiplistNode *node = next;
-            zslInsertNode((zskiplist *)dstzset->zidx, node);
+            orderedIndexInsertDetached(dstzset->zidx, next);
         }
         hashtableCleanupIterator(&iter);
     } else if (op == SET_OP_DIFF) {

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -195,8 +195,13 @@ zskiplistNode *zslGetHeader(zskiplist *zsl) {
     return &zsl->header;
 }
 
+/* Helper function to get first element (head) of skiplist. Returns NULL if empty. */
+zskiplistNode *zslGetFirst(const zskiplist *zsl) {
+    return zsl->header.level[0].forward;
+}
+
 /* Free the specified skiplist node. */
-static void zslFreeNode(zskiplistNode *node) {
+void zslFreeNode(zskiplistNode *node) {
     zfree(node);
 }
 
@@ -336,8 +341,8 @@ static void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **upda
     zsl->header.length--;
 }
 
-/* Delete specified node from the skiplist. */
-static void zslDelete(zskiplist *zsl, zskiplistNode *node) {
+/* Detach node from skiplist without freeing. Caller owns the node after this. */
+zskiplistNode *zslDetachNode(zskiplist *zsl, zskiplistNode *node) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL];
     zskiplistNode *x = zslGetHeader(zsl);
     for (int i = zslGetHeight(zsl) - 1; i >= 0; i--) {
@@ -346,11 +351,14 @@ static void zslDelete(zskiplist *zsl, zskiplistNode *node) {
         }
         update[i] = x;
     }
-
-    /* We should have arrived at the correct node */
     serverAssert(x->level[0].forward == node);
-
     zslDeleteNode(zsl, node, update);
+    return node;
+}
+
+/* Delete specified node from the skiplist. */
+void zslDelete(zskiplist *zsl, zskiplistNode *node) {
+    zslDetachNode(zsl, node);
     zslFreeNode(node);
 }
 
@@ -362,7 +370,7 @@ static void zslDelete(zskiplist *zsl, zskiplistNode *node) {
  * node can be kept it returns NULL.
  * Otherwise the skiplist is modified by removing and re-adding a new
  * element, which is more costly. A pointer to the new node is returned. */
-static zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore) {
+zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newscore) {
     /* If the node, after the score update, would be still exactly
      * at the same position, we can just update the score without
      * actually removing and re-inserting the element in the skiplist. */
@@ -494,7 +502,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
  * range->maxex). When inclusive a score >= min && score <= max is deleted.
  * Note that this function takes the reference to the hash table view of the
  * sorted set, in order to remove the elements from the hash table too. */
-static unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht) {
+unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
     unsigned long removed = 0;
     int i;
@@ -513,7 +521,7 @@ static unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, ha
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
         sds ele = zslGetNodeElement(x);
-        hashtablePop(ht, ele, NULL);
+        if (ht) hashtablePop(ht, ele, NULL);
         zslFreeNode(x);
         removed++;
         x = next;
@@ -553,7 +561,7 @@ static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, h
 
 /* Delete all the elements with rank between start and end from the skiplist.
  * Start and end are inclusive. Note that start and end need to be 1-based */
-static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned int end, hashtable *ht) {
+unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned int end, hashtable *ht) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
     unsigned long traversed = 0, removed = 0;
     int i;
@@ -572,7 +580,8 @@ static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, un
     while (x && traversed <= end) {
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
-        hashtableDelete(ht, zslGetNodeElement(x));
+        sds ele = zslGetNodeElement(x);
+        if (ht) hashtableDelete(ht, ele);
         zslFreeNode(x);
         removed++;
         traversed++;
@@ -583,7 +592,7 @@ static unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, un
 
 /* Find the rank for a specific skiplist member node. Counts nodes after the one
  * specified and subtracts from list length. Note that rank is 1-based.  */
-static unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
+unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
     unsigned long count_after_node = 0;
     while (node) { /* note this is never null the first time */
         int highest_node_span = zslGetNodeHeight(node) - 1;
@@ -617,6 +626,141 @@ static zskiplistNode *zslGetElementByRankFromNode(zskiplistNode *start_node, int
 /* Finds an element by its rank. The rank argument needs to be 1-based. */
 zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank) {
     return zslGetElementByRankFromNode(zslGetHeader(zsl), zslGetHeight(zsl) - 1, rank);
+}
+
+/*-----------------------------------------------------------------------------
+ * Skiplist iterator
+ *----------------------------------------------------------------------------*/
+
+/* Internal iterator structure */
+typedef struct {
+    zskiplist *zsl;      /* The skiplist being iterated */
+    zskiplistNode *node; /* Current node (NULL before first call) */
+} zslIter;
+
+static_assert(sizeof(zskiplistIterator) >= sizeof(zslIter), "zskiplistIterator must be large enough to hold zslIter");
+
+/* Helper macros to convert between opaque and internal types */
+#define zslIterFromOpaque(iter) ((zslIter *)(iter))
+#define zslIterToOpaque(iter) ((zskiplistIterator *)(iter))
+
+/* Initialize a stack-allocated iterator */
+void zslInitIterator(zskiplistIterator *iterator, zskiplist *zsl) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    iter->zsl = zsl;
+    iter->node = NULL;
+}
+
+/* Reset a stack-allocated iterator */
+void zslResetIterator(zskiplistIterator *iterator) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    iter->zsl = NULL;
+    iter->node = NULL;
+}
+
+/* Allocate and initialize an iterator (heap-allocated) */
+zskiplistIterator *zslCreateIterator(zskiplist *zsl) {
+    zslIter *iter = zmalloc(sizeof(*iter));
+    zskiplistIterator *opaque = zslIterToOpaque(iter);
+    zslInitIterator(opaque, zsl);
+    return opaque;
+}
+
+/* Reset and free a heap-allocated iterator */
+void zslReleaseIterator(zskiplistIterator *iterator) {
+    zslResetIterator(iterator);
+    zslIter *iter = zslIterFromOpaque(iterator);
+    zfree(iter);
+}
+
+/* Get the next node (forward direction)
+ * Returns the node at the current iterator position and advances the iterator.
+ * For the "between items" mental model: if positioned between N and N+1,
+ * this returns N+1 and positions between N+1 and N+2. */
+bool zslNext(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    if (iter->zsl == NULL) return false;
+
+    if (iter->node == NULL) {
+        /* First call - start from head */
+        iter->node = zslGetHeader(iter->zsl)->level[0].forward;
+    } else {
+        iter->node = iter->node->level[0].forward;
+    }
+    if (iter->node == NULL) {
+        iter->zsl = NULL; /* reached end - invalidate iterator */
+        return false;
+    } else {
+        *nodeptr = iter->node;
+        return true;
+    }
+}
+
+/* Get the previous node (backward direction)
+ * Returns the node at the current iterator position and moves backward.
+ * For the "between items" mental model: if positioned between N and N+1,
+ * this returns N and positions between N-1 and N. */
+bool zslPrev(zskiplistIterator *iterator, zskiplistNode **nodeptr) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    if (iter->zsl == NULL) return false;
+    if (iter->node == zslGetHeader(iter->zsl)) {
+        iter->zsl = NULL;
+        return false;
+    }
+
+    if (iter->node == NULL) {
+        /* First call - start from tail */
+        iter->node = zslGetTail(iter->zsl);
+    }
+
+    *nodeptr = iter->node;
+    iter->node = iter->node->backward;
+    if (iter->node == zslGetHeader(iter->zsl) || iter->node == NULL) iter->zsl = NULL;
+    return true;
+}
+
+/* Seek to rank position. The mental model is that the iterator is positioned
+ * "between" ranks. Seeking to rank N positions the iterator at N.5:
+ * - next() will return rank N+1
+ * - prev() will return rank N
+ * Rank is 1-based. */
+void zslSeekToRank(zskiplistIterator *iterator, unsigned long rank) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    if (iter->zsl == NULL) return;
+    if (rank == 0)
+        iter->node = zslGetHeader(iter->zsl);
+    else
+        iter->node = zslGetElementByRank(iter->zsl, rank);
+}
+
+/* Seek to a position within a score range with offset.
+ * min/max: score range bounds
+ * min_ex/max_ex: 1 for exclusive bounds, 0 for inclusive
+ * offset: 0-based position within range (negative counts from end) */
+void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    if (iter->zsl == NULL) return;
+    zrangespec range = {.min = min, .max = max, .minex = min_ex, .maxex = max_ex};
+    zskiplistNode *node = zslNthInRange(iter->zsl, &range, offset, NULL);
+    if (node == NULL) {
+        iter->node = NULL;
+        iter->zsl = NULL;
+        return;
+    }
+    iter->node = node->backward;
+}
+
+void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
+    zslIter *iter = zslIterFromOpaque(iterator);
+    if (iter->zsl == NULL) return;
+    zlexrangespec range = {.min = (sds)min, .max = (sds)max, .minex = min_ex, .maxex = max_ex};
+    zskiplistNode *node = zslNthInLexRange(iter->zsl, &range, offset);
+    if (node == NULL) {
+        iter->node = NULL;
+        iter->zsl = NULL;
+        return;
+    }
+    iter->node = node->backward;
 }
 
 /* Populate the rangespec according to the objects min and max. */

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -4010,8 +4010,8 @@ void genericZpopCommand(client *c,
 
             /* Pop the first or last element from the ordered index. */
             OrderedIndexItem *item = (where == ZSET_MAX
-                ? orderedIndexPopLast(zs->zidx)
-                : orderedIndexPopFirst(zs->zidx));
+                                          ? orderedIndexPopLast(zs->zidx)
+                                          : orderedIndexPopFirst(zs->zidx));
 
             /* There must be an element in the sorted set. */
             serverAssertWithInfo(c, zobj, item != NULL);

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -323,9 +323,9 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele) {
     return node;
 }
 
-/* Internal function used by zslDelete, zsetIndexDeleteRangeByScore and
- * zsetIndexDeleteRangeByRank. */
-static void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
+/* Internal function used by zslDelete/zslDetachNode and range deletion in
+ * skiplist_ordered_index.c. Unlinks a node given its update[] predecessors. */
+void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
     int i;
     for (i = 0; i < zslGetHeight(zsl); i++) {
         if (update[i]->level[i].forward == x) {
@@ -404,11 +404,11 @@ zskiplistNode *zslUpdateScore(zskiplist *zsl, zskiplistNode *node, double newsco
     return node;
 }
 
-int zslValueGteMin(double value, zrangespec *spec) {
+int zsetValueGteMin(double value, zrangespec *spec) {
     return spec->minex ? (value > spec->min) : (value >= spec->min);
 }
 
-int zslValueLteMax(double value, zrangespec *spec) {
+int zsetValueLteMax(double value, zrangespec *spec) {
     return spec->maxex ? (value < spec->max) : (value <= spec->max);
 }
 
@@ -419,10 +419,10 @@ int zslIsInRange(zskiplist *zsl, zrangespec *range) {
     /* Test for ranges that will always be empty. */
     if (range->min > range->max || (range->min == range->max && (range->minex || range->maxex))) return 0;
     x = zslGetTail(zsl);
-    if (x == NULL || !zslValueGteMin(x->score, range)) return 0;
+    if (x == NULL || !zsetValueGteMin(x->score, range)) return 0;
     zskiplistNode *zheader = zslGetHeader(zsl);
     x = zheader->level[0].forward;
-    if (x == NULL || !zslValueLteMax(x->score, range)) return 0;
+    if (x == NULL || !zsetValueLteMax(x->score, range)) return 0;
     return 1;
 }
 
@@ -438,7 +438,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
     zskiplistNode *x = zslGetHeader(zsl);
     int i = zslGetHeight(zsl) - 1;
     long last_highest_level_rank = 0;
-    while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, range)) {
+    while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, range)) {
         last_highest_level_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
@@ -449,7 +449,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
         long start_rank = last_highest_level_rank;
         for (i = zslGetHeight(zsl) - 2; i >= 0; i--) {
             /* Go forward while *OUT* of range. */
-            while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, range)) {
+            while (x->level[i].forward && !zsetValueGteMin(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element smaller than the range. */
                 start_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -469,13 +469,13 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score <= max. */
-        if (x && !zslValueLteMax(x->score, range)) return NULL;
+        if (x && !zsetValueLteMax(x->score, range)) return NULL;
         if (rank) *rank = start_rank + n;
     } else {
         long end_rank = last_highest_level_rank;
         for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
-            while (x->level[i].forward && zslValueLteMax(x->level[i].forward->score, range)) {
+            while (x->level[i].forward && zsetValueLteMax(x->level[i].forward->score, range)) {
                 /* Count the rank of the last element in range. */
                 end_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -496,7 +496,7 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score >= min. */
-        if (x && !zslValueGteMin(x->score, range)) return NULL;
+        if (x && !zsetValueGteMin(x->score, range)) return NULL;
         if (rank) *rank = end_rank + n;
     }
 
@@ -813,11 +813,11 @@ static int sdscmplex(const char *a, size_t alen, sds b) {
     return cmp;
 }
 
-int zslLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec) {
+int zsetLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec) {
     return spec->minex ? (sdscmplex(value, value_len, spec->min) > 0) : (sdscmplex(value, value_len, spec->min) >= 0);
 }
 
-int zslLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec) {
+int zsetLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec) {
     return spec->maxex ? (sdscmplex(value, value_len, spec->max) < 0) : (sdscmplex(value, value_len, spec->max) <= 0);
 }
 
@@ -831,12 +831,12 @@ static int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
     x = zslGetTail(zsl);
     if (x == NULL) return 0;
     sds ele = zslGetNodeElement(x);
-    if (!zslLexValueGteMin(ele, sdslen(ele), range)) return 0;
+    if (!zsetLexValueGteMin(ele, sdslen(ele), range)) return 0;
     zskiplistNode *zheader = zslGetHeader(zsl);
     x = zheader->level[0].forward;
     if (x == NULL) return 0;
     ele = zslGetNodeElement(x);
-    if (!zslLexValueLteMax(ele, sdslen(ele), range)) return 0;
+    if (!zsetLexValueLteMax(ele, sdslen(ele), range)) return 0;
     return 1;
 }
 
@@ -860,7 +860,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
     i = zslGetHeight(zsl) - 1;
     while (x->level[i].forward) {
         ele = zslGetNodeElement(x->level[i].forward);
-        if (zslLexValueGteMin(ele, sdslen(ele), range)) break;
+        if (zsetLexValueGteMin(ele, sdslen(ele), range)) break;
         edge_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
@@ -873,7 +873,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
             /* Go forward while *OUT* of range. */
             while (x->level[i].forward) {
                 ele = zslGetNodeElement(x->level[i].forward);
-                if (zslLexValueGteMin(ele, sdslen(ele), range)) break;
+                if (zsetLexValueGteMin(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element smaller than the range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -895,14 +895,14 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
         /* Check if score <= max. */
         if (x) {
             ele = zslGetNodeElement(x);
-            if (!zslLexValueLteMax(ele, sdslen(ele), range)) return NULL;
+            if (!zsetLexValueLteMax(ele, sdslen(ele), range)) return NULL;
         }
     } else {
         for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
             while (x->level[i].forward) {
                 ele = zslGetNodeElement(x->level[i].forward);
-                if (!zslLexValueLteMax(ele, sdslen(ele), range)) break;
+                if (!zsetLexValueLteMax(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element in range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -924,7 +924,7 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
         /* Check if score >= min. */
         if (x) {
             ele = zslGetNodeElement(x);
-            if (!zslLexValueGteMin(ele, sdslen(ele), range)) return NULL;
+            if (!zsetLexValueGteMin(ele, sdslen(ele), range)) return NULL;
         }
     }
 
@@ -1048,12 +1048,12 @@ int zzlIsInRange(unsigned char *zl, zrangespec *range) {
     p = lpSeek(zl, -1);      /* Last score. */
     if (p == NULL) return 0; /* Empty sorted set */
     score = zzlGetScore(p);
-    if (!zslValueGteMin(score, range)) return 0;
+    if (!zsetValueGteMin(score, range)) return 0;
 
     p = lpSeek(zl, 1); /* First score. */
     serverAssert(p != NULL);
     score = zzlGetScore(p);
-    if (!zslValueLteMax(score, range)) return 0;
+    if (!zsetValueLteMax(score, range)) return 0;
 
     return 1;
 }
@@ -1072,9 +1072,9 @@ unsigned char *zzlFirstInRange(unsigned char *zl, zrangespec *range) {
         serverAssert(sptr != NULL);
 
         score = zzlGetScore(sptr);
-        if (zslValueGteMin(score, range)) {
+        if (zsetValueGteMin(score, range)) {
             /* Check if score <= max. */
-            if (zslValueLteMax(score, range)) return eptr;
+            if (zsetValueLteMax(score, range)) return eptr;
             return NULL;
         }
 
@@ -1099,9 +1099,9 @@ unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range) {
         serverAssert(sptr != NULL);
 
         score = zzlGetScore(sptr);
-        if (zslValueLteMax(score, range)) {
+        if (zsetValueLteMax(score, range)) {
             /* Check if score >= min. */
-            if (zslValueGteMin(score, range)) return eptr;
+            if (zsetValueGteMin(score, range)) return eptr;
             return NULL;
         }
 
@@ -1119,14 +1119,14 @@ unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range) {
 
 int zzlLexValueGteMin(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zslLexValueGteMin(value, sdslen(value), spec);
+    int res = zsetLexValueGteMin(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
 
 int zzlLexValueLteMax(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zslLexValueLteMax(value, sdslen(value), spec);
+    int res = zsetLexValueLteMax(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
@@ -1298,7 +1298,7 @@ static unsigned char *zzlDeleteRangeByScore(unsigned char *zl, zrangespec *range
     /* When the tail of the listpack is deleted, eptr will be NULL. */
     while (eptr && (sptr = lpNext(zl, eptr)) != NULL) {
         score = zzlGetScore(sptr);
-        if (zslValueLteMax(score, range)) {
+        if (zsetValueLteMax(score, range)) {
             /* Delete both the element and the score. */
             zl = lpDeleteRangeWithEntry(zl, &eptr, 2);
             num++;
@@ -3326,9 +3326,9 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
 
             /* Abort when the node is no longer in range. */
             if (reverse) {
-                if (!zslValueGteMin(score, range)) break;
+                if (!zsetValueGteMin(score, range)) break;
             } else {
-                if (!zslValueLteMax(score, range)) break;
+                if (!zsetValueLteMax(score, range)) break;
             }
 
             vstr = lpGetValue(eptr, &vlen, &vlong);
@@ -3428,14 +3428,14 @@ void zcountCommand(client *c) {
         /* First element is in range */
         sptr = lpNext(zl, eptr);
         score = zzlGetScore(sptr);
-        serverAssertWithInfo(c, zobj, zslValueLteMax(score, &range));
+        serverAssertWithInfo(c, zobj, zsetValueLteMax(score, &range));
 
         /* Iterate over elements in range */
         while (eptr) {
             score = zzlGetScore(sptr);
 
             /* Abort when the node is no longer in range. */
-            if (!zslValueLteMax(score, &range)) {
+            if (!zsetValueLteMax(score, &range)) {
                 break;
             } else {
                 count++;
@@ -3587,7 +3587,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zslLexValueGteMin(ele_ptr, ele_len, range)) break;
+                if (!zsetLexValueGteMin(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }
@@ -3597,7 +3597,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zslLexValueLteMax(ele_ptr, ele_len, range)) break;
+                if (!zsetLexValueLteMax(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1225,7 +1225,7 @@ static unsigned char *zzlDelete(unsigned char *zl, unsigned char *eptr) {
     return lpDeleteRangeWithEntry(zl, &eptr, 2);
 }
 
-static unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, sds ele, double score) {
+static unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, const char *ele, size_t ele_len, double score) {
     unsigned char *sptr;
     char scorebuf[MAX_D2STRING_CHARS];
     int scorelen = 0;
@@ -1233,14 +1233,14 @@ static unsigned char *zzlInsertAt(unsigned char *zl, unsigned char *eptr, sds el
     int score_is_long = double2ll(score, &lscore);
     if (!score_is_long) scorelen = d2string(scorebuf, sizeof(scorebuf), score);
     if (eptr == NULL) {
-        zl = lpAppend(zl, (unsigned char *)ele, sdslen(ele));
+        zl = lpAppend(zl, (unsigned char *)ele, ele_len);
         if (score_is_long)
             zl = lpAppendInteger(zl, lscore);
         else
             zl = lpAppend(zl, (unsigned char *)scorebuf, scorelen);
     } else {
         /* Insert member before the element 'eptr'. */
-        zl = lpInsertString(zl, (unsigned char *)ele, sdslen(ele), eptr, LP_BEFORE, &sptr);
+        zl = lpInsertString(zl, (unsigned char *)ele, ele_len, eptr, LP_BEFORE, &sptr);
 
         /* Insert score after the member. */
         if (score_is_long)
@@ -1266,12 +1266,12 @@ static unsigned char *zzlInsert(unsigned char *zl, sds ele, double score) {
             /* First element with score larger than score for element to be
              * inserted. This means we should take its spot in the list to
              * maintain ordering. */
-            zl = zzlInsertAt(zl, eptr, ele, score);
+            zl = zzlInsertAt(zl, eptr, ele, sdslen(ele), score);
             break;
         } else if (s == score) {
             /* Ensure lexicographical ordering for elements. */
             if (zzlCompareElements(eptr, (unsigned char *)ele, sdslen(ele)) > 0) {
-                zl = zzlInsertAt(zl, eptr, ele, score);
+                zl = zzlInsertAt(zl, eptr, ele, sdslen(ele), score);
                 break;
             }
         }
@@ -1281,7 +1281,7 @@ static unsigned char *zzlInsert(unsigned char *zl, sds ele, double score) {
     }
 
     /* Push on tail of list when it was not yet inserted. */
-    if (eptr == NULL) zl = zzlInsertAt(zl, NULL, ele, score);
+    if (eptr == NULL) zl = zzlInsertAt(zl, NULL, ele, sdslen(ele), score);
     return zl;
 }
 
@@ -1397,6 +1397,16 @@ void zsetConvert(robj *zobj, int encoding) {
     zsetConvertAndExpand(zobj, encoding, zsetLength(zobj));
 }
 
+/* Callback for orderedIndexDeleteRangeByRank used during skiplist→listpack
+ * conversion. Appends each removed item to the listpack pointed to by ctx. */
+static void zsetConvertToListpackCallback(OrderedIndexItem *item, void *ctx) {
+    unsigned char **zl = ctx;
+    const char *ele_ptr;
+    size_t ele_len;
+    orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+    *zl = zzlInsertAt(*zl, NULL, ele_ptr, ele_len, orderedIndexGetScore(item));
+}
+
 /* Converts a zset to the specified encoding, pre-sizing it for 'cap' elements. */
 void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
     if (zobj->encoding == encoding) return;
@@ -1443,29 +1453,13 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         if (encoding != OBJ_ENCODING_LISTPACK) serverPanic("Unknown target encoding");
 
-        /* Approach similar to zslFree(), since we want to free the skiplist at
-         * the same time as creating the listpack. */
+        /* Delete all elements via range deletion, building the listpack
+         * in the on_delete callback as nodes are removed in order. */
         zset *zs = objectGetVal(zobj);
         hashtableRelease(zs->ht);
-        /* TODO: migrate to OrderedIndex when interface supports destructive iteration.
-         * This manually walks and frees skiplist nodes after releasing the header. */
-        zskiplistNode *zheader = zslGetHeader((zskiplist *)zs->zidx);
-        
-        zskiplistNode *node = zheader->level[0].forward;
-        zfree(zs->zidx);
-
-        while (node) {
-            const char *ele_ptr;
-            size_t ele_len;
-            orderedIndexGetElementRaw((OrderedIndexItem *)node, &ele_ptr, &ele_len);
-            sds ele_sds = sdsnewlen(ele_ptr, ele_len);
-            zl = zzlInsertAt(zl, NULL, ele_sds, orderedIndexGetScore((OrderedIndexItem *)node));
-            sdsfree(ele_sds);
-            zskiplistNode *next = node->level[0].forward;
-            orderedIndexFreeItem((OrderedIndexItem *)node);
-            node = next;
-        }
-
+        unsigned long len = orderedIndexLength(zs->zidx);
+        orderedIndexDeleteRangeByRank(zs->zidx, 1, len, zsetConvertToListpackCallback, &zl);
+        orderedIndexFree(zs->zidx);
         zfree(zs);
         objectSetVal(zobj, zl);
         zobj->encoding = OBJ_ENCODING_LISTPACK;
@@ -3453,26 +3447,7 @@ void zcountCommand(client *c) {
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        /* TODO: migrate to OrderedIndex when interface supports rank-returning range lookup. */
-        zskiplist *zsl = (zskiplist *)zs->zidx;
-        zskiplistNode *zn;
-        long rank;
-
-        /* Find first element in range */
-        zn = zslNthInRange(zsl, &range, 0, &rank);
-
-        /* Use rank of first element, if any, to determine preliminary count */
-        if (zn != NULL) {
-            count = (orderedIndexLength(zs->zidx) - (rank - 1));
-
-            /* Find last element in range */
-            zn = zslNthInRange(zsl, &range, -1, &rank);
-
-            /* Use rank of last element, if any, to determine the actual count */
-            if (zn != NULL) {
-                count -= (orderedIndexLength(zs->zidx) - rank);
-            }
-        }
+        count = orderedIndexCountScoreRange(zs->zidx, range.min, range.max, range.minex, range.maxex);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -3528,28 +3503,7 @@ void zlexcountCommand(client *c) {
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        /* TODO: migrate to OrderedIndex when interface supports rank-returning range lookup. */
-        zskiplist *zsl = (zskiplist *)zs->zidx;
-        zskiplistNode *zn;
-        unsigned long rank;
-
-        /* Find first element in range */
-        zn = zslNthInLexRange(zsl, &range, 0);
-
-        /* Use rank of first element, if any, to determine preliminary count */
-        if (zn != NULL) {
-            rank = orderedIndexGetRank(zs->zidx, (OrderedIndexItem *)zn);
-            count = (orderedIndexLength(zs->zidx) - (rank - 1));
-
-            /* Find last element in range */
-            zn = zslNthInLexRange(zsl, &range, -1);
-
-            /* Use rank of last element, if any, to determine the actual count */
-            if (zn != NULL) {
-                rank = orderedIndexGetRank(zs->zidx, (OrderedIndexItem *)zn);
-                count -= (orderedIndexLength(zs->zidx) - rank);
-            }
-        }
+        count = orderedIndexCountLexRange(zs->zidx, range.min, range.max, range.minex, range.maxex);
     } else {
         serverPanic("Unknown sorted set encoding");
     }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -63,9 +63,44 @@
 #include "server.h"
 #include "intset.h" /* Compact integer set structure */
 #include "mt19937-64.h"
+#include "ordered_index.h"
+#include "skiplist_internal.h"
 #include <math.h>
 
 #include "valkey_strtod.h"
+
+/*-----------------------------------------------------------------------------
+ * Zset hashtable type
+ *
+ * The zset hashtable stores OrderedIndexItem pointers as entries.
+ * entryGetKey extracts the element SDS string from an OrderedIndexItem.
+ * hashFunction and keyCompare operate on the SDS keys returned by entryGetKey.
+ *----------------------------------------------------------------------------*/
+
+static const void *zsetHashtableGetKey(const void *element) {
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(element, &ptr, &len);
+    return ptr;
+}
+
+/* Defined in server.c */
+extern uint64_t sdsHashConfigurableSeed(const void *key);
+
+/* Sorted sets hashtable (note: a skiplist is used in addition to the hash table) */
+static hashtableType zsetHashtableType = {
+    .hashFunction = sdsHashConfigurableSeed,
+    .entryGetKey = zsetHashtableGetKey,
+    .keyCompare = dictSdsKeyCompare,
+};
+
+/* Allocate and initialize a new zset (skiplist + hashtable). */
+zset *zsetCreate(void) {
+    zset *zs = zmalloc(sizeof(*zs));
+    zs->ht = hashtableCreate(&zsetHashtableType);
+    zs->zidx = orderedIndexCreate();
+    return zs;
+}
 
 /*-----------------------------------------------------------------------------
  * Skiplist implementation of the low level API
@@ -76,38 +111,6 @@ int zslLexValueLteMax(sds value, zlexrangespec *spec);
 void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap);
 static zskiplistNode *zslGetElementByRankFromNode(zskiplistNode *start_node, int start_level, unsigned long rank);
 zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
-
-static inline unsigned long zslGetNodeSpanAtLevel(const zskiplistNode *x, int level) {
-    /* We use the level 0 span in order to hold the node height, so in case the span is requested on
-     * level 0 and this is not the last node we return 1 and 0 otherwise. For the rest of the levels we just return
-     * the recorded span in that level. */
-    if (level > 0) return x->level[level].span;
-    return x->level[level].forward ? 1 : 0;
-}
-
-static inline void zslSetNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long span) {
-    /* We use the level 0 span in order to hold the node height, so we avoid overriding it. */
-    if (level > 0)
-        x->level[level].span = span;
-}
-
-static inline void zslIncrNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long incr) {
-    /* We use the level 0 span in order to hold the node height, so we avoid overriding it. */
-    if (level > 0)
-        x->level[level].span += incr;
-}
-
-static inline void zslDecrNodeSpanAtLevel(zskiplistNode *x, int level, unsigned long decr) {
-    /* We use the level 0 span in order to hold the node height, so we avoid overriding it. */
-    if (level > 0)
-        x->level[level].span -= decr;
-}
-
-static inline unsigned long zslGetNodeHeight(const zskiplistNode *x) {
-    /* Since the span at level 0 is always 1 (or 0 for the last node), this
-     * field is instead used for storing the height of the node. */
-    return x->level[0].span;
-}
 
 static inline void zslSetNodeHeight(zskiplistNode *x, int height) {
     /* Since the span at level 0 is always 1 (or 0 for the last node), this
@@ -322,8 +325,8 @@ zskiplistNode *zslInsert(zskiplist *zsl, double score, const_sds ele) {
     return node;
 }
 
-/* Internal function used by zslDelete, zslDeleteRangeByScore and
- * zslDeleteRangeByRank. */
+/* Internal function used by zslDelete, zsetIndexDeleteRangeByScore and
+ * zsetIndexDeleteRangeByRank. */
 static void zslDeleteNode(zskiplist *zsl, zskiplistNode *x, zskiplistNode **update) {
     int i;
     for (i = 0; i < zslGetHeight(zsl); i++) {
@@ -502,100 +505,13 @@ zskiplistNode *zslNthInRange(zskiplist *zsl, zrangespec *range, long n, long *ra
     return x;
 }
 
-/* Delete all the elements with score between min and max from the skiplist.
- * Both min and max can be inclusive or exclusive (see range->minex and
- * range->maxex). When inclusive a score >= min && score <= max is deleted.
- * Note that this function takes the reference to the hash table view of the
- * sorted set, in order to remove the elements from the hash table too. */
-unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable *ht) {
-    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
-    unsigned long removed = 0;
-    int i;
-
-    x = zslGetHeader(zsl);
-    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward && !zslValueGteMin(x->level[i].forward->score, range)) x = x->level[i].forward;
-        update[i] = x;
-    }
-
-    /* Current node is the last with score < or <= min. */
-    x = x->level[0].forward;
-
-    /* Delete nodes while in range. */
-    while (x && zslValueLteMax(x->score, range)) {
-        zskiplistNode *next = x->level[0].forward;
-        zslDeleteNode(zsl, x, update);
-        sds ele = zslGetNodeElement(x);
-        if (ht) hashtablePop(ht, ele, NULL);
-        zslFreeNode(x);
-        removed++;
-        x = next;
-    }
-    return removed;
+/* Callback for orderedIndexDeleteRangeBy* — removes the item from the hashtable. */
+static void zsetIndexDeleteCallback(OrderedIndexItem *item, void *ctx) {
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(item, &ptr, &len);
+    hashtableDelete(ctx, (sds)ptr);
 }
-
-unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, hashtable *ht) {
-    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
-    unsigned long removed = 0;
-    int i;
-
-
-    x = zslGetHeader(zsl);
-    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward &&
-               !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), range)) {
-            x = x->level[i].forward;
-        }
-        update[i] = x;
-    }
-
-    /* Current node is the last with score < or <= min. */
-    x = x->level[0].forward;
-
-    /* Delete nodes while in range. */
-    while (x && zslLexValueLteMax(zslGetNodeElement(x), range)) {
-        zskiplistNode *next = x->level[0].forward;
-        zslDeleteNode(zsl, x, update);
-        sds ele = zslGetNodeElement(x);
-        if (ht) hashtableDelete(ht, ele);
-        zslFreeNode(x); /* Here is where x->ele is actually released. */
-        removed++;
-        x = next;
-    }
-    return removed;
-}
-
-/* Delete all the elements with rank between start and end from the skiplist.
- * Start and end are inclusive. Note that start and end need to be 1-based */
-unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned long start, unsigned long end, hashtable *ht) {
-    zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
-    unsigned long traversed = 0, removed = 0;
-    int i;
-
-    x = zslGetHeader(zsl);
-    for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
-        while (x->level[i].forward && (traversed + zslGetNodeSpanAtLevel(x, i)) < start) {
-            traversed += zslGetNodeSpanAtLevel(x, i);
-            x = x->level[i].forward;
-        }
-        update[i] = x;
-    }
-
-    traversed++;
-    x = x->level[0].forward;
-    while (x && traversed <= end) {
-        zskiplistNode *next = x->level[0].forward;
-        zslDeleteNode(zsl, x, update);
-        sds ele = zslGetNodeElement(x);
-        if (ht) hashtableDelete(ht, ele);
-        zslFreeNode(x);
-        removed++;
-        traversed++;
-        x = next;
-    }
-    return removed;
-}
-
 /* Find the rank for a specific skiplist member node. Counts nodes after the one
  * specified and subtracts from list length. Note that rank is 1-based.  */
 unsigned long zslGetRank(zskiplist *zsl, const zskiplistNode *node) {
@@ -735,6 +651,8 @@ void zslSeekToRank(zskiplistIterator *iterator, unsigned long rank) {
     if (iter->zsl == NULL) return;
     if (rank == 0)
         iter->node = zslGetHeader(iter->zsl);
+    else if (rank >= zslGetLength(iter->zsl))
+        iter->node = zslGetTail(iter->zsl);
     else
         iter->node = zslGetElementByRank(iter->zsl, rank);
 }
@@ -742,7 +660,8 @@ void zslSeekToRank(zskiplistIterator *iterator, unsigned long rank) {
 /* Seek to a position within a score range with offset.
  * min/max: score range bounds
  * min_ex/max_ex: 1 for exclusive bounds, 0 for inclusive
- * offset: 0-based position within range (negative counts from end) */
+ * offset >= 0: positions for forward iteration via next(). 0 = first in range.
+ * offset < 0:  positions for reverse iteration via prev(). -1 = last in range. */
 void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, int min_ex, int max_ex, long offset) {
     zslIter *iter = zslIterFromOpaque(iterator);
     if (iter->zsl == NULL) return;
@@ -753,7 +672,9 @@ void zslSeekToScoreRange(zskiplistIterator *iterator, double min, double max, in
         iter->zsl = NULL;
         return;
     }
-    iter->node = node->backward;
+    /* Negative offset means reverse iteration: position so prev() returns node.
+     * Non-negative offset means forward iteration: position so next() returns node. */
+    iter->node = (offset < 0) ? node : node->backward;
 }
 
 void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max, int min_ex, int max_ex, long offset) {
@@ -766,7 +687,7 @@ void zslSeekToLexRange(zskiplistIterator *iterator, const_sds min, const_sds max
         iter->zsl = NULL;
         return;
     }
-    iter->node = node->backward;
+    iter->node = (offset < 0) ? node : node->backward;
 }
 
 /* Populate the rangespec according to the objects min and max. */
@@ -1415,7 +1336,7 @@ unsigned long zsetLength(const robj *zobj) {
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         length = zzlLength(objectGetVal(zobj));
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
-        length = zslGetLength(((const zset *)objectGetVal(zobj))->zsl);
+        length = orderedIndexLength(((const zset *)objectGetVal(zobj))->zidx);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -1459,11 +1380,6 @@ void zsetConvert(robj *zobj, int encoding) {
 
 /* Converts a zset to the specified encoding, pre-sizing it for 'cap' elements. */
 void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
-    zset *zs;
-    zskiplistNode *node, *next;
-    sds ele;
-    double score;
-
     if (zobj->encoding == encoding) return;
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *zl = objectGetVal(zobj);
@@ -1474,9 +1390,7 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         if (encoding != OBJ_ENCODING_SKIPLIST) serverPanic("Unknown target encoding");
 
-        zs = zmalloc(sizeof(*zs));
-        zs->ht = hashtableCreate(&zsetHashtableType);
-        zs->zsl = zslCreate();
+        zset *zs = zsetCreate();
 
         /* Presize the dict to avoid rehashing */
         hashtableExpand(zs->ht, cap);
@@ -1488,16 +1402,17 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
         }
 
         while (eptr != NULL) {
-            score = zzlGetScore(sptr);
+            double score = zzlGetScore(sptr);
             vstr = lpGetValue(eptr, &vlen, &vlong);
-            if (vstr == NULL)
-                ele = sdsfromlonglong(vlong);
-            else
-                ele = sdsnewlen((char *)vstr, vlen);
-
-            node = zslInsert(zs->zsl, score, ele);
-            sdsfree(ele);
-            serverAssert(hashtableAdd(zs->ht, node));
+            OrderedIndexItem *item;
+            if (vstr == NULL) {
+                sds ele = sdsfromlonglong(vlong);
+                item = orderedIndexInsert(zs->zidx, score, ele);
+                sdsfree(ele);
+            } else {
+                item = orderedIndexInsertRaw(zs->zidx, score, (const char *)vstr, vlen);
+            }
+            serverAssert(hashtableAdd(zs->ht, item));
             zzlNext(zl, &eptr, &sptr);
         }
 
@@ -1511,16 +1426,24 @@ void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap) {
 
         /* Approach similar to zslFree(), since we want to free the skiplist at
          * the same time as creating the listpack. */
-        zs = objectGetVal(zobj);
+        zset *zs = objectGetVal(zobj);
         hashtableRelease(zs->ht);
-        zskiplistNode *zheader = zslGetHeader(zs->zsl);
-        node = zheader->level[0].forward;
-        zfree(zs->zsl);
+        /* TODO: migrate to OrderedIndex when interface supports destructive iteration.
+         * This manually walks and frees skiplist nodes after releasing the header. */
+        zskiplistNode *zheader = zslGetHeader((zskiplist *)zs->zidx);
+        
+        zskiplistNode *node = zheader->level[0].forward;
+        zfree(zs->zidx);
 
         while (node) {
-            zl = zzlInsertAt(zl, NULL, zslGetNodeElement(node), node->score);
-            next = node->level[0].forward;
-            zslFreeNode(node);
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw((OrderedIndexItem *)node, &ele_ptr, &ele_len);
+            sds ele_sds = sdsnewlen(ele_ptr, ele_len);
+            zl = zzlInsertAt(zl, NULL, ele_sds, orderedIndexGetScore((OrderedIndexItem *)node));
+            sdsfree(ele_sds);
+            zskiplistNode *next = node->level[0].forward;
+            orderedIndexFreeItem((OrderedIndexItem *)node);
             node = next;
         }
 
@@ -1539,7 +1462,7 @@ void zsetConvertToListpackIfNeeded(robj *zobj, size_t maxelelen, size_t totelele
     if (zobj->encoding == OBJ_ENCODING_LISTPACK) return;
     zset *zset = objectGetVal(zobj);
 
-    if (zslGetLength(zset->zsl) <= server.zset_max_listpack_entries &&
+    if (orderedIndexLength(zset->zidx) <= server.zset_max_listpack_entries &&
         maxelelen <= server.zset_max_listpack_value && lpSafeToAdd(NULL, totelelen)) {
         zsetConvert(zobj, OBJ_ENCODING_LISTPACK);
     }
@@ -1558,8 +1481,8 @@ int zsetScore(robj *zobj, sds member, double *score) {
         zset *zs = objectGetVal(zobj);
         void *entry;
         if (!hashtableFind(zs->ht, member, &entry)) return C_ERR;
-        zskiplistNode *setElement = entry;
-        *score = setElement->score;
+        OrderedIndexItem *node = entry;
+        *score = orderedIndexGetScore(node);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -1693,8 +1616,8 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
                 return 1;
             }
 
-            zskiplistNode *old_node = *node_ref_in_hashtable;
-            curscore = old_node->score;
+            OrderedIndexItem *old_item = *node_ref_in_hashtable;
+            curscore = orderedIndexGetScore(old_item);
 
             /* Prepare the score for the increment if needed. */
             if (incr) {
@@ -1715,16 +1638,15 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 
             /* Remove and re-insert when score changes. */
             if (score != curscore) {
-                zskiplistNode *new_node = zslUpdateScore(zs->zsl, old_node, score);
-                /* Note that this assignment updates the node pointer stored in
-                 * the hashtable */
-                if (new_node) *node_ref_in_hashtable = new_node;
+                /* orderedIndexUpdateScore always returns the (possibly new) item.
+                 * Update the hashtable reference to point to the current node. */
+                *node_ref_in_hashtable = orderedIndexUpdateScore(zs->zidx, old_item, score);
                 *out_flags |= ZADD_OUT_UPDATED;
             }
             return 1;
         } else if (!xx) {
-            zskiplistNode *new_node = zslInsert(zs->zsl, score, ele);
-            serverAssert(hashtableAdd(zs->ht, new_node));
+            OrderedIndexItem *new_item = orderedIndexInsert(zs->zidx, score, ele);
+            serverAssert(hashtableAdd(zs->ht, new_item));
             *out_flags |= ZADD_OUT_ADDED;
             if (newscore) *newscore = score;
             return 1;
@@ -1744,12 +1666,8 @@ int zsetAdd(robj *zobj, double score, sds ele, int in_flags, int *out_flags, dou
 static int zsetRemoveFromSkiplist(zset *zs, sds ele) {
     void *entry;
     if (!hashtablePop(zs->ht, ele, &entry)) return 0;
-    zskiplistNode *node = entry;
-
-    /* hashtable only contains pointers to skiplist nodes. Nothing to free. */
-
-    /* Delete from skiplist. */
-    zslDelete(zs->zsl, node);
+    OrderedIndexItem *item = entry;
+    orderedIndexDelete(zs->zidx, item);
 
     return 1;
 }
@@ -1822,12 +1740,12 @@ static long zsetRank(robj *zobj, sds ele, int reverse, double *output_score) {
 
         void *entry;
         if (!hashtableFind(zs->ht, ele, &entry)) return -1;
-        zskiplistNode *node = entry;
+        OrderedIndexItem *item = entry;
 
-        rank = zslGetRank(zs->zsl, node);
+        rank = orderedIndexGetRank(zs->zidx, item);
         /* Existing elements always have a rank. */
         serverAssert(rank != 0);
-        if (output_score) *output_score = node->score;
+        if (output_score) *output_score = orderedIndexGetScore(item);
         if (reverse)
             return llen - rank;
         else
@@ -1862,24 +1780,20 @@ robj *zsetDup(robj *o) {
         zs = objectGetVal(o);
         new_zs = objectGetVal(zobj);
         hashtableExpand(new_zs->ht, hashtableSize(zs->ht));
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
-        sds ele;
-        long llen = zsetLength(o);
+        OrderedIndexIterator iter;
+        OrderedIndexItem *node;
 
-        /* We copy the skiplist elements from the greatest to the
-         * smallest (that's trivial since the elements are already ordered in
-         * the skiplist): this improves the load process, since the next loaded
-         * element will always be the smaller, so adding to the skiplist
-         * will always immediately stop at the head, making the insertion
-         * O(1) instead of O(log(N)). */
-        ln = zslGetTail(zsl);
-        while (llen--) {
-            ele = zslGetNodeElement(ln);
-            zskiplistNode *znode = zslInsert(new_zs->zsl, ln->score, ele);
-            hashtableAdd(new_zs->ht, znode);
-            ln = ln->backward;
+        /* We copy the skiplist elements from the greatest to the smallest.
+         * Append/prepend is O(1) instead of O(log(N)). */
+        orderedIndexInitIterator(&iter, zs->zidx);
+        while (orderedIndexPrev(&iter, &node)) {
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+            OrderedIndexItem *new_item = orderedIndexInsertRaw(new_zs->zidx, orderedIndexGetScore(node), ele_ptr, ele_len);
+            hashtableAdd(new_zs->ht, new_item);
         }
+        orderedIndexResetIterator(&iter);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -1909,11 +1823,13 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
         zset *zs = objectGetVal(zsetobj);
         void *entry;
         hashtableFairRandomEntry(zs->ht, &entry);
-        zskiplistNode *node = entry;
-        sds ele = zslGetNodeElement(node);
-        key->sval = (unsigned char *)ele;
-        key->slen = sdslen(ele);
-        if (score) *score = node->score;
+        OrderedIndexItem *item = entry;
+        const char *ele_ptr;
+        size_t ele_len;
+        orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+        key->sval = (unsigned char *)ele_ptr;
+        key->slen = ele_len;
+        if (score) *score = orderedIndexGetScore(item);
     } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
         listpackEntry val;
         lpRandomPair(objectGetVal(zsetobj), zsetsize, key, &val);
@@ -2180,9 +2096,9 @@ void zremrangeGenericCommand(client *c, zrange_type rangetype) {
         hashtablePauseAutoShrink(zs->ht);
         switch (rangetype) {
         case ZRANGE_AUTO:
-        case ZRANGE_RANK: deleted = zslDeleteRangeByRank(zs->zsl, start + 1, end + 1, zs->ht); break;
-        case ZRANGE_SCORE: deleted = zslDeleteRangeByScore(zs->zsl, &range, zs->ht); break;
-        case ZRANGE_LEX: deleted = zslDeleteRangeByLex(zs->zsl, &lexrange, zs->ht); break;
+        case ZRANGE_RANK: deleted = orderedIndexDeleteRangeByRank(zs->zidx, start + 1, end + 1, zsetIndexDeleteCallback, zs->ht); break;
+        case ZRANGE_SCORE: deleted = orderedIndexDeleteRangeByScore(zs->zidx, range.min, range.max, range.minex, range.maxex, zsetIndexDeleteCallback, zs->ht); break;
+        case ZRANGE_LEX: deleted = orderedIndexDeleteRangeByLex(zs->zidx, lexrange.min, lexrange.max, lexrange.minex, lexrange.maxex, zsetIndexDeleteCallback, zs->ht); break;
         }
         hashtableResumeAutoShrink(zs->ht);
         if (hashtableSize(zs->ht) == 0) {
@@ -2248,7 +2164,7 @@ typedef struct {
             } zl;
             struct {
                 zset *zs;
-                zskiplistNode *node;
+                OrderedIndexIterator iter;
             } sl;
         } zset;
     } iter;
@@ -2309,7 +2225,7 @@ static void zuiInitIterator(zsetopsrc *op) {
             }
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             it->sl.zs = objectGetVal(op->subject);
-            it->sl.node = zslGetTail(it->sl.zs->zsl);
+            orderedIndexInitIterator(&it->sl.iter, it->sl.zs->zidx);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2337,7 +2253,7 @@ static void zuiClearIterator(zsetopsrc *op) {
         if (op->encoding == OBJ_ENCODING_LISTPACK) {
             UNUSED(it); /* skip */
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
-            UNUSED(it); /* skip */
+            orderedIndexResetIterator(&it->sl.iter);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2364,7 +2280,7 @@ static unsigned long zuiLength(zsetopsrc *op) {
             return zzlLength(objectGetVal(op->subject));
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(op->subject);
-            return zslGetLength(zs->zsl);
+            return orderedIndexLength(zs->zidx);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2420,12 +2336,14 @@ static int zuiNext(zsetopsrc *op, zsetopval *val) {
             /* Move to next element (going backwards, see zuiInitIterator). */
             zzlPrev(it->zl.zl, &it->zl.eptr, &it->zl.sptr);
         } else if (op->encoding == OBJ_ENCODING_SKIPLIST) {
-            if (it->sl.node == NULL) return 0;
-            val->ele = zslGetNodeElement(it->sl.node);
-            val->score = it->sl.node->score;
-
-            /* Move to next element. (going backwards, see zuiInitIterator) */
-            it->sl.node = it->sl.node->backward;
+            OrderedIndexItem *item;
+            if (!orderedIndexPrev(&it->sl.iter, &item)) return 0;
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+            val->estr = (unsigned char *)ele_ptr;
+            val->elen = ele_len;
+            val->score = orderedIndexGetScore(item);
         } else {
             serverPanic("Unknown sorted set encoding");
         }
@@ -2493,8 +2411,8 @@ static int zuiFind(zsetopsrc *op, zsetopval *val, double *score) {
             zset *zs = objectGetVal(op->subject);
             void *entry;
             if (hashtableFind(zs->ht, val->ele, &entry)) {
-                zskiplistNode *node = entry;
-                *score = node->score;
+                OrderedIndexItem *item = entry;
+                *score = orderedIndexGetScore(item);
                 return 1;
             } else {
                 return 0;
@@ -2548,11 +2466,12 @@ static size_t zsetHashtableGetMaxElementLength(hashtable *ht, size_t *totallen) 
     hashtableInitIterator(&iter, ht, 0);
     void *next;
     while (hashtableNext(&iter, &next)) {
-        zskiplistNode *node = next;
-        sds ele = zslGetNodeElement(node);
-        size_t elelen = sdslen(ele);
-        if (elelen > maxelelen) maxelelen = elelen;
-        if (totallen) (*totallen) += elelen;
+        OrderedIndexItem *item = next;
+        const char *ele_ptr;
+        size_t ele_len;
+        orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+        if (ele_len > maxelelen) maxelelen = ele_len;
+        if (totallen) (*totallen) += ele_len;
     }
     hashtableCleanupIterator(&iter);
 
@@ -2573,10 +2492,7 @@ static void zdiffAlgorithm1(zsetopsrc *src, long setnum, zset *dstzset, size_t *
      * to the target set, where K is the final size of the target set.
      *
      * The final complexity of this algorithm is O(N*M + K*log(K)). */
-    int j;
     zsetopval zval;
-    zskiplistNode *znode;
-    sds tmp;
 
     /* With algorithm 1 it is better to order the sets to subtract
      * by decreasing size, so that we are more likely to find
@@ -2589,7 +2505,7 @@ static void zdiffAlgorithm1(zsetopsrc *src, long setnum, zset *dstzset, size_t *
         double value;
         int exists = 0;
 
-        for (j = 1; j < setnum; j++) {
+        for (int j = 1; j < setnum; j++) {
             /* It is not safe to access the zset we are
              * iterating, so explicitly check for equal object.
              * This check isn't really needed anymore since we already
@@ -2602,8 +2518,8 @@ static void zdiffAlgorithm1(zsetopsrc *src, long setnum, zset *dstzset, size_t *
         }
 
         if (!exists) {
-            tmp = zuiNewSdsFromValue(&zval);
-            znode = zslInsert(dstzset->zsl, zval.score, tmp);
+            sds tmp = zuiNewSdsFromValue(&zval);
+            OrderedIndexItem *znode = orderedIndexInsert(dstzset->zidx, zval.score, tmp);
             hashtableAdd(dstzset->ht, znode);
             if (sdslen(tmp) > *maxelelen) *maxelelen = sdslen(tmp);
             (*totelelen) += sdslen(tmp);
@@ -2630,27 +2546,24 @@ static void zdiffAlgorithm2(zsetopsrc *src, long setnum, zset *dstzset, size_t *
      * There is also a O(K) cost at the end for finding the largest element
      * size, but this doesn't change the algorithm complexity since K < L, and
      * O(2L) is the same as O(L). */
-    int j;
     int cardinality = 0;
     zsetopval zval;
-    zskiplistNode *znode;
-    sds tmp;
 
     hashtablePauseAutoShrink(dstzset->ht);
-    for (j = 0; j < setnum; j++) {
+    for (int j = 0; j < setnum; j++) {
         if (zuiLength(&src[j]) == 0) continue;
 
         memset(&zval, 0, sizeof(zval));
         zuiInitIterator(&src[j]);
         while (zuiNext(&src[j], &zval)) {
             if (j == 0) {
-                tmp = zuiNewSdsFromValue(&zval);
-                znode = zslInsert(dstzset->zsl, zval.score, tmp);
+                sds tmp = zuiNewSdsFromValue(&zval);
+                OrderedIndexItem *znode = orderedIndexInsert(dstzset->zidx, zval.score, tmp);
                 sdsfree(tmp);
                 hashtableAdd(dstzset->ht, znode);
                 cardinality++;
             } else {
-                tmp = zuiSdsFromValue(&zval);
+                sds tmp = zuiSdsFromValue(&zval);
                 if (zsetRemoveFromSkiplist(dstzset, tmp)) {
                     cardinality--;
                 }
@@ -2744,7 +2657,6 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
     int aggregate = REDIS_AGGR_SUM;
     zsetopsrc *src;
     zsetopval zval;
-    sds tmp;
     size_t maxelelen = 0, totelelen = 0;
     robj *dstobj = NULL;
     zset *dstzset = NULL;
@@ -2901,8 +2813,8 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                         break;
                     }
                 } else if (j == setnum) {
-                    tmp = zuiNewSdsFromValue(&zval);
-                    zskiplistNode *znode = zslInsert(dstzset->zsl, score, tmp);
+                    sds tmp = zuiNewSdsFromValue(&zval);
+                    OrderedIndexItem *znode = orderedIndexInsert(dstzset->zidx, score, tmp);
                     hashtableAdd(dstzset->ht, znode);
                     totelelen += sdslen(tmp);
                     if (sdslen(tmp) > maxelelen) maxelelen = sdslen(tmp);
@@ -2936,20 +2848,25 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
                 void *existing;
                 if (hashtableFindPositionForInsert(dstzset->ht, sdsval, &position, &existing)) {
                     sds tmp_ele = zuiNewSdsFromValue(&zval);
+                    /* TODO: migrate to OrderedIndex when interface supports deferred insertion.
+                     * This creates a node without inserting it into the skiplist. */
                     zskiplistNode *new_node = zslCreateNode(zslRandomLevel(), score, tmp_ele);
                     sdsfree(tmp_ele);
                     hashtableInsertAtPosition(dstzset->ht, new_node, &position);
                     /* Remember the longest single element encountered,
                      * to understand if it's possible to convert to listpack
                      * at the end. */
-                    sds ele = zslGetNodeElement(new_node);
-                    totelelen += sdslen(ele);
-                    if (sdslen(ele) > maxelelen) {
-                        maxelelen = sdslen(ele);
+                    const char *ele_ptr;
+                    size_t ele_len;
+                    orderedIndexGetElementRaw((OrderedIndexItem *)new_node, &ele_ptr, &ele_len);
+                    totelelen += ele_len;
+                    if (ele_len > maxelelen) {
+                        maxelelen = ele_len;
                     }
                 } else {
                     /* Update the score with the score of the new instance
-                     * of the element found in the current sorted set. */
+                     * of the element found in the current sorted set.
+                     * TODO: migrate to OrderedIndex when interface supports in-place score mutation. */
                     zskiplistNode *node = existing;
                     zunionInterAggregate(&node->score, score, aggregate);
                 }
@@ -2957,14 +2874,15 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
             zuiClearIterator(&src[i]);
         }
 
-        /* Step 2: Create the skiplist using final score ordering */
+        /* Step 2: Create the skiplist using final score ordering
+         * TODO: migrate to OrderedIndex when interface supports deferred insertion. */
         hashtableIterator iter;
         hashtableInitIterator(&iter, dstzset->ht, 0);
 
         void *next;
         while (hashtableNext(&iter, &next)) {
             zskiplistNode *node = next;
-            zslInsertNode(dstzset->zsl, node);
+            zslInsertNode((zskiplist *)dstzset->zidx, node);
         }
         hashtableCleanupIterator(&iter);
     } else if (op == SET_OP_DIFF) {
@@ -2974,7 +2892,7 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
     }
 
     if (dstkey) {
-        if (zslGetLength(dstzset->zsl)) {
+        if (orderedIndexLength(dstzset->zidx)) {
             zsetConvertToListpackIfNeeded(dstobj, maxelelen, totelelen);
             setKey(c, c->db, dstkey, &dstobj, 0);
             notifyKeyspaceEvent(NOTIFY_ZSET, (op == SET_OP_UNION) ? "zunionstore" : (op == SET_OP_INTER ? "zinterstore" : "zdiffstore"),
@@ -2993,10 +2911,11 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
     } else if (cardinality_only) {
         addReplyLongLong(c, cardinality);
     } else {
-        unsigned long length = zslGetLength(dstzset->zsl);
-        zskiplist *zsl = dstzset->zsl;
-        zskiplistNode *zheader = zslGetHeader(zsl);
-        zskiplistNode *zn = zheader->level[0].forward;
+        unsigned long length = orderedIndexLength(dstzset->zidx);
+        OrderedIndexIterator iter;
+        OrderedIndexItem *node;
+
+        orderedIndexInitIterator(&iter, dstzset->zidx);
         /* In case of WITHSCORES, respond with a single array in RESP2, and
          * nested arrays in RESP3. We can't use a map response type since the
          * client library needs to know to respect the order. */
@@ -3005,13 +2924,15 @@ static void zunionInterDiffGenericCommand(client *c, robj *dstkey, int numkeysIn
         else
             addReplyArrayLen(c, length);
 
-        while (zn != NULL) {
+        while (orderedIndexNext(&iter, &node)) {
             if (withscores && c->resp > 2) addReplyArrayLen(c, 2);
-            sds ele = zslGetNodeElement(zn);
-            addReplyBulkCBuffer(c, ele, sdslen(ele));
-            if (withscores) addReplyDouble(c, zn->score);
-            zn = zn->level[0].forward;
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+            addReplyBulkCBuffer(c, ele_ptr, ele_len);
+            if (withscores) addReplyDouble(c, orderedIndexGetScore(node));
         }
+        orderedIndexResetIterator(&iter);
         server.lazyfree_lazy_server_del ? freeObjAsync(NULL, dstobj, -1) : decrRefCount(dstobj);
     }
     zfree(src);
@@ -3295,25 +3216,27 @@ void genericZrangebyrankCommand(zrange_result_handler *handler,
 
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *node;
 
-        /* Check if starting point is trivial, before doing log(N) lookup. */
+        orderedIndexInitIterator(&iter, zs->zidx);
+        /* Seek to the rank just before the starting element. */
         if (reverse) {
-            ln = zslGetTail(zsl);
-            if (start > 0) ln = zslGetElementByRank(zsl, llen - start);
+            unsigned long seek_rank = (start > 0) ? (unsigned long)(llen - start) : orderedIndexLength(zs->zidx);
+            orderedIndexSeekToRank(&iter, seek_rank);
         } else {
-            zskiplistNode *zheader = zslGetHeader(zsl);
-            ln = zheader->level[0].forward;
-            if (start > 0) ln = zslGetElementByRank(zsl, start + 1);
+            orderedIndexSeekToRank(&iter, (unsigned long)start);
         }
 
         while (rangelen--) {
-            serverAssertWithInfo(c, zobj, ln != NULL);
-            sds ele = zslGetNodeElement(ln);
-            handler->emitResultFromCBuffer(handler, ele, sdslen(ele), ln->score);
-            ln = reverse ? ln->backward : ln->level[0].forward;
+            bool has_node = reverse ? orderedIndexPrev(&iter, &node) : orderedIndexNext(&iter, &node);
+            serverAssertWithInfo(c, zobj, has_node && node != NULL);
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+            handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
         }
+        orderedIndexResetIterator(&iter);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -3415,35 +3338,33 @@ void genericZrangebyscoreCommand(zrange_result_handler *handler,
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *item;
 
+        orderedIndexInitIterator(&iter, zs->zidx);
         /* If reversed, get the last node in range as starting point. */
         if (reverse) {
-            ln = zslNthInRange(zsl, range, -offset - 1, NULL);
+            orderedIndexSeekToScoreRange(&iter, range->min, range->max, range->minex, range->maxex, -offset - 1);
+            while (orderedIndexPrev(&iter, &item) && limit--) {
+                if (!zsetScoreGteMin(orderedIndexGetScore(item), range->min, range->minex)) break;
+                rangelen++;
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+                handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(item));
+            }
         } else {
-            ln = zslNthInRange(zsl, range, offset, NULL);
-        }
-
-        while (ln && limit--) {
-            /* Abort when the node is no longer in range. */
-            if (reverse) {
-                if (!zslValueGteMin(ln->score, range)) break;
-            } else {
-                if (!zslValueLteMax(ln->score, range)) break;
-            }
-
-            rangelen++;
-            sds ele = zslGetNodeElement(ln);
-            handler->emitResultFromCBuffer(handler, ele, sdslen(ele), ln->score);
-
-            /* Move to next node */
-            if (reverse) {
-                ln = ln->backward;
-            } else {
-                ln = ln->level[0].forward;
+            orderedIndexSeekToScoreRange(&iter, range->min, range->max, range->minex, range->maxex, offset);
+            while (orderedIndexNext(&iter, &item) && limit--) {
+                if (!zsetScoreLteMax(orderedIndexGetScore(item), range->max, range->maxex)) break;
+                rangelen++;
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+                handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(item));
             }
         }
+        orderedIndexResetIterator(&iter);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -3513,7 +3434,8 @@ void zcountCommand(client *c) {
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
+        /* TODO: migrate to OrderedIndex when interface supports rank-returning range lookup. */
+        zskiplist *zsl = (zskiplist *)zs->zidx;
         zskiplistNode *zn;
         long rank;
 
@@ -3522,14 +3444,14 @@ void zcountCommand(client *c) {
 
         /* Use rank of first element, if any, to determine preliminary count */
         if (zn != NULL) {
-            count = (zslGetLength(zsl) - (rank - 1));
+            count = (orderedIndexLength(zs->zidx) - (rank - 1));
 
             /* Find last element in range */
             zn = zslNthInRange(zsl, &range, -1, &rank);
 
             /* Use rank of last element, if any, to determine the actual count */
             if (zn != NULL) {
-                count -= (zslGetLength(zsl) - rank);
+                count -= (orderedIndexLength(zs->zidx) - rank);
             }
         }
     } else {
@@ -3587,7 +3509,8 @@ void zlexcountCommand(client *c) {
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
+        /* TODO: migrate to OrderedIndex when interface supports rank-returning range lookup. */
+        zskiplist *zsl = (zskiplist *)zs->zidx;
         zskiplistNode *zn;
         unsigned long rank;
 
@@ -3596,16 +3519,16 @@ void zlexcountCommand(client *c) {
 
         /* Use rank of first element, if any, to determine preliminary count */
         if (zn != NULL) {
-            rank = zslGetRank(zsl, zn);
-            count = (zslGetLength(zsl) - (rank - 1));
+            rank = orderedIndexGetRank(zs->zidx, (OrderedIndexItem *)zn);
+            count = (orderedIndexLength(zs->zidx) - (rank - 1));
 
             /* Find last element in range */
             zn = zslNthInLexRange(zsl, &range, -1);
 
             /* Use rank of last element, if any, to determine the actual count */
             if (zn != NULL) {
-                rank = zslGetRank(zsl, zn);
-                count -= (zslGetLength(zsl) - rank);
+                rank = orderedIndexGetRank(zs->zidx, (OrderedIndexItem *)zn);
+                count -= (orderedIndexLength(zs->zidx) - rank);
             }
         }
     } else {
@@ -3684,35 +3607,32 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
         }
     } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zobj);
-        zskiplist *zsl = zs->zsl;
-        zskiplistNode *ln;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *node;
 
-        /* If reversed, get the last node in range as starting point. */
+        orderedIndexInitIterator(&iter, zs->zidx);
         if (reverse) {
-            ln = zslNthInLexRange(zsl, range, -offset - 1);
+            orderedIndexSeekToLexRange(&iter, range->min, range->max, range->minex, range->maxex, -offset - 1);
+            while (orderedIndexPrev(&iter, &node) && limit--) {
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+                if (!zslLexValueGteMin((sds)ele_ptr, range)) break;
+                rangelen++;
+                handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
+            }
         } else {
-            ln = zslNthInLexRange(zsl, range, offset);
-        }
-
-        while (ln && limit--) {
-            /* Abort when the node is no longer in range. */
-            sds ele = zslGetNodeElement(ln);
-            if (reverse) {
-                if (!zslLexValueGteMin(ele, range)) break;
-            } else {
-                if (!zslLexValueLteMax(ele, range)) break;
-            }
-
-            rangelen++;
-            handler->emitResultFromCBuffer(handler, ele, sdslen(ele), ln->score);
-
-            /* Move to next node */
-            if (reverse) {
-                ln = ln->backward;
-            } else {
-                ln = ln->level[0].forward;
+            orderedIndexSeekToLexRange(&iter, range->min, range->max, range->minex, range->maxex, offset);
+            while (orderedIndexNext(&iter, &node) && limit--) {
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+                if (!zslLexValueLteMax((sds)ele_ptr, range)) break;
+                rangelen++;
+                handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }
         }
+        orderedIndexResetIterator(&iter);
     } else {
         serverPanic("Unknown sorted set encoding");
     }
@@ -4096,39 +4016,62 @@ void genericZpopCommand(client *c,
             sptr = lpNext(zl, eptr);
             serverAssertWithInfo(c, zobj, sptr != NULL);
             score = zzlGetScore(sptr);
+
+            /* Delete from listpack. */
+            serverAssertWithInfo(c, zobj, zsetDel(zobj, ele));
+
+            server.dirty++;
+
+            if (result_count == 0) { /* Do this only for the first iteration. */
+                char *events[2] = {"zpopmin", "zpopmax"};
+                notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
+                addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
+            }
+
+            if (use_nested_array) {
+                addReplyArrayLen(c, 2);
+            }
+            addReplyBulkCBuffer(c, ele, sdslen(ele));
+            addReplyDouble(c, score);
+            sdsfree(ele);
+            ++result_count;
         } else if (zobj->encoding == OBJ_ENCODING_SKIPLIST) {
             zset *zs = objectGetVal(zobj);
-            zskiplist *zsl = zs->zsl;
-            zskiplistNode *zln;
 
-            /* Get the first or last element in the sorted set. */
-            zskiplistNode *zheader = zslGetHeader(zsl);
-            zln = (where == ZSET_MAX ? zslGetTail(zsl) : zheader->level[0].forward);
+            /* Pop the first or last element from the ordered index. */
+            OrderedIndexItem *item = (where == ZSET_MAX
+                ? orderedIndexPopLast(zs->zidx)
+                : orderedIndexPopFirst(zs->zidx));
 
             /* There must be an element in the sorted set. */
-            serverAssertWithInfo(c, zobj, zln != NULL);
-            ele = sdsdup(zslGetNodeElement(zln));
-            score = zln->score;
+            serverAssertWithInfo(c, zobj, item != NULL);
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+            score = orderedIndexGetScore(item);
+
+            /* Remove from hashtable. */
+            hashtablePop(zs->ht, (sds)ele_ptr, NULL);
+
+            server.dirty++;
+
+            if (result_count == 0) { /* Do this only for the first iteration. */
+                char *events[2] = {"zpopmin", "zpopmax"};
+                notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
+                addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
+            }
+
+            if (use_nested_array) {
+                addReplyArrayLen(c, 2);
+            }
+            /* Reply directly from the item's buffer, then free. */
+            addReplyBulkCBuffer(c, ele_ptr, ele_len);
+            addReplyDouble(c, score);
+            orderedIndexFreeItem(item);
+            ++result_count;
         } else {
             serverPanic("Unknown sorted set encoding");
         }
-
-        serverAssertWithInfo(c, zobj, zsetDel(zobj, ele));
-        server.dirty++;
-
-        if (result_count == 0) { /* Do this only for the first iteration. */
-            char *events[2] = {"zpopmin", "zpopmax"};
-            notifyKeyspaceEvent(NOTIFY_ZSET, events[where], key, c->db->id);
-            addZpopInitialReply(c, emitkey, use_nested_array, rangelen, key);
-        }
-
-        if (use_nested_array) {
-            addReplyArrayLen(c, 2);
-        }
-        addReplyBulkCBuffer(c, ele, sdslen(ele));
-        addReplyDouble(c, score);
-        sdsfree(ele);
-        ++result_count;
     } while (--rangelen);
 
     /* Remove the key, if indeed needed. */
@@ -4315,11 +4258,13 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
             while (count--) {
                 void *entry;
                 serverAssert(hashtableFairRandomEntry(zs->ht, &entry));
-                zskiplistNode *node = entry;
+                OrderedIndexItem *item = entry;
                 if (withscores && c->resp > 2) addReplyArrayLen(c, 2);
-                sds ele = zslGetNodeElement(node);
-                addReplyBulkCBuffer(c, ele, sdslen(ele));
-                if (withscores) addReplyDouble(c, node->score);
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(item, &ele_ptr, &ele_len);
+                addReplyBulkCBuffer(c, ele_ptr, ele_len);
+                if (withscores) addReplyDouble(c, orderedIndexGetScore(item));
                 if (c->flag.close_asap) break;
             }
         } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
@@ -4417,7 +4362,10 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         while (size > count) {
             void *element;
             hashtableFairRandomEntry(ht, &element);
-            hashtableDelete(ht, zslGetNodeElement((zskiplistNode *)element));
+            const char *ele_ptr;
+            size_t ele_len;
+            orderedIndexGetElementRaw(element, &ele_ptr, &ele_len);
+            hashtableDelete(ht, (sds)ele_ptr);
             size--;
         }
         hashtableCleanupIterator(&iter);
@@ -4426,11 +4374,13 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         hashtableInitIterator(&iter, ht, 0);
         void *next;
         while (hashtableNext(&iter, &next)) {
-            zskiplistNode *node = (zskiplistNode *)next;
-            sds key = zslGetNodeElement(node);
+            OrderedIndexItem *node = next;
+            const char *key_ptr;
+            size_t key_len;
+            orderedIndexGetElementRaw(node, &key_ptr, &key_len);
             if (withscores && c->resp > 2) addReplyArrayLen(c, 2);
-            addReplyBulkCBuffer(c, key, sdslen(key));
-            if (withscores) addReplyDouble(c, node->score);
+            addReplyBulkCBuffer(c, key_ptr, key_len);
+            if (withscores) addReplyDouble(c, orderedIndexGetScore(node));
         }
 
         hashtableCleanupIterator(&iter);
@@ -4449,7 +4399,7 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
 
         while (added < count) {
             listpackEntry key;
-            double score;
+            double score = 0;
             zsetTypeRandomElement(zsetobj, size, &key, withscores ? &score : NULL);
 
             /* Try to add the object to the hashtable. If it already exists

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -106,8 +106,6 @@ zset *zsetCreate(void) {
  * Skiplist implementation of the low level API
  *----------------------------------------------------------------------------*/
 
-int zslLexValueGteMin(sds value, zlexrangespec *spec);
-int zslLexValueLteMax(sds value, zlexrangespec *spec);
 void zsetConvertAndExpand(robj *zobj, int encoding, unsigned long cap);
 static zskiplistNode *zslGetElementByRankFromNode(zskiplistNode *start_node, int start_level, unsigned long rank);
 zskiplistNode *zslGetElementByRank(zskiplist *zsl, unsigned long rank);
@@ -799,22 +797,28 @@ int zsetParseLexRange(robj *min, robj *max, zlexrangespec *spec) {
     }
 }
 
-/* This is just a wrapper to sdscmp() that is able to
+/* This is a comparison helper that is able to
  * handle shared.minstring and shared.maxstring as the equivalent of
- * -inf and +inf for strings */
-static int sdscmplex(sds a, sds b) {
-    if (a == b) return 0;
-    if (a == shared.minstring || b == shared.maxstring) return -1;
-    if (a == shared.maxstring || b == shared.minstring) return 1;
-    return sdscmp(a, b);
+ * -inf and +inf for strings.
+ * The first argument is a raw (ptr, len) pair from the element.
+ * The second argument is an sds from the lex range spec. */
+static int sdscmplex(const char *a, size_t alen, sds b) {
+    if (a == (const char *)b) return 0;
+    if (a == (const char *)shared.minstring || b == shared.maxstring) return -1;
+    if (a == (const char *)shared.maxstring || b == shared.minstring) return 1;
+    size_t blen = sdslen(b);
+    size_t minlen = (alen < blen) ? alen : blen;
+    int cmp = memcmp(a, b, minlen);
+    if (cmp == 0) return (alen > blen) - (alen < blen);
+    return cmp;
 }
 
-int zslLexValueGteMin(sds value, zlexrangespec *spec) {
-    return spec->minex ? (sdscmplex(value, spec->min) > 0) : (sdscmplex(value, spec->min) >= 0);
+int zslLexValueGteMin(const char *value, size_t value_len, zlexrangespec *spec) {
+    return spec->minex ? (sdscmplex(value, value_len, spec->min) > 0) : (sdscmplex(value, value_len, spec->min) >= 0);
 }
 
-int zslLexValueLteMax(sds value, zlexrangespec *spec) {
-    return spec->maxex ? (sdscmplex(value, spec->max) < 0) : (sdscmplex(value, spec->max) <= 0);
+int zslLexValueLteMax(const char *value, size_t value_len, zlexrangespec *spec) {
+    return spec->maxex ? (sdscmplex(value, value_len, spec->max) < 0) : (sdscmplex(value, value_len, spec->max) <= 0);
 }
 
 /* Returns if there is a part of the zset is in the lex range. */
@@ -822,15 +826,17 @@ static int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
     zskiplistNode *x;
 
     /* Test for ranges that will always be empty. */
-    int cmp = sdscmplex(range->min, range->max);
+    int cmp = sdscmplex(range->min, sdslen(range->min), range->max);
     if (cmp > 0 || (cmp == 0 && (range->minex || range->maxex))) return 0;
     x = zslGetTail(zsl);
+    if (x == NULL) return 0;
     sds ele = zslGetNodeElement(x);
-    if (x == NULL || !zslLexValueGteMin(ele, range)) return 0;
+    if (!zslLexValueGteMin(ele, sdslen(ele), range)) return 0;
     zskiplistNode *zheader = zslGetHeader(zsl);
     x = zheader->level[0].forward;
+    if (x == NULL) return 0;
     ele = zslGetNodeElement(x);
-    if (x == NULL || !zslLexValueLteMax(ele, range)) return 0;
+    if (!zslLexValueLteMax(ele, sdslen(ele), range)) return 0;
     return 1;
 }
 
@@ -839,6 +845,7 @@ static int zslIsInLexRange(zskiplist *zsl, zlexrangespec *range) {
  * NULL when no element is contained in the range. */
 zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
     zskiplistNode *x;
+    sds ele;
     int i;
     long edge_rank = 0;
     long last_highest_level_rank = 0;
@@ -851,7 +858,9 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
     /* Go forward while *OUT* of range at highest level. */
     x = zslGetHeader(zsl);
     i = zslGetHeight(zsl) - 1;
-    while (x->level[i].forward && !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), range)) {
+    while (x->level[i].forward) {
+        ele = zslGetNodeElement(x->level[i].forward);
+        if (zslLexValueGteMin(ele, sdslen(ele), range)) break;
         edge_rank += zslGetNodeSpanAtLevel(x, i);
         x = x->level[i].forward;
     }
@@ -862,7 +871,9 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
     if (n >= 0) {
         for (i = zslGetHeight(zsl) - 2; i >= 0; i--) {
             /* Go forward while *OUT* of range. */
-            while (x->level[i].forward && !zslLexValueGteMin(zslGetNodeElement(x->level[i].forward), range)) {
+            while (x->level[i].forward) {
+                ele = zslGetNodeElement(x->level[i].forward);
+                if (zslLexValueGteMin(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element smaller than the range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -877,16 +888,21 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
                 x = x->level[0].forward;
             }
         } else {
-            /* If offset is big, we caasn jump from the last zslGetHeight(zsl)-1 node. */
+            /* If offset is big, we can jump from the last zslGetHeight(zsl)-1 node. */
             rank_diff = edge_rank + 1 + n - last_highest_level_rank;
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score <= max. */
-        if (x && !zslLexValueLteMax(zslGetNodeElement(x), range)) return NULL;
+        if (x) {
+            ele = zslGetNodeElement(x);
+            if (!zslLexValueLteMax(ele, sdslen(ele), range)) return NULL;
+        }
     } else {
         for (i = zslGetHeight(zsl) - 1; i >= 0; i--) {
             /* Go forward while *IN* range. */
-            while (x->level[i].forward && zslLexValueLteMax(zslGetNodeElement(x->level[i].forward), range)) {
+            while (x->level[i].forward) {
+                ele = zslGetNodeElement(x->level[i].forward);
+                if (!zslLexValueLteMax(ele, sdslen(ele), range)) break;
                 /* Count the rank of the last element in range. */
                 edge_rank += zslGetNodeSpanAtLevel(x, i);
                 x = x->level[i].forward;
@@ -906,7 +922,10 @@ zskiplistNode *zslNthInLexRange(zskiplist *zsl, zlexrangespec *range, long n) {
             x = zslGetElementByRankFromNode(last_highest_level_node, zslGetHeight(zsl) - 1, rank_diff);
         }
         /* Check if score >= min. */
-        if (x && !zslLexValueGteMin(zslGetNodeElement(x), range)) return NULL;
+        if (x) {
+            ele = zslGetNodeElement(x);
+            if (!zslLexValueGteMin(ele, sdslen(ele), range)) return NULL;
+        }
     }
 
     return x;
@@ -1100,14 +1119,14 @@ unsigned char *zzlLastInRange(unsigned char *zl, zrangespec *range) {
 
 int zzlLexValueGteMin(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zslLexValueGteMin(value, spec);
+    int res = zslLexValueGteMin(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
 
 int zzlLexValueLteMax(unsigned char *p, zlexrangespec *spec) {
     sds value = lpGetObject(p);
-    int res = zslLexValueLteMax(value, spec);
+    int res = zslLexValueLteMax(value, sdslen(value), spec);
     sdsfree(value);
     return res;
 }
@@ -1118,7 +1137,7 @@ int zzlIsInLexRange(unsigned char *zl, zlexrangespec *range) {
     unsigned char *p;
 
     /* Test for ranges that will always be empty. */
-    int cmp = sdscmplex(range->min, range->max);
+    int cmp = sdscmplex(range->min, sdslen(range->min), range->max);
     if (cmp > 0 || (cmp == 0 && (range->minex || range->maxex))) return 0;
 
     p = lpSeek(zl, -2); /* Last element. */
@@ -3617,7 +3636,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zslLexValueGteMin((sds)ele_ptr, range)) break;
+                if (!zslLexValueGteMin(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }
@@ -3627,7 +3646,7 @@ void genericZrangebylexCommand(zrange_result_handler *handler,
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                if (!zslLexValueLteMax((sds)ele_ptr, range)) break;
+                if (!zslLexValueLteMax(ele_ptr, ele_len, range)) break;
                 rangelen++;
                 handler->emitResultFromCBuffer(handler, ele_ptr, ele_len, orderedIndexGetScore(node));
             }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -158,6 +158,11 @@ sds zslGetNodeElement(const zskiplistNode *x) {
     return (sds)data;
 }
 
+/* Helper function to return the score from a skip list node. */
+double zslGetScore(const zskiplistNode *node) {
+    return node->score;
+}
+
 /* Helper function to set the height of skiplist. */
 static void zslSetHeight(zskiplist *zsl, int height) {
     zsl->header.level[0].span = height;
@@ -529,7 +534,7 @@ unsigned long zslDeleteRangeByScore(zskiplist *zsl, zrangespec *range, hashtable
     return removed;
 }
 
-static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, hashtable *ht) {
+unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, hashtable *ht) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
     unsigned long removed = 0;
     int i;
@@ -551,7 +556,8 @@ static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, h
     while (x && zslLexValueLteMax(zslGetNodeElement(x), range)) {
         zskiplistNode *next = x->level[0].forward;
         zslDeleteNode(zsl, x, update);
-        hashtableDelete(ht, zslGetNodeElement(x));
+        sds ele = zslGetNodeElement(x);
+        if (ht) hashtableDelete(ht, ele);
         zslFreeNode(x); /* Here is where x->ele is actually released. */
         removed++;
         x = next;
@@ -561,7 +567,7 @@ static unsigned long zslDeleteRangeByLex(zskiplist *zsl, zlexrangespec *range, h
 
 /* Delete all the elements with rank between start and end from the skiplist.
  * Start and end are inclusive. Note that start and end need to be 1-based */
-unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned int start, unsigned int end, hashtable *ht) {
+unsigned long zslDeleteRangeByRank(zskiplist *zsl, unsigned long start, unsigned long end, hashtable *ht) {
     zskiplistNode *update[ZSKIPLIST_MAXLEVEL], *x;
     unsigned long traversed = 0, removed = 0;
     int i;

--- a/src/unit/ordered_index_test.h
+++ b/src/unit/ordered_index_test.h
@@ -21,7 +21,7 @@ extern "C" {
 /* ---- Abstract interface ---- */
 
 class OrderedIndexTestApi {
-public:
+  public:
     virtual ~OrderedIndexTestApi() = default;
 
     /* Lifecycle */
@@ -35,12 +35,9 @@ public:
     virtual OrderedIndexItem *popFirst(OrderedIndex *idx) = 0;
     virtual OrderedIndexItem *popLast(OrderedIndex *idx) = 0;
     virtual void freeItem(OrderedIndexItem *item) = 0;
-    virtual unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex,
-                                             OrderedIndexOnDelete on_delete, void *ctx) = 0;
-    virtual unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
-                                            OrderedIndexOnDelete on_delete, void *ctx) = 0;
-    virtual unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex,
-                                           OrderedIndexOnDelete on_delete, void *ctx) = 0;
+    virtual unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) = 0;
+    virtual unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end, OrderedIndexOnDelete on_delete, void *ctx) = 0;
+    virtual unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) = 0;
 
     /* Query */
     virtual unsigned long length(OrderedIndex *idx) = 0;
@@ -65,10 +62,8 @@ public:
     virtual bool next(OrderedIndexIterator *iter, OrderedIndexItem **pos) = 0;
     virtual bool prev(OrderedIndexIterator *iter, OrderedIndexItem **pos) = 0;
     virtual void seekToRank(OrderedIndexIterator *iter, unsigned long rank) = 0;
-    virtual void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex,
-                                  long offset) = 0;
-    virtual void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex,
-                                long offset) = 0;
+    virtual void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) = 0;
+    virtual void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) = 0;
 
     /* Convenience (non-virtual) */
     OrderedIndexItem *insertSds(OrderedIndex *idx, double score, const_sds ele) {
@@ -94,34 +89,45 @@ public:
 /* ---- Skiplist implementation ---- */
 
 class SkiplistOrderedIndex : public OrderedIndexTestApi {
-public:
-    OrderedIndex *create() override { return skiplistCreate(); }
-    void free(OrderedIndex *idx) override { skiplistFree(idx); }
+  public:
+    OrderedIndex *create() override {
+        return skiplistCreate();
+    }
+    void free(OrderedIndex *idx) override {
+        skiplistFree(idx);
+    }
 
     OrderedIndexItem *insert(OrderedIndex *idx, double score, const char *ele, size_t len) override {
         return skiplistInsert(idx, score, ele, len);
     }
-    void deleteItem(OrderedIndex *idx, OrderedIndexItem *pos) override { skiplistDelete(idx, pos); }
+    void deleteItem(OrderedIndex *idx, OrderedIndexItem *pos) override {
+        skiplistDelete(idx, pos);
+    }
     OrderedIndexItem *updateScore(OrderedIndex *idx, OrderedIndexItem *pos, double newscore) override {
         return skiplistUpdateScore(idx, pos, newscore);
     }
-    OrderedIndexItem *popFirst(OrderedIndex *idx) override { return skiplistPopFirst(idx); }
-    OrderedIndexItem *popLast(OrderedIndex *idx) override { return skiplistPopLast(idx); }
-    void freeItem(OrderedIndexItem *item) override { skiplistFreeItem(item); }
-    unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex,
-                                     OrderedIndexOnDelete on_delete, void *ctx) override {
+    OrderedIndexItem *popFirst(OrderedIndex *idx) override {
+        return skiplistPopFirst(idx);
+    }
+    OrderedIndexItem *popLast(OrderedIndex *idx) override {
+        return skiplistPopLast(idx);
+    }
+    void freeItem(OrderedIndexItem *item) override {
+        skiplistFreeItem(item);
+    }
+    unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) override {
         return skiplistDeleteRangeByScore(idx, min, max, min_ex, max_ex, on_delete, ctx);
     }
-    unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
-                                    OrderedIndexOnDelete on_delete, void *ctx) override {
+    unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end, OrderedIndexOnDelete on_delete, void *ctx) override {
         return skiplistDeleteRangeByRank(idx, start, end, on_delete, ctx);
     }
-    unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex,
-                                   OrderedIndexOnDelete on_delete, void *ctx) override {
+    unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex, OrderedIndexOnDelete on_delete, void *ctx) override {
         return skiplistDeleteRangeByLex(idx, min, max, min_ex, max_ex, on_delete, ctx);
     }
 
-    unsigned long length(OrderedIndex *idx) override { return skiplistLength(idx); }
+    unsigned long length(OrderedIndex *idx) override {
+        return skiplistLength(idx);
+    }
     OrderedIndexItem *getByRank(OrderedIndex *idx, unsigned long rank) override {
         return skiplistGetByRank(idx, rank);
     }
@@ -131,7 +137,9 @@ public:
     void getElementRaw(const OrderedIndexItem *pos, const char **ptr, size_t *len) override {
         skiplistGetElementRaw(pos, ptr, len);
     }
-    double getScore(const OrderedIndexItem *pos) override { return skiplistGetScore(pos); }
+    double getScore(const OrderedIndexItem *pos) override {
+        return skiplistGetScore(pos);
+    }
 
     size_t estimateMemory(OrderedIndex *idx, size_t sample_size) override {
         return skiplistEstimateMemory(idx, sample_size);
@@ -151,18 +159,22 @@ public:
     void initIterator(OrderedIndexIterator *iter, OrderedIndex *idx) override {
         skiplistInitIterator(iter, idx);
     }
-    void resetIterator(OrderedIndexIterator *iter) override { skiplistResetIterator(iter); }
-    bool next(OrderedIndexIterator *iter, OrderedIndexItem **pos) override { return skiplistNext(iter, pos); }
-    bool prev(OrderedIndexIterator *iter, OrderedIndexItem **pos) override { return skiplistPrev(iter, pos); }
+    void resetIterator(OrderedIndexIterator *iter) override {
+        skiplistResetIterator(iter);
+    }
+    bool next(OrderedIndexIterator *iter, OrderedIndexItem **pos) override {
+        return skiplistNext(iter, pos);
+    }
+    bool prev(OrderedIndexIterator *iter, OrderedIndexItem **pos) override {
+        return skiplistPrev(iter, pos);
+    }
     void seekToRank(OrderedIndexIterator *iter, unsigned long rank) override {
         skiplistSeekToRank(iter, rank);
     }
-    void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex,
-                          long offset) override {
+    void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex, long offset) override {
         skiplistSeekToScoreRange(iter, min, max, min_ex, max_ex, offset);
     }
-    void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex,
-                        long offset) override {
+    void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex, long offset) override {
         skiplistSeekToLexRange(iter, min, max, min_ex, max_ex, offset);
     }
 };

--- a/src/unit/ordered_index_test.h
+++ b/src/unit/ordered_index_test.h
@@ -1,0 +1,161 @@
+#ifndef ORDERED_INDEX_TEST_H
+#define ORDERED_INDEX_TEST_H
+
+/*
+ * Test-only interface for ordered index implementations.
+ *
+ * Defines an abstract C++ interface that each implementation subclasses.
+ * Production code uses compile-time dispatch via the inline wrappers in
+ * ordered_index.h instead.
+ */
+
+extern "C" {
+#include "ordered_index.h"
+#include "skiplist_ordered_index.h"
+}
+
+#include <string>
+#include <utility>
+#include <vector>
+
+/* ---- Abstract interface ---- */
+
+class OrderedIndexTestApi {
+public:
+    virtual ~OrderedIndexTestApi() = default;
+
+    /* Lifecycle */
+    virtual OrderedIndex *create() = 0;
+    virtual void free(OrderedIndex *idx) = 0;
+
+    /* Modification */
+    virtual OrderedIndexItem *insert(OrderedIndex *idx, double score, const char *ele, size_t len) = 0;
+    virtual void deleteItem(OrderedIndex *idx, OrderedIndexItem *pos) = 0;
+    virtual OrderedIndexItem *updateScore(OrderedIndex *idx, OrderedIndexItem *pos, double newscore) = 0;
+    virtual OrderedIndexItem *popFirst(OrderedIndex *idx) = 0;
+    virtual OrderedIndexItem *popLast(OrderedIndex *idx) = 0;
+    virtual void freeItem(OrderedIndexItem *item) = 0;
+    virtual unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex,
+                                             OrderedIndexOnDelete on_delete, void *ctx) = 0;
+    virtual unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
+                                            OrderedIndexOnDelete on_delete, void *ctx) = 0;
+    virtual unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex,
+                                           OrderedIndexOnDelete on_delete, void *ctx) = 0;
+
+    /* Query */
+    virtual unsigned long length(OrderedIndex *idx) = 0;
+    virtual OrderedIndexItem *getByRank(OrderedIndex *idx, unsigned long rank) = 0;
+    virtual unsigned long getRank(OrderedIndex *idx, const OrderedIndexItem *pos) = 0;
+    virtual void getElementRaw(const OrderedIndexItem *pos, const char **ptr, size_t *len) = 0;
+    virtual double getScore(const OrderedIndexItem *pos) = 0;
+
+    /* Memory */
+    virtual size_t estimateMemory(OrderedIndex *idx, size_t sample_size) = 0;
+
+    /* Iterator */
+    virtual void initIterator(OrderedIndexIterator *iter, OrderedIndex *idx) = 0;
+    virtual void resetIterator(OrderedIndexIterator *iter) = 0;
+    virtual bool next(OrderedIndexIterator *iter, OrderedIndexItem **pos) = 0;
+    virtual bool prev(OrderedIndexIterator *iter, OrderedIndexItem **pos) = 0;
+    virtual void seekToRank(OrderedIndexIterator *iter, unsigned long rank) = 0;
+    virtual void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex,
+                                  long offset) = 0;
+    virtual void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex,
+                                long offset) = 0;
+
+    /* Convenience (non-virtual) */
+    OrderedIndexItem *insertSds(OrderedIndex *idx, double score, const_sds ele) {
+        return insert(idx, score, ele, sdslen(ele));
+    }
+
+    std::vector<std::pair<double, std::string>> collectAll(OrderedIndex *idx) {
+        std::vector<std::pair<double, std::string>> result;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        initIterator(&iter, idx);
+        while (next(&iter, &pos)) {
+            const char *ptr;
+            size_t len;
+            getElementRaw(pos, &ptr, &len);
+            result.emplace_back(getScore(pos), std::string(ptr, len));
+        }
+        resetIterator(&iter);
+        return result;
+    }
+};
+
+/* ---- Skiplist implementation ---- */
+
+class SkiplistOrderedIndex : public OrderedIndexTestApi {
+public:
+    OrderedIndex *create() override { return skiplistCreate(); }
+    void free(OrderedIndex *idx) override { skiplistFree(idx); }
+
+    OrderedIndexItem *insert(OrderedIndex *idx, double score, const char *ele, size_t len) override {
+        return skiplistInsert(idx, score, ele, len);
+    }
+    void deleteItem(OrderedIndex *idx, OrderedIndexItem *pos) override { skiplistDelete(idx, pos); }
+    OrderedIndexItem *updateScore(OrderedIndex *idx, OrderedIndexItem *pos, double newscore) override {
+        return skiplistUpdateScore(idx, pos, newscore);
+    }
+    OrderedIndexItem *popFirst(OrderedIndex *idx) override { return skiplistPopFirst(idx); }
+    OrderedIndexItem *popLast(OrderedIndex *idx) override { return skiplistPopLast(idx); }
+    void freeItem(OrderedIndexItem *item) override { skiplistFreeItem(item); }
+    unsigned long deleteRangeByScore(OrderedIndex *idx, double min, double max, int min_ex, int max_ex,
+                                     OrderedIndexOnDelete on_delete, void *ctx) override {
+        return skiplistDeleteRangeByScore(idx, min, max, min_ex, max_ex, on_delete, ctx);
+    }
+    unsigned long deleteRangeByRank(OrderedIndex *idx, unsigned long start, unsigned long end,
+                                    OrderedIndexOnDelete on_delete, void *ctx) override {
+        return skiplistDeleteRangeByRank(idx, start, end, on_delete, ctx);
+    }
+    unsigned long deleteRangeByLex(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex,
+                                   OrderedIndexOnDelete on_delete, void *ctx) override {
+        return skiplistDeleteRangeByLex(idx, min, max, min_ex, max_ex, on_delete, ctx);
+    }
+
+    unsigned long length(OrderedIndex *idx) override { return skiplistLength(idx); }
+    OrderedIndexItem *getByRank(OrderedIndex *idx, unsigned long rank) override {
+        return skiplistGetByRank(idx, rank);
+    }
+    unsigned long getRank(OrderedIndex *idx, const OrderedIndexItem *pos) override {
+        return skiplistGetRank(idx, pos);
+    }
+    void getElementRaw(const OrderedIndexItem *pos, const char **ptr, size_t *len) override {
+        skiplistGetElementRaw(pos, ptr, len);
+    }
+    double getScore(const OrderedIndexItem *pos) override { return skiplistGetScore(pos); }
+
+    size_t estimateMemory(OrderedIndex *idx, size_t sample_size) override {
+        return skiplistEstimateMemory(idx, sample_size);
+    }
+
+    void initIterator(OrderedIndexIterator *iter, OrderedIndex *idx) override {
+        skiplistInitIterator(iter, idx);
+    }
+    void resetIterator(OrderedIndexIterator *iter) override { skiplistResetIterator(iter); }
+    bool next(OrderedIndexIterator *iter, OrderedIndexItem **pos) override { return skiplistNext(iter, pos); }
+    bool prev(OrderedIndexIterator *iter, OrderedIndexItem **pos) override { return skiplistPrev(iter, pos); }
+    void seekToRank(OrderedIndexIterator *iter, unsigned long rank) override {
+        skiplistSeekToRank(iter, rank);
+    }
+    void seekToScoreRange(OrderedIndexIterator *iter, double min, double max, int min_ex, int max_ex,
+                          long offset) override {
+        skiplistSeekToScoreRange(iter, min, max, min_ex, max_ex, offset);
+    }
+    void seekToLexRange(OrderedIndexIterator *iter, const_sds min, const_sds max, int min_ex, int max_ex,
+                        long offset) override {
+        skiplistSeekToLexRange(iter, min, max, min_ex, max_ex, offset);
+    }
+};
+
+/* ---- Static instances & test parameterization helpers ---- */
+
+static SkiplistOrderedIndex skiplistImpl;
+
+static std::string orderedIndexTestName(const ::testing::TestParamInfo<OrderedIndexTestApi *> &info) {
+    if (info.param == &skiplistImpl) return "Skiplist";
+    return "Unknown";
+}
+
+#endif /* ORDERED_INDEX_TEST_H */

--- a/src/unit/ordered_index_test.h
+++ b/src/unit/ordered_index_test.h
@@ -52,6 +52,13 @@ public:
     /* Memory */
     virtual size_t estimateMemory(OrderedIndex *idx, size_t sample_size) = 0;
 
+    /* Debug / verification */
+    virtual int verifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) = 0;
+
+    /* Count */
+    virtual unsigned long countScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) = 0;
+    virtual unsigned long countLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) = 0;
+
     /* Iterator */
     virtual void initIterator(OrderedIndexIterator *iter, OrderedIndex *idx) = 0;
     virtual void resetIterator(OrderedIndexIterator *iter) = 0;
@@ -128,6 +135,17 @@ public:
 
     size_t estimateMemory(OrderedIndex *idx, size_t sample_size) override {
         return skiplistEstimateMemory(idx, sample_size);
+    }
+
+    int verifyIntegrity(OrderedIndex *idx, char *errmsg, size_t errmsg_len) override {
+        return skiplistVerifyIntegrity(idx, errmsg, errmsg_len);
+    }
+
+    unsigned long countScoreRange(OrderedIndex *idx, double min, double max, int min_ex, int max_ex) override {
+        return skiplistCountScoreRange(idx, min, max, min_ex, max_ex);
+    }
+    unsigned long countLexRange(OrderedIndex *idx, const_sds min, const_sds max, int min_ex, int max_ex) override {
+        return skiplistCountLexRange(idx, min, max, min_ex, max_ex);
     }
 
     void initIterator(OrderedIndexIterator *iter, OrderedIndex *idx) override {

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -44,7 +44,7 @@ static const double NEG_INF = (double)-INFINITY;
 /* ========== Parameterized test fixture ========== */
 
 class OrderedIndexTest : public ::testing::TestWithParam<OrderedIndexTestApi *> {
-protected:
+  protected:
     OrderedIndexTestApi &api = *GetParam();
 };
 
@@ -1457,8 +1457,7 @@ static double test_random_score(std::mt19937 &rng) {
     return dist(rng);
 }
 
-static std::vector<RandomIndexEntry> test_build_random_index(OrderedIndexTestApi &api, OrderedIndex *idx,
-                                                              std::mt19937 &rng, int count) {
+static std::vector<RandomIndexEntry> test_build_random_index(OrderedIndexTestApi &api, OrderedIndex *idx, std::mt19937 &rng, int count) {
     std::vector<RandomIndexEntry> entries;
     for (int i = 0; i < count; i++) {
         double score = test_random_score(rng);
@@ -1732,7 +1731,7 @@ TEST_P(OrderedIndexTest, RandomizedDeleteRangeByRank) {
 
         unsigned long deleted = api.deleteRangeByRank(idx, start, end, NULL, NULL);
         ASSERT_EQ(deleted, expectedDeleted);
-        ASSERT_EQ(api.length(idx), (unsigned long)(n) - expectedDeleted);
+        ASSERT_EQ(api.length(idx), (unsigned long)(n)-expectedDeleted);
         VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
@@ -1919,7 +1918,7 @@ static void testOnDeleteCallback(OrderedIndexItem *item, void *ctx) {
 }
 
 class OnDeleteCallbackTest : public ::testing::Test {
-protected:
+  protected:
     SkiplistOrderedIndex api;
 
     void insertN(OrderedIndex *idx, int n) {
@@ -2274,7 +2273,7 @@ static void hashtableConsistencyOnDelete(OrderedIndexItem *item, void *ctx) {
 }
 
 class RangeDeleteHashtableConsistencyTest : public ::testing::Test {
-protected:
+  protected:
     SkiplistOrderedIndex api;
 
     void insertN(OrderedIndex *idx, std::set<std::string> &ht, int n) {

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -27,6 +27,16 @@ extern "C" {
 #define TEST_ASSERT(x) ASSERT_TRUE(x)
 #define TEST_ASSERT_SCORE_EQ(a, b) ASSERT_DOUBLE_EQ(a, b)
 
+/* Verify structural integrity of the ordered index after mutations. */
+static ::testing::AssertionResult verifyIntegrity(OrderedIndexTestApi &api, OrderedIndex *idx) {
+    char errmsg[256];
+    if (api.verifyIntegrity(idx, errmsg, sizeof(errmsg)))
+        return ::testing::AssertionResult(true);
+    return ::testing::AssertionFailure() << errmsg;
+}
+
+#define VERIFY_INTEGRITY(api_ref, idx_ptr) ASSERT_TRUE(verifyIntegrity(api_ref, idx_ptr))
+
 /* Use double infinity to avoid -Wdouble-promotion on macOS where INFINITY is float */
 static const double POS_INF = (double)INFINITY;
 static const double NEG_INF = (double)-INFINITY;
@@ -1741,6 +1751,116 @@ TEST_P(OrderedIndexTest, RandomizedForwardBackwardMirror) {
         }
         api.free(idx);
     }
+}
+
+/* ========== Count range tests ========== */
+
+TEST_P(OrderedIndexTest, CountScoreRange) {
+    OrderedIndex *idx = api.create();
+
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        api.insertSds(idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Full range */
+    ASSERT_EQ(api.countScoreRange(idx, NEG_INF, POS_INF, 0, 0), 10UL);
+
+    /* Inclusive [3, 6] */
+    ASSERT_EQ(api.countScoreRange(idx, 3.0, 6.0, 0, 0), 4UL);
+
+    /* Exclusive (3, 6) */
+    ASSERT_EQ(api.countScoreRange(idx, 3.0, 6.0, 1, 1), 2UL);
+
+    /* Single element [5, 5] */
+    ASSERT_EQ(api.countScoreRange(idx, 5.0, 5.0, 0, 0), 1UL);
+
+    /* Empty exclusive (5, 5) */
+    ASSERT_EQ(api.countScoreRange(idx, 5.0, 5.0, 1, 0), 0UL);
+
+    /* No match above */
+    ASSERT_EQ(api.countScoreRange(idx, 10.0, 20.0, 0, 0), 0UL);
+
+    /* No match below */
+    ASSERT_EQ(api.countScoreRange(idx, -20.0, -10.0, 0, 0), 0UL);
+
+    /* Min > max */
+    ASSERT_EQ(api.countScoreRange(idx, 6.0, 3.0, 0, 0), 0UL);
+
+    /* First element only [0, 0] */
+    ASSERT_EQ(api.countScoreRange(idx, 0.0, 0.0, 0, 0), 1UL);
+
+    /* Last element only [9, 9] */
+    ASSERT_EQ(api.countScoreRange(idx, 9.0, 9.0, 0, 0), 1UL);
+
+    api.free(idx);
+}
+
+TEST_P(OrderedIndexTest, CountScoreRangeEmpty) {
+    OrderedIndex *idx = api.create();
+    ASSERT_EQ(api.countScoreRange(idx, NEG_INF, POS_INF, 0, 0), 0UL);
+    api.free(idx);
+}
+
+TEST_P(OrderedIndexTest, CountLexRange) {
+    OrderedIndex *idx = api.create();
+
+    const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
+    for (int i = 0; i < 5; i++) {
+        sds ele = sdsnew(elements[i]);
+        api.insertSds(idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    /* Inclusive [banana, date] */
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 0, 0), 3UL);
+    sdsfree(min);
+    sdsfree(max);
+
+    /* Exclusive (banana, date) */
+    min = sdsnew("banana");
+    max = sdsnew("date");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 1, 1), 1UL);
+    sdsfree(min);
+    sdsfree(max);
+
+    /* Single element [cherry, cherry] */
+    min = sdsnew("cherry");
+    max = sdsnew("cherry");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 0, 0), 1UL);
+    sdsfree(min);
+    sdsfree(max);
+
+    /* No match */
+    min = sdsnew("fig");
+    max = sdsnew("grape");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 0, 0), 0UL);
+    sdsfree(min);
+    sdsfree(max);
+
+    /* All elements */
+    min = sdsnew("a");
+    max = sdsnew("z");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 0, 0), 5UL);
+    sdsfree(min);
+    sdsfree(max);
+
+    api.free(idx);
+}
+
+TEST_P(OrderedIndexTest, CountLexRangeEmpty) {
+    OrderedIndex *idx = api.create();
+    sds min = sdsnew("a");
+    sds max = sdsnew("z");
+    ASSERT_EQ(api.countLexRange(idx, min, max, 0, 0), 0UL);
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
 }
 
 /* ========== Instantiate parameterized tests for all implementations ========== */

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -54,6 +54,7 @@ TEST_P(OrderedIndexTest, CreateFree) {
     OrderedIndex *idx = api.create();
     TEST_ASSERT(idx != NULL);
     TEST_ASSERT(api.length(idx) == 0);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -68,6 +69,7 @@ TEST_P(OrderedIndexTest, InsertSingle) {
     OrderedIndex *idx = api.create();
     sds ele = sdsnew("test");
     OrderedIndexItem *node = api.insertSds(idx, 1.0, ele);
+    VERIFY_INTEGRITY(api, idx);
 
     TEST_ASSERT(node != NULL);
     TEST_ASSERT(api.length(idx) == 1);
@@ -102,6 +104,7 @@ TEST_P(OrderedIndexTest, InsertMultipleOrdered) {
     }
 
     TEST_ASSERT(api.length(idx) == 10);
+    VERIFY_INTEGRITY(api, idx);
 
     /* Verify forward traversal */
     OrderedIndexIterator iter;
@@ -138,6 +141,7 @@ TEST_P(OrderedIndexTest, DuplicateScores) {
     }
 
     TEST_ASSERT(api.length(idx) == 5);
+    VERIFY_INTEGRITY(api, idx);
 
     /* Verify lexicographic ordering for same scores */
     OrderedIndexIterator iter;
@@ -169,6 +173,7 @@ TEST_P(OrderedIndexTest, RankOperations) {
         nodes[i] = api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
+    VERIFY_INTEGRITY(api, idx);
 
     for (int i = 0; i < 10; i++) {
         unsigned long rank = api.getRank(idx, nodes[i]);
@@ -199,6 +204,7 @@ TEST_P(OrderedIndexTest, Delete) {
 
     api.deleteItem(idx, nodes[2]);
     TEST_ASSERT(api.length(idx) == 4);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -239,11 +245,13 @@ TEST_P(OrderedIndexTest, PopFirst) {
     TEST_ASSERT(len == 4 && memcmp(ptr, "key0", 4) == 0);
     api.freeItem(item);
     TEST_ASSERT(api.length(idx) == 4);
+    VERIFY_INTEGRITY(api, idx);
 
     item = api.popFirst(idx);
     TEST_ASSERT_SCORE_EQ(api.getScore(item), 1.0);
     api.freeItem(item);
     TEST_ASSERT(api.length(idx) == 3);
+    VERIFY_INTEGRITY(api, idx);
 
     api.free(idx);
 }
@@ -271,11 +279,13 @@ TEST_P(OrderedIndexTest, PopLast) {
     TEST_ASSERT(len == 4 && memcmp(ptr, "key4", 4) == 0);
     api.freeItem(item);
     TEST_ASSERT(api.length(idx) == 4);
+    VERIFY_INTEGRITY(api, idx);
 
     item = api.popLast(idx);
     TEST_ASSERT_SCORE_EQ(api.getScore(item), 3.0);
     api.freeItem(item);
     TEST_ASSERT(api.length(idx) == 3);
+    VERIFY_INTEGRITY(api, idx);
 
     api.free(idx);
 }
@@ -296,6 +306,7 @@ TEST_P(OrderedIndexTest, UpdateScore) {
     OrderedIndexItem *updated = api.updateScore(idx, node2, 4.0);
     TEST_ASSERT(updated != NULL);
     TEST_ASSERT_SCORE_EQ(api.getScore(updated), 4.0);
+    VERIFY_INTEGRITY(api, idx);
     const char *ptr;
     size_t len;
     api.getElementRaw(updated, &ptr, &len);
@@ -318,6 +329,7 @@ TEST_P(OrderedIndexTest, UpdateScore) {
     /* Update to same score (no-op) */
     updated = api.updateScore(idx, node1, 1.0);
     TEST_ASSERT_SCORE_EQ(api.getScore(updated), 1.0);
+    VERIFY_INTEGRITY(api, idx);
 
     api.free(idx);
 }
@@ -337,6 +349,7 @@ TEST_P(OrderedIndexTest, DeleteRangeByScore) {
     unsigned long deleted = api.deleteRangeByScore(idx, 3.0, 6.0, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 4); /* 3, 4, 5, 6 */
     TEST_ASSERT(api.length(idx) == 6);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -355,6 +368,7 @@ TEST_P(OrderedIndexTest, DeleteRangeByScore) {
     deleted = api.deleteRangeByScore(idx, 2.0, 8.0, 1, 1, NULL, NULL);
     TEST_ASSERT(deleted == 1);
     TEST_ASSERT(api.length(idx) == 5);
+    VERIFY_INTEGRITY(api, idx);
 
     api.free(idx);
 }
@@ -374,6 +388,7 @@ TEST_P(OrderedIndexTest, DeleteRangeByRank) {
     unsigned long deleted = api.deleteRangeByRank(idx, 3, 5, NULL, NULL);
     TEST_ASSERT(deleted == 3);
     TEST_ASSERT(api.length(idx) == 7);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -405,9 +420,11 @@ TEST_P(OrderedIndexTest, MixedOperationsRankIntegrity) {
         api.deleteItem(idx, nodes[i]);
         nodes[i] = NULL;
     }
+    VERIFY_INTEGRITY(api, idx);
 
     if (nodes[10]) nodes[10] = api.updateScore(idx, nodes[10], 150.0);
     if (nodes[20]) nodes[20] = api.updateScore(idx, nodes[20], 160.0);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -438,6 +455,7 @@ TEST_P(OrderedIndexTest, BackwardTraversalAfterDeletions) {
     api.deleteItem(idx, nodes[5]);
     api.deleteItem(idx, nodes[10]);
     api.deleteItem(idx, nodes[15]);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -648,6 +666,7 @@ TEST_P(OrderedIndexTest, DeleteEdgeCases) {
     OrderedIndexItem *node = api.insertSds(idx, 1.0, ele);
     api.deleteItem(idx, node);
     TEST_ASSERT(api.length(idx) == 0);
+    VERIFY_INTEGRITY(api, idx);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     api.initIterator(&iter, idx);
@@ -666,6 +685,7 @@ TEST_P(OrderedIndexTest, DeleteEdgeCases) {
     }
     api.deleteItem(idx, nodes[0]);
     TEST_ASSERT(api.length(idx) == 2);
+    VERIFY_INTEGRITY(api, idx);
     api.initIterator(&iter, idx);
     TEST_ASSERT(api.next(&iter, &pos));
     TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
@@ -674,6 +694,7 @@ TEST_P(OrderedIndexTest, DeleteEdgeCases) {
     /* Delete last element */
     api.deleteItem(idx, nodes[2]);
     TEST_ASSERT(api.length(idx) == 1);
+    VERIFY_INTEGRITY(api, idx);
     api.initIterator(&iter, idx);
     TEST_ASSERT(api.prev(&iter, &pos));
     TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
@@ -784,6 +805,7 @@ TEST_P(OrderedIndexTest, RangeDeleteEdgeCases) {
     /* Delete first elements by rank */
     deleted = api.deleteRangeByRank(idx, 1, 2, NULL, NULL);
     TEST_ASSERT(deleted == 2);
+    VERIFY_INTEGRITY(api, idx);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     api.initIterator(&iter, idx);
@@ -795,6 +817,7 @@ TEST_P(OrderedIndexTest, RangeDeleteEdgeCases) {
     unsigned long len = api.length(idx);
     deleted = api.deleteRangeByRank(idx, len - 1, len, NULL, NULL);
     TEST_ASSERT(deleted == 2);
+    VERIFY_INTEGRITY(api, idx);
     api.initIterator(&iter, idx);
     TEST_ASSERT(api.prev(&iter, &pos));
     TEST_ASSERT_SCORE_EQ(api.getScore(pos), 7.0);
@@ -804,6 +827,7 @@ TEST_P(OrderedIndexTest, RangeDeleteEdgeCases) {
     deleted = api.deleteRangeByScore(idx, -100.0, 100.0, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 6);
     TEST_ASSERT(api.length(idx) == 0);
+    VERIFY_INTEGRITY(api, idx);
 
     api.free(idx);
 }
@@ -1229,6 +1253,7 @@ TEST_P(OrderedIndexTest, DeleteRangeByLexInclusive) {
     unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 3);
     TEST_ASSERT(api.length(idx) == 2);
+    VERIFY_INTEGRITY(api, idx);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
@@ -1456,6 +1481,7 @@ TEST_P(OrderedIndexTest, RandomizedInsertAndTraversal) {
         test_build_random_index(api, idx, rng, n);
 
         ASSERT_EQ(api.length(idx), (unsigned long)n);
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
@@ -1556,6 +1582,7 @@ TEST_P(OrderedIndexTest, RandomizedDelete) {
         api.deleteItem(idx, entries[delIdx].node);
 
         ASSERT_EQ(api.length(idx), (unsigned long)(n - 1));
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
@@ -1590,6 +1617,7 @@ TEST_P(OrderedIndexTest, RandomizedUpdateScore) {
         ASSERT_NE(updated, nullptr);
         ASSERT_EQ(api.getScore(updated), newScore);
         ASSERT_EQ(api.length(idx), (unsigned long)n);
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
@@ -1630,12 +1658,14 @@ TEST_P(OrderedIndexTest, RandomizedPop) {
         ASSERT_EQ(api.getScore(first), minScore);
         ASSERT_EQ(api.length(idx), (unsigned long)(n - 1));
         api.freeItem(first);
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexItem *last = api.popLast(idx);
         ASSERT_NE(last, nullptr);
         ASSERT_EQ(api.getScore(last), maxScore);
         ASSERT_EQ(api.length(idx), (unsigned long)(n - 2));
         api.freeItem(last);
+        VERIFY_INTEGRITY(api, idx);
 
         api.initIterator(&iter, idx);
         double prevScore = -INFINITY;
@@ -1668,6 +1698,7 @@ TEST_P(OrderedIndexTest, RandomizedDeleteRangeByScore) {
         unsigned long deleted = api.deleteRangeByScore(idx, lo, hi, 0, 0, NULL, NULL);
         ASSERT_EQ(deleted, (unsigned long)expectedDeleted);
         ASSERT_EQ(api.length(idx), (unsigned long)(n - expectedDeleted));
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
@@ -1702,6 +1733,7 @@ TEST_P(OrderedIndexTest, RandomizedDeleteRangeByRank) {
         unsigned long deleted = api.deleteRangeByRank(idx, start, end, NULL, NULL);
         ASSERT_EQ(deleted, expectedDeleted);
         ASSERT_EQ(api.length(idx), (unsigned long)(n) - expectedDeleted);
+        VERIFY_INTEGRITY(api, idx);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
@@ -1953,6 +1985,7 @@ TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_Subset) {
     ASSERT_EQ(deleted, 4UL);
     ASSERT_EQ(rec.count, 4);
     ASSERT_EQ(api.length(idx), 6UL);
+    VERIFY_INTEGRITY(api, idx);
 
     std::sort(rec.elements.begin(), rec.elements.end());
     ASSERT_EQ(rec.elements, (std::vector<std::string>{"key3", "key4", "key5", "key6"}));
@@ -1971,6 +2004,7 @@ TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_All) {
     ASSERT_EQ(deleted, 5UL);
     ASSERT_EQ(rec.count, 5);
     ASSERT_EQ(api.length(idx), 0UL);
+    VERIFY_INTEGRITY(api, idx);
     api.free(idx);
 }
 

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -18,6 +18,10 @@ extern "C" {
 #define TEST_ASSERT(x) ASSERT_TRUE(x)
 #define TEST_ASSERT_SCORE_EQ(a, b) ASSERT_DOUBLE_EQ(a, b)
 
+/* Use double infinity to avoid -Wdouble-promotion on macOS where INFINITY is float */
+static const double POS_INF = (double)INFINITY;
+static const double NEG_INF = (double)-INFINITY;
+
 /* Generic tests that work with any OrderedIndex implementation */
 
 static void test_create_free_generic(const OrderedIndexOps *ops) {
@@ -560,8 +564,8 @@ static void test_special_double_values_generic(const OrderedIndexOps *ops) {
     sds zero = sdsnew("zero");
     sds one = sdsnew("one");
 
-    orderedIndexInsert(ops, idx, -INFINITY, neg_inf);
-    orderedIndexInsert(ops, idx, INFINITY, pos_inf);
+    orderedIndexInsert(ops, idx, NEG_INF, neg_inf);
+    orderedIndexInsert(ops, idx, POS_INF, pos_inf);
     orderedIndexInsert(ops, idx, 0.0, zero);
     orderedIndexInsert(ops, idx, 1.0, one);
 
@@ -570,13 +574,13 @@ static void test_special_double_values_generic(const OrderedIndexOps *ops) {
     OrderedIndexItem *pos;
     orderedIndexInitIterator(ops, &iter, idx);
     TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), -INFINITY);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), NEG_INF);
     TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
     TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
     TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
     TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
     TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), INFINITY);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), POS_INF);
     orderedIndexResetIterator(ops, &iter);
 
     sdsfree(neg_inf);
@@ -1120,7 +1124,7 @@ static void test_seek_inf_reverse_iteration_generic(const OrderedIndexOps *ops) 
     /* Seek to [-inf, +inf] with offset -1 (last element), then iterate backwards.
      * This is how ZREVRANGEBYSCORE -inf +inf works. */
     orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, -INFINITY, INFINITY, 0, 0, -1);
+    orderedIndexSeekToScoreRange(ops, &iter, NEG_INF, POS_INF, 0, 0, -1);
     int count = 0;
     double expected = 5.0;
     while (orderedIndexNext(ops, &iter, &pos)) {
@@ -1164,7 +1168,7 @@ static void test_seek_inf_forward_iteration_generic(const OrderedIndexOps *ops) 
     /* Seek to [-inf, +inf] with offset 0 (first element), then iterate forwards.
      * This is how ZRANGEBYSCORE -inf +inf works. */
     orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, -INFINITY, INFINITY, 0, 0, 0);
+    orderedIndexSeekToScoreRange(ops, &iter, NEG_INF, POS_INF, 0, 0, 0);
     int count = 0;
     double expected = 1.0;
     while (orderedIndexNext(ops, &iter, &pos)) {

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -7,7 +7,6 @@
 #include "generated_wrappers.hpp"
 
 extern "C" {
-#include "ordered_index.h"
 #include "server.h"
 }
 
@@ -15,10 +14,13 @@ extern "C" {
 #undef min
 #undef max
 
+#include "ordered_index_test.h"
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <random>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -29,505 +31,481 @@ extern "C" {
 static const double POS_INF = (double)INFINITY;
 static const double NEG_INF = (double)-INFINITY;
 
-/* Generic tests that work with any OrderedIndex implementation */
+/* ========== Parameterized test fixture ========== */
 
-static void test_create_free_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+class OrderedIndexTest : public ::testing::TestWithParam<OrderedIndexTestApi *> {
+protected:
+    OrderedIndexTestApi &api = *GetParam();
+};
+
+/* ========== Basic tests ========== */
+
+TEST_P(OrderedIndexTest, CreateFree) {
+    OrderedIndex *idx = api.create();
     TEST_ASSERT(idx != NULL);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    TEST_ASSERT(api.length(idx) == 0);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_insert_single_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, InsertSingle) {
+    OrderedIndex *idx = api.create();
     sds ele = sdsnew("test");
-    OrderedIndexItem *node = orderedIndexInsert(ops, idx, 1.0, ele);
+    OrderedIndexItem *node = api.insertSds(idx, 1.0, ele);
 
     TEST_ASSERT(node != NULL);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 1);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, node), 1.0);
+    TEST_ASSERT(api.length(idx) == 1);
+    TEST_ASSERT_SCORE_EQ(api.getScore(node), 1.0);
 
     const char *ptr;
     size_t len;
-    orderedIndexGetElementRaw(ops, node, &ptr, &len);
+    api.getElementRaw(node, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "test", 4) == 0);
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
     TEST_ASSERT(pos == node);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     sdsfree(ele);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_insert_multiple_ordered_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, InsertMultipleOrdered) {
+    OrderedIndex *idx = api.create();
 
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+    TEST_ASSERT(api.length(idx) == 10);
 
     /* Verify forward traversal */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     for (int i = 0; i < 10; i++) {
-        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+        TEST_ASSERT(api.next(&iter, &pos));
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), (double)i);
     }
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     /* Verify backward traversal */
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     for (int i = 9; i >= 0; i--) {
-        TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+        TEST_ASSERT(api.prev(&iter, &pos));
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), (double)i);
     }
-    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.prev(&iter, &pos));
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_duplicate_scores_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DuplicateScores) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with same score but different keys */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+    TEST_ASSERT(api.length(idx) == 5);
 
     /* Verify lexicographic ordering for same scores */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     for (int i = 0; i < 5; i++) {
-        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+        TEST_ASSERT(api.next(&iter, &pos));
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
         const char *ptr;
         size_t len;
-        orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+        api.getElementRaw(pos, &ptr, &len);
         char expected[32];
         snprintf(expected, sizeof(expected), "key%d", i);
         TEST_ASSERT(len == strlen(expected) && memcmp(ptr, expected, len) == 0);
     }
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_rank_operations_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, RankOperations) {
+    OrderedIndex *idx = api.create();
     OrderedIndexItem *nodes[10];
 
-    /* Insert 10 elements */
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        nodes[i] = api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    /* Test get_rank */
     for (int i = 0; i < 10; i++) {
-        unsigned long rank = orderedIndexGetRank(ops, idx, nodes[i]);
+        unsigned long rank = api.getRank(idx, nodes[i]);
         TEST_ASSERT(rank == (unsigned long)(i + 1)); /* 1-based */
     }
 
-    /* Test get_by_rank */
     for (int i = 0; i < 10; i++) {
-        OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, i + 1);
+        OrderedIndexItem *node = api.getByRank(idx, i + 1);
         TEST_ASSERT(node == nodes[i]);
     }
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, Delete) {
+    OrderedIndex *idx = api.create();
     OrderedIndexItem *nodes[5];
 
-    /* Insert 5 elements */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        nodes[i] = api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+    TEST_ASSERT(api.length(idx) == 5);
 
-    /* Delete middle element */
-    orderedIndexDelete(ops, idx, nodes[2]);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+    api.deleteItem(idx, nodes[2]);
+    TEST_ASSERT(api.length(idx) == 4);
 
-    /* Verify remaining elements */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0); /* Skipped 2.0 */
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 0.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 3.0); /* Skipped 2.0 */
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_pop_first_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, PopFirst) {
+    OrderedIndex *idx = api.create();
 
-    /* Pop from empty - should return NULL */
-    TEST_ASSERT(orderedIndexPopFirst(ops, idx) == NULL);
+    TEST_ASSERT(api.popFirst(idx) == NULL);
 
-    /* Insert elements */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+    TEST_ASSERT(api.length(idx) == 5);
 
-    /* Pop first - should get score 0.0 */
-    OrderedIndexItem *item = orderedIndexPopFirst(ops, idx);
+    OrderedIndexItem *item = api.popFirst(idx);
     TEST_ASSERT(item != NULL);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 0.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(item), 0.0);
     const char *ptr;
     size_t len;
-    orderedIndexGetElementRaw(ops, item, &ptr, &len);
+    api.getElementRaw(item, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "key0", 4) == 0);
-    orderedIndexFreeItem(ops, item);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+    api.freeItem(item);
+    TEST_ASSERT(api.length(idx) == 4);
 
-    /* Pop again - should get score 1.0 */
-    item = orderedIndexPopFirst(ops, idx);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 1.0);
-    orderedIndexFreeItem(ops, item);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+    item = api.popFirst(idx);
+    TEST_ASSERT_SCORE_EQ(api.getScore(item), 1.0);
+    api.freeItem(item);
+    TEST_ASSERT(api.length(idx) == 3);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_pop_last_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, PopLast) {
+    OrderedIndex *idx = api.create();
 
-    /* Pop from empty - should return NULL */
-    TEST_ASSERT(orderedIndexPopLast(ops, idx) == NULL);
+    TEST_ASSERT(api.popLast(idx) == NULL);
 
-    /* Insert elements */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+    TEST_ASSERT(api.length(idx) == 5);
 
-    /* Pop last - should get score 4.0 */
-    OrderedIndexItem *item = orderedIndexPopLast(ops, idx);
+    OrderedIndexItem *item = api.popLast(idx);
     TEST_ASSERT(item != NULL);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 4.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(item), 4.0);
     const char *ptr;
     size_t len;
-    orderedIndexGetElementRaw(ops, item, &ptr, &len);
+    api.getElementRaw(item, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "key4", 4) == 0);
-    orderedIndexFreeItem(ops, item);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+    api.freeItem(item);
+    TEST_ASSERT(api.length(idx) == 4);
 
-    /* Pop again - should get score 3.0 */
-    item = orderedIndexPopLast(ops, idx);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 3.0);
-    orderedIndexFreeItem(ops, item);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+    item = api.popLast(idx);
+    TEST_ASSERT_SCORE_EQ(api.getScore(item), 3.0);
+    api.freeItem(item);
+    TEST_ASSERT(api.length(idx) == 3);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_update_score_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, UpdateScore) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements */
     sds ele1 = sdsnew("key1");
     sds ele2 = sdsnew("key2");
     sds ele3 = sdsnew("key3");
-    OrderedIndexItem *node1 = orderedIndexInsert(ops, idx, 1.0, ele1);
-    OrderedIndexItem *node2 = orderedIndexInsert(ops, idx, 2.0, ele2);
-    orderedIndexInsert(ops, idx, 3.0, ele3);
+    OrderedIndexItem *node1 = api.insertSds(idx, 1.0, ele1);
+    OrderedIndexItem *node2 = api.insertSds(idx, 2.0, ele2);
+    api.insertSds(idx, 3.0, ele3);
     sdsfree(ele1);
     sdsfree(ele2);
     sdsfree(ele3);
 
-    /* Update middle element to move it to end */
-    OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, node2, 4.0);
+    OrderedIndexItem *updated = api.updateScore(idx, node2, 4.0);
     TEST_ASSERT(updated != NULL);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 4.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(updated), 4.0);
     const char *ptr;
     size_t len;
-    orderedIndexGetElementRaw(ops, updated, &ptr, &len);
+    api.getElementRaw(updated, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "key2", 4) == 0);
 
     /* Verify order: key1(1.0), key3(3.0), key2(4.0) */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 3.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "key2", 4) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Update to same score (no-op) */
-    updated = orderedIndexUpdateScore(ops, idx, node1, 1.0);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 1.0);
+    updated = api.updateScore(idx, node1, 1.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(updated), 1.0);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_range_by_score_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DeleteRangeByScore) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 10 elements with scores 0-9 */
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
     /* Delete range [3, 6] inclusive */
-    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, 3.0, 6.0, 0, 0);
+    unsigned long deleted = api.deleteRangeByScore(idx, 3.0, 6.0, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 4); /* 3, 4, 5, 6 */
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 6);
+    TEST_ASSERT(api.length(idx) == 6);
 
-    /* Verify remaining: 0,1,2,7,8,9 */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     for (int i = 0; i < 3; i++) {
-        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+        TEST_ASSERT(api.next(&iter, &pos));
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), (double)i);
     }
     for (int i = 7; i < 10; i++) {
-        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+        TEST_ASSERT(api.next(&iter, &pos));
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), (double)i);
     }
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Delete with exclusive bounds (2, 8) - should delete 7 */
-    deleted = orderedIndexDeleteRangeByScore(ops, idx, 2.0, 8.0, 1, 1);
+    deleted = api.deleteRangeByScore(idx, 2.0, 8.0, 1, 1, NULL, NULL);
     TEST_ASSERT(deleted == 1);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+    TEST_ASSERT(api.length(idx) == 5);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_range_by_rank_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DeleteRangeByRank) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 10 elements */
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
     /* Delete ranks 3-5 (1-based, so elements at scores 2,3,4) */
-    unsigned long deleted = orderedIndexDeleteRangeByRank(ops, idx, 3, 5);
+    unsigned long deleted = api.deleteRangeByRank(idx, 3, 5, NULL, NULL);
     TEST_ASSERT(deleted == 3);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 7);
+    TEST_ASSERT(api.length(idx) == 7);
 
-    /* Verify first element is still score 0 */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 0.0);
+    api.resetIterator(&iter);
 
     /* Verify rank 3 is now score 5 (was rank 6) */
-    OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, 3);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, node), 5.0);
+    OrderedIndexItem *node = api.getByRank(idx, 3);
+    TEST_ASSERT_SCORE_EQ(api.getScore(node), 5.0);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_mixed_operations_rank_integrity_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, MixedOperationsRankIntegrity) {
+    OrderedIndex *idx = api.create();
     OrderedIndexItem *nodes[100];
 
-    /* Insert 100 elements */
     for (int i = 0; i < 100; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        nodes[i] = api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    /* Delete every 3rd element */
     for (int i = 2; i < 100; i += 3) {
-        orderedIndexDelete(ops, idx, nodes[i]);
+        api.deleteItem(idx, nodes[i]);
         nodes[i] = NULL;
     }
 
-    /* Update scores of some remaining elements */
-    if (nodes[10]) nodes[10] = orderedIndexUpdateScore(ops, idx, nodes[10], 150.0);
-    if (nodes[20]) nodes[20] = orderedIndexUpdateScore(ops, idx, nodes[20], 160.0);
+    if (nodes[10]) nodes[10] = api.updateScore(idx, nodes[10], 150.0);
+    if (nodes[20]) nodes[20] = api.updateScore(idx, nodes[20], 160.0);
 
-    /* Verify all ranks are correct by forward traversal */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     unsigned long expected_rank = 1;
-    while (orderedIndexNext(ops, &iter, &pos)) {
-        unsigned long actual_rank = orderedIndexGetRank(ops, idx, pos);
+    while (api.next(&iter, &pos)) {
+        unsigned long actual_rank = api.getRank(idx, pos);
         TEST_ASSERT(actual_rank == expected_rank);
         expected_rank++;
     }
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_backward_traversal_after_deletions_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, BackwardTraversalAfterDeletions) {
+    OrderedIndex *idx = api.create();
     OrderedIndexItem *nodes[20];
 
-    /* Insert 20 elements */
     for (int i = 0; i < 20; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        nodes[i] = api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    /* Delete elements at positions 5, 10, 15 */
-    orderedIndexDelete(ops, idx, nodes[5]);
-    orderedIndexDelete(ops, idx, nodes[10]);
-    orderedIndexDelete(ops, idx, nodes[15]);
+    api.deleteItem(idx, nodes[5]);
+    api.deleteItem(idx, nodes[10]);
+    api.deleteItem(idx, nodes[15]);
 
-    /* Traverse backward and verify prev() pointers work correctly */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     int expected_scores[] = {19, 18, 17, 16, 14, 13, 12, 11, 9, 8, 7, 6, 4, 3, 2, 1, 0};
     int idx_score = 0;
 
-    while (orderedIndexPrev(ops, &iter, &pos)) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)expected_scores[idx_score]);
+    while (api.prev(&iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), (double)expected_scores[idx_score]);
         idx_score++;
     }
     TEST_ASSERT(idx_score == 17); /* Should have traversed all 17 remaining elements */
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_lexicographic_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, LexicographicEdgeCases) {
+    OrderedIndex *idx = api.create();
 
-    /* Test empty string */
     sds empty = sdsnew("");
     sds a = sdsnew("a");
     sds z = sdsnew("z");
 
-    orderedIndexInsert(ops, idx, 1.0, z);
-    orderedIndexInsert(ops, idx, 1.0, empty);
-    orderedIndexInsert(ops, idx, 1.0, a);
+    api.insertSds(idx, 1.0, z);
+    api.insertSds(idx, 1.0, empty);
+    api.insertSds(idx, 1.0, a);
 
     /* Verify lexicographic order: "", "a", "z" */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     const char *ptr;
     size_t len;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 1 && memcmp(ptr, "a", 1) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 1 && memcmp(ptr, "z", 1) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     sdsfree(empty);
     sdsfree(a);
     sdsfree(z);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 
     /* Test very long string (1KB) */
-    idx = orderedIndexCreate(ops);
+    idx = api.create();
     char long_buf[1024];
     memset(long_buf, 'x', 1023);
     long_buf[1023] = '\0';
     sds long_str = sdsnew(long_buf);
     sds short_str = sdsnew("short");
 
-    orderedIndexInsert(ops, idx, 1.0, long_str);
-    orderedIndexInsert(ops, idx, 1.0, short_str);
+    api.insertSds(idx, 1.0, long_str);
+    api.insertSds(idx, 1.0, short_str);
 
-    /* Verify ordering */
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 5 && memcmp(ptr, "short", 5) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 1023 && memcmp(ptr, long_buf, 1023) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     sdsfree(long_str);
     sdsfree(short_str);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_range_boundary_precision_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, RangeBoundaryPrecision) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with very close scores */
     double base = 1.0;
     double epsilon = 1e-10;
 
@@ -535,142 +513,136 @@ static void test_range_boundary_precision_generic(const OrderedIndexOps *ops) {
     sds ele2 = sdsnew("at_base_plus_epsilon");
     sds ele3 = sdsnew("at_base_plus_2epsilon");
 
-    orderedIndexInsert(ops, idx, base, ele1);
-    orderedIndexInsert(ops, idx, base + epsilon, ele2);
-    orderedIndexInsert(ops, idx, base + 2 * epsilon, ele3);
+    api.insertSds(idx, base, ele1);
+    api.insertSds(idx, base + epsilon, ele2);
+    api.insertSds(idx, base + 2 * epsilon, ele3);
 
-    /* Query with exclusive bounds (base, base+2*epsilon) - should only get middle element */
-    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, base, base + 2 * epsilon, 1, 1);
+    unsigned long deleted = api.deleteRangeByScore(idx, base, base + 2 * epsilon, 1, 1, NULL, NULL);
     TEST_ASSERT(deleted == 1);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    TEST_ASSERT(api.length(idx) == 2);
 
-    /* Verify remaining elements */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), base);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), base + 2 * epsilon);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), base);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), base + 2 * epsilon);
+    api.resetIterator(&iter);
 
     sdsfree(ele1);
     sdsfree(ele2);
     sdsfree(ele3);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_special_double_values_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SpecialDoubleValues) {
+    OrderedIndex *idx = api.create();
     const char *ptr;
     size_t len;
 
-    /* Test ±infinity */
     sds neg_inf = sdsnew("neg_inf");
     sds pos_inf = sdsnew("pos_inf");
     sds zero = sdsnew("zero");
     sds one = sdsnew("one");
 
-    orderedIndexInsert(ops, idx, NEG_INF, neg_inf);
-    orderedIndexInsert(ops, idx, POS_INF, pos_inf);
-    orderedIndexInsert(ops, idx, 0.0, zero);
-    orderedIndexInsert(ops, idx, 1.0, one);
+    api.insertSds(idx, NEG_INF, neg_inf);
+    api.insertSds(idx, POS_INF, pos_inf);
+    api.insertSds(idx, 0.0, zero);
+    api.insertSds(idx, 1.0, one);
 
     /* Verify ordering: -inf, 0, 1, +inf */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), NEG_INF);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), POS_INF);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), NEG_INF);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 0.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), POS_INF);
+    api.resetIterator(&iter);
 
     sdsfree(neg_inf);
     sdsfree(pos_inf);
     sdsfree(zero);
     sdsfree(one);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 
-    /* Test +0.0 vs -0.0 (should be treated as equal) */
-    idx = orderedIndexCreate(ops);
+    /* Test +0.0 vs -0.0 */
+    idx = api.create();
     sds pos_zero = sdsnew("pos_zero");
     sds neg_zero = sdsnew("neg_zero");
 
-    orderedIndexInsert(ops, idx, 0.0, pos_zero);
-    orderedIndexInsert(ops, idx, -0.0, neg_zero);
+    api.insertSds(idx, 0.0, pos_zero);
+    api.insertSds(idx, -0.0, neg_zero);
 
     /* Both should be in the list, ordered lexicographically since scores are equal */
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.length(idx) == 2);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 8 && memcmp(ptr, "neg_zero", 8) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 8 && memcmp(ptr, "pos_zero", 8) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     sdsfree(pos_zero);
     sdsfree(neg_zero);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 
-    /* Test denormalized double (very small number near zero) */
-    idx = orderedIndexCreate(ops);
+    /* Test denormalized double */
+    idx = api.create();
     double denorm = 1e-320; /* Denormalized double */
     sds denorm_ele = sdsnew("denorm");
     sds normal_ele = sdsnew("normal");
 
-    orderedIndexInsert(ops, idx, denorm, denorm_ele);
-    orderedIndexInsert(ops, idx, 1.0, normal_ele);
+    api.insertSds(idx, denorm, denorm_ele);
+    api.insertSds(idx, 1.0, normal_ele);
 
-    /* Verify denormalized value is handled correctly */
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), denorm);
-    TEST_ASSERT(orderedIndexGetScore(ops, pos) < 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(api.length(idx) == 2);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), denorm);
+    TEST_ASSERT(api.getScore(pos) < 1.0);
+    api.resetIterator(&iter);
 
     sdsfree(denorm_ele);
     sdsfree(normal_ele);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
+TEST_P(OrderedIndexTest, EdgeCases) {
+    OrderedIndex *idx = api.create();
 
-static void test_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
-
-    /* Empty index operations */
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    TEST_ASSERT(api.length(idx) == 0);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
-    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 1) == NULL);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    TEST_ASSERT(!api.prev(&iter, &pos));
+    api.resetIterator(&iter);
+    TEST_ASSERT(api.getByRank(idx, 1) == NULL);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DeleteEdgeCases) {
+    OrderedIndex *idx = api.create();
 
     /* Delete only element */
     sds ele = sdsnew("only");
-    OrderedIndexItem *node = orderedIndexInsert(ops, idx, 1.0, ele);
-    orderedIndexDelete(ops, idx, node);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    OrderedIndexItem *node = api.insertSds(idx, 1.0, ele);
+    api.deleteItem(idx, node);
+    TEST_ASSERT(api.length(idx) == 0);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
     sdsfree(ele);
 
     /* Delete first element */
@@ -679,268 +651,252 @@ static void test_delete_edge_cases_generic(const OrderedIndexOps *ops) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds e = sdsnew(buf);
-        nodes[i] = orderedIndexInsert(ops, idx, (double)i, e);
+        nodes[i] = api.insertSds(idx, (double)i, e);
         sdsfree(e);
     }
-    orderedIndexDelete(ops, idx, nodes[0]);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.deleteItem(idx, nodes[0]);
+    TEST_ASSERT(api.length(idx) == 2);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    api.resetIterator(&iter);
 
     /* Delete last element */
-    orderedIndexDelete(ops, idx, nodes[2]);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 1);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.deleteItem(idx, nodes[2]);
+    TEST_ASSERT(api.length(idx) == 1);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_rank_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, RankEdgeCases) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 5 elements */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    /* Rank 0 returns header node (not NULL, not first element - implementation quirk)
-     * We don't test this as it's an implementation detail that shouldn't be relied upon */
+    TEST_ASSERT(api.getByRank(idx, 6) == NULL);
+    TEST_ASSERT(api.getByRank(idx, 100) == NULL);
+    TEST_ASSERT(api.getByRank(idx, 1) != NULL);
+    TEST_ASSERT(api.getByRank(idx, 5) != NULL);
 
-    /* Rank beyond length returns NULL */
-    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 6) == NULL);
-    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 100) == NULL);
-
-    /* Valid boundary ranks */
-    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 1) != NULL);
-    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 5) != NULL);
-
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_duplicate_insert_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DuplicateInsert) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert same score+element twice */
     sds ele1 = sdsnew("duplicate");
     sds ele2 = sdsnew("duplicate");
-    OrderedIndexItem *node1 = orderedIndexInsert(ops, idx, 1.0, ele1);
-    OrderedIndexItem *node2 = orderedIndexInsert(ops, idx, 1.0, ele2);
+    OrderedIndexItem *node1 = api.insertSds(idx, 1.0, ele1);
+    OrderedIndexItem *node2 = api.insertSds(idx, 1.0, ele2);
 
     /* Should have 2 nodes (duplicates allowed) */
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    TEST_ASSERT(api.length(idx) == 2);
     TEST_ASSERT(node1 != node2);
 
     sdsfree(ele1);
     sdsfree(ele2);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_update_score_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, UpdateScoreEdgeCases) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
-    /* Update first element to move backward (should stay first) */
-    OrderedIndexItem *first = orderedIndexGetByRank(ops, idx, 1);
-    OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, first, -1.0);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), -1.0);
+    /* Update first element to move backward */
+    OrderedIndexItem *first = api.getByRank(idx, 1);
+    OrderedIndexItem *updated = api.updateScore(idx, first, -1.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(updated), -1.0);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
     TEST_ASSERT(pos == updated);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Update last element to move forward */
-    unsigned long len = orderedIndexLength(ops, idx);
-    OrderedIndexItem *last = orderedIndexGetByRank(ops, idx, len);
-    updated = orderedIndexUpdateScore(ops, idx, last, 10.0);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 10.0);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    unsigned long len = api.length(idx);
+    OrderedIndexItem *last = api.getByRank(idx, len);
+    updated = api.updateScore(idx, last, 10.0);
+    TEST_ASSERT_SCORE_EQ(api.getScore(updated), 10.0);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.prev(&iter, &pos));
     TEST_ASSERT(pos == updated);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Update middle element to move backward */
-    OrderedIndexItem *middle = orderedIndexGetByRank(ops, idx, 3);
-    double old_score = orderedIndexGetScore(ops, middle);
-    updated = orderedIndexUpdateScore(ops, idx, middle, 0.5);
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 0.5);
-    TEST_ASSERT(orderedIndexGetScore(ops, updated) < old_score);
+    OrderedIndexItem *middle = api.getByRank(idx, 3);
+    double old_score = api.getScore(middle);
+    updated = api.updateScore(idx, middle, 0.5);
+    TEST_ASSERT_SCORE_EQ(api.getScore(updated), 0.5);
+    TEST_ASSERT(api.getScore(updated) < old_score);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_range_delete_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, RangeDeleteEdgeCases) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 10 elements */
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
     /* Delete empty range (min > max) */
-    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, 5.0, 4.0, 0, 0);
+    unsigned long deleted = api.deleteRangeByScore(idx, 5.0, 4.0, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 0);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+    TEST_ASSERT(api.length(idx) == 10);
 
     /* Delete range with no matches */
-    deleted = orderedIndexDeleteRangeByScore(ops, idx, 10.5, 11.5, 0, 0);
+    deleted = api.deleteRangeByScore(idx, 10.5, 11.5, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 0);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+    TEST_ASSERT(api.length(idx) == 10);
 
     /* Delete first elements by rank */
-    deleted = orderedIndexDeleteRangeByRank(ops, idx, 1, 2);
+    deleted = api.deleteRangeByRank(idx, 1, 2, NULL, NULL);
     TEST_ASSERT(deleted == 2);
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 2.0);
+    api.resetIterator(&iter);
 
     /* Delete last elements by rank */
-    unsigned long len = orderedIndexLength(ops, idx);
-    deleted = orderedIndexDeleteRangeByRank(ops, idx, len - 1, len);
+    unsigned long len = api.length(idx);
+    deleted = api.deleteRangeByRank(idx, len - 1, len, NULL, NULL);
     TEST_ASSERT(deleted == 2);
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 7.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 7.0);
+    api.resetIterator(&iter);
 
     /* Delete entire remaining index by score */
-    deleted = orderedIndexDeleteRangeByScore(ops, idx, -100.0, 100.0, 0, 0);
+    deleted = api.deleteRangeByScore(idx, -100.0, 100.0, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 6);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    TEST_ASSERT(api.length(idx) == 0);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
+TEST_P(OrderedIndexTest, TraversalEdgeCases) {
+    OrderedIndex *idx = api.create();
 
-static void test_traversal_edge_cases_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
-
-    /* Insert single element */
     sds ele = sdsnew("single");
-    orderedIndexInsert(ops, idx, 1.0, ele);
+    api.insertSds(idx, 1.0, ele);
 
-    /* Iterator should get one element then return false */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Same for prev */
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(!api.prev(&iter, &pos));
+    api.resetIterator(&iter);
 
     sdsfree(ele);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_seek_to_rank_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SeekToRank) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 5 elements */
     for (int i = 1; i <= 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
 
-    /* Seek to rank 0 (before first) - next should return rank 1, prev should return NULL */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to rank 0 (before first) */
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    api.resetIterator(&iter);
 
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 0);
-    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 0);
+    TEST_ASSERT(!api.prev(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Seek to rank 1 - next should return rank 2, prev should return rank 1 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to rank 1 */
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 1);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 2.0);
+    api.resetIterator(&iter);
 
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 1);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 1);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    api.resetIterator(&iter);
 
-    /* Seek to rank 3 (middle) - next should return rank 4, prev should return rank 3 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 3);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to rank 3 (middle) */
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 3);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.resetIterator(&iter);
 
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 3);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 3);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 3.0);
+    api.resetIterator(&iter);
 
-    /* Seek to rank 5 (last) - next should return NULL, prev should return rank 5 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 5);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to rank 5 (last) */
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 5);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToRank(ops, &iter, 5);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToRank(&iter, 5);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 5.0);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_reverse_iteration_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, ReverseIteration) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert 5 elements */
     for (int i = 1; i <= 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
@@ -948,45 +904,45 @@ static void test_reverse_iteration_generic(const OrderedIndexOps *ops) {
     OrderedIndexItem *pos;
 
     /* Full reverse traversal */
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     int count = 0;
     double expected = 5.0;
-    while (orderedIndexPrev(ops, &iter, &pos)) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+    while (api.prev(&iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), expected);
         expected -= 1.0;
         count++;
     }
     TEST_ASSERT(count == 5);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Reverse then forward */
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 5.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 5.0);
+    api.resetIterator(&iter);
 
     /* Forward then reverse */
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_seek_to_score_range_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SeekToScoreRange) {
+    OrderedIndex *idx = api.create();
 
     /* Insert elements with scores 0,2,4,6,8 */
     for (int i = 0; i < 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)(i * 2), ele);
+        api.insertSds(idx, (double)(i * 2), ele);
         sdsfree(ele);
     }
 
@@ -994,76 +950,81 @@ static void test_seek_to_score_range_generic(const OrderedIndexOps *ops) {
     OrderedIndexItem *pos;
 
     /* Seek to first in range [2, 6] with offset 0 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, 0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 2.0);
+    api.resetIterator(&iter);
 
     /* Seek to second in range [2, 6] with offset 1 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, 1);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.resetIterator(&iter);
 
-    /* Seek to last in range [2, 6] with offset -1 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 6.0);
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to last in range [2, 6] with offset -1, positioned for prev() */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, -1);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 6.0);
+    api.resetIterator(&iter);
 
     /* Seek with exclusive bounds (2, 6) - should start at 4 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 1, 1, 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 1, 1, 0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.resetIterator(&iter);
 
-    /* Seek to empty range - should position at end */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 10.0, 20.0, 0, 0, 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to empty range above all elements */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 10.0, 20.0, 0, 0, 0);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Out of range positive offset - should position at end */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 10);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    /* Seek to empty range below all elements */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, -20.0, -10.0, 0, 0, 0);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Negative offset beyond range - should position at end */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -10);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    /* Out of range positive offset */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, 10);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Second from last with offset -2 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -2);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    orderedIndexResetIterator(ops, &iter);
+    /* Negative offset beyond range */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, -10);
+    TEST_ASSERT(!api.prev(&iter, &pos));
+    api.resetIterator(&iter);
 
-    /* Empty range where min > max - should position at end */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 6.0, 2.0, 0, 0, 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    /* Second from last with offset -2, positioned for prev() */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 6.0, 0, 0, -2);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    /* Empty range where min > max */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 6.0, 2.0, 0, 0, 0);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
+
+    api.free(idx);
 }
 
-static void test_seek_to_score_range_iteration_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SeekToScoreRangeIteration) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with scores 0-9 */
     for (int i = 0; i < 10; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
@@ -1071,134 +1032,108 @@ static void test_seek_to_score_range_iteration_generic(const OrderedIndexOps *op
     OrderedIndexItem *pos;
 
     /* Seek to range [3, 7] and iterate forward */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 3.0, 7.0, 0, 0, 0);
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 3.0, 7.0, 0, 0, 0);
     int count = 0;
     double expected = 3.0;
-    while (orderedIndexNext(ops, &iter, &pos) && orderedIndexGetScore(ops, pos) <= 7.0) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+    while (api.next(&iter, &pos) && api.getScore(pos) <= 7.0) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), expected);
         expected += 1.0;
         count++;
     }
-    TEST_ASSERT(count == 5); /* 3,4,5,6,7 */
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(count == 5);
+    api.resetIterator(&iter);
 
     /* Seek to last in range and iterate backward */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 3.0, 7.0, 0, 0, -1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 7.0);
-    /* Now go backward */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 3.0, 7.0, 0, 0, -1);
     count = 0;
     expected = 7.0;
-    while (orderedIndexPrev(ops, &iter, &pos) && orderedIndexGetScore(ops, pos) >= 3.0) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
-        expected -= 1.0;
-        count++;
-    }
-    TEST_ASSERT(count == 5); /* 7,6,5,4,3 */
-    orderedIndexResetIterator(ops, &iter);
-
-    /* Seek with offset and continue iteration */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 8.0, 0, 0, 2); /* Start at 4 (3rd element) */
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
-    orderedIndexResetIterator(ops, &iter);
-
-    orderedIndexFree(ops, idx);
-}
-
-/* Test ZREVRANGEBYSCORE +inf behavior: seek to last element and iterate backwards.
- * This is the pattern used by ZREVRANGEBYSCORE -inf +inf to get all elements in reverse. */
-static void test_seek_inf_reverse_iteration_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
-
-    /* Insert elements with scores 1-5 */
-    for (int i = 1; i <= 5; i++) {
-        char buf[32];
-        snprintf(buf, sizeof(buf), "key%d", i);
-        sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
-        sdsfree(ele);
-    }
-
-    OrderedIndexIterator iter;
-    OrderedIndexItem *pos;
-
-    /* Seek to [-inf, +inf] with offset -1 (last element), then iterate backwards.
-     * This is how ZREVRANGEBYSCORE -inf +inf works. */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, NEG_INF, POS_INF, 0, 0, -1);
-    int count = 0;
-    double expected = 5.0;
-    while (orderedIndexNext(ops, &iter, &pos)) {
-        if (count == 0) {
-            TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
-        }
-        count++;
-        break; /* Just verify first element is correct */
-    }
-    /* Now iterate backwards through all elements */
-    count = 0;
-    expected = 5.0;
-    while (orderedIndexPrev(ops, &iter, &pos)) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+    while (api.prev(&iter, &pos) && api.getScore(pos) >= 3.0) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), expected);
         expected -= 1.0;
         count++;
     }
     TEST_ASSERT(count == 5);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    /* Seek with offset and continue iteration */
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, 2.0, 8.0, 0, 0, 2);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 4.0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    TEST_ASSERT_SCORE_EQ(api.getScore(pos), 5.0);
+    api.resetIterator(&iter);
+
+    api.free(idx);
 }
 
-/* Test ZRANGEBYSCORE -inf behavior: seek to first element and iterate forwards.
- * This is the pattern used by ZRANGEBYSCORE -inf +inf to get all elements. */
-static void test_seek_inf_forward_iteration_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SeekInfReverseIteration) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with scores 1-5 */
     for (int i = 1; i <= 5; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "key%d", i);
         sds ele = sdsnew(buf);
-        orderedIndexInsert(ops, idx, (double)i, ele);
+        api.insertSds(idx, (double)i, ele);
         sdsfree(ele);
     }
 
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
 
-    /* Seek to [-inf, +inf] with offset 0 (first element), then iterate forwards.
-     * This is how ZRANGEBYSCORE -inf +inf works. */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToScoreRange(ops, &iter, NEG_INF, POS_INF, 0, 0, 0);
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, NEG_INF, POS_INF, 0, 0, -1);
+    int count = 0;
+    double expected = 5.0;
+    while (api.prev(&iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), expected);
+        expected -= 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5);
+    api.resetIterator(&iter);
+
+    api.free(idx);
+}
+
+TEST_P(OrderedIndexTest, SeekInfForwardIteration) {
+    OrderedIndex *idx = api.create();
+
+    for (int i = 1; i <= 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        api.insertSds(idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    api.initIterator(&iter, idx);
+    api.seekToScoreRange(&iter, NEG_INF, POS_INF, 0, 0, 0);
     int count = 0;
     double expected = 1.0;
-    while (orderedIndexNext(ops, &iter, &pos)) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+    while (api.next(&iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), expected);
         expected += 1.0;
         count++;
     }
     TEST_ASSERT(count == 5);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-/* Test seek_to_lex_range for ZRANGEBYLEX-style operations.
- * Lex range is meaningful when all elements have the same score. */
-static void test_seek_to_lex_range_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, SeekToLexRange) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with same score, different lex values */
     const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
     for (int i = 0; i < 5; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
@@ -1211,273 +1146,262 @@ static void test_seek_to_lex_range_generic(const OrderedIndexOps *ops) {
     sds maxLex = sdsnew("date");
 
     /* Seek to first in lex range [banana, date] with offset 0 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minLex, maxLex, 0, 0, 0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 6 && memcmp(ptr, "banana", 6) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    /* Seek to second in lex range [banana, date] with offset 1 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    /* Seek to second in lex range with offset 1 */
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minLex, maxLex, 0, 0, 1);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
-    /* Seek to last in lex range [banana, date] with offset -1 */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, -1);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    /* Seek to last in lex range with offset -1 */
+    /* Seek to last in lex range with offset -1, positioned for prev() */
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minLex, maxLex, 0, 0, -1);
+    TEST_ASSERT(api.prev(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "date", 4) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Seek with exclusive bounds (banana, date) - should start at cherry */
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 1, 1, 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minLex, maxLex, 1, 1, 0);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     sdsfree(minLex);
     sdsfree(maxLex);
 
-    /* Seek to empty lex range - should position at end */
+    /* Seek to empty lex range */
     sds minEmpty = sdsnew("zzz");
     sds maxEmpty = sdsnew("zzzz");
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minEmpty, maxEmpty, 0, 0, 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minEmpty, maxEmpty, 0, 0, 0);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
     sdsfree(minEmpty);
     sdsfree(maxEmpty);
 
-    /* Out of range positive offset - should position at end */
+    /* Out of range positive offset */
     minLex = sdsnew("banana");
     maxLex = sdsnew("date");
-    orderedIndexInitIterator(ops, &iter, idx);
-    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 10);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    api.initIterator(&iter, idx);
+    api.seekToLexRange(&iter, minLex, maxLex, 0, 0, 10);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
     sdsfree(minLex);
     sdsfree(maxLex);
 
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-/* ========== delete_range_by_lex tests ========== */
+TEST_P(OrderedIndexTest, DeleteRangeByLexInclusive) {
+    OrderedIndex *idx = api.create();
 
-static void test_delete_range_by_lex_inclusive_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
-
-    /* Insert elements with same score (lex range is meaningful when scores are equal) */
     const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
     for (int i = 0; i < 5; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
-    /* Delete inclusive range [banana, date] — should remove banana, cherry, date */
     sds min = sdsnew("banana");
     sds max = sdsnew("date");
-    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 3);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    TEST_ASSERT(api.length(idx) == 2);
 
-    /* Verify remaining: apple, elderberry */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     const char *ptr;
     size_t len;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 10 && memcmp(ptr, "elderberry", 10) == 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_range_by_lex_exclusive_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DeleteRangeByLexExclusive) {
+    OrderedIndex *idx = api.create();
 
     const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
     for (int i = 0; i < 5; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
-    /* Delete exclusive range (banana, date) — should remove only cherry */
     sds min = sdsnew("banana");
     sds max = sdsnew("date");
-    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 1, 1);
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 1, 1, NULL, NULL);
     TEST_ASSERT(deleted == 1);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+    TEST_ASSERT(api.length(idx) == 4);
 
-    /* Verify remaining: apple, banana, date, elderberry */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     const char *ptr;
     size_t len;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 6 && memcmp(ptr, "banana", 6) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 4 && memcmp(ptr, "date", 4) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 10 && memcmp(ptr, "elderberry", 10) == 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_range_by_lex_boundary_cases_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, DeleteRangeByLexBoundaryCases) {
     /* Empty range: min > max lexicographically */
-    OrderedIndex *idx = orderedIndexCreate(ops);
+    OrderedIndex *idx = api.create();
     const char *elements[] = {"apple", "banana", "cherry"};
     for (int i = 0; i < 3; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
     sds min = sdsnew("zzz");
     sds max = sdsnew("aaa");
-    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 0);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+    TEST_ASSERT(api.length(idx) == 3);
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 
-    /* Delete all elements: range covers everything */
-    idx = orderedIndexCreate(ops);
+    /* Delete all elements */
+    idx = api.create();
     for (int i = 0; i < 3; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
     min = sdsnew("a");
     max = sdsnew("z");
-    deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 3);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    TEST_ASSERT(api.length(idx) == 0);
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 
-    /* Delete single element: range matches exactly one */
-    idx = orderedIndexCreate(ops);
+    /* Delete single element */
+    idx = api.create();
     for (int i = 0; i < 3; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
     min = sdsnew("banana");
     max = sdsnew("banana");
-    deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 1);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    TEST_ASSERT(api.length(idx) == 2);
 
-    /* Verify remaining: apple, cherry */
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     const char *ptr;
     size_t len;
-    orderedIndexInitIterator(ops, &iter, idx);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    api.initIterator(&iter, idx);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
-    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(api.next(&iter, &pos));
+    api.getElementRaw(pos, &ptr, &len);
     TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-static void test_delete_range_by_lex_preserves_outside_generic(const OrderedIndexOps *ops) {
-    OrderedIndex *idx = orderedIndexCreate(ops);
+TEST_P(OrderedIndexTest, DeleteRangeByLexPreservesOutside) {
+    OrderedIndex *idx = api.create();
 
-    /* Insert elements with same score */
     const char *elements[] = {"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"};
     for (int i = 0; i < 6; i++) {
         sds ele = sdsnew(elements[i]);
-        orderedIndexInsert(ops, idx, 1.0, ele);
+        api.insertSds(idx, 1.0, ele);
         sdsfree(ele);
     }
 
-    /* Delete [charlie, delta] — should preserve alpha, bravo, echo, foxtrot */
     sds min = sdsnew("charlie");
     sds max = sdsnew("delta");
-    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
     TEST_ASSERT(deleted == 2);
-    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+    TEST_ASSERT(api.length(idx) == 4);
 
-    /* Verify all preserved elements are present and in order */
     const char *expected[] = {"alpha", "bravo", "echo", "foxtrot"};
     size_t expected_lens[] = {5, 5, 4, 7};
     OrderedIndexIterator iter;
     OrderedIndexItem *pos;
     const char *ptr;
     size_t len;
-    orderedIndexInitIterator(ops, &iter, idx);
+    api.initIterator(&iter, idx);
     for (int i = 0; i < 4; i++) {
-        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
-        orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+        TEST_ASSERT(api.next(&iter, &pos));
+        api.getElementRaw(pos, &ptr, &len);
         TEST_ASSERT(len == expected_lens[i] && memcmp(ptr, expected[i], len) == 0);
     }
-    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
-    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(!api.next(&iter, &pos));
+    api.resetIterator(&iter);
 
     /* Verify scores are preserved */
-    orderedIndexInitIterator(ops, &iter, idx);
-    while (orderedIndexNext(ops, &iter, &pos)) {
-        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    api.initIterator(&iter, idx);
+    while (api.next(&iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(api.getScore(pos), 1.0);
     }
-    orderedIndexResetIterator(ops, &iter);
+    api.resetIterator(&iter);
 
     /* Verify ranks are correct after deletion */
     for (unsigned long r = 1; r <= 4; r++) {
-        OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, r);
+        OrderedIndexItem *node = api.getByRank(idx, r);
         TEST_ASSERT(node != NULL);
-        unsigned long rank = orderedIndexGetRank(ops, idx, node);
+        unsigned long rank = api.getRank(idx, node);
         TEST_ASSERT(rank == r);
     }
 
     sdsfree(min);
     sdsfree(max);
-    orderedIndexFree(ops, idx);
+    api.free(idx);
 }
 
-/* ========== Randomized property tests (generic) ========== */
+/* ========== Randomized property tests ========== */
 
-/* Helpers for randomized tests */
 struct RandomIndexEntry {
     OrderedIndexItem *node;
     double score;
@@ -1498,238 +1422,230 @@ static double test_random_score(std::mt19937 &rng) {
     return dist(rng);
 }
 
-static std::vector<RandomIndexEntry> test_build_random_index(const OrderedIndexOps *ops, OrderedIndex *idx,
+static std::vector<RandomIndexEntry> test_build_random_index(OrderedIndexTestApi &api, OrderedIndex *idx,
                                                               std::mt19937 &rng, int count) {
     std::vector<RandomIndexEntry> entries;
     for (int i = 0; i < count; i++) {
         double score = test_random_score(rng);
         std::string elem = test_random_element(rng) + std::to_string(i);
         sds ele = sdsnew(elem.c_str());
-        OrderedIndexItem *node = orderedIndexInsert(ops, idx, score, ele);
+        OrderedIndexItem *node = api.insertSds(idx, score, ele);
         entries.push_back({node, score, elem});
         sdsfree(ele);
     }
     return entries;
 }
 
-/* Property: Insert N random elements, then verify length and forward traversal order. */
-static void test_randomized_insert_and_traversal_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedInsertAndTraversal) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(1, 50);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)n);
+        ASSERT_EQ(api.length(idx), (unsigned long)n);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         int count = 0;
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            double s = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            double s = api.getScore(pos);
             ASSERT_GE(s, prevScore);
             prevScore = s;
             count++;
         }
         ASSERT_EQ(count, n);
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: Backward traversal visits elements in non-increasing score order. */
-static void test_randomized_backward_traversal_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedBackwardTraversal) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(1, 50);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         int count = 0;
         double prevScore = INFINITY;
-        while (orderedIndexPrev(ops, &iter, &pos)) {
-            double s = orderedIndexGetScore(ops, pos);
+        while (api.prev(&iter, &pos)) {
+            double s = api.getScore(pos);
             ASSERT_LE(s, prevScore);
             prevScore = s;
             count++;
         }
         ASSERT_EQ(count, n);
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: get_score returns the exact same double value that was inserted. */
-static void test_randomized_score_retrieval_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedScoreRetrieval) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(1, 50);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        auto entries = test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        auto entries = test_build_random_index(api, idx, rng, n);
 
         for (auto &e : entries) {
-            ASSERT_EQ(orderedIndexGetScore(ops, e.node), e.score);
+            ASSERT_EQ(api.getScore(e.node), e.score);
         }
-        orderedIndexFree(ops, idx);
+        api.free(idx);
     }
 }
 
-/* Property: get_rank returns correct 1-based rank consistent with traversal order. */
-static void test_randomized_rank_consistency_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedRankConsistency) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(1, 50);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         unsigned long expectedRank = 1;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            unsigned long rank = orderedIndexGetRank(ops, idx, pos);
+        while (api.next(&iter, &pos)) {
+            unsigned long rank = api.getRank(idx, pos);
             ASSERT_EQ(rank, expectedRank);
-            OrderedIndexItem *byRank = orderedIndexGetByRank(ops, idx, expectedRank);
+            OrderedIndexItem *byRank = api.getByRank(idx, expectedRank);
             ASSERT_EQ(byRank, pos);
             expectedRank++;
         }
         ASSERT_EQ(expectedRank - 1, (unsigned long)n);
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: Delete a random element, length decreases, remaining in order. */
-static void test_randomized_delete_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedDelete) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(2, 30);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        auto entries = test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        auto entries = test_build_random_index(api, idx, rng, n);
 
         std::uniform_int_distribution<int> pickDist(0, n - 1);
         int delIdx = pickDist(rng);
-        orderedIndexDelete(ops, idx, entries[delIdx].node);
+        api.deleteItem(idx, entries[delIdx].node);
 
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 1));
+        ASSERT_EQ(api.length(idx), (unsigned long)(n - 1));
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         int count = 0;
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
-            prevScore = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            ASSERT_GE(api.getScore(pos), prevScore);
+            prevScore = api.getScore(pos);
             count++;
         }
         ASSERT_EQ(count, n - 1);
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: update_score moves element to correct position, preserves exact score. */
-static void test_randomized_update_score_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedUpdateScore) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(2, 30);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        auto entries = test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        auto entries = test_build_random_index(api, idx, rng, n);
 
         std::uniform_int_distribution<int> pickDist(0, n - 1);
         int updIdx = pickDist(rng);
         double newScore = test_random_score(rng);
 
-        OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, entries[updIdx].node, newScore);
+        OrderedIndexItem *updated = api.updateScore(idx, entries[updIdx].node, newScore);
         ASSERT_NE(updated, nullptr);
-        ASSERT_EQ(orderedIndexGetScore(ops, updated), newScore);
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)n);
+        ASSERT_EQ(api.getScore(updated), newScore);
+        ASSERT_EQ(api.length(idx), (unsigned long)n);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
-            prevScore = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            ASSERT_GE(api.getScore(pos), prevScore);
+            prevScore = api.getScore(pos);
         }
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: pop_first/pop_last remove min/max elements correctly. */
-static void test_randomized_pop_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedPop) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 10; trial++) {
         std::uniform_int_distribution<int> sizeDist(3, 30);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
-        ASSERT_TRUE(orderedIndexNext(ops, &iter, &pos));
-        double minScore = orderedIndexGetScore(ops, pos);
-        orderedIndexResetIterator(ops, &iter);
+        api.initIterator(&iter, idx);
+        ASSERT_TRUE(api.next(&iter, &pos));
+        double minScore = api.getScore(pos);
+        api.resetIterator(&iter);
 
-        orderedIndexInitIterator(ops, &iter, idx);
-        ASSERT_TRUE(orderedIndexPrev(ops, &iter, &pos));
-        double maxScore = orderedIndexGetScore(ops, pos);
-        orderedIndexResetIterator(ops, &iter);
+        api.initIterator(&iter, idx);
+        ASSERT_TRUE(api.prev(&iter, &pos));
+        double maxScore = api.getScore(pos);
+        api.resetIterator(&iter);
 
-        OrderedIndexItem *first = orderedIndexPopFirst(ops, idx);
+        OrderedIndexItem *first = api.popFirst(idx);
         ASSERT_NE(first, nullptr);
-        ASSERT_EQ(orderedIndexGetScore(ops, first), minScore);
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 1));
-        orderedIndexFreeItem(ops, first);
+        ASSERT_EQ(api.getScore(first), minScore);
+        ASSERT_EQ(api.length(idx), (unsigned long)(n - 1));
+        api.freeItem(first);
 
-        OrderedIndexItem *last = orderedIndexPopLast(ops, idx);
+        OrderedIndexItem *last = api.popLast(idx);
         ASSERT_NE(last, nullptr);
-        ASSERT_EQ(orderedIndexGetScore(ops, last), maxScore);
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 2));
-        orderedIndexFreeItem(ops, last);
+        ASSERT_EQ(api.getScore(last), maxScore);
+        ASSERT_EQ(api.length(idx), (unsigned long)(n - 2));
+        api.freeItem(last);
 
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
-            prevScore = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            ASSERT_GE(api.getScore(pos), prevScore);
+            prevScore = api.getScore(pos);
         }
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: delete_range_by_score removes exactly the right elements. */
-static void test_randomized_delete_range_by_score_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedDeleteRangeByScore) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(5, 40);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        auto entries = test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        auto entries = test_build_random_index(api, idx, rng, n);
 
         double s1 = test_random_score(rng), s2 = test_random_score(rng);
         double lo = (std::min)(s1, s2), hi = (std::max)(s1, s2);
@@ -1739,34 +1655,33 @@ static void test_randomized_delete_range_by_score_generic(const OrderedIndexOps 
             if (e.score >= lo && e.score <= hi) expectedDeleted++;
         }
 
-        unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, lo, hi, 0, 0);
+        unsigned long deleted = api.deleteRangeByScore(idx, lo, hi, 0, 0, NULL, NULL);
         ASSERT_EQ(deleted, (unsigned long)expectedDeleted);
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - expectedDeleted));
+        ASSERT_EQ(api.length(idx), (unsigned long)(n - expectedDeleted));
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            double s = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            double s = api.getScore(pos);
             ASSERT_TRUE(s < lo || s > hi);
             ASSERT_GE(s, prevScore);
             prevScore = s;
         }
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: delete_range_by_rank removes exactly the right rank positions. */
-static void test_randomized_delete_range_by_rank_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedDeleteRangeByRank) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(5, 40);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
         std::uniform_int_distribution<int> rankDist(1, n);
         int r1 = rankDist(rng), r2 = rankDist(rng);
@@ -1774,225 +1689,615 @@ static void test_randomized_delete_range_by_rank_generic(const OrderedIndexOps *
         unsigned long end = (unsigned long)(std::max)(r1, r2);
         unsigned long expectedDeleted = end - start + 1;
 
-        unsigned long deleted = orderedIndexDeleteRangeByRank(ops, idx, start, end);
+        unsigned long deleted = api.deleteRangeByRank(idx, start, end, NULL, NULL);
         ASSERT_EQ(deleted, expectedDeleted);
-        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n) - expectedDeleted);
+        ASSERT_EQ(api.length(idx), (unsigned long)(n) - expectedDeleted);
 
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
+        api.initIterator(&iter, idx);
         int remaining = 0;
         double prevScore = -INFINITY;
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
-            prevScore = orderedIndexGetScore(ops, pos);
+        while (api.next(&iter, &pos)) {
+            ASSERT_GE(api.getScore(pos), prevScore);
+            prevScore = api.getScore(pos);
             remaining++;
         }
         ASSERT_EQ(remaining, n - (int)expectedDeleted);
-        orderedIndexResetIterator(ops, &iter);
-        orderedIndexFree(ops, idx);
+        api.resetIterator(&iter);
+        api.free(idx);
     }
 }
 
-/* Property: Forward and backward traversal produce mirror-image sequences. */
-static void test_randomized_forward_backward_mirror_generic(const OrderedIndexOps *ops) {
+TEST_P(OrderedIndexTest, RandomizedForwardBackwardMirror) {
     std::mt19937 rng(42);
     for (int trial = 0; trial < 20; trial++) {
         std::uniform_int_distribution<int> sizeDist(1, 50);
         int n = sizeDist(rng);
 
-        OrderedIndex *idx = orderedIndexCreate(ops);
-        test_build_random_index(ops, idx, rng, n);
+        OrderedIndex *idx = api.create();
+        test_build_random_index(api, idx, rng, n);
 
         std::vector<double> forwardScores;
         OrderedIndexIterator iter;
         OrderedIndexItem *pos;
-        orderedIndexInitIterator(ops, &iter, idx);
-        while (orderedIndexNext(ops, &iter, &pos)) {
-            forwardScores.push_back(orderedIndexGetScore(ops, pos));
+        api.initIterator(&iter, idx);
+        while (api.next(&iter, &pos)) {
+            forwardScores.push_back(api.getScore(pos));
         }
-        orderedIndexResetIterator(ops, &iter);
+        api.resetIterator(&iter);
 
         std::vector<double> backwardScores;
-        orderedIndexInitIterator(ops, &iter, idx);
-        while (orderedIndexPrev(ops, &iter, &pos)) {
-            backwardScores.push_back(orderedIndexGetScore(ops, pos));
+        api.initIterator(&iter, idx);
+        while (api.prev(&iter, &pos)) {
+            backwardScores.push_back(api.getScore(pos));
         }
-        orderedIndexResetIterator(ops, &iter);
+        api.resetIterator(&iter);
 
         ASSERT_EQ(forwardScores.size(), backwardScores.size());
         std::reverse(backwardScores.begin(), backwardScores.end());
         for (size_t i = 0; i < forwardScores.size(); i++) {
             ASSERT_EQ(forwardScores[i], backwardScores[i]);
         }
-        orderedIndexFree(ops, idx);
+        api.free(idx);
     }
 }
 
-/* Verify all vtable function pointers are non-null. */
-static void test_vtable_fully_populated_generic(const OrderedIndexOps *ops) {
-    ASSERT_NE(ops->create, nullptr);
-    ASSERT_NE(ops->free, nullptr);
-    ASSERT_NE(ops->insert, nullptr);
-    ASSERT_NE(ops->delete_item, nullptr);
-    ASSERT_NE(ops->update_score, nullptr);
-    ASSERT_NE(ops->pop_first, nullptr);
-    ASSERT_NE(ops->pop_last, nullptr);
-    ASSERT_NE(ops->free_item, nullptr);
-    ASSERT_NE(ops->delete_range_by_score, nullptr);
-    ASSERT_NE(ops->delete_range_by_rank, nullptr);
-    ASSERT_NE(ops->length, nullptr);
-    ASSERT_NE(ops->get_by_rank, nullptr);
-    ASSERT_NE(ops->get_rank, nullptr);
-    ASSERT_NE(ops->get_element_raw, nullptr);
-    ASSERT_NE(ops->get_score, nullptr);
-    ASSERT_NE(ops->init_iterator, nullptr);
-    ASSERT_NE(ops->reset_iterator, nullptr);
-    ASSERT_NE(ops->next, nullptr);
-    ASSERT_NE(ops->prev, nullptr);
-    ASSERT_NE(ops->seek_to_rank, nullptr);
-    ASSERT_NE(ops->seek_to_score_range, nullptr);
-    ASSERT_NE(ops->seek_to_lex_range, nullptr);
+/* ========== Instantiate parameterized tests for all implementations ========== */
+
+INSTANTIATE_TEST_SUITE_P(AllImplementations,
+                         OrderedIndexTest,
+                         ::testing::Values(&skiplistImpl),
+                         orderedIndexTestName);
+
+/* ========== On-Delete Callback Tests ========== */
+
+struct OnDeleteRecord {
+    int count;
+    std::vector<std::string> elements;
+};
+
+static void testOnDeleteCallback(OrderedIndexItem *item, void *ctx) {
+    OnDeleteRecord *rec = (OnDeleteRecord *)ctx;
+    rec->count++;
+    const char *ptr;
+    size_t len;
+    skiplistGetElementRaw(item, &ptr, &len);
+    rec->elements.emplace_back(ptr, len);
 }
 
-/* ========== Skiplist Tests ========== */
+class OnDeleteCallbackTest : public ::testing::Test {
+protected:
+    SkiplistOrderedIndex api;
 
-class SkiplistOrderedIndexTest : public ::testing::Test {};
+    void insertN(OrderedIndex *idx, int n) {
+        for (int i = 0; i < n; i++) {
+            std::string name = "key" + std::to_string(i);
+            sds ele = sdsnew(name.c_str());
+            api.insertSds(idx, (double)i, ele);
+            sdsfree(ele);
+        }
+    }
 
-TEST_F(SkiplistOrderedIndexTest, CreateFree) {
-    test_create_free_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, InsertSingle) {
-    test_insert_single_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, InsertMultipleOrdered) {
-    test_insert_multiple_ordered_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DuplicateScores) {
-    test_duplicate_scores_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RankOperations) {
-    test_rank_operations_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, Delete) {
-    test_delete_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, PopFirst) {
-    test_pop_first_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, PopLast) {
-    test_pop_last_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, UpdateScore) {
-    test_update_score_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByScore) {
-    test_delete_range_by_score_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByRank) {
-    test_delete_range_by_rank_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, EdgeCases) {
-    test_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteEdgeCases) {
-    test_delete_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RankEdgeCases) {
-    test_rank_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DuplicateInsert) {
-    test_duplicate_insert_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, UpdateScoreEdgeCases) {
-    test_update_score_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RangeDeleteEdgeCases) {
-    test_range_delete_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, TraversalEdgeCases) {
-    test_traversal_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, MixedOperationsRankIntegrity) {
-    test_mixed_operations_rank_integrity_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, BackwardTraversalAfterDeletions) {
-    test_backward_traversal_after_deletions_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, LexicographicEdgeCases) {
-    test_lexicographic_edge_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RangeBoundaryPrecision) {
-    test_range_boundary_precision_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SpecialDoubleValues) {
-    test_special_double_values_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekToRank) {
-    test_seek_to_rank_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, ReverseIteration) {
-    test_reverse_iteration_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekToScoreRange) {
-    test_seek_to_score_range_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekToScoreRangeIteration) {
-    test_seek_to_score_range_iteration_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekInfReverseIteration) {
-    test_seek_inf_reverse_iteration_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekInfForwardIteration) {
-    test_seek_inf_forward_iteration_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, SeekToLexRange) {
-    test_seek_to_lex_range_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexInclusive) {
-    test_delete_range_by_lex_inclusive_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexExclusive) {
-    test_delete_range_by_lex_exclusive_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexBoundaryCases) {
-    test_delete_range_by_lex_boundary_cases_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexPreservesOutside) {
-    test_delete_range_by_lex_preserves_outside_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedInsertAndTraversal) {
-    test_randomized_insert_and_traversal_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedBackwardTraversal) {
-    test_randomized_backward_traversal_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedScoreRetrieval) {
-    test_randomized_score_retrieval_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedRankConsistency) {
-    test_randomized_rank_consistency_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedDelete) {
-    test_randomized_delete_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedUpdateScore) {
-    test_randomized_update_score_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedPop) {
-    test_randomized_pop_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedDeleteRangeByScore) {
-    test_randomized_delete_range_by_score_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedDeleteRangeByRank) {
-    test_randomized_delete_range_by_rank_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, RandomizedForwardBackwardMirror) {
-    test_randomized_forward_backward_mirror_generic(&skiplistOrderedIndexOps);
-}
-TEST_F(SkiplistOrderedIndexTest, VtableFullyPopulated) {
-    test_vtable_fully_populated_generic(&skiplistOrderedIndexOps);
+    void insertLex(OrderedIndex *idx, const std::vector<std::string> &elems, double score = 1.0) {
+        for (auto &e : elems) {
+            sds ele = sdsnew(e.c_str());
+            api.insertSds(idx, score, ele);
+            sdsfree(ele);
+        }
+    }
+
+    std::vector<std::string> collectElements(OrderedIndex *idx) {
+        std::vector<std::string> result;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        api.initIterator(&iter, idx);
+        while (api.next(&iter, &pos)) {
+            const char *ptr;
+            size_t len;
+            api.getElementRaw(pos, &ptr, &len);
+            result.emplace_back(ptr, len);
+        }
+        api.resetIterator(&iter);
+        return result;
+    }
+};
+
+/* DeleteRangeByScore */
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_EmptyAndNoMatch) {
+    OnDeleteRecord rec = {0, {}};
+
+    OrderedIndex *idx = api.create();
+    unsigned long deleted = api.deleteRangeByScore(idx, 0.0, 10.0, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    api.free(idx);
+
+    idx = api.create();
+    insertN(idx, 5);
+    rec = {0, {}};
+    deleted = api.deleteRangeByScore(idx, 10.0, 20.0, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    ASSERT_EQ(api.length(idx), 5UL);
+    api.free(idx);
 }
 
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_Subset) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 10);
 
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByScore(idx, 3.0, 6.0, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 4UL);
+    ASSERT_EQ(rec.count, 4);
+    ASSERT_EQ(api.length(idx), 6UL);
+
+    std::sort(rec.elements.begin(), rec.elements.end());
+    ASSERT_EQ(rec.elements, (std::vector<std::string>{"key3", "key4", "key5", "key6"}));
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"key0", "key1", "key2", "key7", "key8", "key9"}));
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_All) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByScore(idx, NEG_INF, POS_INF, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 5UL);
+    ASSERT_EQ(rec.count, 5);
+    ASSERT_EQ(api.length(idx), 0UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_NullCallback) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    unsigned long deleted = api.deleteRangeByScore(idx, 1.0, 3.0, 0, 0, NULL, NULL);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(api.length(idx), 2UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_ExclusiveBounds) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 10);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByScore(idx, 3.0, 7.0, 1, 1, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(rec.count, 3);
+    std::sort(rec.elements.begin(), rec.elements.end());
+    ASSERT_EQ(rec.elements, (std::vector<std::string>{"key4", "key5", "key6"}));
+    ASSERT_EQ(api.length(idx), 7UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByScore_SingleElement) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByScore(idx, 2.0, 2.0, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 1UL);
+    ASSERT_EQ(rec.count, 1);
+    ASSERT_EQ(rec.elements[0], "key2");
+    ASSERT_EQ(api.length(idx), 4UL);
+    api.free(idx);
+}
+
+/* DeleteRangeByRank */
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_EmptyAndNoMatch) {
+    OnDeleteRecord rec = {0, {}};
+
+    OrderedIndex *idx = api.create();
+    unsigned long deleted = api.deleteRangeByRank(idx, 1, 5, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    api.free(idx);
+
+    idx = api.create();
+    insertN(idx, 3);
+    rec = {0, {}};
+    deleted = api.deleteRangeByRank(idx, 10, 20, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    ASSERT_EQ(api.length(idx), 3UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_Subset) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 10);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByRank(idx, 3, 5, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(rec.count, 3);
+    ASSERT_EQ(api.length(idx), 7UL);
+
+    std::sort(rec.elements.begin(), rec.elements.end());
+    ASSERT_EQ(rec.elements, (std::vector<std::string>{"key2", "key3", "key4"}));
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"key0", "key1", "key5", "key6", "key7", "key8", "key9"}));
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_All) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByRank(idx, 1, 5, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 5UL);
+    ASSERT_EQ(rec.count, 5);
+    ASSERT_EQ(api.length(idx), 0UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_NullCallback) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    unsigned long deleted = api.deleteRangeByRank(idx, 2, 4, NULL, NULL);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(api.length(idx), 2UL);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_ExclusiveBounds) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByRank(idx, 3, 3, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 1UL);
+    ASSERT_EQ(rec.count, 1);
+    ASSERT_EQ(rec.elements[0], "key2");
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"key0", "key1", "key3", "key4"}));
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByRank_SingleElement) {
+    OrderedIndex *idx = api.create();
+    insertN(idx, 5);
+
+    OnDeleteRecord rec = {0, {}};
+    unsigned long deleted = api.deleteRangeByRank(idx, 1, 1, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 1UL);
+    ASSERT_EQ(rec.count, 1);
+    ASSERT_EQ(rec.elements[0], "key0");
+    ASSERT_EQ(api.length(idx), 4UL);
+    api.free(idx);
+}
+
+/* DeleteRangeByLex */
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_EmptyAndNoMatch) {
+    OnDeleteRecord rec = {0, {}};
+
+    OrderedIndex *idx = api.create();
+    sds min = sdsnew("a");
+    sds max = sdsnew("z");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+
+    idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry"});
+    rec = {0, {}};
+    min = sdsnew("x");
+    max = sdsnew("z");
+    deleted = api.deleteRangeByLex(idx, min, max, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 0UL);
+    ASSERT_EQ(rec.count, 0);
+    ASSERT_EQ(api.length(idx), 3UL);
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_Subset) {
+    OrderedIndex *idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry", "date", "elderberry"});
+
+    OnDeleteRecord rec = {0, {}};
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(rec.count, 3);
+    ASSERT_EQ(api.length(idx), 2UL);
+
+    std::sort(rec.elements.begin(), rec.elements.end());
+    ASSERT_EQ(rec.elements, (std::vector<std::string>{"banana", "cherry", "date"}));
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"apple", "elderberry"}));
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_All) {
+    OrderedIndex *idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry"});
+
+    OnDeleteRecord rec = {0, {}};
+    sds min = sdsnew("a");
+    sds max = sdsnew("z");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 3UL);
+    ASSERT_EQ(rec.count, 3);
+    ASSERT_EQ(api.length(idx), 0UL);
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_NullCallback) {
+    OrderedIndex *idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry", "date"});
+
+    sds min = sdsnew("banana");
+    sds max = sdsnew("cherry");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, NULL, NULL);
+    ASSERT_EQ(deleted, 2UL);
+    ASSERT_EQ(api.length(idx), 2UL);
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"apple", "date"}));
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_ExclusiveBounds) {
+    OrderedIndex *idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry", "date", "elderberry"});
+
+    OnDeleteRecord rec = {0, {}};
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 1, 1, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 1UL);
+    ASSERT_EQ(rec.count, 1);
+    ASSERT_EQ(rec.elements[0], "cherry");
+    ASSERT_EQ(api.length(idx), 4UL);
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"apple", "banana", "date", "elderberry"}));
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(OnDeleteCallbackTest, DeleteRangeByLex_SingleElement) {
+    OrderedIndex *idx = api.create();
+    insertLex(idx, {"apple", "banana", "cherry"});
+
+    OnDeleteRecord rec = {0, {}};
+    sds min = sdsnew("banana");
+    sds max = sdsnew("banana");
+    unsigned long deleted = api.deleteRangeByLex(idx, min, max, 0, 0, testOnDeleteCallback, &rec);
+    ASSERT_EQ(deleted, 1UL);
+    ASSERT_EQ(rec.count, 1);
+    ASSERT_EQ(rec.elements[0], "banana");
+    ASSERT_EQ(api.length(idx), 2UL);
+
+    auto remaining = collectElements(idx);
+    ASSERT_EQ(remaining, (std::vector<std::string>{"apple", "cherry"}));
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+/* ========== Range-Delete Hashtable Consistency Tests ========== */
+
+static void hashtableConsistencyOnDelete(OrderedIndexItem *item, void *ctx) {
+    std::set<std::string> *ht = (std::set<std::string> *)ctx;
+    const char *ptr;
+    size_t len;
+    skiplistGetElementRaw(item, &ptr, &len);
+    ht->erase(std::string(ptr, len));
+}
+
+class RangeDeleteHashtableConsistencyTest : public ::testing::Test {
+protected:
+    SkiplistOrderedIndex api;
+
+    void insertN(OrderedIndex *idx, std::set<std::string> &ht, int n) {
+        for (int i = 0; i < n; i++) {
+            std::string name = "key" + std::to_string(i);
+            sds ele = sdsnew(name.c_str());
+            api.insertSds(idx, (double)i, ele);
+            ht.insert(name);
+            sdsfree(ele);
+        }
+    }
+
+    void insertLex(OrderedIndex *idx, std::set<std::string> &ht, const std::vector<std::string> &elems, double score = 1.0) {
+        for (auto &e : elems) {
+            sds ele = sdsnew(e.c_str());
+            api.insertSds(idx, score, ele);
+            ht.insert(e);
+            sdsfree(ele);
+        }
+    }
+
+    std::set<std::string> collectIndexElements(OrderedIndex *idx) {
+        std::set<std::string> result;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        api.initIterator(&iter, idx);
+        while (api.next(&iter, &pos)) {
+            const char *ptr;
+            size_t len;
+            api.getElementRaw(pos, &ptr, &len);
+            result.insert(std::string(ptr, len));
+        }
+        api.resetIterator(&iter);
+        return result;
+    }
+};
+
+/* ByScore */
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByScore_PartialDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByScore(idx, 3.0, 6.0, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 6UL);
+
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByScore_FullDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByScore(idx, NEG_INF, POS_INF, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_TRUE(indexElements.empty());
+
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByScore_EmptyRange) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByScore(idx, 20.0, 30.0, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 10UL);
+
+    api.free(idx);
+}
+
+/* ByRank */
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByRank_PartialDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByRank(idx, 3, 5, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 7UL);
+
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByRank_FullDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByRank(idx, 1, 10, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_TRUE(indexElements.empty());
+
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByRank_EmptyRange) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertN(idx, simulatedHt, 10);
+
+    api.deleteRangeByRank(idx, 20, 30, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 10UL);
+
+    api.free(idx);
+}
+
+/* ByLex */
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByLex_PartialDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertLex(idx, simulatedHt, {"apple", "banana", "cherry", "date", "elderberry"});
+
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    api.deleteRangeByLex(idx, min, max, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 2UL);
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByLex_FullDelete) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertLex(idx, simulatedHt, {"apple", "banana", "cherry", "date", "elderberry"});
+
+    sds min = sdsnew("a");
+    sds max = sdsnew("z");
+    api.deleteRangeByLex(idx, min, max, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_TRUE(indexElements.empty());
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}
+
+TEST_F(RangeDeleteHashtableConsistencyTest, ByLex_EmptyRange) {
+    OrderedIndex *idx = api.create();
+    std::set<std::string> simulatedHt;
+    insertLex(idx, simulatedHt, {"apple", "banana", "cherry", "date", "elderberry"});
+
+    sds min = sdsnew("zzz");
+    sds max = sdsnew("zzzz");
+    api.deleteRangeByLex(idx, min, max, 0, 0, hashtableConsistencyOnDelete, &simulatedHt);
+
+    std::set<std::string> indexElements = collectIndexElements(idx);
+    ASSERT_EQ(indexElements, simulatedHt);
+    ASSERT_EQ(indexElements.size(), 5UL);
+
+    sdsfree(min);
+    sdsfree(max);
+    api.free(idx);
+}

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -1,0 +1,1353 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include "ordered_index.h"
+#include "server.h"
+}
+
+#define TEST_ASSERT(x) ASSERT_TRUE(x)
+#define TEST_ASSERT_SCORE_EQ(a, b) ASSERT_DOUBLE_EQ(a, b)
+
+/* Generic tests that work with any OrderedIndex implementation */
+
+static void test_create_free_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    TEST_ASSERT(idx != NULL);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_insert_single_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    sds ele = sdsnew("test");
+    OrderedIndexItem *node = orderedIndexInsert(ops, idx, 1.0, ele);
+
+    TEST_ASSERT(node != NULL);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 1);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, node), 1.0);
+
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(ops, node, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "test", 4) == 0);
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT(pos == node);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(ele);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_insert_multiple_ordered_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+
+    /* Verify forward traversal */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    for (int i = 0; i < 10; i++) {
+        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+    }
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Verify backward traversal */
+    orderedIndexInitIterator(ops, &iter, idx);
+    for (int i = 9; i >= 0; i--) {
+        TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+    }
+    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_duplicate_scores_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with same score but different keys */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+
+    /* Verify lexicographic ordering for same scores */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    for (int i = 0; i < 5; i++) {
+        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+        const char *ptr;
+        size_t len;
+        orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+        char expected[32];
+        snprintf(expected, sizeof(expected), "key%d", i);
+        TEST_ASSERT(len == strlen(expected) && memcmp(ptr, expected, len) == 0);
+    }
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_rank_operations_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    OrderedIndexItem *nodes[10];
+
+    /* Insert 10 elements */
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Test get_rank */
+    for (int i = 0; i < 10; i++) {
+        unsigned long rank = orderedIndexGetRank(ops, idx, nodes[i]);
+        TEST_ASSERT(rank == (unsigned long)(i + 1)); /* 1-based */
+    }
+
+    /* Test get_by_rank */
+    for (int i = 0; i < 10; i++) {
+        OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, i + 1);
+        TEST_ASSERT(node == nodes[i]);
+    }
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    OrderedIndexItem *nodes[5];
+
+    /* Insert 5 elements */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+
+    /* Delete middle element */
+    orderedIndexDelete(ops, idx, nodes[2]);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+
+    /* Verify remaining elements */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0); /* Skipped 2.0 */
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_pop_first_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Pop from empty - should return NULL */
+    TEST_ASSERT(orderedIndexPopFirst(ops, idx) == NULL);
+
+    /* Insert elements */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+
+    /* Pop first - should get score 0.0 */
+    OrderedIndexItem *item = orderedIndexPopFirst(ops, idx);
+    TEST_ASSERT(item != NULL);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 0.0);
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(ops, item, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "key0", 4) == 0);
+    orderedIndexFreeItem(ops, item);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+
+    /* Pop again - should get score 1.0 */
+    item = orderedIndexPopFirst(ops, idx);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 1.0);
+    orderedIndexFreeItem(ops, item);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_pop_last_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Pop from empty - should return NULL */
+    TEST_ASSERT(orderedIndexPopLast(ops, idx) == NULL);
+
+    /* Insert elements */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+
+    /* Pop last - should get score 4.0 */
+    OrderedIndexItem *item = orderedIndexPopLast(ops, idx);
+    TEST_ASSERT(item != NULL);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 4.0);
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(ops, item, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "key4", 4) == 0);
+    orderedIndexFreeItem(ops, item);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+
+    /* Pop again - should get score 3.0 */
+    item = orderedIndexPopLast(ops, idx);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, item), 3.0);
+    orderedIndexFreeItem(ops, item);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_update_score_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements */
+    sds ele1 = sdsnew("key1");
+    sds ele2 = sdsnew("key2");
+    sds ele3 = sdsnew("key3");
+    OrderedIndexItem *node1 = orderedIndexInsert(ops, idx, 1.0, ele1);
+    OrderedIndexItem *node2 = orderedIndexInsert(ops, idx, 2.0, ele2);
+    orderedIndexInsert(ops, idx, 3.0, ele3);
+    sdsfree(ele1);
+    sdsfree(ele2);
+    sdsfree(ele3);
+
+    /* Update middle element to move it to end */
+    OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, node2, 4.0);
+    TEST_ASSERT(updated != NULL);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 4.0);
+    const char *ptr;
+    size_t len;
+    orderedIndexGetElementRaw(ops, updated, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "key2", 4) == 0);
+
+    /* Verify order: key1(1.0), key3(3.0), key2(4.0) */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "key2", 4) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Update to same score (no-op) */
+    updated = orderedIndexUpdateScore(ops, idx, node1, 1.0);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 1.0);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_range_by_score_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 10 elements with scores 0-9 */
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete range [3, 6] inclusive */
+    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, 3.0, 6.0, 0, 0);
+    TEST_ASSERT(deleted == 4); /* 3, 4, 5, 6 */
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 6);
+
+    /* Verify remaining: 0,1,2,7,8,9 */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+    }
+    for (int i = 7; i < 10; i++) {
+        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)i);
+    }
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Delete with exclusive bounds (2, 8) - should delete 7 */
+    deleted = orderedIndexDeleteRangeByScore(ops, idx, 2.0, 8.0, 1, 1);
+    TEST_ASSERT(deleted == 1);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 5);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_range_by_rank_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 10 elements */
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete ranks 3-5 (1-based, so elements at scores 2,3,4) */
+    unsigned long deleted = orderedIndexDeleteRangeByRank(ops, idx, 3, 5);
+    TEST_ASSERT(deleted == 3);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 7);
+
+    /* Verify first element is still score 0 */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Verify rank 3 is now score 5 (was rank 6) */
+    OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, 3);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, node), 5.0);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_mixed_operations_rank_integrity_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    OrderedIndexItem *nodes[100];
+
+    /* Insert 100 elements */
+    for (int i = 0; i < 100; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete every 3rd element */
+    for (int i = 2; i < 100; i += 3) {
+        orderedIndexDelete(ops, idx, nodes[i]);
+        nodes[i] = NULL;
+    }
+
+    /* Update scores of some remaining elements */
+    if (nodes[10]) nodes[10] = orderedIndexUpdateScore(ops, idx, nodes[10], 150.0);
+    if (nodes[20]) nodes[20] = orderedIndexUpdateScore(ops, idx, nodes[20], 160.0);
+
+    /* Verify all ranks are correct by forward traversal */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    unsigned long expected_rank = 1;
+    while (orderedIndexNext(ops, &iter, &pos)) {
+        unsigned long actual_rank = orderedIndexGetRank(ops, idx, pos);
+        TEST_ASSERT(actual_rank == expected_rank);
+        expected_rank++;
+    }
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_backward_traversal_after_deletions_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    OrderedIndexItem *nodes[20];
+
+    /* Insert 20 elements */
+    for (int i = 0; i < 20; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        nodes[i] = orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete elements at positions 5, 10, 15 */
+    orderedIndexDelete(ops, idx, nodes[5]);
+    orderedIndexDelete(ops, idx, nodes[10]);
+    orderedIndexDelete(ops, idx, nodes[15]);
+
+    /* Traverse backward and verify prev() pointers work correctly */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    int expected_scores[] = {19, 18, 17, 16, 14, 13, 12, 11, 9, 8, 7, 6, 4, 3, 2, 1, 0};
+    int idx_score = 0;
+
+    while (orderedIndexPrev(ops, &iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), (double)expected_scores[idx_score]);
+        idx_score++;
+    }
+    TEST_ASSERT(idx_score == 17); /* Should have traversed all 17 remaining elements */
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_lexicographic_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Test empty string */
+    sds empty = sdsnew("");
+    sds a = sdsnew("a");
+    sds z = sdsnew("z");
+
+    orderedIndexInsert(ops, idx, 1.0, z);
+    orderedIndexInsert(ops, idx, 1.0, empty);
+    orderedIndexInsert(ops, idx, 1.0, a);
+
+    /* Verify lexicographic order: "", "a", "z" */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 1 && memcmp(ptr, "a", 1) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 1 && memcmp(ptr, "z", 1) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(empty);
+    sdsfree(a);
+    sdsfree(z);
+    orderedIndexFree(ops, idx);
+
+    /* Test very long string (1KB) */
+    idx = orderedIndexCreate(ops);
+    char long_buf[1024];
+    memset(long_buf, 'x', 1023);
+    long_buf[1023] = '\0';
+    sds long_str = sdsnew(long_buf);
+    sds short_str = sdsnew("short");
+
+    orderedIndexInsert(ops, idx, 1.0, long_str);
+    orderedIndexInsert(ops, idx, 1.0, short_str);
+
+    /* Verify ordering */
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 5 && memcmp(ptr, "short", 5) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 1023 && memcmp(ptr, long_buf, 1023) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(long_str);
+    sdsfree(short_str);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_range_boundary_precision_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with very close scores */
+    double base = 1.0;
+    double epsilon = 1e-10;
+
+    sds ele1 = sdsnew("at_base");
+    sds ele2 = sdsnew("at_base_plus_epsilon");
+    sds ele3 = sdsnew("at_base_plus_2epsilon");
+
+    orderedIndexInsert(ops, idx, base, ele1);
+    orderedIndexInsert(ops, idx, base + epsilon, ele2);
+    orderedIndexInsert(ops, idx, base + 2 * epsilon, ele3);
+
+    /* Query with exclusive bounds (base, base+2*epsilon) - should only get middle element */
+    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, base, base + 2 * epsilon, 1, 1);
+    TEST_ASSERT(deleted == 1);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+
+    /* Verify remaining elements */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), base);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), base + 2 * epsilon);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(ele1);
+    sdsfree(ele2);
+    sdsfree(ele3);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_special_double_values_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    const char *ptr;
+    size_t len;
+
+    /* Test ±infinity */
+    sds neg_inf = sdsnew("neg_inf");
+    sds pos_inf = sdsnew("pos_inf");
+    sds zero = sdsnew("zero");
+    sds one = sdsnew("one");
+
+    orderedIndexInsert(ops, idx, -INFINITY, neg_inf);
+    orderedIndexInsert(ops, idx, INFINITY, pos_inf);
+    orderedIndexInsert(ops, idx, 0.0, zero);
+    orderedIndexInsert(ops, idx, 1.0, one);
+
+    /* Verify ordering: -inf, 0, 1, +inf */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), -INFINITY);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 0.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), INFINITY);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(neg_inf);
+    sdsfree(pos_inf);
+    sdsfree(zero);
+    sdsfree(one);
+    orderedIndexFree(ops, idx);
+
+    /* Test +0.0 vs -0.0 (should be treated as equal) */
+    idx = orderedIndexCreate(ops);
+    sds pos_zero = sdsnew("pos_zero");
+    sds neg_zero = sdsnew("neg_zero");
+
+    orderedIndexInsert(ops, idx, 0.0, pos_zero);
+    orderedIndexInsert(ops, idx, -0.0, neg_zero);
+
+    /* Both should be in the list, ordered lexicographically since scores are equal */
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 8 && memcmp(ptr, "neg_zero", 8) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 8 && memcmp(ptr, "pos_zero", 8) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(pos_zero);
+    sdsfree(neg_zero);
+    orderedIndexFree(ops, idx);
+
+    /* Test denormalized double (very small number near zero) */
+    idx = orderedIndexCreate(ops);
+    double denorm = 1e-320; /* Denormalized double */
+    sds denorm_ele = sdsnew("denorm");
+    sds normal_ele = sdsnew("normal");
+
+    orderedIndexInsert(ops, idx, denorm, denorm_ele);
+    orderedIndexInsert(ops, idx, 1.0, normal_ele);
+
+    /* Verify denormalized value is handled correctly */
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), denorm);
+    TEST_ASSERT(orderedIndexGetScore(ops, pos) < 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(denorm_ele);
+    sdsfree(normal_ele);
+    orderedIndexFree(ops, idx);
+}
+
+
+static void test_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Empty index operations */
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 1) == NULL);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Delete only element */
+    sds ele = sdsnew("only");
+    OrderedIndexItem *node = orderedIndexInsert(ops, idx, 1.0, ele);
+    orderedIndexDelete(ops, idx, node);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+    sdsfree(ele);
+
+    /* Delete first element */
+    OrderedIndexItem *nodes[3];
+    for (int i = 0; i < 3; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds e = sdsnew(buf);
+        nodes[i] = orderedIndexInsert(ops, idx, (double)i, e);
+        sdsfree(e);
+    }
+    orderedIndexDelete(ops, idx, nodes[0]);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Delete last element */
+    orderedIndexDelete(ops, idx, nodes[2]);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 1);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_rank_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 5 elements */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Rank 0 returns header node (not NULL, not first element - implementation quirk)
+     * We don't test this as it's an implementation detail that shouldn't be relied upon */
+
+    /* Rank beyond length returns NULL */
+    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 6) == NULL);
+    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 100) == NULL);
+
+    /* Valid boundary ranks */
+    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 1) != NULL);
+    TEST_ASSERT(orderedIndexGetByRank(ops, idx, 5) != NULL);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_duplicate_insert_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert same score+element twice */
+    sds ele1 = sdsnew("duplicate");
+    sds ele2 = sdsnew("duplicate");
+    OrderedIndexItem *node1 = orderedIndexInsert(ops, idx, 1.0, ele1);
+    OrderedIndexItem *node2 = orderedIndexInsert(ops, idx, 1.0, ele2);
+
+    /* Should have 2 nodes (duplicates allowed) */
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+    TEST_ASSERT(node1 != node2);
+
+    sdsfree(ele1);
+    sdsfree(ele2);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_update_score_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Update first element to move backward (should stay first) */
+    OrderedIndexItem *first = orderedIndexGetByRank(ops, idx, 1);
+    OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, first, -1.0);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), -1.0);
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT(pos == updated);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Update last element to move forward */
+    unsigned long len = orderedIndexLength(ops, idx);
+    OrderedIndexItem *last = orderedIndexGetByRank(ops, idx, len);
+    updated = orderedIndexUpdateScore(ops, idx, last, 10.0);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 10.0);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT(pos == updated);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Update middle element to move backward */
+    OrderedIndexItem *middle = orderedIndexGetByRank(ops, idx, 3);
+    double old_score = orderedIndexGetScore(ops, middle);
+    updated = orderedIndexUpdateScore(ops, idx, middle, 0.5);
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, updated), 0.5);
+    TEST_ASSERT(orderedIndexGetScore(ops, updated) < old_score);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_range_delete_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 10 elements */
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete empty range (min > max) */
+    unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, 5.0, 4.0, 0, 0);
+    TEST_ASSERT(deleted == 0);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+
+    /* Delete range with no matches */
+    deleted = orderedIndexDeleteRangeByScore(ops, idx, 10.5, 11.5, 0, 0);
+    TEST_ASSERT(deleted == 0);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 10);
+
+    /* Delete first elements by rank */
+    deleted = orderedIndexDeleteRangeByRank(ops, idx, 1, 2);
+    TEST_ASSERT(deleted == 2);
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Delete last elements by rank */
+    unsigned long len = orderedIndexLength(ops, idx);
+    deleted = orderedIndexDeleteRangeByRank(ops, idx, len - 1, len);
+    TEST_ASSERT(deleted == 2);
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 7.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Delete entire remaining index by score */
+    deleted = orderedIndexDeleteRangeByScore(ops, idx, -100.0, 100.0, 0, 0);
+    TEST_ASSERT(deleted == 6);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+
+    orderedIndexFree(ops, idx);
+}
+
+
+static void test_traversal_edge_cases_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert single element */
+    sds ele = sdsnew("single");
+    orderedIndexInsert(ops, idx, 1.0, ele);
+
+    /* Iterator should get one element then return false */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Same for prev */
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(ele);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_seek_to_rank_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 5 elements */
+    for (int i = 1; i <= 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Seek to rank 0 (before first) - next should return rank 1, prev should return NULL */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 0);
+    TEST_ASSERT(!orderedIndexPrev(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to rank 1 - next should return rank 2, prev should return rank 1 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 1);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to rank 3 (middle) - next should return rank 4, prev should return rank 3 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 3);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 3);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 3.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to rank 5 (last) - next should return NULL, prev should return rank 5 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 5);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToRank(ops, &iter, 5);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_reverse_iteration_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert 5 elements */
+    for (int i = 1; i <= 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Full reverse traversal */
+    orderedIndexInitIterator(ops, &iter, idx);
+    int count = 0;
+    double expected = 5.0;
+    while (orderedIndexPrev(ops, &iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+        expected -= 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Reverse then forward */
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Forward then reverse */
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    TEST_ASSERT(orderedIndexPrev(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_seek_to_score_range_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with scores 0,2,4,6,8 */
+    for (int i = 0; i < 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)(i * 2), ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Seek to first in range [2, 6] with offset 0 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 2.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to second in range [2, 6] with offset 1 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to last in range [2, 6] with offset -1 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 6.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek with exclusive bounds (2, 6) - should start at 4 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 1, 1, 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to empty range - should position at end */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 10.0, 20.0, 0, 0, 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Out of range positive offset - should position at end */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, 10);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Negative offset beyond range - should position at end */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -10);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Second from last with offset -2 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 6.0, 0, 0, -2);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Empty range where min > max - should position at end */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 6.0, 2.0, 0, 0, 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+static void test_seek_to_score_range_iteration_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with scores 0-9 */
+    for (int i = 0; i < 10; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Seek to range [3, 7] and iterate forward */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 3.0, 7.0, 0, 0, 0);
+    int count = 0;
+    double expected = 3.0;
+    while (orderedIndexNext(ops, &iter, &pos) && orderedIndexGetScore(ops, pos) <= 7.0) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+        expected += 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5); /* 3,4,5,6,7 */
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to last in range and iterate backward */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 3.0, 7.0, 0, 0, -1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 7.0);
+    /* Now go backward */
+    count = 0;
+    expected = 7.0;
+    while (orderedIndexPrev(ops, &iter, &pos) && orderedIndexGetScore(ops, pos) >= 3.0) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+        expected -= 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5); /* 7,6,5,4,3 */
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek with offset and continue iteration */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, 2.0, 8.0, 0, 0, 2); /* Start at 4 (3rd element) */
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 4.0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+/* Test ZREVRANGEBYSCORE +inf behavior: seek to last element and iterate backwards.
+ * This is the pattern used by ZREVRANGEBYSCORE -inf +inf to get all elements in reverse. */
+static void test_seek_inf_reverse_iteration_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with scores 1-5 */
+    for (int i = 1; i <= 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Seek to [-inf, +inf] with offset -1 (last element), then iterate backwards.
+     * This is how ZREVRANGEBYSCORE -inf +inf works. */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, -INFINITY, INFINITY, 0, 0, -1);
+    int count = 0;
+    double expected = 5.0;
+    while (orderedIndexNext(ops, &iter, &pos)) {
+        if (count == 0) {
+            TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 5.0);
+        }
+        count++;
+        break; /* Just verify first element is correct */
+    }
+    /* Now iterate backwards through all elements */
+    count = 0;
+    expected = 5.0;
+    while (orderedIndexPrev(ops, &iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+        expected -= 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+/* Test ZRANGEBYSCORE -inf behavior: seek to first element and iterate forwards.
+ * This is the pattern used by ZRANGEBYSCORE -inf +inf to get all elements. */
+static void test_seek_inf_forward_iteration_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with scores 1-5 */
+    for (int i = 1; i <= 5; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "key%d", i);
+        sds ele = sdsnew(buf);
+        orderedIndexInsert(ops, idx, (double)i, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+
+    /* Seek to [-inf, +inf] with offset 0 (first element), then iterate forwards.
+     * This is how ZRANGEBYSCORE -inf +inf works. */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToScoreRange(ops, &iter, -INFINITY, INFINITY, 0, 0, 0);
+    int count = 0;
+    double expected = 1.0;
+    while (orderedIndexNext(ops, &iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), expected);
+        expected += 1.0;
+        count++;
+    }
+    TEST_ASSERT(count == 5);
+    orderedIndexResetIterator(ops, &iter);
+
+    orderedIndexFree(ops, idx);
+}
+
+/* Test seek_to_lex_range for ZRANGEBYLEX-style operations.
+ * Lex range is meaningful when all elements have the same score. */
+static void test_seek_to_lex_range_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with same score, different lex values */
+    const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
+    for (int i = 0; i < 5; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+
+    sds minLex = sdsnew("banana");
+    sds maxLex = sdsnew("date");
+
+    /* Seek to first in lex range [banana, date] with offset 0 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 6 && memcmp(ptr, "banana", 6) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to second in lex range [banana, date] with offset 1 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek to last in lex range [banana, date] with offset -1 */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, -1);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "date", 4) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Seek with exclusive bounds (banana, date) - should start at cherry */
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 1, 1, 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(minLex);
+    sdsfree(maxLex);
+
+    /* Seek to empty lex range - should position at end */
+    sds minEmpty = sdsnew("zzz");
+    sds maxEmpty = sdsnew("zzzz");
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minEmpty, maxEmpty, 0, 0, 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+    sdsfree(minEmpty);
+    sdsfree(maxEmpty);
+
+    /* Out of range positive offset - should position at end */
+    minLex = sdsnew("banana");
+    maxLex = sdsnew("date");
+    orderedIndexInitIterator(ops, &iter, idx);
+    orderedIndexSeekToLexRange(ops, &iter, minLex, maxLex, 0, 0, 10);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+    sdsfree(minLex);
+    sdsfree(maxLex);
+
+    orderedIndexFree(ops, idx);
+}
+
+/* ========== Skiplist Tests ========== */
+
+class SkiplistOrderedIndexTest : public ::testing::Test {};
+
+TEST_F(SkiplistOrderedIndexTest, CreateFree) {
+    test_create_free_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, InsertSingle) {
+    test_insert_single_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, InsertMultipleOrdered) {
+    test_insert_multiple_ordered_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DuplicateScores) {
+    test_duplicate_scores_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RankOperations) {
+    test_rank_operations_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, Delete) {
+    test_delete_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, PopFirst) {
+    test_pop_first_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, PopLast) {
+    test_pop_last_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, UpdateScore) {
+    test_update_score_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByScore) {
+    test_delete_range_by_score_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByRank) {
+    test_delete_range_by_rank_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, EdgeCases) {
+    test_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteEdgeCases) {
+    test_delete_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RankEdgeCases) {
+    test_rank_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DuplicateInsert) {
+    test_duplicate_insert_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, UpdateScoreEdgeCases) {
+    test_update_score_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RangeDeleteEdgeCases) {
+    test_range_delete_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, TraversalEdgeCases) {
+    test_traversal_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, MixedOperationsRankIntegrity) {
+    test_mixed_operations_rank_integrity_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, BackwardTraversalAfterDeletions) {
+    test_backward_traversal_after_deletions_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, LexicographicEdgeCases) {
+    test_lexicographic_edge_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RangeBoundaryPrecision) {
+    test_range_boundary_precision_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SpecialDoubleValues) {
+    test_special_double_values_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekToRank) {
+    test_seek_to_rank_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, ReverseIteration) {
+    test_reverse_iteration_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekToScoreRange) {
+    test_seek_to_score_range_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekToScoreRangeIteration) {
+    test_seek_to_score_range_iteration_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekInfReverseIteration) {
+    test_seek_inf_reverse_iteration_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekInfForwardIteration) {
+    test_seek_inf_forward_iteration_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, SeekToLexRange) {
+    test_seek_to_lex_range_generic(&skiplistOrderedIndexOps);
+}

--- a/src/unit/test_ordered_index.cpp
+++ b/src/unit/test_ordered_index.cpp
@@ -6,14 +6,21 @@
 
 #include "generated_wrappers.hpp"
 
-#include <cmath>
-#include <cstdio>
-#include <cstring>
-
 extern "C" {
 #include "ordered_index.h"
 #include "server.h"
 }
+
+/* Undefine min/max macros from server.h to avoid conflicts with C++ standard library */
+#undef min
+#undef max
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
 
 #define TEST_ASSERT(x) ASSERT_TRUE(x)
 #define TEST_ASSERT_SCORE_EQ(a, b) ASSERT_DOUBLE_EQ(a, b)
@@ -1261,6 +1268,593 @@ static void test_seek_to_lex_range_generic(const OrderedIndexOps *ops) {
     orderedIndexFree(ops, idx);
 }
 
+/* ========== delete_range_by_lex tests ========== */
+
+static void test_delete_range_by_lex_inclusive_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with same score (lex range is meaningful when scores are equal) */
+    const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
+    for (int i = 0; i < 5; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete inclusive range [banana, date] — should remove banana, cherry, date */
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    TEST_ASSERT(deleted == 3);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+
+    /* Verify remaining: apple, elderberry */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 10 && memcmp(ptr, "elderberry", 10) == 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_range_by_lex_exclusive_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    const char *elements[] = {"apple", "banana", "cherry", "date", "elderberry"};
+    for (int i = 0; i < 5; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete exclusive range (banana, date) — should remove only cherry */
+    sds min = sdsnew("banana");
+    sds max = sdsnew("date");
+    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 1, 1);
+    TEST_ASSERT(deleted == 1);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+
+    /* Verify remaining: apple, banana, date, elderberry */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 6 && memcmp(ptr, "banana", 6) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 4 && memcmp(ptr, "date", 4) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 10 && memcmp(ptr, "elderberry", 10) == 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_range_by_lex_boundary_cases_generic(const OrderedIndexOps *ops) {
+    /* Empty range: min > max lexicographically */
+    OrderedIndex *idx = orderedIndexCreate(ops);
+    const char *elements[] = {"apple", "banana", "cherry"};
+    for (int i = 0; i < 3; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    sds min = sdsnew("zzz");
+    sds max = sdsnew("aaa");
+    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    TEST_ASSERT(deleted == 0);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 3);
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+
+    /* Delete all elements: range covers everything */
+    idx = orderedIndexCreate(ops);
+    for (int i = 0; i < 3; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    min = sdsnew("a");
+    max = sdsnew("z");
+    deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    TEST_ASSERT(deleted == 3);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 0);
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+
+    /* Delete single element: range matches exactly one */
+    idx = orderedIndexCreate(ops);
+    for (int i = 0; i < 3; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    min = sdsnew("banana");
+    max = sdsnew("banana");
+    deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    TEST_ASSERT(deleted == 1);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 2);
+
+    /* Verify remaining: apple, cherry */
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+    orderedIndexInitIterator(ops, &iter, idx);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 5 && memcmp(ptr, "apple", 5) == 0);
+    TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+    orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+    TEST_ASSERT(len == 6 && memcmp(ptr, "cherry", 6) == 0);
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+}
+
+static void test_delete_range_by_lex_preserves_outside_generic(const OrderedIndexOps *ops) {
+    OrderedIndex *idx = orderedIndexCreate(ops);
+
+    /* Insert elements with same score */
+    const char *elements[] = {"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"};
+    for (int i = 0; i < 6; i++) {
+        sds ele = sdsnew(elements[i]);
+        orderedIndexInsert(ops, idx, 1.0, ele);
+        sdsfree(ele);
+    }
+
+    /* Delete [charlie, delta] — should preserve alpha, bravo, echo, foxtrot */
+    sds min = sdsnew("charlie");
+    sds max = sdsnew("delta");
+    unsigned long deleted = orderedIndexDeleteRangeByLex(ops, idx, min, max, 0, 0);
+    TEST_ASSERT(deleted == 2);
+    TEST_ASSERT(orderedIndexLength(ops, idx) == 4);
+
+    /* Verify all preserved elements are present and in order */
+    const char *expected[] = {"alpha", "bravo", "echo", "foxtrot"};
+    size_t expected_lens[] = {5, 5, 4, 7};
+    OrderedIndexIterator iter;
+    OrderedIndexItem *pos;
+    const char *ptr;
+    size_t len;
+    orderedIndexInitIterator(ops, &iter, idx);
+    for (int i = 0; i < 4; i++) {
+        TEST_ASSERT(orderedIndexNext(ops, &iter, &pos));
+        orderedIndexGetElementRaw(ops, pos, &ptr, &len);
+        TEST_ASSERT(len == expected_lens[i] && memcmp(ptr, expected[i], len) == 0);
+    }
+    TEST_ASSERT(!orderedIndexNext(ops, &iter, &pos));
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Verify scores are preserved */
+    orderedIndexInitIterator(ops, &iter, idx);
+    while (orderedIndexNext(ops, &iter, &pos)) {
+        TEST_ASSERT_SCORE_EQ(orderedIndexGetScore(ops, pos), 1.0);
+    }
+    orderedIndexResetIterator(ops, &iter);
+
+    /* Verify ranks are correct after deletion */
+    for (unsigned long r = 1; r <= 4; r++) {
+        OrderedIndexItem *node = orderedIndexGetByRank(ops, idx, r);
+        TEST_ASSERT(node != NULL);
+        unsigned long rank = orderedIndexGetRank(ops, idx, node);
+        TEST_ASSERT(rank == r);
+    }
+
+    sdsfree(min);
+    sdsfree(max);
+    orderedIndexFree(ops, idx);
+}
+
+/* ========== Randomized property tests (generic) ========== */
+
+/* Helpers for randomized tests */
+struct RandomIndexEntry {
+    OrderedIndexItem *node;
+    double score;
+    std::string element;
+};
+
+static std::string test_random_element(std::mt19937 &rng, int maxLen = 16) {
+    std::uniform_int_distribution<int> lenDist(1, maxLen);
+    std::uniform_int_distribution<int> charDist('a', 'z');
+    int len = lenDist(rng);
+    std::string s(len, ' ');
+    for (int i = 0; i < len; i++) s[i] = (char)charDist(rng);
+    return s;
+}
+
+static double test_random_score(std::mt19937 &rng) {
+    std::uniform_real_distribution<double> dist(-1e6, 1e6);
+    return dist(rng);
+}
+
+static std::vector<RandomIndexEntry> test_build_random_index(const OrderedIndexOps *ops, OrderedIndex *idx,
+                                                              std::mt19937 &rng, int count) {
+    std::vector<RandomIndexEntry> entries;
+    for (int i = 0; i < count; i++) {
+        double score = test_random_score(rng);
+        std::string elem = test_random_element(rng) + std::to_string(i);
+        sds ele = sdsnew(elem.c_str());
+        OrderedIndexItem *node = orderedIndexInsert(ops, idx, score, ele);
+        entries.push_back({node, score, elem});
+        sdsfree(ele);
+    }
+    return entries;
+}
+
+/* Property: Insert N random elements, then verify length and forward traversal order. */
+static void test_randomized_insert_and_traversal_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(1, 50);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)n);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        int count = 0;
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            double s = orderedIndexGetScore(ops, pos);
+            ASSERT_GE(s, prevScore);
+            prevScore = s;
+            count++;
+        }
+        ASSERT_EQ(count, n);
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: Backward traversal visits elements in non-increasing score order. */
+static void test_randomized_backward_traversal_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(1, 50);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        int count = 0;
+        double prevScore = INFINITY;
+        while (orderedIndexPrev(ops, &iter, &pos)) {
+            double s = orderedIndexGetScore(ops, pos);
+            ASSERT_LE(s, prevScore);
+            prevScore = s;
+            count++;
+        }
+        ASSERT_EQ(count, n);
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: get_score returns the exact same double value that was inserted. */
+static void test_randomized_score_retrieval_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(1, 50);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        auto entries = test_build_random_index(ops, idx, rng, n);
+
+        for (auto &e : entries) {
+            ASSERT_EQ(orderedIndexGetScore(ops, e.node), e.score);
+        }
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: get_rank returns correct 1-based rank consistent with traversal order. */
+static void test_randomized_rank_consistency_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(1, 50);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        unsigned long expectedRank = 1;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            unsigned long rank = orderedIndexGetRank(ops, idx, pos);
+            ASSERT_EQ(rank, expectedRank);
+            OrderedIndexItem *byRank = orderedIndexGetByRank(ops, idx, expectedRank);
+            ASSERT_EQ(byRank, pos);
+            expectedRank++;
+        }
+        ASSERT_EQ(expectedRank - 1, (unsigned long)n);
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: Delete a random element, length decreases, remaining in order. */
+static void test_randomized_delete_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(2, 30);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        auto entries = test_build_random_index(ops, idx, rng, n);
+
+        std::uniform_int_distribution<int> pickDist(0, n - 1);
+        int delIdx = pickDist(rng);
+        orderedIndexDelete(ops, idx, entries[delIdx].node);
+
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 1));
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        int count = 0;
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
+            prevScore = orderedIndexGetScore(ops, pos);
+            count++;
+        }
+        ASSERT_EQ(count, n - 1);
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: update_score moves element to correct position, preserves exact score. */
+static void test_randomized_update_score_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(2, 30);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        auto entries = test_build_random_index(ops, idx, rng, n);
+
+        std::uniform_int_distribution<int> pickDist(0, n - 1);
+        int updIdx = pickDist(rng);
+        double newScore = test_random_score(rng);
+
+        OrderedIndexItem *updated = orderedIndexUpdateScore(ops, idx, entries[updIdx].node, newScore);
+        ASSERT_NE(updated, nullptr);
+        ASSERT_EQ(orderedIndexGetScore(ops, updated), newScore);
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)n);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
+            prevScore = orderedIndexGetScore(ops, pos);
+        }
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: pop_first/pop_last remove min/max elements correctly. */
+static void test_randomized_pop_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 10; trial++) {
+        std::uniform_int_distribution<int> sizeDist(3, 30);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        ASSERT_TRUE(orderedIndexNext(ops, &iter, &pos));
+        double minScore = orderedIndexGetScore(ops, pos);
+        orderedIndexResetIterator(ops, &iter);
+
+        orderedIndexInitIterator(ops, &iter, idx);
+        ASSERT_TRUE(orderedIndexPrev(ops, &iter, &pos));
+        double maxScore = orderedIndexGetScore(ops, pos);
+        orderedIndexResetIterator(ops, &iter);
+
+        OrderedIndexItem *first = orderedIndexPopFirst(ops, idx);
+        ASSERT_NE(first, nullptr);
+        ASSERT_EQ(orderedIndexGetScore(ops, first), minScore);
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 1));
+        orderedIndexFreeItem(ops, first);
+
+        OrderedIndexItem *last = orderedIndexPopLast(ops, idx);
+        ASSERT_NE(last, nullptr);
+        ASSERT_EQ(orderedIndexGetScore(ops, last), maxScore);
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - 2));
+        orderedIndexFreeItem(ops, last);
+
+        orderedIndexInitIterator(ops, &iter, idx);
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
+            prevScore = orderedIndexGetScore(ops, pos);
+        }
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: delete_range_by_score removes exactly the right elements. */
+static void test_randomized_delete_range_by_score_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(5, 40);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        auto entries = test_build_random_index(ops, idx, rng, n);
+
+        double s1 = test_random_score(rng), s2 = test_random_score(rng);
+        double lo = (std::min)(s1, s2), hi = (std::max)(s1, s2);
+
+        int expectedDeleted = 0;
+        for (auto &e : entries) {
+            if (e.score >= lo && e.score <= hi) expectedDeleted++;
+        }
+
+        unsigned long deleted = orderedIndexDeleteRangeByScore(ops, idx, lo, hi, 0, 0);
+        ASSERT_EQ(deleted, (unsigned long)expectedDeleted);
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n - expectedDeleted));
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            double s = orderedIndexGetScore(ops, pos);
+            ASSERT_TRUE(s < lo || s > hi);
+            ASSERT_GE(s, prevScore);
+            prevScore = s;
+        }
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: delete_range_by_rank removes exactly the right rank positions. */
+static void test_randomized_delete_range_by_rank_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(5, 40);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        std::uniform_int_distribution<int> rankDist(1, n);
+        int r1 = rankDist(rng), r2 = rankDist(rng);
+        unsigned long start = (unsigned long)(std::min)(r1, r2);
+        unsigned long end = (unsigned long)(std::max)(r1, r2);
+        unsigned long expectedDeleted = end - start + 1;
+
+        unsigned long deleted = orderedIndexDeleteRangeByRank(ops, idx, start, end);
+        ASSERT_EQ(deleted, expectedDeleted);
+        ASSERT_EQ(orderedIndexLength(ops, idx), (unsigned long)(n) - expectedDeleted);
+
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        int remaining = 0;
+        double prevScore = -INFINITY;
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            ASSERT_GE(orderedIndexGetScore(ops, pos), prevScore);
+            prevScore = orderedIndexGetScore(ops, pos);
+            remaining++;
+        }
+        ASSERT_EQ(remaining, n - (int)expectedDeleted);
+        orderedIndexResetIterator(ops, &iter);
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Property: Forward and backward traversal produce mirror-image sequences. */
+static void test_randomized_forward_backward_mirror_generic(const OrderedIndexOps *ops) {
+    std::mt19937 rng(42);
+    for (int trial = 0; trial < 20; trial++) {
+        std::uniform_int_distribution<int> sizeDist(1, 50);
+        int n = sizeDist(rng);
+
+        OrderedIndex *idx = orderedIndexCreate(ops);
+        test_build_random_index(ops, idx, rng, n);
+
+        std::vector<double> forwardScores;
+        OrderedIndexIterator iter;
+        OrderedIndexItem *pos;
+        orderedIndexInitIterator(ops, &iter, idx);
+        while (orderedIndexNext(ops, &iter, &pos)) {
+            forwardScores.push_back(orderedIndexGetScore(ops, pos));
+        }
+        orderedIndexResetIterator(ops, &iter);
+
+        std::vector<double> backwardScores;
+        orderedIndexInitIterator(ops, &iter, idx);
+        while (orderedIndexPrev(ops, &iter, &pos)) {
+            backwardScores.push_back(orderedIndexGetScore(ops, pos));
+        }
+        orderedIndexResetIterator(ops, &iter);
+
+        ASSERT_EQ(forwardScores.size(), backwardScores.size());
+        std::reverse(backwardScores.begin(), backwardScores.end());
+        for (size_t i = 0; i < forwardScores.size(); i++) {
+            ASSERT_EQ(forwardScores[i], backwardScores[i]);
+        }
+        orderedIndexFree(ops, idx);
+    }
+}
+
+/* Verify all vtable function pointers are non-null. */
+static void test_vtable_fully_populated_generic(const OrderedIndexOps *ops) {
+    ASSERT_NE(ops->create, nullptr);
+    ASSERT_NE(ops->free, nullptr);
+    ASSERT_NE(ops->insert, nullptr);
+    ASSERT_NE(ops->delete_item, nullptr);
+    ASSERT_NE(ops->update_score, nullptr);
+    ASSERT_NE(ops->pop_first, nullptr);
+    ASSERT_NE(ops->pop_last, nullptr);
+    ASSERT_NE(ops->free_item, nullptr);
+    ASSERT_NE(ops->delete_range_by_score, nullptr);
+    ASSERT_NE(ops->delete_range_by_rank, nullptr);
+    ASSERT_NE(ops->length, nullptr);
+    ASSERT_NE(ops->get_by_rank, nullptr);
+    ASSERT_NE(ops->get_rank, nullptr);
+    ASSERT_NE(ops->get_element_raw, nullptr);
+    ASSERT_NE(ops->get_score, nullptr);
+    ASSERT_NE(ops->init_iterator, nullptr);
+    ASSERT_NE(ops->reset_iterator, nullptr);
+    ASSERT_NE(ops->next, nullptr);
+    ASSERT_NE(ops->prev, nullptr);
+    ASSERT_NE(ops->seek_to_rank, nullptr);
+    ASSERT_NE(ops->seek_to_score_range, nullptr);
+    ASSERT_NE(ops->seek_to_lex_range, nullptr);
+}
+
 /* ========== Skiplist Tests ========== */
 
 class SkiplistOrderedIndexTest : public ::testing::Test {};
@@ -1355,3 +1949,50 @@ TEST_F(SkiplistOrderedIndexTest, SeekInfForwardIteration) {
 TEST_F(SkiplistOrderedIndexTest, SeekToLexRange) {
     test_seek_to_lex_range_generic(&skiplistOrderedIndexOps);
 }
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexInclusive) {
+    test_delete_range_by_lex_inclusive_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexExclusive) {
+    test_delete_range_by_lex_exclusive_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexBoundaryCases) {
+    test_delete_range_by_lex_boundary_cases_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, DeleteRangeByLexPreservesOutside) {
+    test_delete_range_by_lex_preserves_outside_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedInsertAndTraversal) {
+    test_randomized_insert_and_traversal_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedBackwardTraversal) {
+    test_randomized_backward_traversal_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedScoreRetrieval) {
+    test_randomized_score_retrieval_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedRankConsistency) {
+    test_randomized_rank_consistency_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedDelete) {
+    test_randomized_delete_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedUpdateScore) {
+    test_randomized_update_score_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedPop) {
+    test_randomized_pop_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedDeleteRangeByScore) {
+    test_randomized_delete_range_by_score_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedDeleteRangeByRank) {
+    test_randomized_delete_range_by_rank_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, RandomizedForwardBackwardMirror) {
+    test_randomized_forward_backward_mirror_generic(&skiplistOrderedIndexOps);
+}
+TEST_F(SkiplistOrderedIndexTest, VtableFullyPopulated) {
+    test_vtable_fully_populated_generic(&skiplistOrderedIndexOps);
+}
+
+

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -33,6 +33,7 @@
 #include "module.h"
 #include "hdr_histogram.h"
 #include "fpconv_dtoa.h"
+#include "ordered_index.h"
 
 #include <stdarg.h>
 #include <sys/time.h>
@@ -323,13 +324,15 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
 
             void *next;
             while (hashtableNext(&iter, &next)) {
-                zskiplistNode *node = next;
+                OrderedIndexItem *node = next;
                 size_t eleLen = 0;
 
-                const int len = fpconv_dtoa(node->score, buf);
+                const int len = fpconv_dtoa(orderedIndexGetScore(node), buf);
                 buf[len] = '\0';
-                sds ele = zslGetNodeElement(node);
-                eleLen += sdslen(ele) + strlen(buf);
+                const char *ele_ptr;
+                size_t ele_len;
+                orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
+                eleLen += ele_len + strlen(buf);
                 statsRecordElementSize(eleLen, 1, stats);
             }
             hashtableCleanupIterator(&iter);

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -325,15 +325,13 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
             void *next;
             while (hashtableNext(&iter, &next)) {
                 OrderedIndexItem *node = next;
-                size_t eleLen = 0;
 
                 const int len = fpconv_dtoa(orderedIndexGetScore(node), buf);
                 buf[len] = '\0';
                 const char *ele_ptr;
                 size_t ele_len;
                 orderedIndexGetElementRaw(node, &ele_ptr, &ele_len);
-                eleLen += ele_len + strlen(buf);
-                statsRecordElementSize(eleLen, 1, stats);
+                statsRecordElementSize(ele_len + strlen(buf), 1, stats);
             }
             hashtableCleanupIterator(&iter);
             statsRecordCount(hashtableSize(zs->ht), stats);

--- a/tests/unit/sort.tcl
+++ b/tests/unit/sort.tcl
@@ -171,6 +171,54 @@ foreach command {SORT SORT_RO} {
         assert_equal [r sort zset by nosort limit -10 100] {a c e b d}
     }
 
+    test "SORT sorted set skiplist BY nosort should retain ordering" {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+        r del zset
+        r zadd zset 1 a
+        r zadd zset 5 b
+        r zadd zset 2 c
+        r zadd zset 10 d
+        r zadd zset 3 e
+        assert_encoding skiplist zset
+        assert_equal [r sort zset by nosort asc] {a c e b d}
+        assert_equal [r sort zset by nosort desc] {d b e c a}
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test "SORT sorted set skiplist BY nosort + LIMIT" {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+        r del zset
+        r zadd zset 1 a
+        r zadd zset 5 b
+        r zadd zset 2 c
+        r zadd zset 10 d
+        r zadd zset 3 e
+        assert_encoding skiplist zset
+        assert_equal [r sort zset by nosort asc limit 0 1] {a}
+        assert_equal [r sort zset by nosort desc limit 0 1] {d}
+        assert_equal [r sort zset by nosort asc limit 0 2] {a c}
+        assert_equal [r sort zset by nosort desc limit 0 2] {d b}
+        assert_equal [r sort zset by nosort limit 5 10] {}
+        assert_equal [r sort zset by nosort limit -10 100] {a c e b d}
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test "SORT sorted set skiplist with BY pattern" {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+        r del zset
+        r zadd zset 1 a
+        r zadd zset 5 b
+        r zadd zset 2 c
+        r zadd zset 10 d
+        r zadd zset 3 e
+        assert_encoding skiplist zset
+        assert_equal [r sort zset alpha desc] {e d c b a}
+        r config set zset-max-ziplist-entries $original_max
+    }
+
     test "SORT sorted set BY nosort works as expected from scripts" {
         r del zset
         r zadd zset 1 a

--- a/tests/unit/type/zset.tcl
+++ b/tests/unit/type/zset.tcl
@@ -2949,3 +2949,198 @@ start_server [list overrides [list save ""] tags {"zset needs:debug external:ski
         assert_equal 1 $can_break
     }
 }
+
+start_server {tags {"zset"}} {
+    test {ZUNIONSTORE with skiplist-encoded inputs} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del src1 src2 dst
+        r zadd src1 1 a 2 b 3 c
+        r zadd src2 2 b 4 d 5 e
+        assert_encoding skiplist src1
+        assert_encoding skiplist src2
+
+        assert_equal 5 [r zunionstore dst 2 src1 src2]
+        assert_encoding skiplist dst
+        assert_equal {a 1 c 3 b 4 d 4 e 5} [r zrange dst 0 -1 WITHSCORES]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZUNIONSTORE with skiplist-encoded inputs and WEIGHTS} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del src1 src2 dst
+        r zadd src1 1 a 2 b
+        r zadd src2 3 b 4 c
+        assert_encoding skiplist src1
+        assert_encoding skiplist src2
+
+        assert_equal 3 [r zunionstore dst 2 src1 src2 WEIGHTS 2 1]
+        assert_equal {a 2 c 4 b 7} [r zrange dst 0 -1 WITHSCORES]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZINTERSTORE with skiplist-encoded inputs} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del src1 src2 dst
+        r zadd src1 1 a 2 b 3 c
+        r zadd src2 10 b 20 c 30 d
+        assert_encoding skiplist src1
+        assert_encoding skiplist src2
+
+        assert_equal 2 [r zinterstore dst 2 src1 src2]
+        assert_equal {b 12 c 23} [r zrange dst 0 -1 WITHSCORES]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZINTERSTORE with skiplist-encoded inputs and AGGREGATE MIN} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del src1 src2 dst
+        r zadd src1 5 a 10 b
+        r zadd src2 1 a 20 b
+        assert_encoding skiplist src1
+        assert_encoding skiplist src2
+
+        assert_equal 2 [r zinterstore dst 2 src1 src2 AGGREGATE MIN]
+        assert_equal {a 1 b 10} [r zrange dst 0 -1 WITHSCORES]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZRANGEBYSCORE with LIMIT on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        for {set i 0} {$i < 20} {incr i} {
+            r zadd zset $i "key:$i"
+        }
+        assert_encoding skiplist zset
+
+        # Forward with offset and count
+        assert_equal {key:5 key:6 key:7} [r zrangebyscore zset 0 19 LIMIT 5 3]
+        # Reverse with offset and count
+        assert_equal {key:14 key:13 key:12} [r zrevrangebyscore zset 19 0 LIMIT 5 3]
+        # Offset past end
+        assert_equal {} [r zrangebyscore zset 0 19 LIMIT 25 5]
+        # Count of 0
+        assert_equal {} [r zrangebyscore zset 0 19 LIMIT 0 0]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZRANGEBYLEX with LIMIT on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        foreach elem {a b c d e f g h i j} {
+            r zadd zset 0 $elem
+        }
+        assert_encoding skiplist zset
+
+        # Forward with offset and count
+        assert_equal {d e f} [r zrangebylex zset "\[a" "\[j" LIMIT 3 3]
+        # Reverse with offset and count
+        assert_equal {g f e} [r zrevrangebylex zset "\[j" "\[a" LIMIT 3 3]
+        # Offset past end
+        assert_equal {} [r zrangebylex zset "\[a" "\[j" LIMIT 15 5]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZPOPMIN on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        r zadd zset 3 c 1 a 2 b 5 e 4 d
+        assert_encoding skiplist zset
+
+        assert_equal {a 1} [r zpopmin zset]
+        assert_equal {b 2} [r zpopmin zset]
+        assert_equal 3 [r zcard zset]
+
+        # Pop multiple
+        assert_equal {c 3 d 4} [r zpopmin zset 2]
+        assert_equal 1 [r zcard zset]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZPOPMAX on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        r zadd zset 3 c 1 a 2 b 5 e 4 d
+        assert_encoding skiplist zset
+
+        assert_equal {e 5} [r zpopmax zset]
+        assert_equal {d 4} [r zpopmax zset]
+        assert_equal 3 [r zcard zset]
+
+        # Pop multiple
+        assert_equal {c 3 b 2} [r zpopmax zset 2]
+        assert_equal 1 [r zcard zset]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZPOPMIN/ZPOPMAX empty skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        r zadd zset 1 a
+        r zpopmin zset
+        assert_equal 0 [r exists zset]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZCOUNT on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        for {set i 0} {$i < 10} {incr i} {
+            r zadd zset $i "key:$i"
+        }
+        assert_encoding skiplist zset
+
+        assert_equal 10 [r zcount zset -inf +inf]
+        assert_equal 4 [r zcount zset 3 6]
+        assert_equal 2 [r zcount zset (3 (6]
+        assert_equal 0 [r zcount zset 20 30]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+
+    test {ZLEXCOUNT on skiplist-encoded set} {
+        set original_max [lindex [r config get zset-max-ziplist-entries] 1]
+        r config set zset-max-ziplist-entries 0
+
+        r del zset
+        foreach elem {a b c d e f} {
+            r zadd zset 0 $elem
+        }
+        assert_encoding skiplist zset
+
+        assert_equal 6 [r zlexcount zset - +]
+        assert_equal 3 [r zlexcount zset "\[b" "\[d"]
+        assert_equal 1 [r zlexcount zset "(b" "(d"]
+        assert_equal 0 [r zlexcount zset "\[x" "\[z"]
+
+        r config set zset-max-ziplist-entries $original_max
+    }
+}


### PR DESCRIPTION
🚧 Currently a draft, but feel free to take a look. I think it's complete but I'm self-reviewing first. 🚧 

This is the first PR that lays the foundation for  #3166. I add an interface and unit tests to codify current zskiplist behavior. I also refactored so that across Valkey we respect the interface abstraction and don't leak implementation details.

The next PR planned will introduce the new data structure (fbtree) and use it to implement this interface. Unit tests will run on both zskiplist and fbtree implementations to ensure behavior is the same.