### PR TITLE
Refactor dict restoring abstraction

### DIFF
--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -13,6 +13,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/hashtable.c
     ${CMAKE_SOURCE_DIR}/src/kvstore.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
+    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
     ${CMAKE_SOURCE_DIR}/src/zmalloc.c
     ${CMAKE_SOURCE_DIR}/src/lzf_c.c
     ${CMAKE_SOURCE_DIR}/src/lzf_d.c
@@ -130,6 +131,7 @@ set(VALKEY_CLI_SRCS
     ${CMAKE_SOURCE_DIR}/src/adlist.c
     ${CMAKE_SOURCE_DIR}/src/hashtable.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
+    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
     ${CMAKE_SOURCE_DIR}/src/sha256.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/valkey-cli.c
@@ -154,6 +156,7 @@ set(VALKEY_BENCHMARK_SRCS
     ${CMAKE_SOURCE_DIR}/src/ae.c
     ${CMAKE_SOURCE_DIR}/src/anet.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
+    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
     ${CMAKE_SOURCE_DIR}/src/sha256.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/valkey-benchmark.c

--- a/cmake/Modules/SourceFiles.cmake
+++ b/cmake/Modules/SourceFiles.cmake
@@ -13,7 +13,7 @@ set(VALKEY_SERVER_SRCS
     ${CMAKE_SOURCE_DIR}/src/hashtable.c
     ${CMAKE_SOURCE_DIR}/src/kvstore.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
-    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
+    ${CMAKE_SOURCE_DIR}/src/dictht.c
     ${CMAKE_SOURCE_DIR}/src/zmalloc.c
     ${CMAKE_SOURCE_DIR}/src/lzf_c.c
     ${CMAKE_SOURCE_DIR}/src/lzf_d.c
@@ -131,7 +131,7 @@ set(VALKEY_CLI_SRCS
     ${CMAKE_SOURCE_DIR}/src/adlist.c
     ${CMAKE_SOURCE_DIR}/src/hashtable.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
-    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
+    ${CMAKE_SOURCE_DIR}/src/dictht.c
     ${CMAKE_SOURCE_DIR}/src/sha256.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/valkey-cli.c
@@ -156,7 +156,7 @@ set(VALKEY_BENCHMARK_SRCS
     ${CMAKE_SOURCE_DIR}/src/ae.c
     ${CMAKE_SOURCE_DIR}/src/anet.c
     ${CMAKE_SOURCE_DIR}/src/sds.c
-    ${CMAKE_SOURCE_DIR}/src/dict_ht.c
+    ${CMAKE_SOURCE_DIR}/src/dictht.c
     ${CMAKE_SOURCE_DIR}/src/sha256.c
     ${CMAKE_SOURCE_DIR}/src/util.c
     ${CMAKE_SOURCE_DIR}/src/valkey-benchmark.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -498,6 +498,7 @@ ENGINE_SERVER_OBJ = \
     db.o \
     debug.o \
     defrag.o \
+	dict_ht.o \
     entry.o \
     eval.o \
     evict.o \
@@ -594,6 +595,7 @@ ENGINE_CLI_OBJ = \
     crc64.o \
     crccombine.o \
     crcspeed.o \
+	dict_ht.o \
     hashtable.o \
     monotonic.o \
     mt19937-64.o \
@@ -618,6 +620,7 @@ ENGINE_BENCHMARK_OBJ = \
     crc64.o \
     crccombine.o \
     crcspeed.o \
+	dict_ht.o \
     fuzzer_client.o \
     fuzzer_command_generator.o \
     hashtable.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -498,7 +498,7 @@ ENGINE_SERVER_OBJ = \
     db.o \
     debug.o \
     defrag.o \
-	dict_ht.o \
+    dictht.o \
     entry.o \
     eval.o \
     evict.o \
@@ -582,7 +582,7 @@ ENGINE_SERVER_OBJ = \
     ziplist.o \
     zipmap.o \
     zmalloc.o \
-	queues.o
+    queues.o
 ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ = \
@@ -595,7 +595,7 @@ ENGINE_CLI_OBJ = \
     crc64.o \
     crccombine.o \
     crcspeed.o \
-	dict_ht.o \
+    dictht.o \
     hashtable.o \
     monotonic.o \
     mt19937-64.o \
@@ -620,7 +620,7 @@ ENGINE_BENCHMARK_OBJ = \
     crc64.o \
     crccombine.o \
     crcspeed.o \
-	dict_ht.o \
+    dictht.o \
     fuzzer_client.o \
     fuzzer_command_generator.o \
     hashtable.o \

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -247,7 +247,6 @@ static_assert(offsetof(clusterMsg, type) + sizeof(uint16_t) == RCVBUF_MIN_READ_L
 /* Cluster nodes hash table, mapping nodes addresses 1.2.3.4:6379 to
  * clusterNode structures. */
 dictType clusterNodesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -257,7 +256,6 @@ dictType clusterNodesDictType = {
  * we can re-add this node. The goal is to avoid reading a removed
  * node for some time. */
 dictType clusterNodesBlackListDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -265,7 +263,6 @@ dictType clusterNodesBlackListDictType = {
 
 /* Cluster shards hash table, mapping shard id to list of nodes */
 dictType clusterSdsToListType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKeyListValue,
@@ -283,7 +280,6 @@ static int dictPtrCompare(const void *key1, const void *key2) {
 /* Dictionary type for mapping hash slots to cluster nodes.
  * Keys are slot numbers encoded directly as pointer values, values are clusterNode pointers. */
 dictType clusterSlotDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictPtrHash,
     .keyCompare = dictPtrCompare,
     .entryDestructor = zfree,

--- a/src/config.c
+++ b/src/config.c
@@ -1047,14 +1047,12 @@ void rewriteConfigSentinelOption(struct rewriteConfigState *state);
  * like "maxmemory" -> list of line numbers (first line is zero).
  */
 dictType optionToLineDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyListValue,
 };
 
 dictType optionSetDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKey,

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -303,7 +303,7 @@ static void activeDefragZsetNode(void *privdata, void *entry_ref) {
 static void activeDefragDictCallback(void *privdata, void *entry_ref) {
     dictDefragFunctions *defragfns = privdata;
     dictEntry **de_ref = (dictEntry **)entry_ref;
-    htdictDefragEntry(de_ref, defragfns);
+    dicthtDefragEntry(de_ref, defragfns);
 }
 
 /* Defrag a dict with sds key and optional value (either ptr, sds or robj string) */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -299,41 +299,18 @@ static void activeDefragZsetNode(void *privdata, void *entry_ref) {
 #define DEFRAG_SDS_DICT_VAL_VOID_PTR 3
 #define DEFRAG_SDS_DICT_VAL_LUA_SCRIPT 4
 
-typedef void *(dictDefragAllocFunction)(void *ptr);
-typedef struct {
-    dictDefragAllocFunction *defragKey;
-    dictDefragAllocFunction *defragVal;
-} dictDefragFunctions;
 
 static void activeDefragDictCallback(void *privdata, void *entry_ref) {
     dictDefragFunctions *defragfns = privdata;
     dictEntry **de_ref = (dictEntry **)entry_ref;
-    dictEntry *de = *de_ref;
-
-    /* Defrag the entry itself */
-    dictEntry *newentry = activeDefragAlloc(de);
-    if (newentry) {
-        de = newentry;
-        *de_ref = newentry;
-    }
-
-    /* Defrag the key */
-    if (defragfns->defragKey) {
-        void *newkey = defragfns->defragKey(de->key);
-        if (newkey) de->key = newkey;
-    }
-
-    /* Defrag the value */
-    if (defragfns->defragVal) {
-        void *newval = defragfns->defragVal(de->v.val);
-        if (newval) de->v.val = newval;
-    }
+    htdictDefragEntry(de_ref, defragfns);
 }
 
 /* Defrag a dict with sds key and optional value (either ptr, sds or robj string) */
 static void activeDefragSdsDict(dict *d, int val_type) {
     unsigned long cursor = 0;
     dictDefragFunctions defragfns = {
+        .defragAlloc = activeDefragAlloc,
         .defragKey = (dictDefragAllocFunction *)activeDefragSds,
         .defragVal = (val_type == DEFRAG_SDS_DICT_VAL_IS_SDS       ? (dictDefragAllocFunction *)activeDefragSds
                       : val_type == DEFRAG_SDS_DICT_VAL_IS_STROB   ? (dictDefragAllocFunction *)activeDefragStringOb

--- a/src/dict.h
+++ b/src/dict.h
@@ -35,7 +35,6 @@
 #define __DICT_H
 
 #include "hashtable.h"
-#include "zmalloc.h"
 #include <stdint.h>
 
 #define DICT_OK 0
@@ -46,23 +45,12 @@ typedef hashtable dict;
 typedef hashtableType dictType;
 typedef hashtableIterator dictIterator;
 
-/* dictEntry represents a key-value pair for use with hashtable */
-typedef struct dictEntry {
-    void *key;
-    union {
-        void *val;
-        uint64_t u64;
-        int64_t s64;
-        double d;
-    } v;
-} dictEntry;
+typedef struct dictEntry dictEntry; // opaque
 
-#define UNUSED(V) ((void)V)
-
+/* functions replaced by hashtable equivalents */
 #define dictSize(d) hashtableSize(d)
 #define dictIsEmpty(d) (hashtableSize(d) == 0)
 #define dictIsRehashing(d) hashtableIsRehashing(d)
-#define dictCreate(type) hashtableCreate(type)
 #define dictRelease(d) hashtableRelease(d)
 #define dictEmpty(d, callback) hashtableEmpty(d, callback)
 #define dictGetSomeKeys(d, dst, count) hashtableSampleEntries(d, dst, count)
@@ -76,223 +64,83 @@ typedef struct dictEntry {
 #define dictInitSafeIterator(iter, d) hashtableInitIterator(iter, d, HASHTABLE_ITER_SAFE)
 #define dictResetIterator(iter) hashtableCleanupIterator(iter)
 
-/* Expand the hash table if needed. Returns DICT_OK if expand was performed
- * or if the dictionary is already large enough, DICT_ERR if expand was not
- * performed. */
-static inline int dictExpand(dict *d, unsigned long size) {
-    return hashtableExpand(d, size) ? DICT_OK : DICT_ERR;
-}
+/* functions with variation for hashtable implementation
+ * the "htdict" prefix is used to avoid colliding with the "dict" in libvalkey */
+#define dictCreate(type) htdictCreate(type)
+#define dictExpand(d, size) htdictExpand(d, size)
+#define dictSetKey(d, de, key) htdictSetKey(d, de, key)
+#define dictSetVal(d, de, val) htdictSetVal(d, de, val)
+#define dictSetSignedIntegerVal(de, val) htdictSetSignedIntegerVal(de, val)
+#define dictSetUnsignedIntegerVal(de, val) htdictSetUnsignedIntegerVal(de, val)
+#define dictSetDoubleVal(de, val) htdictSetDoubleVal(de, val)
+#define dictIncrSignedIntegerVal(de, val) htdictIncrSignedIntegerVal(de, val)
+#define dictIncrUnsignedIntegerVal(de, val) htdictIncrUnsignedIntegerVal(de, val)
+#define dictIncrDoubleVal(de, val) htdictIncrDoubleVal(de, val)
 
-/* Entry accessor functions */
-static inline void dictSetKey(dict *d, dictEntry *de, void *key) {
-    UNUSED(d);
-    de->key = key;
-}
+#define dictGetKey(de) htdictGetKey(de)
+#define dictGetVal(de) htdictGetVal(de)
 
-static inline void dictSetVal(dict *d, dictEntry *de, void *val) {
-    UNUSED(d);
-    de->v.val = val;
-}
+#define dictGetSignedIntegerVal(de) htdictGetSignedIntegerVal(de)
+#define dictGetUnsignedIntegerVal(de) htdictGetUnsignedIntegerVal(de)
+#define dictGetDoubleVal(de) htdictGetDoubleVal(de)
+#define dictGetDoubleValPtr(de) htdictGetDoubleValPtr(de)
 
-static inline void dictSetSignedIntegerVal(dictEntry *de, int64_t val) {
-    de->v.s64 = val;
-}
+#define dictEntryMemUsage(de) htdictEntryMemUsage(de)
+#define dictMemUsage(d) htdictMemUsage(d)
 
-static inline void dictSetUnsignedIntegerVal(dictEntry *de, uint64_t val) {
-    de->v.u64 = val;
-}
+#define dictFind(d, key) htdictFind(d, key)
+#define dictFetchValue(d, key) htdictFetchValue(d, key)
+#define dictDelete(d, key) htdictDelete(d, key)
 
-static inline void dictSetDoubleVal(dictEntry *de, double val) {
-    de->v.d = val;
-}
+#define dictFreeUnlinkedEntry(d, de) htdictFreeUnlinkedEntry(d, de)
+#define dictGetRandomKey(d) htdictGetRandomKey(d)
+#define dictGetFairRandomKey(d) htdictGetFairRandomKey(d)
 
-static inline int64_t dictIncrSignedIntegerVal(dictEntry *de, int64_t val) {
-    de->v.s64 += val;
-    return de->v.s64;
-}
+#define dictUnlink(d, key) htdictUnlink(d, key)
+#define dictAdd(d, key, val) htdictAdd(d, key, val)
+#define dictAddRaw(d, key, existing) htdictAddRaw(d, key, existing)
+#define dictAddOrFind(d, key) htdictAddOrFind(d, key)
+#define dictReplace(d, key, val) htdictReplace(d, key, val)
 
-static inline uint64_t dictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val) {
-    de->v.u64 += val;
-    return de->v.u64;
-}
+#define dictNext(iter) htdictNext(iter)
 
-static inline double dictIncrDoubleVal(dictEntry *de, double val) {
-    de->v.d += val;
-    return de->v.d;
-}
+dict *htdictCreate(dictType *type);
+int htdictExpand(dict *d, unsigned long size);
+void htdictSetKey(dict *d, dictEntry *de, void *key);
+void htdictSetVal(dict *d, dictEntry *de, void *val);
+void htdictSetSignedIntegerVal(dictEntry *de, int64_t val);
+void htdictSetUnsignedIntegerVal(dictEntry *de, uint64_t val);
+void htdictSetDoubleVal(dictEntry *de, double val);
+int64_t htdictIncrSignedIntegerVal(dictEntry *de, int64_t val);
+uint64_t htdictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val);
+double htdictIncrDoubleVal(dictEntry *de, double val);
+void *htdictGetKey(const dictEntry *de);
+void *htdictGetVal(const dictEntry *de);
+int64_t htdictGetSignedIntegerVal(const dictEntry *de);
+uint64_t htdictGetUnsignedIntegerVal(const dictEntry *de);
+double htdictGetDoubleVal(const dictEntry *de);
+double *htdictGetDoubleValPtr(dictEntry *de);
+size_t htdictEntryMemUsage(dictEntry *de);
+size_t htdictMemUsage(const dict *d);
+dictEntry *htdictFind(dict *d, const void *key);
+void *htdictFetchValue(dict *d, const void *key);
+int htdictDelete(dict *d, const void *key);
+void htdictFreeUnlinkedEntry(dict *d, dictEntry *de);
+dictEntry *htdictGetRandomKey(dict *d);
+dictEntry *htdictGetFairRandomKey(dict *d);
+dictEntry *htdictUnlink(dict *d, const void *key);
+int htdictAdd(dict *d, void *key, void *val);
+dictEntry *htdictAddRaw(dict *d, void *key, dictEntry **existing);
+dictEntry *htdictAddOrFind(dict *d, void *key);
+int htdictReplace(dict *d, void *key, void *val);
+dictEntry *htdictNext(dictIterator *iter);
 
-static inline void *dictGetKey(const dictEntry *de) {
-    return de->key;
-}
-
-/* Callback for dictType.entryGetKey, which expects void pointers. */
-static inline const void *dictEntryGetKey(const void *entry) {
-    return dictGetKey((const dictEntry *)entry);
-}
-
-static inline void *dictGetVal(const dictEntry *de) {
-    return de->v.val;
-}
-
-static inline int64_t dictGetSignedIntegerVal(const dictEntry *de) {
-    return de->v.s64;
-}
-
-static inline uint64_t dictGetUnsignedIntegerVal(const dictEntry *de) {
-    return de->v.u64;
-}
-
-static inline double dictGetDoubleVal(const dictEntry *de) {
-    return de->v.d;
-}
-
-static inline double *dictGetDoubleValPtr(dictEntry *de) {
-    return &de->v.d;
-}
-
-static inline size_t dictEntryMemUsage(dictEntry *de) {
-    return sizeof(*de);
-}
-
-static inline size_t dictMemUsage(const dict *d) {
-    return hashtableMemUsage(d) + hashtableSize(d) * sizeof(dictEntry);
-}
-
-/* Search for a key in the dictionary. Returns the dictEntry if found,
- * or NULL if the key doesn't exist. */
-static inline dictEntry *dictFind(dict *d, const void *key) {
-    void *found = NULL;
-    return hashtableFind(d, key, &found) ? (dictEntry *)found : NULL;
-}
-
-/* Fetch the value associated with a key. Returns the value if the key exists,
- * or NULL if the key doesn't exist. */
-static inline void *dictFetchValue(dict *d, const void *key) {
-    dictEntry *de = dictFind(d, key);
-    return de ? de->v.val : NULL;
-}
-
-/* Remove a key from the dictionary. Returns DICT_OK if the key was found
- * and removed, DICT_ERR if the key was not found. */
-static inline int dictDelete(dict *d, const void *key) {
-    return hashtableDelete(d, key) ? DICT_OK : DICT_ERR;
-}
-
-/* Free an entry that was previously unlinked with dictUnlink().
- * It's safe to call this function with de = NULL. */
-static inline void dictFreeUnlinkedEntry(dict *d, dictEntry *de) {
-    if (de == NULL) return;
-    hashtableType *type = hashtableGetType(d);
-    type->entryDestructor(de);
-}
-
-/* Return a random entry from the hash table. */
-static inline dictEntry *dictGetRandomKey(dict *d) {
-    void *entry = NULL;
-    return hashtableRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
-}
-
-/* A more fair random entry selection that considers chain lengths.
- * This provides better distribution than dictGetRandomKey(). */
-static inline dictEntry *dictGetFairRandomKey(dict *d) {
-    void *entry = NULL;
-    return hashtableFairRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
-}
-
-/* Remove an element from the table, but without actually releasing
- * the key, value and dictionary entry. The dictionary entry is returned
- * if the element was found (and unlinked from the table), and the user
- * should later call `dictFreeUnlinkedEntry()` with it in order to release
- * it. Otherwise if the key is not found, NULL is returned.
- *
- * This function is useful when we want to remove something from the hash
- * table but want to use its value before actually deleting the entry.
- * Without this function the pattern would require two lookups. */
-static inline dictEntry *dictUnlink(dict *d, const void *key) {
-    void *entry = NULL;
-    return hashtablePop(d, key, &entry) ? (dictEntry *)entry : NULL;
-}
-
-/* Add an entry to the dictionary. */
-static inline int dictAdd(dict *d, void *key, void *val) {
-    hashtablePosition pos;
-    void *existing = NULL;
-
-    if (!hashtableFindPositionForInsert(d, key, &pos, &existing)) {
-        return DICT_ERR; /* Key already exists */
-    }
-
-    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
-    entry->key = key;
-    entry->v.val = val;
-    hashtableInsertAtPosition(d, entry, &pos);
-    return DICT_OK;
-}
-
-/* Adds a key to the dictionary without setting a value.
- *
- * If key already exists, NULL is returned, and "*existing" is populated
- * with the existing entry if existing is not NULL.
- *
- * If key was added, the dictEntry is returned to be manipulated by the
- * caller. */
-static inline dictEntry *dictAddRaw(dict *d, void *key, dictEntry **existing) {
-    hashtablePosition pos;
-    void *existing_entry = NULL;
-
-    if (!hashtableFindPositionForInsert(d, key, &pos, &existing_entry)) {
-        if (existing) *existing = (dictEntry *)existing_entry;
-        return NULL;
-    }
-
-    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
-    entry->key = key;
-    hashtableInsertAtPosition(d, entry, &pos);
-    if (existing) *existing = NULL;
-    return entry;
-}
-
-/* Adds a key to the dictionary if it doesn't already exists. Returns the
- * dictEntry of the key, whether it was just added or not. */
-static inline dictEntry *dictAddOrFind(dict *d, void *key) {
-    dictEntry *existing = NULL;
-    dictEntry *entry = dictAddRaw(d, key, &existing);
-    return entry ? entry : existing;
-}
-
-/* Adds an element to the dictionary. If the key already exists, the old
- * value is replaced with the new one.
- *
- * Always returns 1 to indicate the key was consumed (either added or used
- * to replace). The caller should not free the key after calling this. */
-static inline int dictReplace(dict *d, void *key, void *val) {
-    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
-    entry->key = key;
-    entry->v.val = val;
-
-    void *existing = NULL;
-    if (hashtableAddOrFind(d, entry, &existing)) {
-        return 1; /* Entry was added */
-    }
-
-    /* Entry already exists. Put the old value in our new entry and free it. */
-    dictEntry *existing_entry = (dictEntry *)existing;
-    entry->v.val = existing_entry->v.val;
-    hashtableType *type = hashtableGetType(d);
-    type->entryDestructor(entry);
-
-    /* Update the existing entry with the new value. */
-    existing_entry->v.val = val;
-    return 1;
-}
-
-/* Iterator operations */
-static inline dictEntry *dictNext(dictIterator *iter) {
-    void *entry = NULL;
-    if (hashtableNext(iter, &entry)) {
-        return (dictEntry *)entry;
-    }
-    return NULL;
-}
+typedef void *(dictDefragAllocFunction)(void *ptr);
+typedef struct {
+    dictDefragAllocFunction *defragAlloc;
+    dictDefragAllocFunction *defragKey;
+    dictDefragAllocFunction *defragVal;
+} dictDefragFunctions;
+void htdictDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns);
 
 #endif /* __DICT_H */

--- a/src/dict.h
+++ b/src/dict.h
@@ -40,75 +40,75 @@ typedef struct dictEntry dictEntry; // opaque
 #define dictResetIterator(iter) hashtableCleanupIterator(iter)
 
 /* functions with variation for hashtable implementation
- * the "htdict" prefix is used to avoid colliding with the "dict" in libvalkey */
-#define dictCreate(type) htdictCreate(type)
-#define dictExpand(d, size) htdictExpand(d, size)
-#define dictSetKey(d, de, key) htdictSetKey(d, de, key)
-#define dictSetVal(d, de, val) htdictSetVal(d, de, val)
-#define dictSetSignedIntegerVal(de, val) htdictSetSignedIntegerVal(de, val)
-#define dictSetUnsignedIntegerVal(de, val) htdictSetUnsignedIntegerVal(de, val)
-#define dictSetDoubleVal(de, val) htdictSetDoubleVal(de, val)
-#define dictIncrSignedIntegerVal(de, val) htdictIncrSignedIntegerVal(de, val)
-#define dictIncrUnsignedIntegerVal(de, val) htdictIncrUnsignedIntegerVal(de, val)
-#define dictIncrDoubleVal(de, val) htdictIncrDoubleVal(de, val)
+ * the "dictht" prefix is used to avoid colliding with the "dict" in libvalkey */
+#define dictCreate(type) dicthtCreate(type)
+#define dictExpand(d, size) dicthtExpand(d, size)
+#define dictSetKey(d, de, key) dicthtSetKey(d, de, key)
+#define dictSetVal(d, de, val) dicthtSetVal(d, de, val)
+#define dictSetSignedIntegerVal(de, val) dicthtSetSignedIntegerVal(de, val)
+#define dictSetUnsignedIntegerVal(de, val) dicthtSetUnsignedIntegerVal(de, val)
+#define dictSetDoubleVal(de, val) dicthtSetDoubleVal(de, val)
+#define dictIncrSignedIntegerVal(de, val) dicthtIncrSignedIntegerVal(de, val)
+#define dictIncrUnsignedIntegerVal(de, val) dicthtIncrUnsignedIntegerVal(de, val)
+#define dictIncrDoubleVal(de, val) dicthtIncrDoubleVal(de, val)
 
-#define dictGetKey(de) htdictGetKey(de)
-#define dictGetVal(de) htdictGetVal(de)
+#define dictGetKey(de) dicthtGetKey(de)
+#define dictGetVal(de) dicthtGetVal(de)
 
-#define dictGetSignedIntegerVal(de) htdictGetSignedIntegerVal(de)
-#define dictGetUnsignedIntegerVal(de) htdictGetUnsignedIntegerVal(de)
-#define dictGetDoubleVal(de) htdictGetDoubleVal(de)
-#define dictGetDoubleValPtr(de) htdictGetDoubleValPtr(de)
+#define dictGetSignedIntegerVal(de) dicthtGetSignedIntegerVal(de)
+#define dictGetUnsignedIntegerVal(de) dicthtGetUnsignedIntegerVal(de)
+#define dictGetDoubleVal(de) dicthtGetDoubleVal(de)
+#define dictGetDoubleValPtr(de) dicthtGetDoubleValPtr(de)
 
-#define dictEntryMemUsage(de) htdictEntryMemUsage(de)
-#define dictMemUsage(d) htdictMemUsage(d)
+#define dictEntryMemUsage(de) dicthtEntryMemUsage(de)
+#define dictMemUsage(d) dicthtMemUsage(d)
 
-#define dictFind(d, key) htdictFind(d, key)
-#define dictFetchValue(d, key) htdictFetchValue(d, key)
-#define dictDelete(d, key) htdictDelete(d, key)
+#define dictFind(d, key) dicthtFind(d, key)
+#define dictFetchValue(d, key) dicthtFetchValue(d, key)
+#define dictDelete(d, key) dicthtDelete(d, key)
 
-#define dictFreeUnlinkedEntry(d, de) htdictFreeUnlinkedEntry(d, de)
-#define dictGetRandomKey(d) htdictGetRandomKey(d)
-#define dictGetFairRandomKey(d) htdictGetFairRandomKey(d)
+#define dictFreeUnlinkedEntry(d, de) dicthtFreeUnlinkedEntry(d, de)
+#define dictGetRandomKey(d) dicthtGetRandomKey(d)
+#define dictGetFairRandomKey(d) dicthtGetFairRandomKey(d)
 
-#define dictUnlink(d, key) htdictUnlink(d, key)
-#define dictAdd(d, key, val) htdictAdd(d, key, val)
-#define dictAddRaw(d, key, existing) htdictAddRaw(d, key, existing)
-#define dictAddOrFind(d, key) htdictAddOrFind(d, key)
-#define dictReplace(d, key, val) htdictReplace(d, key, val)
+#define dictUnlink(d, key) dicthtUnlink(d, key)
+#define dictAdd(d, key, val) dicthtAdd(d, key, val)
+#define dictAddRaw(d, key, existing) dicthtAddRaw(d, key, existing)
+#define dictAddOrFind(d, key) dicthtAddOrFind(d, key)
+#define dictReplace(d, key, val) dicthtReplace(d, key, val)
 
-#define dictNext(iter) htdictNext(iter)
+#define dictNext(iter) dicthtNext(iter)
 
-dict *htdictCreate(dictType *type);
-int htdictExpand(dict *d, unsigned long size);
-void htdictSetKey(dict *d, dictEntry *de, void *key);
-void htdictSetVal(dict *d, dictEntry *de, void *val);
-void htdictSetSignedIntegerVal(dictEntry *de, int64_t val);
-void htdictSetUnsignedIntegerVal(dictEntry *de, uint64_t val);
-void htdictSetDoubleVal(dictEntry *de, double val);
-int64_t htdictIncrSignedIntegerVal(dictEntry *de, int64_t val);
-uint64_t htdictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val);
-double htdictIncrDoubleVal(dictEntry *de, double val);
-void *htdictGetKey(const dictEntry *de);
-void *htdictGetVal(const dictEntry *de);
-int64_t htdictGetSignedIntegerVal(const dictEntry *de);
-uint64_t htdictGetUnsignedIntegerVal(const dictEntry *de);
-double htdictGetDoubleVal(const dictEntry *de);
-double *htdictGetDoubleValPtr(dictEntry *de);
-size_t htdictEntryMemUsage(dictEntry *de);
-size_t htdictMemUsage(const dict *d);
-dictEntry *htdictFind(dict *d, const void *key);
-void *htdictFetchValue(dict *d, const void *key);
-int htdictDelete(dict *d, const void *key);
-void htdictFreeUnlinkedEntry(dict *d, dictEntry *de);
-dictEntry *htdictGetRandomKey(dict *d);
-dictEntry *htdictGetFairRandomKey(dict *d);
-dictEntry *htdictUnlink(dict *d, const void *key);
-int htdictAdd(dict *d, void *key, void *val);
-dictEntry *htdictAddRaw(dict *d, void *key, dictEntry **existing);
-dictEntry *htdictAddOrFind(dict *d, void *key);
-int htdictReplace(dict *d, void *key, void *val);
-dictEntry *htdictNext(dictIterator *iter);
+dict *dicthtCreate(dictType *type);
+int dicthtExpand(dict *d, unsigned long size);
+void dicthtSetKey(dict *d, dictEntry *de, void *key);
+void dicthtSetVal(dict *d, dictEntry *de, void *val);
+void dicthtSetSignedIntegerVal(dictEntry *de, int64_t val);
+void dicthtSetUnsignedIntegerVal(dictEntry *de, uint64_t val);
+void dicthtSetDoubleVal(dictEntry *de, double val);
+int64_t dicthtIncrSignedIntegerVal(dictEntry *de, int64_t val);
+uint64_t dicthtIncrUnsignedIntegerVal(dictEntry *de, uint64_t val);
+double dicthtIncrDoubleVal(dictEntry *de, double val);
+void *dicthtGetKey(const dictEntry *de);
+void *dicthtGetVal(const dictEntry *de);
+int64_t dicthtGetSignedIntegerVal(const dictEntry *de);
+uint64_t dicthtGetUnsignedIntegerVal(const dictEntry *de);
+double dicthtGetDoubleVal(const dictEntry *de);
+double *dicthtGetDoubleValPtr(dictEntry *de);
+size_t dicthtEntryMemUsage(dictEntry *de);
+size_t dicthtMemUsage(const dict *d);
+dictEntry *dicthtFind(dict *d, const void *key);
+void *dicthtFetchValue(dict *d, const void *key);
+int dicthtDelete(dict *d, const void *key);
+void dicthtFreeUnlinkedEntry(dict *d, dictEntry *de);
+dictEntry *dicthtGetRandomKey(dict *d);
+dictEntry *dicthtGetFairRandomKey(dict *d);
+dictEntry *dicthtUnlink(dict *d, const void *key);
+int dicthtAdd(dict *d, void *key, void *val);
+dictEntry *dicthtAddRaw(dict *d, void *key, dictEntry **existing);
+dictEntry *dicthtAddOrFind(dict *d, void *key);
+int dicthtReplace(dict *d, void *key, void *val);
+dictEntry *dicthtNext(dictIterator *iter);
 
 typedef void *(dictDefragAllocFunction)(void *ptr);
 typedef struct {
@@ -116,6 +116,6 @@ typedef struct {
     dictDefragAllocFunction *defragKey;
     dictDefragAllocFunction *defragVal;
 } dictDefragFunctions;
-void htdictDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns);
+void dicthtDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns);
 
 #endif /* __DICT_H */

--- a/src/dict.h
+++ b/src/dict.h
@@ -1,35 +1,10 @@
-/* Dict, a key-value hashtable API.
- *
- * This file implements the dict API as a thin wrapper of the newer hashtable
- * API. The dictEntry struct is used as the entry type in underlying hashtable.
- *
- * Copyright (c) 2006-2012, Redis Ltd.
+/*
+ * Copyright Valkey Contributors.
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *   * Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of Redis nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD 3-Clause
  */
+
+/* Dict, a key-value hashtable API. */
 
 #ifndef __DICT_H
 #define __DICT_H

--- a/src/dict_ht.c
+++ b/src/dict_ht.c
@@ -1,0 +1,294 @@
+/* Dict, a key-value hashtable API.
+ *
+ * This file implements the dict API as a thin wrapper of the newer hashtable
+ * API. The dictEntry struct is used as the entry type in underlying hashtable.
+ *
+ * Copyright (c) 2006-2012, Redis Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dict.h"
+#include "zmalloc.h"
+
+/* dictEntry represents a key-value pair for use with hashtable */
+struct dictEntry {
+    void *key;
+    union {
+        void *val;
+        uint64_t u64;
+        int64_t s64;
+        double d;
+    } v;
+};
+
+#define UNUSED(V) ((void)V)
+
+/* Callback for dictType.entryGetKey, which expects void pointers. */
+const void *htdictEntryGetKey(const void *entry) {
+    return dictGetKey((const dictEntry *)entry);
+}
+
+
+dict *htdictCreate(dictType *type) {
+    type->entryGetKey = htdictEntryGetKey;
+    return hashtableCreate(type);
+}
+
+/* Expand the hash table if needed. Returns DICT_OK if expand was performed
+ * or if the dictionary is already large enough, DICT_ERR if expand was not
+ * performed. */
+int htdictExpand(dict *d, unsigned long size) {
+    return hashtableExpand(d, size) ? DICT_OK : DICT_ERR;
+}
+
+/* Entry accessor functions */
+void htdictSetKey(dict *d, dictEntry *de, void *key) {
+    UNUSED(d);
+    de->key = key;
+}
+
+void htdictSetVal(dict *d, dictEntry *de, void *val) {
+    UNUSED(d);
+    de->v.val = val;
+}
+
+void htdictSetSignedIntegerVal(dictEntry *de, int64_t val) {
+    de->v.s64 = val;
+}
+
+void htdictSetUnsignedIntegerVal(dictEntry *de, uint64_t val) {
+    de->v.u64 = val;
+}
+
+void htdictSetDoubleVal(dictEntry *de, double val) {
+    de->v.d = val;
+}
+
+int64_t htdictIncrSignedIntegerVal(dictEntry *de, int64_t val) {
+    de->v.s64 += val;
+    return de->v.s64;
+}
+
+uint64_t htdictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val) {
+    de->v.u64 += val;
+    return de->v.u64;
+}
+
+double htdictIncrDoubleVal(dictEntry *de, double val) {
+    de->v.d += val;
+    return de->v.d;
+}
+
+void *htdictGetKey(const dictEntry *de) {
+    return de->key;
+}
+
+void *htdictGetVal(const dictEntry *de) {
+    return de->v.val;
+}
+
+int64_t htdictGetSignedIntegerVal(const dictEntry *de) {
+    return de->v.s64;
+}
+
+uint64_t htdictGetUnsignedIntegerVal(const dictEntry *de) {
+    return de->v.u64;
+}
+
+double htdictGetDoubleVal(const dictEntry *de) {
+    return de->v.d;
+}
+
+double *htdictGetDoubleValPtr(dictEntry *de) {
+    return &de->v.d;
+}
+
+size_t htdictEntryMemUsage(dictEntry *de) {
+    return sizeof(*de);
+}
+
+size_t htdictMemUsage(const dict *d) {
+    return hashtableMemUsage(d) + hashtableSize(d) * sizeof(dictEntry);
+}
+
+/* Search for a key in the dictionary. Returns the dictEntry if found,
+ * or NULL if the key doesn't exist. */
+dictEntry *htdictFind(dict *d, const void *key) {
+    void *found = NULL;
+    return hashtableFind(d, key, &found) ? (dictEntry *)found : NULL;
+}
+
+/* Fetch the value associated with a key. Returns the value if the key exists,
+ * or NULL if the key doesn't exist. */
+void *htdictFetchValue(dict *d, const void *key) {
+    dictEntry *de = dictFind(d, key);
+    return de ? de->v.val : NULL;
+}
+
+/* Remove a key from the dictionary. Returns DICT_OK if the key was found
+ * and removed, DICT_ERR if the key was not found. */
+int htdictDelete(dict *d, const void *key) {
+    return hashtableDelete(d, key) ? DICT_OK : DICT_ERR;
+}
+
+/* Free an entry that was previously unlinked with dictUnlink().
+ * It's safe to call this function with de = NULL. */
+void htdictFreeUnlinkedEntry(dict *d, dictEntry *de) {
+    if (de == NULL) return;
+    hashtableType *type = hashtableGetType(d);
+    type->entryDestructor(de);
+}
+
+/* Return a random entry from the hash table. */
+dictEntry *htdictGetRandomKey(dict *d) {
+    void *entry = NULL;
+    return hashtableRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
+}
+
+/* A more fair random entry selection that considers chain lengths.
+ * This provides better distribution than dictGetRandomKey(). */
+dictEntry *htdictGetFairRandomKey(dict *d) {
+    void *entry = NULL;
+    return hashtableFairRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
+}
+
+/* Remove an element from the table, but without actually releasing
+ * the key, value and dictionary entry. The dictionary entry is returned
+ * if the element was found (and unlinked from the table), and the user
+ * should later call `dictFreeUnlinkedEntry()` with it in order to release
+ * it. Otherwise if the key is not found, NULL is returned.
+ *
+ * This function is useful when we want to remove something from the hash
+ * table but want to use its value before actually deleting the entry.
+ * Without this function the pattern would require two lookups. */
+dictEntry *htdictUnlink(dict *d, const void *key) {
+    void *entry = NULL;
+    return hashtablePop(d, key, &entry) ? (dictEntry *)entry : NULL;
+}
+
+/* Add an entry to the dictionary. */
+int htdictAdd(dict *d, void *key, void *val) {
+    hashtablePosition pos;
+    void *existing = NULL;
+
+    if (!hashtableFindPositionForInsert(d, key, &pos, &existing)) {
+        return DICT_ERR; /* Key already exists */
+    }
+
+    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
+    entry->key = key;
+    entry->v.val = val;
+    hashtableInsertAtPosition(d, entry, &pos);
+    return DICT_OK;
+}
+
+/* Adds a key to the dictionary without setting a value.
+ *
+ * If key already exists, NULL is returned, and "*existing" is populated
+ * with the existing entry if existing is not NULL.
+ *
+ * If key was added, the dictEntry is returned to be manipulated by the
+ * caller. */
+dictEntry *htdictAddRaw(dict *d, void *key, dictEntry **existing) {
+    hashtablePosition pos;
+    void *existing_entry = NULL;
+
+    if (!hashtableFindPositionForInsert(d, key, &pos, &existing_entry)) {
+        if (existing) *existing = (dictEntry *)existing_entry;
+        return NULL;
+    }
+
+    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
+    entry->key = key;
+    hashtableInsertAtPosition(d, entry, &pos);
+    if (existing) *existing = NULL;
+    return entry;
+}
+
+/* Adds a key to the dictionary if it doesn't already exists. Returns the
+ * dictEntry of the key, whether it was just added or not. */
+dictEntry *htdictAddOrFind(dict *d, void *key) {
+    dictEntry *existing = NULL;
+    dictEntry *entry = dictAddRaw(d, key, &existing);
+    return entry ? entry : existing;
+}
+
+/* Adds an element to the dictionary. If the key already exists, the old
+ * value is replaced with the new one.
+ *
+ * Always returns 1 to indicate the key was consumed (either added or used
+ * to replace). The caller should not free the key after calling this. */
+int htdictReplace(dict *d, void *key, void *val) {
+    dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
+    entry->key = key;
+    entry->v.val = val;
+
+    void *existing = NULL;
+    if (hashtableAddOrFind(d, entry, &existing)) {
+        return 1; /* Entry was added */
+    }
+
+    /* Entry already exists. Put the old value in our new entry and free it. */
+    dictEntry *existing_entry = (dictEntry *)existing;
+    entry->v.val = existing_entry->v.val;
+    hashtableType *type = hashtableGetType(d);
+    type->entryDestructor(entry);
+
+    /* Update the existing entry with the new value. */
+    existing_entry->v.val = val;
+    return 1;
+}
+
+/* Iterator operations */
+dictEntry *htdictNext(dictIterator *iter) {
+    void *entry = NULL;
+    if (hashtableNext(iter, &entry)) {
+        return (dictEntry *)entry;
+    }
+    return NULL;
+}
+
+void htdictDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns) {
+    dictEntry *de = *de_ref;
+
+    /* Defrag the entry itself */
+    dictEntry *newentry = defragfns->defragAlloc(de);
+    if (newentry) {
+        de = newentry;
+        *de_ref = newentry;
+    }
+    /* Defrag the key */
+    if (defragfns->defragKey) {
+        void *newkey = defragfns->defragKey(de->key);
+        if (newkey) de->key = newkey;
+    }
+    /* Defrag the value */
+    if (defragfns->defragVal) {
+        void *newval = defragfns->defragVal(de->v.val);
+        if (newval) de->v.val = newval;
+    }
+}

--- a/src/dict_ht.c
+++ b/src/dict_ht.c
@@ -1,35 +1,10 @@
-/* Dict, a key-value hashtable API.
- *
- * This file implements the dict API as a thin wrapper of the newer hashtable
- * API. The dictEntry struct is used as the entry type in underlying hashtable.
- *
- * Copyright (c) 2006-2012, Redis Ltd.
+/*
+ * Copyright Valkey Contributors.
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *   * Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of Redis nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: BSD 3-Clause
  */
+
+/* Dict, a key-value hashtable API. */
 
 #include "dict.h"
 #include "zmalloc.h"

--- a/src/dictht.c
+++ b/src/dictht.c
@@ -23,130 +23,130 @@ struct dictEntry {
 #define UNUSED(V) ((void)V)
 
 /* Callback for dictType.entryGetKey, which expects void pointers. */
-const void *htdictEntryGetKey(const void *entry) {
+static const void *dicthtEntryGetKey(const void *entry) {
     return dictGetKey((const dictEntry *)entry);
 }
 
 
-dict *htdictCreate(dictType *type) {
-    type->entryGetKey = htdictEntryGetKey;
+dict *dicthtCreate(dictType *type) {
+    type->entryGetKey = dicthtEntryGetKey;
     return hashtableCreate(type);
 }
 
 /* Expand the hash table if needed. Returns DICT_OK if expand was performed
  * or if the dictionary is already large enough, DICT_ERR if expand was not
  * performed. */
-int htdictExpand(dict *d, unsigned long size) {
+int dicthtExpand(dict *d, unsigned long size) {
     return hashtableExpand(d, size) ? DICT_OK : DICT_ERR;
 }
 
 /* Entry accessor functions */
-void htdictSetKey(dict *d, dictEntry *de, void *key) {
+void dicthtSetKey(dict *d, dictEntry *de, void *key) {
     UNUSED(d);
     de->key = key;
 }
 
-void htdictSetVal(dict *d, dictEntry *de, void *val) {
+void dicthtSetVal(dict *d, dictEntry *de, void *val) {
     UNUSED(d);
     de->v.val = val;
 }
 
-void htdictSetSignedIntegerVal(dictEntry *de, int64_t val) {
+void dicthtSetSignedIntegerVal(dictEntry *de, int64_t val) {
     de->v.s64 = val;
 }
 
-void htdictSetUnsignedIntegerVal(dictEntry *de, uint64_t val) {
+void dicthtSetUnsignedIntegerVal(dictEntry *de, uint64_t val) {
     de->v.u64 = val;
 }
 
-void htdictSetDoubleVal(dictEntry *de, double val) {
+void dicthtSetDoubleVal(dictEntry *de, double val) {
     de->v.d = val;
 }
 
-int64_t htdictIncrSignedIntegerVal(dictEntry *de, int64_t val) {
+int64_t dicthtIncrSignedIntegerVal(dictEntry *de, int64_t val) {
     de->v.s64 += val;
     return de->v.s64;
 }
 
-uint64_t htdictIncrUnsignedIntegerVal(dictEntry *de, uint64_t val) {
+uint64_t dicthtIncrUnsignedIntegerVal(dictEntry *de, uint64_t val) {
     de->v.u64 += val;
     return de->v.u64;
 }
 
-double htdictIncrDoubleVal(dictEntry *de, double val) {
+double dicthtIncrDoubleVal(dictEntry *de, double val) {
     de->v.d += val;
     return de->v.d;
 }
 
-void *htdictGetKey(const dictEntry *de) {
+void *dicthtGetKey(const dictEntry *de) {
     return de->key;
 }
 
-void *htdictGetVal(const dictEntry *de) {
+void *dicthtGetVal(const dictEntry *de) {
     return de->v.val;
 }
 
-int64_t htdictGetSignedIntegerVal(const dictEntry *de) {
+int64_t dicthtGetSignedIntegerVal(const dictEntry *de) {
     return de->v.s64;
 }
 
-uint64_t htdictGetUnsignedIntegerVal(const dictEntry *de) {
+uint64_t dicthtGetUnsignedIntegerVal(const dictEntry *de) {
     return de->v.u64;
 }
 
-double htdictGetDoubleVal(const dictEntry *de) {
+double dicthtGetDoubleVal(const dictEntry *de) {
     return de->v.d;
 }
 
-double *htdictGetDoubleValPtr(dictEntry *de) {
+double *dicthtGetDoubleValPtr(dictEntry *de) {
     return &de->v.d;
 }
 
-size_t htdictEntryMemUsage(dictEntry *de) {
+size_t dicthtEntryMemUsage(dictEntry *de) {
     return sizeof(*de);
 }
 
-size_t htdictMemUsage(const dict *d) {
+size_t dicthtMemUsage(const dict *d) {
     return hashtableMemUsage(d) + hashtableSize(d) * sizeof(dictEntry);
 }
 
 /* Search for a key in the dictionary. Returns the dictEntry if found,
  * or NULL if the key doesn't exist. */
-dictEntry *htdictFind(dict *d, const void *key) {
+dictEntry *dicthtFind(dict *d, const void *key) {
     void *found = NULL;
     return hashtableFind(d, key, &found) ? (dictEntry *)found : NULL;
 }
 
 /* Fetch the value associated with a key. Returns the value if the key exists,
  * or NULL if the key doesn't exist. */
-void *htdictFetchValue(dict *d, const void *key) {
+void *dicthtFetchValue(dict *d, const void *key) {
     dictEntry *de = dictFind(d, key);
     return de ? de->v.val : NULL;
 }
 
 /* Remove a key from the dictionary. Returns DICT_OK if the key was found
  * and removed, DICT_ERR if the key was not found. */
-int htdictDelete(dict *d, const void *key) {
+int dicthtDelete(dict *d, const void *key) {
     return hashtableDelete(d, key) ? DICT_OK : DICT_ERR;
 }
 
 /* Free an entry that was previously unlinked with dictUnlink().
  * It's safe to call this function with de = NULL. */
-void htdictFreeUnlinkedEntry(dict *d, dictEntry *de) {
+void dicthtFreeUnlinkedEntry(dict *d, dictEntry *de) {
     if (de == NULL) return;
     hashtableType *type = hashtableGetType(d);
     type->entryDestructor(de);
 }
 
 /* Return a random entry from the hash table. */
-dictEntry *htdictGetRandomKey(dict *d) {
+dictEntry *dicthtGetRandomKey(dict *d) {
     void *entry = NULL;
     return hashtableRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
 }
 
 /* A more fair random entry selection that considers chain lengths.
  * This provides better distribution than dictGetRandomKey(). */
-dictEntry *htdictGetFairRandomKey(dict *d) {
+dictEntry *dicthtGetFairRandomKey(dict *d) {
     void *entry = NULL;
     return hashtableFairRandomEntry(d, &entry) ? (dictEntry *)entry : NULL;
 }
@@ -160,13 +160,13 @@ dictEntry *htdictGetFairRandomKey(dict *d) {
  * This function is useful when we want to remove something from the hash
  * table but want to use its value before actually deleting the entry.
  * Without this function the pattern would require two lookups. */
-dictEntry *htdictUnlink(dict *d, const void *key) {
+dictEntry *dicthtUnlink(dict *d, const void *key) {
     void *entry = NULL;
     return hashtablePop(d, key, &entry) ? (dictEntry *)entry : NULL;
 }
 
 /* Add an entry to the dictionary. */
-int htdictAdd(dict *d, void *key, void *val) {
+int dicthtAdd(dict *d, void *key, void *val) {
     hashtablePosition pos;
     void *existing = NULL;
 
@@ -188,7 +188,7 @@ int htdictAdd(dict *d, void *key, void *val) {
  *
  * If key was added, the dictEntry is returned to be manipulated by the
  * caller. */
-dictEntry *htdictAddRaw(dict *d, void *key, dictEntry **existing) {
+dictEntry *dicthtAddRaw(dict *d, void *key, dictEntry **existing) {
     hashtablePosition pos;
     void *existing_entry = NULL;
 
@@ -206,7 +206,7 @@ dictEntry *htdictAddRaw(dict *d, void *key, dictEntry **existing) {
 
 /* Adds a key to the dictionary if it doesn't already exists. Returns the
  * dictEntry of the key, whether it was just added or not. */
-dictEntry *htdictAddOrFind(dict *d, void *key) {
+dictEntry *dicthtAddOrFind(dict *d, void *key) {
     dictEntry *existing = NULL;
     dictEntry *entry = dictAddRaw(d, key, &existing);
     return entry ? entry : existing;
@@ -217,7 +217,7 @@ dictEntry *htdictAddOrFind(dict *d, void *key) {
  *
  * Always returns 1 to indicate the key was consumed (either added or used
  * to replace). The caller should not free the key after calling this. */
-int htdictReplace(dict *d, void *key, void *val) {
+int dicthtReplace(dict *d, void *key, void *val) {
     dictEntry *entry = (dictEntry *)zmalloc(sizeof(*entry));
     entry->key = key;
     entry->v.val = val;
@@ -239,7 +239,7 @@ int htdictReplace(dict *d, void *key, void *val) {
 }
 
 /* Iterator operations */
-dictEntry *htdictNext(dictIterator *iter) {
+dictEntry *dicthtNext(dictIterator *iter) {
     void *entry = NULL;
     if (hashtableNext(iter, &entry)) {
         return (dictEntry *)entry;
@@ -247,7 +247,7 @@ dictEntry *htdictNext(dictIterator *iter) {
     return NULL;
 }
 
-void htdictDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns) {
+void dicthtDefragEntry(dictEntry **de_ref, dictDefragFunctions *defragfns) {
     dictEntry *de = *de_ref;
 
     /* Defrag the entry itself */

--- a/src/eval.c
+++ b/src/eval.c
@@ -81,7 +81,6 @@ static void dictEntryDestructorSdsKeyScriptValue(void *entry) {
 
 /* evalCtx.scripts sha (as sds string) -> scripts (as evalScript) cache. */
 dictType shaScriptObjectDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyScriptValue,

--- a/src/expire.c
+++ b/src/expire.c
@@ -609,7 +609,6 @@ void expireReplicaKeys(void) {
 void rememberReplicaKeyWithExpire(serverDb *db, robj *key) {
     if (replicaKeysWithExpire == NULL) {
         static dictType dt = {
-            .entryGetKey = dictEntryGetKey,
             .hashFunction = dictSdsHash,
             .keyCompare = dictSdsKeyCompare,
             .entryDestructor = dictEntryDestructorSdsKey,

--- a/src/functions.c
+++ b/src/functions.c
@@ -70,7 +70,6 @@ typedef struct functionsLibMetaData {
 } functionsLibMetaData;
 
 dictType functionDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -84,7 +83,6 @@ static void dictEntryDestructorSdsKeyEngineStatsValue(void *entry) {
 }
 
 dictType engineStatsDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyEngineStatsValue,
@@ -98,7 +96,6 @@ static void dictEntryDestructorSdsKeyEngineFunctionValue(void *entry) {
 }
 
 dictType libraryFunctionDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKeyEngineFunctionValue,
@@ -112,7 +109,6 @@ static void dictEntryDestructorSdsKeyEngineLibraryValue(void *entry) {
 }
 
 dictType librariesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKeyEngineLibraryValue,

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -308,7 +308,6 @@ static void dictEntryDestructorSdsKeyConfigVal(void *entry) {
 
 /* Dictionary type for config entries */
 static dictType configDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = sdsHash,
     .keyCompare = sdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKeyConfigVal,

--- a/src/latency.c
+++ b/src/latency.c
@@ -46,7 +46,6 @@ static void dictEntryDestructorHeapKeyValue(void *entry) {
 }
 
 dictType latencyTimeSeriesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrHash,
     .keyCompare = dictCStrKeyCompare,
     .entryDestructor = dictEntryDestructorHeapKeyValue,

--- a/src/module.c
+++ b/src/module.c
@@ -12986,7 +12986,6 @@ size_t moduleGetMemUsage(robj *key, robj *val, size_t sample_size, int dbid) {
  * this gets queries from modules. */
 
 dictType moduleAPIDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrHash,
     .keyCompare = dictCStrKeyCompare,
     .entryDestructor = zfree,
@@ -13013,7 +13012,6 @@ void moduleInitModulesSystemLast(void) {
 }
 
 dictType sdsKeyValueHashDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyValue,

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -152,7 +152,6 @@ static void dictEntryDestructorSdsKeyHeapValue(void *entry) {
 }
 
 dictType rdbAuxFieldDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyHeapValue,

--- a/src/scripting_engine.c
+++ b/src/scripting_engine.c
@@ -66,7 +66,6 @@ static engineManager engineMgr = {
 };
 
 dictType engineDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = zfree,

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -447,7 +447,6 @@ static void dictEntryDestructorInstancesValue(void *entry) {
 }
 
 dictType instancesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorInstancesValue,
@@ -458,7 +457,6 @@ dictType instancesDictType = {
  * This is useful into sentinelGetObjectiveLeader() function in order to
  * count the votes and understand who is the leader. */
 dictType leaderVotesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = zfree,
@@ -466,7 +464,6 @@ dictType leaderVotesDictType = {
 
 /* Instance renamed commands table. */
 dictType renamedCommandsDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyValue,

--- a/src/server.c
+++ b/src/server.c
@@ -593,7 +593,6 @@ void dictEntryDestructorSdsKeyHeapValue(void *entry) {
 /* Generic hash table type where keys are Objects, Values
  * dummy pointers. */
 dictType objectKeyPointerValueDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictEncObjHash,
     .keyCompare = dictEncObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKey,
@@ -602,7 +601,6 @@ dictType objectKeyPointerValueDictType = {
 /* Like objectKeyPointerValueDictType(), but values can be destroyed, if
  * not NULL, calling zfree(). */
 dictType objectKeyHeapPointerValueDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictEncObjHash,
     .keyCompare = dictEncObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyHeapValue,
@@ -742,7 +740,6 @@ hashtableType sdsReplyHashtableType = {
  * lists as values. It's used for blocking operations (BLPOP) and to
  * map swapped keys to a list of clients waiting for this keys to be loaded. */
 dictType keylistDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictObjHash,
     .keyCompare = dictObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyListValue,
@@ -751,7 +748,6 @@ dictType keylistDictType = {
 /* objToHashtableDictType has unencoded Objects as keys and
  * hashtables as values. It's used for PUBSUB command to track clients subscribing the patterns. */
 dictType objToHashtableDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictObjHash,
     .keyCompare = dictObjKeyCompare,
     .entryDestructor = dictEntryDestructorObjectKeyHashtableValue,
@@ -789,7 +785,6 @@ hashtableType kvstoreChannelHashtableType = {
 /* Modules system dictionary type. Keys are module name,
  * values are pointer to ValkeyModule struct. */
 dictType modulesDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -797,7 +792,6 @@ dictType modulesDictType = {
 
 /* Migrate cache dict type. */
 dictType migrateCacheDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -806,7 +800,6 @@ dictType migrateCacheDictType = {
 /* Dict for for case-insensitive search using null terminated C strings.
  * The keys stored in dict are sds though. */
 dictType stringSetDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
     .keyCompare = dictCStrKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKey,
@@ -815,7 +808,6 @@ dictType stringSetDictType = {
 /* Dict for for case-insensitive search using null terminated C strings.
  * The key and value do not have a destructor. */
 dictType externalStringType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictCStrCaseHash,
     .keyCompare = dictCStrKeyCaseCompare,
     .entryDestructor = zfree,
@@ -824,7 +816,6 @@ dictType externalStringType = {
 /* Dict for case-insensitive search using sds objects with a zmalloc
  * allocated object as the value. */
 dictType sdsHashDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsCaseHash,
     .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyHeapValue,

--- a/src/valkey-benchmark.c
+++ b/src/valkey-benchmark.c
@@ -291,7 +291,6 @@ static int dictSdsKeyCompare(const void *key1, const void *key2) {
 }
 
 static dictType dtype = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = zfree,

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -901,7 +901,6 @@ static void cliLegacyInitHelp(dict *groups) {
 static void cliInitHelp(void) {
     /* Dict type for a set of strings, used to collect names of command groups. */
     dictType groupsdt = {
-        .entryGetKey = dictEntryGetKey,
         .hashFunction = dictSdsHash,
         .keyCompare = dictSdsKeyCompare,
         .entryDestructor = dictEntryDestructorSdsKeyNoVal,
@@ -3680,14 +3679,12 @@ typedef struct clusterManagerLink {
 } clusterManagerLink;
 
 static dictType clusterManagerDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsVal,
 };
 
 static dictType clusterManagerLinkDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorSdsKeyListVal,
@@ -9239,7 +9236,6 @@ static void dictEntryDestructorTypeinfoVal(void *entry) {
 }
 
 static dictType typeinfoDictType = {
-    .entryGetKey = dictEntryGetKey,
     .hashFunction = dictSdsHash,
     .keyCompare = dictSdsKeyCompare,
     .entryDestructor = dictEntryDestructorTypeinfoVal,


### PR DESCRIPTION
The recent update to `dict` (https://github.com/valkey-io/valkey/pull/3366) improves performance by making `dict` a thin wrapper on top of the `hashtable` implementation.

As part of that refactoring, we lost some of our `dict` abstraction.  The `dictEntry` became public (again).  The defrag code was diving into the entry directly.

This update:
* Hardens the `dict` abstraction by making `dictEntry` opaque (again)
* Moving some defrag capability back to the `dict` (out of defrag)
* Uses a `.c` file rather than the `.h` file (allowing for opaqueness in the data structure and code)
* Eliminates the requirement to configure `dictEntryGetKey` on every `dict` (it's essentially a required constant)

Link time optimization (LTO) will result in the same inlining of functions, however it can now use configurable options to tune the level of inlining.  This potentially reduces L1 cache bloat.