### PR TITLE
fix compile warning in util.c

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -636,7 +636,8 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
 VALKEY_NO_SANITIZE("address")
-VALKEY_NO_SANITIZE("thread") __attribute__((used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+VALKEY_NO_SANITIZE("thread")
+__attribute__((used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     /* Ifunc resolvers run before ASan initialization and before CPU detection
      * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();

--- a/src/util.c
+++ b/src/util.c
@@ -635,8 +635,8 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-VALKEY_NO_SANITIZE("address") VALKEY_NO_SANITIZE("thread") __attribute__((used))
-static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+VALKEY_NO_SANITIZE("address")
+VALKEY_NO_SANITIZE("thread") __attribute__((used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     /* Ifunc resolvers run before ASan initialization and before CPU detection
      * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();

--- a/src/util.c
+++ b/src/util.c
@@ -635,7 +635,8 @@ static int string2llScalar(const char *s, size_t slen, long long *value) {
 }
 
 #if HAVE_IFUNC && HAVE_X86_SIMD
-__attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
+VALKEY_NO_SANITIZE("address") VALKEY_NO_SANITIZE("thread") __attribute__((used))
+static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
     /* Ifunc resolvers run before ASan initialization and before CPU detection
      * is initialized, so disable ASan and init CPU detection here. */
     __builtin_cpu_init();


### PR DESCRIPTION
Address this compile warning:
```c
    CC util.o
util.c:638:1: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]
 __attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver(void))(const char *, size_t, long long *) {
 ^~~~~~~~~~~~~
```
Addresses portability concerns around these attributes.