### PR TITLE
Fix compilation error: replace deprecated je_calloc with zcalloc_num

### DIFF
--- a/src/allocator_defrag.c
+++ b/src/allocator_defrag.c
@@ -279,9 +279,9 @@ int allocatorDefragInit(void) {
     je_res = je_mallctl("arenas.nbins", &je_cb.nbins, &sz, NULL, 0);
     assert(je_res == 0 && je_cb.nbins != 0);
 
-    je_cb.bin_info = je_calloc(je_cb.nbins, sizeof(jeBinInfo));
+    je_cb.bin_info = zcalloc_num(je_cb.nbins, sizeof(jeBinInfo));
     assert(je_cb.bin_info != NULL);
-    je_usage_info = je_calloc(je_cb.nbins, sizeof(jemallocBinUsageData));
+    je_usage_info = zcalloc_num(je_cb.nbins, sizeof(jemallocBinUsageData));
     assert(je_usage_info != NULL);
 
     for (unsigned j = 0; j < je_cb.nbins; j++) {


### PR DESCRIPTION
Fixes #1905

## Summary
The direct use of `je_calloc` in `src/allocator_defrag.c` causes compilation failures on systems (e.g., Arch Linux with GCC 14.2.1) where `calloc` is marked as deprecated and `-Werror=deprecated` is enabled.

## Changes
Replace the two `je_calloc` calls in `allocatorDefragInit()` with `zcalloc_num`, which is the proper Valkey allocation wrapper that provides the same semantics (num × size with zero-fill) without directly invoking the deprecated `calloc` symbol.

## Testing
- Build compiles cleanly
- Integration tests pass (unit/memefficiency, defrag, unit/other — 51 passed, 0 failed)