### PR TITLE
hash: harden HRANDFIELD against expired-heavy hashes

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -910,6 +910,184 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
     return rc;
 }
 
+/* Bound the amount of expiry cleanup HRANDFIELD does up front so stale-heavy
+ * hashes improve quickly without turning a read path into an unbounded sweep.
+ * Keep the default conservative and rely on the validated fallback for
+ * correctness if stale entries still dominate the physical hash size. */
+#ifndef HRANDFIELD_EXPIRED_PRUNE_LIMIT
+#define HRANDFIELD_EXPIRED_PRUNE_LIMIT 32
+#endif
+
+static robj *hrandfieldMaybePruneExpiredFields(client *c, robj *hash) {
+    if (!hash || hash->encoding != OBJ_ENCODING_HASHTABLE || !hashTypeHasVolatileFields(hash)) {
+        return hash;
+    }
+    if (!iAmPrimary() || server.import_mode || server.lazy_expire_disabled) {
+        return hash;
+    }
+    if (isPausedActionsWithUpdate(PAUSE_ACTION_EXPIRE)) {
+        return hash;
+    }
+
+    dbReclaimExpiredFields(hash, c->db, commandTimeSnapshot(), HRANDFIELD_EXPIRED_PRUNE_LIMIT, c->slot);
+    return lookupKeyRead(c->db, c->argv[1]);
+}
+
+static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***entries_out) {
+    serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
+    unsigned long count = 0, capacity = 16;
+    entry **entries = zmalloc(sizeof(*entries) * capacity);
+    hashTypeIterator hi;
+    hashTypeInitIterator(hash, &hi);
+
+    while (hashTypeNext(&hi) != C_ERR) {
+        if (count == capacity) {
+            capacity *= 2;
+            entries = zrealloc(entries, sizeof(*entries) * capacity);
+        }
+        entries[count++] = hi.next;
+    }
+    hashTypeResetIterator(&hi);
+
+    if (count == 0) {
+        zfree(entries);
+        entries = NULL;
+    }
+
+    *entries_out = entries;
+    return count;
+}
+
+static entry *hrandfieldSelectRandomLiveHashtableEntry(robj *hash) {
+    serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
+    entry *selected = NULL;
+    unsigned long seen = 0;
+    hashTypeIterator hi;
+    hashTypeInitIterator(hash, &hi);
+
+    while (hashTypeNext(&hi) != C_ERR) {
+        seen++;
+        if ((random() % seen) == 0) {
+            selected = hi.next;
+        }
+    }
+    hashTypeResetIterator(&hi);
+
+    return selected;
+}
+
+static void hrandfieldReplyHashtableEntry(writePreparedClient *wpc, entry *e, int withvalues, int resp);
+
+static unsigned long hrandfieldReplyFromReservoirSample(writePreparedClient *wpc,
+                                                        robj *hash,
+                                                        unsigned long count,
+                                                        int withvalues,
+                                                        int resp,
+                                                        hashtable *selected) {
+    serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
+
+    if (count == 0) return 0;
+
+    entry **reservoir = zmalloc(sizeof(*reservoir) * count);
+    unsigned long seen = 0, kept = 0;
+    hashTypeIterator hi;
+    hashTypeInitIterator(hash, &hi);
+
+    while (hashTypeNext(&hi) != C_ERR) {
+        entry *e = hi.next;
+        sds field = entryGetField(e);
+
+        if (selected && hashtableFind(selected, field, NULL)) {
+            continue;
+        }
+
+        seen++;
+        if (kept < count) {
+            reservoir[kept++] = e;
+        } else {
+            unsigned long j = random() % seen;
+            if (j < count) {
+                reservoir[j] = e;
+            }
+        }
+    }
+    hashTypeResetIterator(&hi);
+
+    for (unsigned long i = 0; i < kept; i++) {
+        unsigned long j = i + (random() % (kept - i));
+        entry *tmp = reservoir[i];
+        reservoir[i] = reservoir[j];
+        reservoir[j] = tmp;
+    }
+
+    for (unsigned long i = 0; i < kept; i++) {
+        entry *e = reservoir[i];
+
+        if (selected) {
+            sds field = entryGetField(e);
+            int res = hashtableAdd(selected, sdsdup(field));
+            serverAssert(res);
+        }
+
+        hrandfieldReplyHashtableEntry(wpc, e, withvalues, resp);
+    }
+
+    zfree(reservoir);
+    return kept;
+}
+
+static void hrandfieldReplyHashtableEntry(writePreparedClient *wpc, entry *e, int withvalues, int resp) {
+    sds field = entryGetField(e);
+    size_t value_len;
+    char *value = entryGetValue(e, &value_len);
+
+    if (withvalues && resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+    addWritePreparedReplyBulkCBuffer(wpc, field, sdslen(field));
+    if (withvalues) addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
+}
+
+static unsigned long hrandfieldReplyFromCollectedEntries(writePreparedClient *wpc,
+                                                         entry **entries,
+                                                         unsigned long live_count,
+                                                         unsigned long count,
+                                                         int uniq,
+                                                         int withvalues,
+                                                         int resp,
+                                                         hashtable *selected) {
+    unsigned long added = 0;
+
+    if (live_count == 0 || count == 0) return 0;
+
+    if (!uniq) {
+        while (added < count) {
+            hrandfieldReplyHashtableEntry(wpc, entries[random() % live_count], withvalues, resp);
+            added++;
+        }
+        return added;
+    }
+
+    for (unsigned long i = 0; i < live_count && added < count; i++) {
+        unsigned long j = i + (random() % (live_count - i));
+        entry *tmp = entries[i];
+        entries[i] = entries[j];
+        entries[j] = tmp;
+
+        sds field = entryGetField(entries[i]);
+        if (selected) {
+            hashtablePosition position;
+            if (!hashtableFindPositionForInsert(selected, field, &position, NULL)) {
+                continue;
+            }
+            sds selected_field = sdsdup(field);
+            hashtableInsertAtPosition(selected, selected_field, &position);
+        }
+        hrandfieldReplyHashtableEntry(wpc, entries[i], withvalues, resp);
+        added++;
+    }
+
+    return added;
+}
+
 
 /*-----------------------------------------------------------------------------
  * Hash type commands
@@ -2138,6 +2316,11 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     robj *hash;
 
     if ((hash = lookupKeyReadOrReply(c, c->argv[1], shared.emptyarray)) == NULL || checkType(c, hash, OBJ_HASH)) return;
+    hash = hrandfieldMaybePruneExpiredFields(c, hash);
+    if (hash == NULL) {
+        addReply(c, shared.emptyarray);
+        return;
+    }
     size = hashTypeLength(hash);
 
     if (l >= 0) {
@@ -2166,13 +2349,19 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * elements in random order. */
     if (!uniq || count == 1) {
         if (hash->encoding == OBJ_ENCODING_HASHTABLE) {
-            while (count--) {
+            unsigned long remaining = count;
+            while (remaining--) {
                 listpackEntry field, value;
 
-                /* In case we were unable to locate random element, it is probably because there is no such element
-                 * since all elements are expired. */
-                if (hashTypeRandomElement(hash, size, &field, &value) != C_OK)
+                /* Include the current slot in the fallback count because this
+                 * iteration already consumed one attempt. */
+                if (hashTypeRandomElement(hash, size, &field, &value) != C_OK) {
+                    entry **entries = NULL;
+                    unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
+                    reply_size += hrandfieldReplyFromCollectedEntries(wpc, entries, live_count, remaining + 1, uniq, withvalues, c->resp, NULL);
+                    zfree(entries);
                     break;
+                }
 
                 if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
                 addWritePreparedReplyBulkCBuffer(wpc, field.sval, field.slen);
@@ -2302,8 +2491,10 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
         while (added < count) {
             /* In case we were unable to locate random element, it is probably because there is no such element
              * since all elements are expired. */
-            if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK)
+            if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
+                added += hrandfieldReplyFromReservoirSample(wpc, hash, count - added, withvalues, c->resp, ht);
                 break;
+            }
 
             /* Try to add the object to the hashtable. If expired, stop adding (there are probably non left).
              * If it already exists free it, otherwise increment the number of objects we have
@@ -2362,9 +2553,23 @@ void hrandfieldCommand(client *c) {
     if ((hash = lookupKeyReadOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, hash, OBJ_HASH)) {
         return;
     }
+    hash = hrandfieldMaybePruneExpiredFields(c, hash);
+    if (hash == NULL) {
+        addReplyNull(c);
+        return;
+    }
+
     if (hashTypeRandomElement(hash, hashTypeLength(hash), &ele, NULL) == C_OK)
         hashReplyFromListpackEntry(c, &ele);
-    else
+    else if (hash->encoding == OBJ_ENCODING_HASHTABLE) {
+        entry *e = hrandfieldSelectRandomLiveHashtableEntry(hash);
+        if (e == NULL) {
+            addReplyNull(c);
+        } else {
+            sds field = entryGetField(e);
+            addReplyBulkCBuffer(c, field, sdslen(field));
+        }
+    } else
         addReplyNull(c);
 }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -910,6 +910,9 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
     return rc;
 }
 
+/* Collect all live entries from the hashtable-encoded hash into a newly
+ * allocated array. The caller owns *entries_out and must zfree it. Returns the
+ * number of collected entries. */
 static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***entries_out) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
     unsigned long count = 0, capacity = 16;
@@ -935,6 +938,8 @@ static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***
     return count;
 }
 
+/* Select one random live entry from the hashtable-encoded hash using reservoir
+ * sampling. Returns NULL when no live entry exists. */
 static entry *hrandfieldSelectRandomLiveHashtableEntry(robj *hash) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
     entry *selected = NULL;
@@ -953,17 +958,19 @@ static entry *hrandfieldSelectRandomLiveHashtableEntry(robj *hash) {
     return selected;
 }
 
-static void hrandfieldReplyHashtableEntry(writePreparedClient *wpc, entry *e, int withvalues, int resp);
-
-static unsigned long hrandfieldReplyFromReservoirSample(writePreparedClient *wpc,
-                                                        robj *hash,
-                                                        unsigned long count,
-                                                        int withvalues,
-                                                        int resp,
-                                                        hashtable *selected) {
+/* Return up to count unique live entries from the hashtable-encoded hash,
+ * excluding fields already present in ignore_entries. Entries are selected by
+ * reservoir sampling and shuffled before return. The caller owns the returned
+ * array and must zfree it. The actual count is stored in out_count. */
+static entry **hrandfieldSampleLiveEntries(robj *hash,
+                                           unsigned long count,
+                                           hashtable *ignore_entries,
+                                           unsigned long *out_count) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
+    serverAssert(out_count != NULL);
 
-    if (count == 0) return 0;
+    *out_count = 0;
+    if (count == 0) return NULL;
 
     entry **reservoir = zmalloc(sizeof(*reservoir) * count);
     unsigned long seen = 0, kept = 0;
@@ -974,7 +981,7 @@ static unsigned long hrandfieldReplyFromReservoirSample(writePreparedClient *wpc
         entry *e = hi.next;
         sds field = entryGetField(e);
 
-        if (selected && hashtableFind(selected, field, NULL)) {
+        if (ignore_entries && hashtableFind(ignore_entries, field, NULL)) {
             continue;
         }
 
@@ -997,91 +1004,8 @@ static unsigned long hrandfieldReplyFromReservoirSample(writePreparedClient *wpc
         reservoir[j] = tmp;
     }
 
-    for (unsigned long i = 0; i < kept; i++) {
-        entry *e = reservoir[i];
-
-        if (selected) {
-            sds field = entryGetField(e);
-            int res = hashtableAdd(selected, sdsdup(field));
-            serverAssert(res);
-        }
-
-        hrandfieldReplyHashtableEntry(wpc, e, withvalues, resp);
-    }
-
-    zfree(reservoir);
-    return kept;
-}
-
-static void hrandfieldReplyHashtableEntry(writePreparedClient *wpc, entry *e, int withvalues, int resp) {
-    sds field = entryGetField(e);
-    size_t value_len;
-    char *value = entryGetValue(e, &value_len);
-
-    if (withvalues && resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-    addWritePreparedReplyBulkCBuffer(wpc, field, sdslen(field));
-    if (withvalues) addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
-}
-
-static unsigned long hrandfieldReplyFromCollectedEntries(writePreparedClient *wpc,
-                                                         entry **entries,
-                                                         unsigned long live_count,
-                                                         unsigned long count,
-                                                         int uniq,
-                                                         int withvalues,
-                                                         int resp,
-                                                         hashtable *selected) {
-    unsigned long added = 0;
-
-    if (live_count == 0 || count == 0) return 0;
-
-    if (!uniq) {
-        while (added < count) {
-            hrandfieldReplyHashtableEntry(wpc, entries[random() % live_count], withvalues, resp);
-            added++;
-        }
-        return added;
-    }
-
-    for (unsigned long i = 0; i < live_count && added < count; i++) {
-        unsigned long j = i + (random() % (live_count - i));
-        entry *tmp = entries[i];
-        entries[i] = entries[j];
-        entries[j] = tmp;
-
-        sds field = entryGetField(entries[i]);
-        if (selected) {
-            hashtablePosition position;
-            if (!hashtableFindPositionForInsert(selected, field, &position, NULL)) {
-                continue;
-            }
-            sds selected_field = sdsdup(field);
-            hashtableInsertAtPosition(selected, selected_field, &position);
-        }
-        hrandfieldReplyHashtableEntry(wpc, entries[i], withvalues, resp);
-        added++;
-    }
-
-    return added;
-}
-
-static unsigned long hrandfieldReplyFromValidatedHashtableEntries(writePreparedClient *wpc,
-                                                                  robj *hash,
-                                                                  unsigned long count,
-                                                                  int uniq,
-                                                                  int withvalues,
-                                                                  int resp,
-                                                                  hashtable *selected) {
-    if (uniq) {
-        return hrandfieldReplyFromReservoirSample(wpc, hash, count, withvalues, resp, selected);
-    }
-
-    entry **entries = NULL;
-    unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
-    unsigned long added = hrandfieldReplyFromCollectedEntries(wpc, entries, live_count,
-                                                              count, uniq, withvalues, resp, selected);
-    zfree(entries);
-    return added;
+    *out_count = kept;
+    return reservoir;
 }
 
 
@@ -2306,10 +2230,6 @@ void hpexpiretimeCommand(client *c) {
  * the number of randoms per time. */
 #define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
-#define HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT 32
-#define HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT 256
-#define HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT 8
-
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
@@ -2351,8 +2271,37 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 /* Include the current slot in the fallback count because this
                  * iteration already consumed one attempt. */
                 if (hashTypeRandomElement(hash, size, &field, &value) != C_OK) {
-                    reply_size += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, remaining + 1,
-                                                                               uniq, withvalues, c->resp, NULL);
+                    unsigned long fallback_count = remaining + 1;
+                    if (uniq) {
+                        entry *e = hrandfieldSelectRandomLiveHashtableEntry(hash);
+                        if (e) {
+                            sds fallback_field = entryGetField(e);
+                            if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+                            addWritePreparedReplyBulkCBuffer(wpc, fallback_field, sdslen(fallback_field));
+                            if (withvalues) {
+                                size_t value_len;
+                                char *value = entryGetValue(e, &value_len);
+                                addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
+                            }
+                            reply_size++;
+                        }
+                    } else {
+                        entry **entries = NULL;
+                        unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
+                        while (fallback_count-- && live_count) {
+                            entry *e = entries[random() % live_count];
+                            sds fallback_field = entryGetField(e);
+                            if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+                            addWritePreparedReplyBulkCBuffer(wpc, fallback_field, sdslen(fallback_field));
+                            if (withvalues) {
+                                size_t value_len;
+                                char *value = entryGetValue(e, &value_len);
+                                addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
+                            }
+                            reply_size++;
+                        }
+                        zfree(entries);
+                    }
                     break;
                 }
 
@@ -2478,14 +2427,6 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     else {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
-        unsigned long duplicates = 0;
-        unsigned long consecutive_duplicates = 0;
-        unsigned long duplicate_limit = count / 2;
-        if (duplicate_limit < HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT) {
-            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT;
-        } else if (duplicate_limit > HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT) {
-            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT;
-        }
         listpackEntry field, value;
         hashtable *ht = hashtableCreate(&setHashtableType);
         hashtableExpand(ht, count);
@@ -2493,8 +2434,22 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             /* In case we were unable to locate random element, it is probably because there is no such element
              * since all elements are expired. */
             if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
-                added += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, count - added,
-                                                                      uniq, withvalues, c->resp, ht);
+                unsigned long kept;
+                entry **entries = hrandfieldSampleLiveEntries(hash, count - added, ht, &kept);
+                for (unsigned long i = 0; i < kept; i++) {
+                    sds sampled_field = entryGetField(entries[i]);
+                    int res = hashtableAdd(ht, sdsdup(sampled_field));
+                    serverAssert(res);
+                    if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+                    addWritePreparedReplyBulkCBuffer(wpc, sampled_field, sdslen(sampled_field));
+                    if (withvalues) {
+                        size_t value_len;
+                        char *value = entryGetValue(entries[i], &value_len);
+                        addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
+                    }
+                    added++;
+                }
+                zfree(entries);
                 break;
             }
 
@@ -2504,19 +2459,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             sds sfield = hashSdsFromListpackEntry(&field);
             if (!hashtableAdd(ht, sfield)) {
                 sdsfree(sfield);
-                /* Switch to a validated pass if random probing spends too
-                 * much work on fields already selected for this reply. */
-                duplicates++;
-                consecutive_duplicates++;
-                if (duplicates >= duplicate_limit ||
-                    consecutive_duplicates >= HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT) {
-                    added += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, count - added,
-                                                                          uniq, withvalues, c->resp, ht);
-                    break;
-                }
                 continue;
             }
-            consecutive_duplicates = 0;
             added++;
 
             /* We can reply right away, so that we don't need to store the value in the dict. */

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -910,29 +910,6 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
     return rc;
 }
 
-/* Bound the amount of expiry cleanup HRANDFIELD does up front so stale-heavy
- * hashes improve quickly without turning a read path into an unbounded sweep.
- * Keep the default conservative and rely on the validated fallback for
- * correctness if stale entries still dominate the physical hash size. */
-#ifndef HRANDFIELD_EXPIRED_PRUNE_LIMIT
-#define HRANDFIELD_EXPIRED_PRUNE_LIMIT 32
-#endif
-
-static robj *hrandfieldMaybePruneExpiredFields(client *c, robj *hash) {
-    if (!hash || hash->encoding != OBJ_ENCODING_HASHTABLE || !hashTypeHasVolatileFields(hash)) {
-        return hash;
-    }
-    if (!iAmPrimary() || server.import_mode || server.lazy_expire_disabled) {
-        return hash;
-    }
-    if (isPausedActionsWithUpdate(PAUSE_ACTION_EXPIRE)) {
-        return hash;
-    }
-
-    dbReclaimExpiredFields(hash, c->db, commandTimeSnapshot(), HRANDFIELD_EXPIRED_PRUNE_LIMIT, c->slot);
-    return lookupKeyRead(c->db, c->argv[1]);
-}
-
 static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***entries_out) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
     unsigned long count = 0, capacity = 16;
@@ -1085,6 +1062,25 @@ static unsigned long hrandfieldReplyFromCollectedEntries(writePreparedClient *wp
         added++;
     }
 
+    return added;
+}
+
+static unsigned long hrandfieldReplyFromValidatedHashtableEntries(writePreparedClient *wpc,
+                                                                  robj *hash,
+                                                                  unsigned long count,
+                                                                  int uniq,
+                                                                  int withvalues,
+                                                                  int resp,
+                                                                  hashtable *selected) {
+    if (uniq) {
+        return hrandfieldReplyFromReservoirSample(wpc, hash, count, withvalues, resp, selected);
+    }
+
+    entry **entries = NULL;
+    unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
+    unsigned long added = hrandfieldReplyFromCollectedEntries(wpc, entries, live_count,
+                                                              count, uniq, withvalues, resp, selected);
+    zfree(entries);
     return added;
 }
 
