### PR TITLE
fix(cluster): Remove per-call srand in clusterManagerNodePrimaryRandom

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -4300,7 +4300,6 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
                           "for anti-affinity\n");
     int node_len = cluster_manager.nodes->len;
     int maxiter = 500 * node_len; // Effort is proportional to cluster size...
-    srand(time(NULL));
     while (maxiter > 0) {
         int offending_len = 0;
         if (offenders != NULL) {
@@ -8975,8 +8974,6 @@ static void pipeMode(void) {
     char magic[20]; /* Special reply we recognize. */
     time_t last_read_time = time(NULL);
 
-    srand(time(NULL));
-
     /* Use non blocking I/O. */
     if (anetNonBlock(aneterr, context->fd) == ANET_ERR) {
         fprintf(stderr, "Can't set the socket in non blocking mode: %s\n", aneterr);
@@ -9834,7 +9831,6 @@ static void LRUTestMode(void) {
     long long start_cycle;
     int j;
 
-    srand(time(NULL) ^ getpid());
     while (1) {
         /* Perform cycles of 1 second with 50% writes and 50% reads.
          * We use pipelining batching writes / reads N times per cycle in order
@@ -10053,6 +10049,8 @@ void testHintSuite(char *filename) {
 int main(int argc, char **argv) {
     int firstarg;
     struct timeval tv;
+
+    srand(time(NULL) ^ getpid());
 
     /* Valkey defaults */
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -6219,7 +6219,6 @@ static clusterManagerNode *clusterManagerNodePrimaryRandom(void) {
     }
 
     assert(primary_count > 0);
-    srand(time(NULL));
     idx = rand() % primary_count;
     listRewind(cluster_manager.nodes, &li);
     while ((ln = listNext(&li)) != NULL) {


### PR DESCRIPTION
clusterManagerNodePrimaryRandom() called srand(time(NULL)) on every invocation, then immediately rand() % primary_count. When called in a tight loop for uncovered slots, all calls within the same wall-clock second produce the identical seed, causing every uncovered slot to be assigned to the same primary node.

Remove the srand() call since the PRNG is already seeded at startup (srand(time(NULL) ^ getpid()) at line 9838). This allows rand() to advance its state across calls, distributing uncovered slots randomly across available primaries.