### PR TITLE
Revert "Pin clang to version 17 in sanitizer CI jobs"

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -950,7 +950,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang-17]
+        compiler: [gcc, clang]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1017,7 +1017,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang-17]
+        compiler: [gcc, clang]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1088,7 +1088,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang-17]
+        compiler: [gcc, clang]
     env:
       CC: ${{ matrix.compiler }}
     steps:
@@ -1155,7 +1155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang-17]
+        compiler: [gcc, clang]
     env:
       CC: ${{ matrix.compiler }}
     steps:


### PR DESCRIPTION
Reverts valkey-io/valkey#3546

This didn't help fix the build issue. Follow up PR is performed on https://github.com/valkey-io/valkey/pull/3555