### PR TITLE
Update provenance action to refine layer2 exemption policies

### DIFF
--- a/.github/workflows/provenance-check.yml
+++ b/.github/workflows/provenance-check.yml
@@ -19,11 +19,12 @@ jobs:
           fetch-depth: 0
 
       - name: Run Provenance Check
-        uses: valkey-io/verify-provenance@ed6147b7254576ba838303f3aa09f558e08617b3
+        uses: valkey-io/verify-provenance@dea1178cfc6555387f59f1df3c070101c977a7cd
         with:
           source_repo: "redis/redis"
           target_repo: "${{ github.repository }}"
           branding_pairs: "Redis:Valkey,KeyDB:Valkey"
           prefix_pairs: "RM_:VM_,REDISMODULE_:VALKEYMODULE_"
+          exclude_dirs: "deps/"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           db_branch: "verify-provenance-db"

--- a/.github/workflows/provenance-refresh.yml
+++ b/.github/workflows/provenance-refresh.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Refresh Fingerprints
-        uses: valkey-io/verify-provenance@ed6147b7254576ba838303f3aa09f558e08617b3
+        uses: valkey-io/verify-provenance@dea1178cfc6555387f59f1df3c070101c977a7cd
         with:
           mode: "refresh"
           source_repo: "redis/redis"


### PR DESCRIPTION
- Point provenance workflows at verify-provenance commit dea1178, which refines layer2 evidence policy.

- The action now filters low-scope isolated single-file matches while preserving large copied-block and related-peer-file detections.

- See https://github.com/valkey-io/verify-provenance/commit/dea11785360761de9d639bc86a07c70e34967ce9 for the implementation.