### PR TITLE
Skip cluster resharding test under valgrind

### DIFF
--- a/tests/unit/cluster/resharding.tcl
+++ b/tests/unit/cluster/resharding.tcl
@@ -1,7 +1,7 @@
 # Resharding test.
 # In this test a live resharding is performed and the test checks
 # that certain properties are preserved across the operation.
-tags {"slow"} {
+tags {"slow valgrind:skip"} {
 run_solo {cluster-resharding} {
 start_cluster 5 5 {tags {external:skip cluster}} {
     test "Enable AOF in all the instances" {


### PR DESCRIPTION
This change was introduced in #3382. This test is already very slow on
its own. Under valgrind it gets slow enough that the per-node restart
step lets primaries be marked FAIL and triggers failovers, after which
"Verify slaves consistency" no longer holds since it assumes the original
topology.

It was never run under valgrind before and exercises nothing valgrind
meaningfully covers, so just tag it valgrind:skip.