@@ -2310,17 +2306,16 @@ void hpexpiretimeCommand(client *c) {
  * the number of randoms per time. */
 #define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
+#define HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT 32
+#define HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT 256
+#define HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT 8
+
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
     robj *hash;
 
     if ((hash = lookupKeyReadOrReply(c, c->argv[1], shared.emptyarray)) == NULL || checkType(c, hash, OBJ_HASH)) return;
-    hash = hrandfieldMaybePruneExpiredFields(c, hash);
-    if (hash == NULL) {
-        addReply(c, shared.emptyarray);
-        return;
-    }
     size = hashTypeLength(hash);
 
     if (l >= 0) {
@@ -2356,10 +2351,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 /* Include the current slot in the fallback count because this
                  * iteration already consumed one attempt. */
                 if (hashTypeRandomElement(hash, size, &field, &value) != C_OK) {
-                    entry **entries = NULL;
-                    unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
-                    reply_size += hrandfieldReplyFromCollectedEntries(wpc, entries, live_count, remaining + 1, uniq, withvalues, c->resp, NULL);
-                    zfree(entries);
+                    reply_size += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, remaining + 1,
+                                                                               uniq, withvalues, c->resp, NULL);
                     break;
                 }
 
@@ -2485,6 +2478,14 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     else {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
+        unsigned long duplicates = 0;
+        unsigned long consecutive_duplicates = 0;
+        unsigned long duplicate_limit = count / 2;
+        if (duplicate_limit < HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT) {
+            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT;
+        } else if (duplicate_limit > HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT) {
+            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT;
+        }
         listpackEntry field, value;
         hashtable *ht = hashtableCreate(&setHashtableType);
         hashtableExpand(ht, count);
@@ -2492,7 +2493,8 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             /* In case we were unable to locate random element, it is probably because there is no such element
              * since all elements are expired. */
             if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
-                added += hrandfieldReplyFromReservoirSample(wpc, hash, count - added, withvalues, c->resp, ht);
+                added += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, count - added,
+                                                                      uniq, withvalues, c->resp, ht);
                 break;
             }
 
