### PR TITLE
Fix: connSocketBlockingConnect ignores aeWait errors (-1)

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -376,9 +376,10 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
 
     conn->fd = fd;
 
-    if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
+    int result = aeWait(fd, AE_WRITABLE, timeout);
+    if (result <= 0) {
         conn->state = CONN_STATE_ERROR;
-        conn->last_errno = ETIMEDOUT;
+        conn->last_errno = (result == 0) ? ETIMEDOUT : errno;
         return C_ERR;
     }
 

--- a/src/unit/test_socket.cpp
+++ b/src/unit/test_socket.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cerrno>
+
+extern "C" {
+#include "connection.h"
+#include "server.h"
+}
+
+class SocketTest : public ::testing::Test {
+  protected:
+    StrictMock<MockValkey> mock;
+
+    static void SetUpTestSuite() {
+        /* serverLog dereferences server.logfile; set it so registration doesn't segfault. */
+        server.logfile = (char *)"";
+        RedisRegisterConnectionTypeSocket();
+    }
+};
+
+/* When the socket connection type (CT_Socket) is in use, connBlockingConnect
+ * dispatches to connSocketBlockingConnect. Verify it returns C_ERR when
+ * aeWait returns -1 and preserves errno from the failed poll(2) call. */
+TEST_F(SocketTest, BlockingConnectReturnsErrorWhenAeWaitFails) {
+    EXPECT_CALL(mock, anetTcpNonBlockConnect(_, _, _)).WillOnce(Return(5));
+    EXPECT_CALL(mock, aeWait(_, _, _)).WillOnce(DoAll(Assign(&errno, EINTR), Return(-1)));
+
+    connection *conn = connCreate(connectionTypeTcp());
+    int ret = connBlockingConnect(conn, "127.0.0.1", 1234, 100);
+
+    EXPECT_EQ(ret, C_ERR);
+    EXPECT_NE(conn->state, CONN_STATE_CONNECTED);
+    EXPECT_EQ(conn->last_errno, EINTR);
+
+    conn->fd = -1;
+    connClose(conn);
+}
+
+/* Same dispatch path (CT_Socket -> connSocketBlockingConnect).
+ * Verify connBlockingConnect returns C_ERR with ETIMEDOUT when aeWait
+ * returns 0 (poll timed out without the fd becoming writable). */
+TEST_F(SocketTest, BlockingConnectReturnsTimeoutWhenAeWaitTimesOut) {
+    EXPECT_CALL(mock, anetTcpNonBlockConnect(_, _, _)).WillOnce(Return(5));
+    EXPECT_CALL(mock, aeWait(_, _, _)).WillOnce(Return(0));
+
+    connection *conn = connCreate(connectionTypeTcp());
+    int ret = connBlockingConnect(conn, "127.0.0.1", 1234, 100);
+
+    EXPECT_EQ(ret, C_ERR);
+    EXPECT_EQ(conn->last_errno, ETIMEDOUT);
+
+    conn->fd = -1;
+    connClose(conn);
+}

--- a/src/unit/wrappers.h
+++ b/src/unit/wrappers.h
@@ -44,6 +44,7 @@ extern "C" {
 #define protected protected_                     /* Avoid conflict with C++ 'protected' keyword */
 
 #include "ae.h"
+#include "anet.h"
 #include "server.h"
 
 /**
@@ -60,6 +61,8 @@ extern "C" {
  *       Example: serverLog(int level, const char *fmt, ...) should NOT be mocked.
  */
 long long __wrap_aeCreateTimeEvent(aeEventLoop *eventLoop, long long milliseconds, aeTimeProc *proc, void *clientData, aeEventFinalizerProc *finalizerProc);
+int __wrap_aeWait(int fd, int mask, long long milliseconds);
+int __wrap_anetTcpNonBlockConnect(char *err, const char *addr, int port);
 #undef protected
 #undef _Bool
 #undef typename


### PR DESCRIPTION
# Summary 
`connSocketBlockingConnect` previously checked `aeWait` with a bitmask `(aeWait(...) & AE_WRITABLE) == 0`. When `aeWait` returns `-1` the bitmask evaluated to non-zero (`-1 & AE_WRITABLE == AE_WRITABLE`), so the error path was skipped entirely and the connection was treated as successfully established.


# Fix
This change captures the `aeWait` return value and distinguishes the two failure cases:

`result == 0` (timeout): sets `last_errno = ETIMEDOUT`, same as before.
`result == -1` (poll error): sets `last_errno = errno`, preserving the actual failure reason (e.g. `EINTR`).

# Tests Added
Two unit tests are added covering both paths:

`BlockingConnectReturnsErrorWhenAeWaitFails` — mocks `aeWait` returning `-1 `with `errno = EINTR` and verifies `last_errno` is `EINTR`.
`BlockingConnectReturnsTimeoutWhenAeWaitTimesOut` — mocks `aeWait` returning `0` and verifies `last_errno` is `ETIMEDOUT`.
The `aeWait` and `anetTcpNonBlockConnect` wrappers are registered in `wrappers.h` to support the new test mocks.