### PR TITLE
Remove redundant count division in genericHgetallCommand

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1792,8 +1792,7 @@ void genericHgetallCommand(client *c, int flags) {
     hashTypeResetIterator(&hi);
     /* Make sure we returned the right number of elements. */
     if (flags & OBJ_HASH_FIELD && flags & OBJ_HASH_VALUE) {
-        setDeferredMapLen(c, replylen, count /= 2);
-        count /= 2;
+        setDeferredMapLen(c, replylen, count / 2);
     } else {
         setDeferredArrayLen(c, replylen, count);
     }


### PR DESCRIPTION
The argument `count /= 2` modifies `count` as a side effect, and the following `count /= 2` divides it again unnecessarily.
Since `count` is not used after this point, fix it by using `count / 2` without the side effect and remove the redundant second assignment.