### PR TITLE
Strip LTO flags from static Lua module build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -734,9 +734,14 @@ $(TLS_MODULE_NAME): $(SERVER_NAME)
 $(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) $(LDFLAGS) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
+# Strip LTO flags from OPTIMIZATION for the static Lua module build.
+# When archiving into a .a, LTO bitcode objects cause linker failures
+# if the system's LLVM gold plugin version doesn't match clang's version.
+LUA_MODULE_OPTIMIZATION=$(subst -flto,,$(subst -ffat-lto-objects,,$(subst -flto=auto,,$(OPTIMIZATION))))
+
 # engine_lua.so
 $(LUA_MODULE_NAME): .make-prerequisites
-	$(MAKE) -C modules/lua OPTIMIZATION="$(OPTIMIZATION)" BUILD_LUA="$(BUILD_LUA)"
+	$(MAKE) -C modules/lua OPTIMIZATION="$(LUA_MODULE_OPTIMIZATION)" BUILD_LUA="$(BUILD_LUA)"
 
 # valkey-cli
 $(ENGINE_CLI_NAME): $(ENGINE_CLI_OBJ)

--- a/src/Makefile
+++ b/src/Makefile
@@ -734,14 +734,9 @@ $(TLS_MODULE_NAME): $(SERVER_NAME)
 $(RDMA_MODULE_NAME): $(SERVER_NAME)
 	$(QUIET_CC)$(CC) $(LDFLAGS) -o $@ rdma.c -shared -fPIC $(RDMA_MODULE_CFLAGS)
 
-# Strip LTO flags from OPTIMIZATION for the static Lua module build.
-# When archiving into a .a, LTO bitcode objects cause linker failures
-# if the system's LLVM gold plugin version doesn't match clang's version.
-LUA_MODULE_OPTIMIZATION=$(subst -flto,,$(subst -ffat-lto-objects,,$(subst -flto=auto,,$(OPTIMIZATION))))
-
 # engine_lua.so
 $(LUA_MODULE_NAME): .make-prerequisites
-	$(MAKE) -C modules/lua OPTIMIZATION="$(LUA_MODULE_OPTIMIZATION)" BUILD_LUA="$(BUILD_LUA)"
+	$(MAKE) -C modules/lua OPTIMIZATION="$(OPTIMIZATION)" BUILD_LUA="$(BUILD_LUA)"
 
 # valkey-cli
 $(ENGINE_CLI_NAME): $(ENGINE_CLI_OBJ)

--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -9,6 +9,10 @@ ifeq ($(BUILD_LUA),module)
 else
 	STATIC_LUA_FLAG=-DSTATIC_LUA=1
 	LUA_TARGET=libvalkeylua.a
+	# Strip LTO flags for the static build. When archiving into a .a,
+	# LTO bitcode objects cause linker failures if the system linker
+	# cannot read them.
+	OPTIMIZATION:=$(subst -flto,,$(subst -ffat-lto-objects,,$(subst -flto=auto,,$(OPTIMIZATION))))
 endif
 
 ifeq ($(uname_S),Darwin)

--- a/src/modules/lua/Makefile
+++ b/src/modules/lua/Makefile
@@ -11,8 +11,9 @@ else
 	LUA_TARGET=libvalkeylua.a
 	# Strip LTO flags for the static build. When archiving into a .a,
 	# LTO bitcode objects cause linker failures if the system linker
-	# cannot read them.
-	OPTIMIZATION:=$(subst -flto,,$(subst -ffat-lto-objects,,$(subst -flto=auto,,$(OPTIMIZATION))))
+	# cannot read them. Use 'override' because OPTIMIZATION is passed
+	# as a command-line variable from the parent Makefile.
+	override OPTIMIZATION:=$(subst -flto,,$(subst -ffat-lto-objects,,$(subst -flto=auto,,$(OPTIMIZATION))))
 endif
 
 ifeq ($(uname_S),Darwin)


### PR DESCRIPTION
### Summary

The daily CI sanitizer jobs with clang are failing during the build step.
When the static Lua module is built with `-flto`, the `.o` files contain
LLVM bitcode that gets archived into `libvalkeylua.a`. The system linker
cannot read this bitcode, causing build failures:

`/usr/bin/ld: /home/runner/work/valkey/valkey/src/modules/lua/libvalkeylua.a: member /home/runner/work/valkey/valkey/src/modules/lua/libvalkeylua.a(debug_lua.o) in archive is not an object`

The previous fix (#3546) pinned clang to version 17, but this was
insufficient, the issue is not just a version mismatch but that the
system linker fundamentally cannot read LTO bitcode from `.a` archives.

Example failure: https://github.com/valkey-io/valkey/actions/runs/24865821147/job/72801509768

### Fix

Strip LTO flags from OPTIMIZATION in the Lua module Makefile using
  `override`


Tested: https://github.com/hanxizh9910/valkey/actions/runs/24913834442