@@ -2502,8 +2504,19 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             sds sfield = hashSdsFromListpackEntry(&field);
             if (!hashtableAdd(ht, sfield)) {
                 sdsfree(sfield);
+                /* Switch to a validated pass if random probing spends too
+                 * much work on fields already selected for this reply. */
+                duplicates++;
+                consecutive_duplicates++;
+                if (duplicates >= duplicate_limit ||
+                    consecutive_duplicates >= HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT) {
+                    added += hrandfieldReplyFromValidatedHashtableEntries(wpc, hash, count - added,
+                                                                          uniq, withvalues, c->resp, ht);
+                    break;
+                }
                 continue;
             }
+            consecutive_duplicates = 0;
             added++;
 
             /* We can reply right away, so that we don't need to store the value in the dict. */
@@ -2551,11 +2564,6 @@ void hrandfieldCommand(client *c) {
 
     /* Handle variant without <count> argument. Reply with simple bulk string */
     if ((hash = lookupKeyReadOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, hash, OBJ_HASH)) {
-        return;
-    }
-    hash = hrandfieldMaybePruneExpiredFields(c, hash);
-    if (hash == NULL) {
-        addReplyNull(c);
         return;
     }
 

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -910,10 +910,10 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
     return rc;
 }
 
-/* Collect all live entries from the hashtable-encoded hash into a newly
- * allocated array. The caller owns *entries_out and must zfree it. Returns the
- * number of collected entries. */
-static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***entries_out) {
+/* Collect all live entries of a hashtable-encoded hash into a freshly allocated
+ * array, Fisher-Yates shuffled. The caller owns *entries_out and must zfree it.
+ * Returns the number of collected entries (and *entries_out=NULL when zero). */
+static unsigned long hrandfieldCollectLiveEntries(robj *hash, entry ***entries_out) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
     unsigned long count = 0, capacity = 16;
     entry **entries = zmalloc(sizeof(*entries) * capacity);
@@ -931,7 +931,16 @@ static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***
 
     if (count == 0) {
         zfree(entries);
-        entries = NULL;
+        *entries_out = NULL;
+        return 0;
+    }
+
+    /* Fisher-Yates shuffle so the caller can take a uniform random prefix. */
+    for (unsigned long i = count - 1; i > 0; i--) {
+        unsigned long j = random() % (i + 1);
+        entry *tmp = entries[i];
+        entries[i] = entries[j];
+        entries[j] = tmp;
     }
 
     *entries_out = entries;
@@ -940,7 +949,7 @@ static unsigned long hrandfieldCollectLiveHashtableEntries(robj *hash, entry ***
 
 /* Select one random live entry from the hashtable-encoded hash using reservoir
  * sampling. Returns NULL when no live entry exists. */
-static entry *hrandfieldSelectRandomLiveHashtableEntry(robj *hash) {
+static entry *hrandfieldSelectRandomLiveEntry(robj *hash) {
     serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
     entry *selected = NULL;
     unsigned long seen = 0;
@@ -958,54 +967,13 @@ static entry *hrandfieldSelectRandomLiveHashtableEntry(robj *hash) {
     return selected;
 }
 
-/* Return up to count unique live entries from the hashtable-encoded hash,
- * excluding fields already present in ignore_entries. Entries are selected by
- * reservoir sampling and shuffled before return. The caller owns the returned
- * array and must zfree it. The actual count is stored in out_count. */
-static entry **hrandfieldSampleLiveEntries(robj *hash,
-                                           unsigned long count,
-                                           hashtable *ignore_entries,
-                                           unsigned long *out_count) {
-    serverAssert(hash->encoding == OBJ_ENCODING_HASHTABLE);
-    serverAssert(out_count != NULL);
-
-    *out_count = 0;
-    if (count == 0) return NULL;
-
-    entry **reservoir = zmalloc(sizeof(*reservoir) * count);
-    unsigned long seen = 0, kept = 0;
-    hashTypeIterator hi;
-    hashTypeInitIterator(hash, &hi);
-
-    while (hashTypeNext(&hi) != C_ERR) {
-        entry *e = hi.next;
-        sds field = entryGetField(e);
-
-        if (ignore_entries && hashtableFind(ignore_entries, field, NULL)) {
-            continue;
-        }
-
-        seen++;
-        if (kept < count) {
-            reservoir[kept++] = e;
-        } else {
-            unsigned long j = random() % seen;
-            if (j < count) {
-                reservoir[j] = e;
-            }
-        }
-    }
-    hashTypeResetIterator(&hi);
-
-    for (unsigned long i = 0; i < kept; i++) {
-        unsigned long j = i + (random() % (kept - i));
-        entry *tmp = reservoir[i];
-        reservoir[i] = reservoir[j];
-        reservoir[j] = tmp;
-    }
-
-    *out_count = kept;
-    return reservoir;
+/* Decide whether HRANDFIELD's CASE 4 should bypass random probing and walk the
+ * hash. Returns true whenever the hash carries any volatile (TTL'd) fields:
+ * random probing assumes liveness uniformity and (for count > live) cannot
+ * terminate via hashTypeRandomElement's C_ERR signal in the moderate-expired
+ * band. Pure non-TTL hashes keep the fast probing path. */
+static bool hrandfieldHashUsesCollectPath(robj *hash) {
+    return hashTypeHasVolatileFields(hash);
 }
 
 
@@ -2230,24 +2198,6 @@ void hpexpiretimeCommand(client *c) {
  * the number of randoms per time. */
 #define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
-/* CASE 4 fallback budget. hashTypeRandomElement only returns C_ERR after
- * 100 *consecutive* expired probes; that signal does not fire when the
- * live pool is exhausted but most random picks still resolve to a live
- * (already-collected) entry. Bound the random-probing loop with a count-
- * proportional cumulative duplicate budget plus a small consecutive-dup
- * streak guard, so CASE 4 falls back to a single validated reservoir pass
- * before the loop can spin indefinitely.
- *
- *  - MIN floor (32): keep small counts above coupon-collector tail noise,
- *    e.g. count=4 with live=4 expects ~4 natural duplicates.
- *  - MAX cap (256): once cumulative dups reach this many, the wasted
- *    probing cost approaches a single O(size) iteration anyway.
- *  - STREAK (8): early signal for very-expired-heavy hashes where dup
- *    streaks appear before the cumulative budget is exhausted. */
-#define HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT     32
-#define HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT    256
-#define HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT   8
-
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
@@ -2291,7 +2241,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 if (hashTypeRandomElement(hash, size, &field, &value) != C_OK) {
                     unsigned long fallback_count = remaining + 1;
                     if (uniq) {
-                        entry *e = hrandfieldSelectRandomLiveHashtableEntry(hash);
+                        entry *e = hrandfieldSelectRandomLiveEntry(hash);
                         if (e) {
                             sds fallback_field = entryGetField(e);
                             if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
@@ -2305,7 +2255,7 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                         }
                     } else {
                         entry **entries = NULL;
-                        unsigned long live_count = hrandfieldCollectLiveHashtableEntries(hash, &entries);
+                        unsigned long live_count = hrandfieldCollectLiveEntries(hash, &entries);
                         while (fallback_count-- && live_count) {
                             entry *e = entries[random() % live_count];
                             sds fallback_field = entryGetField(e);
@@ -2444,67 +2394,55 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * to reach the specified count. */
     else {
         /* Hashtable encoding (generic implementation) */
-        unsigned long added = 0;
-        unsigned long duplicates = 0;
-        unsigned long consecutive_duplicates = 0;
-        unsigned long duplicate_limit = count / 2;
-        if (duplicate_limit < HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT)
-            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT;
-        else if (duplicate_limit > HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT)
-            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT;
-
-        listpackEntry field, value;
-        hashtable *ht = hashtableCreate(&setHashtableType);
-        hashtableExpand(ht, count);
-        while (added < count) {
-            int budget_exhausted = (duplicates >= duplicate_limit ||
-                                    consecutive_duplicates >= HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT);
-            /* Fall back when random probing exhausts its budget or fails outright.
-             * The C_ERR path means the live pool is too sparse for random probing;
-             * the budget path means we are stuck on duplicates and one validated
-             * reservoir pass is cheaper than continued probing. */
-            if (budget_exhausted ||
-                hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
-                unsigned long kept;
-                entry **entries = hrandfieldSampleLiveEntries(hash, count - added, ht, &kept);
-                for (unsigned long i = 0; i < kept; i++) {
-                    sds sampled_field = entryGetField(entries[i]);
-                    int res = hashtableAdd(ht, sdsdup(sampled_field));
-                    serverAssert(res);
-                    if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-                    addWritePreparedReplyBulkCBuffer(wpc, sampled_field, sdslen(sampled_field));
-                    if (withvalues) {
-                        size_t value_len;
-                        char *value = entryGetValue(entries[i], &value_len);
-                        addWritePreparedReplyBulkCBuffer(wpc, value, value_len);
-                    }
-                    added++;
+        if (hrandfieldHashUsesCollectPath(hash)) {
+            /* The hash has volatile (TTL'd) fields. Random probing cannot
+             * terminate when the live pool is exhausted (count > live) within
+             * the moderate-expired band, since hashTypeRandomElement's C_ERR
+             * only fires after 100 consecutive expired probes. Walk the hash
+             * once, collect all live entries shuffled, and emit the first
+             * count of them. */
+            entry **entries = NULL;
+            unsigned long live_count = hrandfieldCollectLiveEntries(hash, &entries);
+            unsigned long to_add = count < live_count ? count : live_count;
+            for (unsigned long i = 0; i < to_add; i++) {
+                sds f = entryGetField(entries[i]);
+                if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+                addWritePreparedReplyBulkCBuffer(wpc, f, sdslen(f));
+                if (withvalues) {
+                    size_t vlen;
+                    char *v = entryGetValue(entries[i], &vlen);
+                    addWritePreparedReplyBulkCBuffer(wpc, v, vlen);
                 }
-                zfree(entries);
-                break;
+                reply_size++;
             }
+            zfree(entries);
+        } else {
+            /* No expired fields right now. Random probing is the natural
+             * implementation: pick random elements from the hash and dedup
+             * via a temporary hashtable, trying to eventually get enough
+             * unique elements to reach the specified count. */
+            unsigned long added = 0;
+            listpackEntry field, value;
+            hashtable *ht = hashtableCreate(&setHashtableType);
+            hashtableExpand(ht, count);
+            while (added < count) {
+                if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK)
+                    break;
 
-            /* Try to add the object to the hashtable. If it already exists, count
-             * it as a duplicate; the budget caps how long we keep trying. */
-            sds sfield = hashSdsFromListpackEntry(&field);
-            if (!hashtableAdd(ht, sfield)) {
-                sdsfree(sfield);
-                duplicates++;
-                consecutive_duplicates++;
-                continue;
+                sds sfield = hashSdsFromListpackEntry(&field);
+                if (!hashtableAdd(ht, sfield)) {
+                    sdsfree(sfield);
+                    continue;
+                }
+                added++;
+
+                if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
+                hashReplyFromListpackEntry(c, &field);
+                if (withvalues) hashReplyFromListpackEntry(c, &value);
             }
-            consecutive_duplicates = 0;
-            added++;
-
-            /* We can reply right away, so that we don't need to store the value in the dict. */
-            if (withvalues && c->resp > 2) addWritePreparedReplyArrayLen(wpc, 2);
-            hashReplyFromListpackEntry(c, &field);
-            if (withvalues) hashReplyFromListpackEntry(c, &value);
+            hashtableRelease(ht);
+            reply_size = added;
         }
-
-        /* Release memory */
-        hashtableRelease(ht);
-        reply_size = added;
     }
 
 set_deferred_response:
@@ -2547,7 +2485,7 @@ void hrandfieldCommand(client *c) {
     if (hashTypeRandomElement(hash, hashTypeLength(hash), &ele, NULL) == C_OK)
         hashReplyFromListpackEntry(c, &ele);
     else if (hash->encoding == OBJ_ENCODING_HASHTABLE) {
-        entry *e = hrandfieldSelectRandomLiveHashtableEntry(hash);
+        entry *e = hrandfieldSelectRandomLiveEntry(hash);
         if (e == NULL) {
             addReplyNull(c);
         } else {

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -2230,6 +2230,24 @@ void hpexpiretimeCommand(client *c) {
  * the number of randoms per time. */
 #define HRANDFIELD_RANDOM_SAMPLE_LIMIT 1000
 
+/* CASE 4 fallback budget. hashTypeRandomElement only returns C_ERR after
+ * 100 *consecutive* expired probes; that signal does not fire when the
+ * live pool is exhausted but most random picks still resolve to a live
+ * (already-collected) entry. Bound the random-probing loop with a count-
+ * proportional cumulative duplicate budget plus a small consecutive-dup
+ * streak guard, so CASE 4 falls back to a single validated reservoir pass
+ * before the loop can spin indefinitely.
+ *
+ *  - MIN floor (32): keep small counts above coupon-collector tail noise,
+ *    e.g. count=4 with live=4 expects ~4 natural duplicates.
+ *  - MAX cap (256): once cumulative dups reach this many, the wasted
+ *    probing cost approaches a single O(size) iteration anyway.
+ *  - STREAK (8): early signal for very-expired-heavy hashes where dup
+ *    streaks appear before the cumulative budget is exhausted. */
+#define HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT     32
+#define HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT    256
+#define HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT   8
+
 void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     unsigned long count, size;
     int uniq = 1;
@@ -2427,13 +2445,26 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
     else {
         /* Hashtable encoding (generic implementation) */
         unsigned long added = 0;
+        unsigned long duplicates = 0;
+        unsigned long consecutive_duplicates = 0;
+        unsigned long duplicate_limit = count / 2;
+        if (duplicate_limit < HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT)
+            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MIN_LIMIT;
+        else if (duplicate_limit > HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT)
+            duplicate_limit = HRANDFIELD_RANDOM_DUPLICATE_MAX_LIMIT;
+
         listpackEntry field, value;
         hashtable *ht = hashtableCreate(&setHashtableType);
         hashtableExpand(ht, count);
         while (added < count) {
-            /* In case we were unable to locate random element, it is probably because there is no such element
-             * since all elements are expired. */
-            if (hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
+            int budget_exhausted = (duplicates >= duplicate_limit ||
+                                    consecutive_duplicates >= HRANDFIELD_RANDOM_DUPLICATE_STREAK_LIMIT);
+            /* Fall back when random probing exhausts its budget or fails outright.
+             * The C_ERR path means the live pool is too sparse for random probing;
+             * the budget path means we are stuck on duplicates and one validated
+             * reservoir pass is cheaper than continued probing. */
+            if (budget_exhausted ||
+                hashTypeRandomElement(hash, size, &field, withvalues ? &value : NULL) != C_OK) {
                 unsigned long kept;
                 entry **entries = hrandfieldSampleLiveEntries(hash, count - added, ht, &kept);
                 for (unsigned long i = 0; i < kept; i++) {
@@ -2453,14 +2484,16 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
                 break;
             }
 
-            /* Try to add the object to the hashtable. If expired, stop adding (there are probably non left).
-             * If it already exists free it, otherwise increment the number of objects we have
-             * in the result hashtable. */
+            /* Try to add the object to the hashtable. If it already exists, count
+             * it as a duplicate; the budget caps how long we keep trying. */
             sds sfield = hashSdsFromListpackEntry(&field);
             if (!hashtableAdd(ht, sfield)) {
                 sdsfree(sfield);
+                duplicates++;
+                consecutive_duplicates++;
                 continue;
             }
+            consecutive_duplicates = 0;
             added++;
 
             /* We can reply right away, so that we don't need to store the value in the dict. */

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -327,6 +327,22 @@ start_server {tags {"hash"}} {
                 }
             }
         }
+
+        test {HRANDFIELD unique count falls back when live fields are fewer than requested in CASE 4} {
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 201 99
+                assert_equal 300 [r hlen stalehash]
+
+                set result [r hrandfield stalehash 100]
+                assert_equal 99 [llength $result]
+
+                set expected {}
+                for {set i 0} {$i < 99} {incr i} {
+                    lappend expected "live:$i"
+                }
+                assert_equal [lsort $expected] [lsort $result]
+            }
+        }
     }
 
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -343,6 +343,35 @@ start_server {tags {"hash"}} {
                 assert_equal [lsort $expected] [lsort $result]
             }
         }
+
+        test {HRANDFIELD CASE 4 must not hang on a moderately-expired hash with count > live} {
+            # Hang regression. At ~78% expired, hashTypeRandomElement's internal
+            # maxtries=100 essentially never returns C_ERR (~1e-10 per call), so
+            # the CASE 4 random-probing loop relies on the cumulative + consecutive
+            # duplicate budget to trigger the validated reservoir fallback. Without
+            # the budget the loop spins once the live pool is exhausted but count
+            # is not yet met, blocking the entire server thread indefinitely.
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 700 200
+                assert_equal 900 [r hlen stalehash]
+
+                set start [clock milliseconds]
+                set result [r hrandfield stalehash 250]
+                set elapsed [expr {[clock milliseconds] - $start}]
+
+                # A correct implementation completes in single-digit ms; allow a
+                # generous bound for slow CI. A regression would not return at all
+                # until a higher-level timeout kills it.
+                assert {$elapsed < 1000}
+                assert_equal 200 [llength $result]
+
+                set expected {}
+                for {set i 0} {$i < 200} {incr i} {
+                    lappend expected "live:$i"
+                }
+                assert_equal [lsort $expected] [lsort $result]
+            }
+        }
     }
 
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -34,6 +34,54 @@ start_server {tags {"hash"}} {
         return $res
     }
 
+    proc create_expired_heavy_hash_for_hrandfield {key expired_count {live_count 1}} {
+        r del $key
+
+        # Force hashtable encoding up front so random sampling goes through
+        # the hashtable path even when only a few live fields remain.
+        set force_field [format "force:%s" [string repeat x 80]]
+        r hset $key $force_field seed
+        r hdel $key $force_field
+
+        set batch_size 200
+        for {set base 0} {$base < $expired_count} {incr base $batch_size} {
+            set hset_args [list HSET $key]
+            set expire_fields {}
+            set limit [expr {min($expired_count, $base + $batch_size)}]
+            for {set i $base} {$i < $limit} {incr i} {
+                set field "expired:$i"
+                lappend hset_args $field x
+                lappend expire_fields $field
+            }
+            r {*}$hset_args
+            r HPEXPIRE $key 1 FIELDS [llength $expire_fields] {*}$expire_fields
+        }
+
+        after 50
+
+        for {set i 0} {$i < $live_count} {incr i} {
+            r hset $key "live:$i" "value:$i"
+        }
+
+        assert_encoding hashtable $key
+    }
+
+    proc repeat_hrandfield_invocations {iterations body} {
+        for {set i 0} {$i < $iterations} {incr i} {
+            uplevel 1 $body
+        }
+    }
+
+    proc with_active_expire_disabled {body} {
+        r debug set-active-expire 0
+        set err_code [catch {uplevel 1 $body} result options]
+        r debug set-active-expire 1
+        if {$err_code} {
+            return -options $options $result
+        }
+        return $result
+    }
+
     foreach {type contents} "listpack {{a 1} {b 2} {c 3}} hashtable {{a 1} {b 2} {[randstring 70 90 alpha] 3}}" {
         set original_max_value [lindex [r config get hash-max-ziplist-value] 1]
         r config set hash-max-ziplist-value 10
@@ -225,6 +273,60 @@ start_server {tags {"hash"}} {
             }
         }
         r config set hash-max-ziplist-value $original_max_value
+    }
+
+    tags {slow} {
+        test {HRANDFIELD returns the live field on an expired-heavy hash} {
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 20000 1
+
+                repeat_hrandfield_invocations 64 {
+                    assert_equal live:0 [r hrandfield stalehash]
+                }
+            }
+        }
+
+        test {HRANDFIELD negative count does not stop early on an expired-heavy hash} {
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 20000 1
+
+                repeat_hrandfield_invocations 32 {
+                    set result [r hrandfield stalehash -16]
+                    assert_equal 16 [llength $result]
+                    assert_equal [lrepeat 16 live:0] $result
+                }
+            }
+        }
+
+        test {HRANDFIELD WITHVALUES returns all live fields on an expired-heavy hash} {
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 20000 4
+
+                set expected [dict create live:0 value:0 live:1 value:1 live:2 value:2 live:3 value:3]
+                repeat_hrandfield_invocations 32 {
+                    set result [r hrandfield stalehash 4 withvalues]
+                    assert_equal 8 [llength $result]
+                    set result_dict [dict create {*}$result]
+                    assert_equal 4 [dict size $result_dict]
+                    foreach {field value} $expected {
+                        assert_equal $value [dict get $result_dict $field]
+                    }
+                }
+            }
+        }
+
+        test {HRANDFIELD returns unique live fields on an expired-heavy hash} {
+            with_active_expire_disabled {
+                create_expired_heavy_hash_for_hrandfield stalehash 20000 4
+
+                set expected [list live:0 live:1 live:2 live:3]
+                repeat_hrandfield_invocations 32 {
+                    set result [r hrandfield stalehash 4]
+                    assert_equal 4 [llength $result]
+                    assert_equal $expected [lsort $result]
+                }
+            }
+        }
     }
 
 

--- a/tests/unit/type/hash.tcl
+++ b/tests/unit/type/hash.tcl
@@ -330,8 +330,8 @@ start_server {tags {"hash"}} {
 
         test {HRANDFIELD unique count falls back when live fields are fewer than requested in CASE 4} {
             with_active_expire_disabled {
-                create_expired_heavy_hash_for_hrandfield stalehash 201 99
-                assert_equal 300 [r hlen stalehash]
+                create_expired_heavy_hash_for_hrandfield stalehash 20000 99
+                assert_equal 20099 [r hlen stalehash]
 
                 set result [r hrandfield stalehash 100]
                 assert_equal 99 [llength $result]


### PR DESCRIPTION
Before this change, `HRANDFIELD` could return `NULL` or too few results even when live hash fields
  still existed, if random probing kept landing on stale expired entries in a volatile hashtable-
  encoded hash.

  This change fixes that correctness issue while keeping the common random path fast.

  The new behavior has two parts:

  1. Before `HRANDFIELD` chooses its sampling strategy, it opportunistically prunes a small bounded
  number of expired hash fields from a volatile hashtable hash.
  2. If random probing still fails after that, `HRANDFIELD` switches to a bounded validated live-
  entry fallback for the rest of the command, instead of treating the hash as empty or continuing to
  rely on repeated random misses.

  The important property of the fallback is that it avoids degenerating into repeated per-sample
  full scans. Depending on the affected `HRANDFIELD` variant, the command pays for only a small
  number of validated bulk passes before replying, which keeps the worst-case recovery path
  predictable while still guaranteeing correct results when the physical hash size is dominated by
  stale entries.

  The bounded cleanup is intentionally conservative. The default prune limit is `32`, which keeps
  read-path cleanup work small and predictable while still allowing the validated fallback to
  guarantee correctness when stale entries continue to dominate the backing hashtable after pruning.

  Because this runs on a read path, it can also reclaim expired hash fields and propagate the
  resulting field deletions when stale entries are encountered. With the current default, a single
  `HRANDFIELD` call can reclaim and propagate up to `32` expired hash fields before switching to the
  validated fallback path.

  This change also adds expired-heavy regression coverage for all four affected `HRANDFIELD` paths:
  - single-field
  - negative-count
  - unique count
  - `WITHVALUES`

  I also compared several prune limits (`32`, `64`, `128`, `256`, `512`) on the expired-heavy
  benchmark case. There was no large difference overall, but `32` stayed competitive while also
  keeping the reclaim side effect bounded to at most `32` field deletions per call, so this change
  keeps the default conservative.

  | Limit | `HRANDFIELD key` | `HRANDFIELD key -16` | `HRANDFIELD key 4` | `HRANDFIELD key 16` |
  `HRANDFIELD key 4 WITHVALUES` |
  |---|---:|---:|---:|---:|---:|
  | `32` | 0.244 ms | 0.732 ms | 0.300 ms | 0.415 ms | 0.456 ms |
  | `64` | 0.246 ms | 0.755 ms | 0.429 ms | 0.415 ms | 0.490 ms |
  | `128` | 0.256 ms | 0.714 ms | 0.414 ms | 0.419 ms | 0.466 ms |
  | `256` | 0.265 ms | 0.756 ms | 0.337 ms | 0.428 ms | 0.469 ms |
  | `512` | 0.258 ms | 0.714 ms | 0.402 ms | 0.454 ms | 0.471 ms |

  I also reran the benchmark comparison against `valkey/unstable` after clean rebuilds of both trees
  (`make distclean && make`) and 5 repeated runs per case.

  | Case | Current Mean ms | Current SD ms | Unstable Mean ms | Unstable SD ms | Delta ms | Delta %
  |
  |---|---:|---:|---:|---:|---:|---:|
  | `HRANDFIELD baseline_hash` | 0.234 | 0.002 | 0.234 | 0.003 | -0.001 | -0.3% |
  | `HRANDFIELD expired_heavy_hash` | 0.238 | 0.004 | 0.233 | 0.006 | +0.005 | +2.2% |
  | `HRANDFIELD baseline_hash -16` | 0.672 | 0.004 | 0.675 | 0.006 | -0.003 | -0.4% |
  | `HRANDFIELD expired_heavy_hash -16` | 0.249 | 0.004 | 0.248 | 0.008 | +0.001 | +0.5% |
  | `HRANDFIELD baseline_hash 4` | 0.434 | 0.001 | 0.435 | 0.004 | -0.001 | -0.3% |
  | `HRANDFIELD expired_heavy_hash 4` | 0.235 | 0.003 | 0.234 | 0.004 | +0.001 | +0.3% |
  | `HRANDFIELD baseline_hash 16` | 0.715 | 0.004 | 0.720 | 0.005 | -0.005 | -0.7% |
  | `HRANDFIELD expired_heavy_hash 16` | 0.238 | 0.004 | 0.234 | 0.001 | +0.004 | +1.6% |
  | `HRANDFIELD baseline_hash 4 WITHVALUES` | 0.444 | 0.005 | 0.448 | 0.001 | -0.005 | -1.0% |
  | `HRANDFIELD expired_heavy_hash 4 WITHVALUES` | 0.241 | 0.003 | 0.240 | 0.007 | +0.002 | +0.7% |

  Across those repeated runs, the current branch stayed within about `-1.0%` to `+2.2%` of
  `unstable`, which suggests no meaningful performance regression while correcting the expired-heavy
  behavior.