### PR TITLE
Ensure client slot migration pointer is cleared during reset

### DIFF
--- a/src/cluster_migrateslots.c
+++ b/src/cluster_migrateslots.c
@@ -2145,6 +2145,7 @@ void resetSlotMigrationJob(slotMigrationJob *job) {
     /* Only one of client or conn should be set. */
     serverAssert(!job->client || !job->conn);
     if (job->client) {
+        job->client->slot_migration_job = NULL;
         freeClientAsync(job->client);
         job->client = NULL;
     } else if (job->conn) {

--- a/src/networking.c
+++ b/src/networking.c
@@ -1950,8 +1950,7 @@ void unlinkClient(client *c) {
         }
         /* Check if this is the slot migration client we are writing to in a
          * child process*/
-        if (c->slot_migration_job && !isImportSlotMigrationJob(c->slot_migration_job) &&
-            server.slot_migration_pipe_conn == c->conn) {
+        if (server.slot_migration_pipe_conn == c->conn) {
             server.slot_migration_pipe_conn = NULL;
             serverLog(LL_NOTICE, "Slot migration target dropped, killing fork child.");
             killSlotMigrationChild();


### PR DESCRIPTION
If not cleared, the job may no longer be valid by the time the client goes to cleanup. This dangling reference could cause a crash if you set slot-migration-log-max-len to 0 and are very unlucky.