### PR TITLE
Fix crash when looking up blocked-inuse clients before initialization (forkless)

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -864,6 +864,7 @@ static hashtableType keyToClientsHashtableType = {
 
 // Return the list of clients blocked on key, or NULL if none exist.
 static list *keyToClients_getBlockedClientsList(robj *key) {
+    if (!inuse_key_to_clients) return NULL;
     keyToClientsEntry *entry;
     if (hashtableFind(inuse_key_to_clients, key, (void **)&entry)) {
         return entry->clients;


### PR DESCRIPTION
Add a NULL check for `inuse_key_to_clients` in `keyToClients_getBlockedClientsList()`. 

The hashtable is lazy-initialized, and this function can be called before it exists. Return NULL early in that case instead of crashing.