### PR TITLE
Fix Deferred Reply Placeholders in Active Deferred Buffers

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1112,9 +1112,15 @@ void *addReplyDeferredLen(client *c) {
      * buffer offset (see function comment) */
     reqresSaveClientReplyOffset(c);
 
+    /* When the deferred reply buffer is active, the placeholder must go into
+     * the same list that subsequent ReplyWith* calls will append to.
+     * Otherwise setDeferredReply will fill the placeholder in c->reply while
+     * the array elements live in c->deferred_reply, producing a malformed
+     * response after commitDeferredReplyBuffer joins the two lists. */
+    list *reply_list = isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
     trimReplyUnusedTailSpace(c);
-    listAddNodeTail(c->reply, NULL); /* NULL is our placeholder. */
-    return listLast(c->reply);
+    listAddNodeTail(reply_list, NULL); /* NULL is our placeholder. */
+    return listLast(reply_list);
 }
 
 void setDeferredReply(client *c, void *node, const char *s, size_t length) {
@@ -1125,6 +1131,11 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
      * we return NULL in addReplyDeferredLen() */
     if (node == NULL) return;
     serverAssert(!listNodeValue(ln));
+
+    /* The placeholder node may live in c->deferred_reply when the deferred
+     * reply buffer is active.  Use the same list for deletion/accounting. */
+    list *reply_list = isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
+    unsigned long long *reply_bytes = isDeferredReplyEnabled(c) ? &c->deferred_reply_bytes : &c->reply_bytes;
 
     /* Normally we fill this dummy NULL node, added by addReplyDeferredLen(),
      * with a new buffer structure containing the protocol needed to specify
@@ -1147,7 +1158,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         prev->used += len_to_copy;
         length -= len_to_copy;
         if (length == 0) {
-            listDelNode(c->reply, ln);
+            listDelNode(reply_list, ln);
             return;
         }
         s += len_to_copy;
@@ -1159,7 +1170,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(next->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
         next->used += length;
-        listDelNode(c->reply, ln);
+        listDelNode(reply_list, ln);
     } else {
         /* Create a new node */
         size_t usable_size;
@@ -1171,7 +1182,7 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
         memcpy(buf->buf, s, length);
         c->net_output_bytes_curr_cmd += length;
         listNodeValue(ln) = buf;
-        c->reply_bytes += buf->size;
+        *reply_bytes += buf->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
     }

--- a/src/networking.c
+++ b/src/networking.c
@@ -524,14 +524,14 @@ void deleteCachedResponseClient(client *recording_client) {
 /* Return the reply list that new reply data should be appended to.
  * When the deferred reply buffer is active, replies go to
  * c->deferred_reply; otherwise they go to c->reply. */
-static inline list *clientGetActiveReplyList(client *c) {
+static inline list *clientGetReplyList(client *c) {
     return isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
 }
 
 /* Return the reply bytes for the client.
  * When the deferred reply buffer is active, replies go to
  * c->deferred_reply_bytes; otherwise they go to c->reply_bytes. */
-static inline unsigned long long *clientGetActiveReplyBytes(client *c) {
+static inline unsigned long long *clientGetReplyBytesPtr(client *c) {
     return isDeferredReplyEnabled(c) ? &c->deferred_reply_bytes : &c->reply_bytes;
 }
 
@@ -689,7 +689,7 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         memcpy(tail->buf + tail->used, payload, len);
         tail->used += len;
         listAddNodeTail(reply_list, tail);
-        unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
+        unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
         *reply_bytes += tail->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
@@ -1079,9 +1079,9 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
  * the previous one, when that happens, we wanna try to trim the unused space
  * at the end of the last reply node which we won't use anymore. */
 void trimReplyUnusedTailSpace(client *c) {
-    listNode *ln = listLast(clientGetActiveReplyList(c));
+    listNode *ln = listLast(clientGetReplyList(c));
     clientReplyBlock *tail = ln ? listNodeValue(ln) : NULL;
-    unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
+    unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used */
@@ -1132,7 +1132,7 @@ void *addReplyDeferredLen(client *c) {
      * Otherwise setDeferredReply will fill the placeholder in c->reply while
      * the array elements live in c->deferred_reply, producing a malformed
      * response after commitDeferredReplyBuffer joins the two lists. */
-    list *reply_list = clientGetActiveReplyList(c);
+    list *reply_list = clientGetReplyList(c);
     trimReplyUnusedTailSpace(c);
     listAddNodeTail(reply_list, NULL); /* NULL is our placeholder. */
     return listLast(reply_list);
@@ -1149,8 +1149,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
 
     /* The placeholder node may live in c->deferred_reply when the deferred
      * reply buffer is active.  Use the same list for deletion/accounting. */
-    list *reply_list = clientGetActiveReplyList(c);
-    unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
+    list *reply_list = clientGetReplyList(c);
+    unsigned long long *reply_bytes = clientGetReplyBytesPtr(c);
 
     /* Normally we fill this dummy NULL node, added by addReplyDeferredLen(),
      * with a new buffer structure containing the protocol needed to specify

--- a/src/networking.c
+++ b/src/networking.c
@@ -521,6 +521,20 @@ void deleteCachedResponseClient(client *recording_client) {
     freeClient(recording_client);
 }
 
+/* Return the reply list that new reply data should be appended to.
+ * When the deferred reply buffer is active, replies go to
+ * c->deferred_reply; otherwise they go to c->reply. */
+static inline list *clientGetActiveReplyList(client *c) {
+    return isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
+}
+
+/* Return the reply bytes for the client.
+ * When the deferred reply buffer is active, replies go to
+ * c->deferred_reply_bytes; otherwise they go to c->reply_bytes. */
+static inline unsigned long long *clientGetActiveReplyBytes(client *c) {
+    return isDeferredReplyEnabled(c) ? &c->deferred_reply_bytes : &c->reply_bytes;
+}
+
 /* -----------------------------------------------------------------------------
  * Low level functions to add more data to output buffers.
  * -------------------------------------------------------------------------- */
@@ -675,7 +689,7 @@ static void _addReplyPayloadToList(client *c, list *reply_list, const char *payl
         memcpy(tail->buf + tail->used, payload, len);
         tail->used += len;
         listAddNodeTail(reply_list, tail);
-        unsigned long long *reply_bytes = (isDeferredReplyEnabled(c)) ? &c->deferred_reply_bytes : &c->reply_bytes;
+        unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
         *reply_bytes += tail->size;
 
         closeClientOnOutputBufferLimitReached(c, 1);
@@ -1065,8 +1079,9 @@ void addReplyStatusFormat(client *c, const char *fmt, ...) {
  * the previous one, when that happens, we wanna try to trim the unused space
  * at the end of the last reply node which we won't use anymore. */
 void trimReplyUnusedTailSpace(client *c) {
-    listNode *ln = listLast(c->reply);
+    listNode *ln = listLast(clientGetActiveReplyList(c));
     clientReplyBlock *tail = ln ? listNodeValue(ln) : NULL;
+    unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
 
     /* Note that 'tail' may be NULL even if we have a tail node, because when
      * addReplyDeferredLen() is used */
@@ -1084,7 +1099,7 @@ void trimReplyUnusedTailSpace(client *c) {
         /* take over the allocation's internal fragmentation (at least for
          * memory usage tracking) */
         tail->size = usable_size - sizeof(clientReplyBlock);
-        c->reply_bytes = c->reply_bytes + tail->size - old_size;
+        *reply_bytes = *reply_bytes + tail->size - old_size;
         listNodeValue(ln) = tail;
     }
 }
@@ -1117,7 +1132,7 @@ void *addReplyDeferredLen(client *c) {
      * Otherwise setDeferredReply will fill the placeholder in c->reply while
      * the array elements live in c->deferred_reply, producing a malformed
      * response after commitDeferredReplyBuffer joins the two lists. */
-    list *reply_list = isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
+    list *reply_list = clientGetActiveReplyList(c);
     trimReplyUnusedTailSpace(c);
     listAddNodeTail(reply_list, NULL); /* NULL is our placeholder. */
     return listLast(reply_list);
@@ -1134,8 +1149,8 @@ void setDeferredReply(client *c, void *node, const char *s, size_t length) {
 
     /* The placeholder node may live in c->deferred_reply when the deferred
      * reply buffer is active.  Use the same list for deletion/accounting. */
-    list *reply_list = isDeferredReplyEnabled(c) ? c->deferred_reply : c->reply;
-    unsigned long long *reply_bytes = isDeferredReplyEnabled(c) ? &c->deferred_reply_bytes : &c->reply_bytes;
+    list *reply_list = clientGetActiveReplyList(c);
+    unsigned long long *reply_bytes = clientGetActiveReplyBytes(c);
 
     /* Normally we fill this dummy NULL node, added by addReplyDeferredLen(),
      * with a new buffer structure containing the protocol needed to specify

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -70,7 +70,8 @@ TEST_MODULES = \
     crash.so \
     cluster.so \
     helloscripting.so \
-    unsupported_features.so
+    unsupported_features.so \
+    deferred_reply.so
 
 .PHONY: all
 

--- a/tests/modules/deferred_reply.c
+++ b/tests/modules/deferred_reply.c
@@ -57,6 +57,8 @@ static int OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
     pthread_t tid;
     if (pthread_create(&tid, NULL, UnblockThread, bc) != 0) {
         ValkeyModule_UnblockClient(bc, NULL);
+    } else {
+        pthread_detach(tid);
     }
     return VALKEYMODULE_OK;
 }

--- a/tests/modules/deferred_reply.c
+++ b/tests/modules/deferred_reply.c
@@ -1,0 +1,89 @@
+/* Test module to verify that addReplyDeferredLen / setDeferredReply work
+ * correctly when the deferred reply buffer is active.
+ *
+ * The module subscribes to NOTIFY_STRING keyspace notifications.  When armed,
+ * the notification callback blocks the client with a reply callback that
+ * builds a nested array using VALKEYMODULE_POSTPONED_LEN (which internally
+ * calls addReplyDeferredLen).
+ *
+ * Without the fix in networking.c the placeholder node for the inner array
+ * ends up in c->reply while the outer array header and elements live in
+ * c->deferred_reply, producing a malformed response after
+ * commitDeferredReplyBuffer joins the two lists. */
+
+#include "valkeymodule.h"
+#include <pthread.h>
+#include <unistd.h>
+
+static int armed = 0;
+
+static void *UnblockThread(void *arg) {
+    ValkeyModuleBlockedClient *bc = arg;
+    usleep(100000); /* 100 ms */
+    ValkeyModule_UnblockClient(bc, NULL);
+    return NULL;
+}
+
+/* Reply callback – builds a two-element array where the second element is
+ * itself an array whose length is set via POSTPONED_LEN.
+ * Expected response: ["first", ["a", "b"]] */
+static int ReplyCallback(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(ctx);
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    ValkeyModule_ReplyWithArray(ctx, 2);
+    ValkeyModule_ReplyWithSimpleString(ctx, "first");
+    ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_LEN);
+    ValkeyModule_ReplyWithSimpleString(ctx, "a");
+    ValkeyModule_ReplyWithSimpleString(ctx, "b");
+    ValkeyModule_ReplySetArrayLength(ctx, 2);
+    return VALKEYMODULE_OK;
+}
+
+static int OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
+                                  const char *event, ValkeyModuleString *key) {
+    VALKEYMODULE_NOT_USED(type);
+    VALKEYMODULE_NOT_USED(event);
+    VALKEYMODULE_NOT_USED(key);
+
+    if (!armed) return VALKEYMODULE_OK;
+    armed = 0;
+
+    ValkeyModuleBlockedClient *bc =
+        ValkeyModule_BlockClient(ctx, ReplyCallback, NULL, NULL, 0);
+    if (!bc) return VALKEYMODULE_OK;
+
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, UnblockThread, bc) != 0) {
+        ValkeyModule_UnblockClient(bc, NULL);
+    }
+    return VALKEYMODULE_OK;
+}
+
+/* DEFERRED_REPLY.ARM – arms the notification handler so the next
+ * NOTIFY_STRING event blocks the client. */
+static int CmdArm(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+    armed = 1;
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return VALKEYMODULE_OK;
+}
+
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    VALKEYMODULE_NOT_USED(argv);
+    VALKEYMODULE_NOT_USED(argc);
+
+    if (ValkeyModule_Init(ctx, "deferred_reply", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_SubscribeToKeyspaceEvents(ctx, VALKEYMODULE_NOTIFY_STRING,
+                                               OnKeyspaceNotification) != VALKEYMODULE_OK)
+        return VALKEYMODULE_ERR;
+
+    if (ValkeyModule_CreateCommand(ctx, "deferred_reply.arm", CmdArm, "", 0, 0, 0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    return VALKEYMODULE_OK;
+}

--- a/tests/unit/moduleapi/deferred_reply.tcl
+++ b/tests/unit/moduleapi/deferred_reply.tcl
@@ -1,0 +1,40 @@
+set testmodule [file normalize tests/modules/deferred_reply.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {Deferred reply with postponed array length during active deferred reply buffer} {
+        r deferred_reply.arm
+
+        set rd [valkey_deferring_client]
+        # SET triggers NOTIFY_STRING.  The module callback blocks the client;
+        # the reply callback builds a nested array using POSTPONED_LEN while
+        # the deferred reply buffer is active.
+        $rd set testkey testval
+
+        wait_for_blocked_clients_count 1
+        wait_for_blocked_clients_count 0
+
+        set set_reply [$rd read]
+        set cb_reply [$rd read]
+
+        # Drain any extra data so we can report it on failure.
+        $rd ping diag
+        set extra {}
+        set tok [$rd read]
+        while {$tok ne "diag"} {
+            lappend extra $tok
+            set tok [$rd read]
+        }
+
+        if {$set_reply ne "OK" || $cb_reply ne "first {a b}" || $extra ne {}} {
+            fail "Malformed deferred reply output: set_reply='$set_reply' cb_reply='$cb_reply' extra='$extra'"
+        }
+
+        $rd close
+    }
+
+    test "Unload the module - deferred_reply" {
+        assert_equal {OK} [r module unload deferred_reply]
+    }
+}


### PR DESCRIPTION
Ensure deferred-length reply placeholders are created and resolved in the same reply list that subsequent nested replies use when the deferred reply buffer is active. This prevents malformed responses when module callbacks build postponed-length arrays while a client is already deferring output.

Add a regression test module and unit test that reproduce the issue through keyspace notifications and verify the nested array reply is serialized correctly. Register the new module with the module test build.

Here is a small illustration of what happens with and without the fix:

## With the fix — placeholder goes to `c->deferred_reply`:

```
   c->buf:            (empty)
   c->reply:          (empty)
   c->deferred_reply: [+OK\r\n] [*2\r\n] [+first\r\n] [*2\r\n] [+a\r\n] [+b\r\n]
                       ^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                       SET reply  reply callback (outer array, inner array via POSTPONED_LEN)
   → commitDeferredReplyBuffer joins into c->reply
   → Wire: +OK\r\n *2\r\n +first\r\n *2\r\n +a\r\n +b\r\n  ✓
            OK      [ "first",        ["a",   "b"] ]
```

##    Without the fix — placeholder goes to `c->reply`:
```
   c->buf:            (empty)
   c->reply:          [*2\r\n]          ← placeholder filled by setDeferredArrayLen (WRONG LIST!)
   c->deferred_reply: [+OK\r\n] [*2\r\n] [+first\r\n] [+a\r\n] [+b\r\n]
                       ^^^^^^^^  outer array  "first"     "a"      "b"
   → commitDeferredReplyBuffer appends deferred_reply AFTER reply
   → Wire: *2\r\n +OK\r\n *2\r\n +first\r\n +a\r\n +b\r\n  ✗
           [ OK,          ["first",   "a"] ]  "b"  ← orphaned   
```

* networking
* tests/modules
* tests/unit/moduleapi

**Generated by CodeLite**