### PR TITLE
Speed up cluster startup by 10 seconds

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1617,11 +1617,10 @@ void replicaStartCommandStream(client *replica) {
     serverAssert(!(replica->flag.repl_rdbonly));
     replica->repl_data->repl_start_cmd_stream_on_ack = 0;
 
-    /* If the replication stream is empty in cluster mode, send a PING so that
-     * master_repl_offset becomes non-zero. This allows replicas to be reported
-     * as available in CLUSTER SLOTS/SHARDS right away. */
-    if (server.cluster_enabled && server.primary_repl_offset == 0 &&
-        server.primary_host == NULL) {
+    /* If the replication stream is empty, send a PING so that replication
+     * offset becomes non-zero. In cluster mode, this allows replicas to be
+     * reported as available in CLUSTER SLOTS/SHARDS right away. */
+    if (server.primary_repl_offset == 0) {
         robj *ping_argv[1] = {shared.ping};
         replicationFeedReplicas(-1, ping_argv, 1);
     }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1594,14 +1594,6 @@ int replicaPutOnline(client *replica) {
     replica->repl_data->repl_state = REPLICA_STATE_ONLINE;
     replica->repl_data->repl_ack_time = server.unixtime; /* Prevent false timeout. */
 
-    /* If the replication stream is empty in cluster mode, send a PING
-     * immediately so that master_repl_offset becomes non-zero. This allows
-     * replicas to be reported as available in CLUSTER SLOTS/SHARDS right away. */
-    if (server.cluster_enabled && server.primary_repl_offset == 0 && server.primary_host == NULL) {
-        robj *ping_argv[1] = {shared.ping};
-        replicationFeedReplicas(-1, ping_argv, 1);
-    }
-
     refreshGoodReplicasCount();
     /* Fire the replica change modules event. */
     moduleFireServerEvent(VALKEYMODULE_EVENT_REPLICA_CHANGE, VALKEYMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE, NULL);
@@ -1624,6 +1616,15 @@ int replicaPutOnline(client *replica) {
 void replicaStartCommandStream(client *replica) {
     serverAssert(!(replica->flag.repl_rdbonly));
     replica->repl_data->repl_start_cmd_stream_on_ack = 0;
+
+    /* If the replication stream is empty in cluster mode, send a PING so that
+     * master_repl_offset becomes non-zero. This allows replicas to be reported
+     * as available in CLUSTER SLOTS/SHARDS right away. */
+    if (server.cluster_enabled && server.primary_repl_offset == 0 &&
+        server.primary_host == NULL) {
+        robj *ping_argv[1] = {shared.ping};
+        replicationFeedReplicas(-1, ping_argv, 1);
+    }
 
     putClientInPendingWriteQueue(replica);
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1594,6 +1594,14 @@ int replicaPutOnline(client *replica) {
     replica->repl_data->repl_state = REPLICA_STATE_ONLINE;
     replica->repl_data->repl_ack_time = server.unixtime; /* Prevent false timeout. */
 
+    /* If the replication stream is empty in cluster mode, send a PING
+     * immediately so that master_repl_offset becomes non-zero. This allows
+     * replicas to be reported as available in CLUSTER SLOTS/SHARDS right away. */
+    if (server.cluster_enabled && server.primary_repl_offset == 0 && server.primary_host == NULL) {
+        robj *ping_argv[1] = {shared.ping};
+        replicationFeedReplicas(-1, ping_argv, 1);
+    }
+
     refreshGoodReplicasCount();
     /* Fire the replica change modules event. */
     moduleFireServerEvent(VALKEYMODULE_EVENT_REPLICA_CHANGE, VALKEYMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE, NULL);

--- a/tests/integration/psync2-master-restart.tcl
+++ b/tests/integration/psync2-master-restart.tcl
@@ -1,4 +1,4 @@
-start_server {tags {"psync2 external:skip"}} {
+start_server {tags {psync2 external:skip cluster:skip}} {
 start_server {} {
 start_server {} {
     set master [srv 0 client]
@@ -36,9 +36,11 @@ start_server {} {
         fail "Replication not started."
     }
 
-    test "PSYNC2: Partial resync after Master restart using RDB aux fields when offset is 0" {
-        assert {[status $master master_repl_offset] == 0}
-
+    test "PSYNC2: Partial resync after Master restart using RDB aux fields with no data" {
+        # The offset may be non-zero due to the initial PING on the replication
+        # stream, but no user data has been written.
+        assert_equal 0 [$master dbsize]
+        set offset [status $master master_repl_offset]
         set replid [status $master master_replid]
         $replica config resetstat
 
@@ -55,13 +57,13 @@ start_server {} {
 
         # Make sure master restore replication info correctly
         assert {[status $master master_replid] != $replid}
-        assert {[status $master master_repl_offset] == 0}
+        assert {[status $master master_repl_offset] == $offset}
         assert {[status $master master_replid2] eq $replid}
-        assert {[status $master second_repl_offset] == 1}
+        assert {[status $master second_repl_offset] == $offset + 1}
 
         # Make sure master set replication backlog correctly
         assert {[status $master repl_backlog_active] == 1}
-        assert {[status $master repl_backlog_first_byte_offset] == 1}
+        assert {[status $master repl_backlog_first_byte_offset] == $offset + 1}
         assert {[status $master repl_backlog_histlen] == 0}
 
         # Partial resync after Master restart

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1478,7 +1478,7 @@ start_server {tags {"repl" "external:skip"}} {
         set lines [count_log_lines 0]
 
         $rd psync replicationid -1
-        assert_match {FULLRESYNC * 0} [$rd read]
+        assert_match {FULLRESYNC * *} [$rd read]
         $rd get foo
         catch {$rd read} e
         if {$::verbose} { puts "PSYNC _addReplyToBufferOrList: $e" }
@@ -1498,7 +1498,7 @@ start_server {tags {"repl" "external:skip"}} {
         set lines [count_log_lines 0]
 
         $rd psync replicationid -1
-        assert_match {FULLRESYNC * 0} [$rd read]
+        assert_match {FULLRESYNC * *} [$rd read]
         $rd slowlog get
         catch {$rd read} e
         if {$::verbose} { puts "PSYNC addReplyDeferredLen: $e" }

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -210,7 +210,7 @@ proc cluster_allocate_replicas {masters replicas} {
 
 # Setup method to be executed to configure the cluster before the
 # tests run.
-proc cluster_setup {masters replicas node_count slot_allocator replica_allocator code options} {
+proc cluster_setup {masters replicas node_count slot_allocator replica_allocator options} {
     # Make it easier to understand how a particular server interacts
     # with other nodes when reading the server logs by assigning human
     # nodenames R0, R1, R2 etc.
@@ -261,8 +261,6 @@ proc cluster_setup {masters replicas node_count slot_allocator replica_allocator
 
     wait_for_cluster_propagation
     wait_for_cluster_state "ok"
-
-    uplevel 1 $code
 }
 
 # Start a cluster with the given number of masters and replicas. Replicas
@@ -271,7 +269,10 @@ proc start_cluster {masters replicas options code {slot_allocator continuous_slo
     set node_count [expr $masters + $replicas]
 
     # Set the final code to be the tests + cluster setup
-    set code [list cluster_setup $masters $replicas $node_count $slot_allocator $replica_allocator $code $options]
+    set setup_code [list cluster_setup $masters $replicas $node_count $slot_allocator $replica_allocator $options]
+    set teardown_code {}
+    set code [list test_fixture "start_cluster" $setup_code $teardown_code $code]
+    #set code [list cluster_setup_then_test $masters $replicas $node_count $slot_allocator $replica_allocator $code $options]
 
     # Configure the starting of multiple servers. Set cluster node timeout
     # aggressively since many tests depend on ping/pong messages.

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -126,7 +126,7 @@ proc cluster_size_consistent {cluster_size} {
 
 # Wait for cluster configuration to propagate and be consistent across nodes.
 proc wait_for_cluster_propagation {} {
-    wait_for_condition 1000 50 {
+    wait_for_condition 1200 50 {
         [cluster_config_consistent] eq 1
     } else {
         for {set j 0} {$j < [llength $::servers]} {incr j} {

--- a/tests/support/cluster_util.tcl
+++ b/tests/support/cluster_util.tcl
@@ -272,7 +272,6 @@ proc start_cluster {masters replicas options code {slot_allocator continuous_slo
     set setup_code [list cluster_setup $masters $replicas $node_count $slot_allocator $replica_allocator $options]
     set teardown_code {}
     set code [list test_fixture "start_cluster" $setup_code $teardown_code $code]
-    #set code [list cluster_setup_then_test $masters $replicas $node_count $slot_allocator $replica_allocator $code $options]
 
     # Configure the starting of multiple servers. Set cluster node timeout
     # aggressively since many tests depend on ping/pong messages.

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -317,3 +317,50 @@ proc test {name code {okpattern undefined} {tags {}}} {
     set ::singledb $old_singledb
     set ::cur_test $prev_test
 }
+
+# Similar to 'test', but used for running setup and teardown blocks in fixtures.
+# Returns 1 on success and 0 if an assertion was caught within the code.
+proc test_block {name code} {
+    if {$::verbose > 1} {
+        puts "starting $name"
+    }
+    incr ::num_tests
+    set details {}
+    lappend details "$name in $::curfile"
+    send_data_packet $::test_server_fd testing $name
+    set test_start_time [clock milliseconds]
+    if {[catch {set retval [uplevel 1 $code]} error]} {
+        # Catch asserts and wait_for_condition.
+        if {[string match "assertion:*" $error]} {
+            set msg [string range $error 10 end]
+            lappend details $msg
+            lappend ::tests_failed $details
+            incr ::num_failed
+            send_data_packet $::test_server_fd err [join $details "\n"]
+            return 0
+        } else {
+            # Re-raise, let handler up the stack take care of this.
+            error $error $::errorInfo
+        }
+    } else {
+        # Succeeded
+        incr ::num_passed
+        set elapsed [expr {[clock milliseconds] - $test_start_time}]
+        send_data_packet $::test_server_fd ok $name $elapsed
+        return 1
+    }
+}
+
+proc test_fixture {name setup teardown code} {
+    if {$setup ne {}} {
+        set setup_ok [test_block "Setup $name" $setup]
+    } else {
+        set setup_ok 1
+    }
+    if {$setup_ok} {
+        uplevel 1 $code
+    }
+    if {$teardown ne {}} {
+        test_block "Teardown $name" $teardown
+    }
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1002,7 +1002,10 @@ proc assert_replication_stream {s patterns} {
         set pattern [lindex $patterns $j]
         lappend patterns_list $pattern
         set value [read_from_replication_stream $s]
-        # Skip pings that can appear depending on timing.
+        # Skip pings that can appear depending on timing. The primary sends
+        # pings at regular intervals when the replication stream is idle. In
+        # cluster mode, a ping is sent immediately when the first replica comes
+        # online, to bump the replication offset to non-zero.
         while {$value eq "ping"} {
             set value [read_from_replication_stream $s]
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -1002,6 +1002,10 @@ proc assert_replication_stream {s patterns} {
         set pattern [lindex $patterns $j]
         lappend patterns_list $pattern
         set value [read_from_replication_stream $s]
+        # Skip pings that can appear depending on timing.
+        while {$value eq "ping"} {
+            set value [read_from_replication_stream $s]
+        }
         lappend values_list $value
         if {![string match $pattern $value]} { incr errors }
     }


### PR DESCRIPTION
Replicas with replication offset 0 are flagged as "loading" in CLUSTER
SHARDS and are hidden in CLUSTER SLOTS. These commands assume that the
replicas have not yet synched from their primary, but the replication
offset is zero also when the primary hasn't had any commands written to
the replication stream yet.

The replication offset becomes non-zero when the primary sends a PING
on the replication stream, which it does every 10 seconds by default.
This eventually marks the replicas "online" in CLUSTER SHARDS / CLUSTER
SLOTS.

This change sends a PING on the replication stream when the first
replica connects, to trigger a non-zero replication offset and make the
replicas show up as "online" immediately.

The test framework's "start_cluster" waits for the all nodes to be
marked "online" before running test cases. Production deployment tools
may have similar checks. With this change, starting a cluster gets up to
10 seconds faster.

Some tests with large clusters need these extra 10 seconds for the
cluster to stabilize, so test framework's wait_for_cluster_propagation
is allowed 10 extra seconds (60 instead of 50).

**Additional test framework change:** Catch assertions and print the
duration of setting up the cluster in start_cluster.

This change catches asserts and timeouts in wait_for_condition during
start_cluster's setup phase, prints the error and skips the test cases
within the cluster_cluster body, instead of crashing the whole test
framework with a Tcl exception and stack trace. This is implemented
as a test fixture with a setup and teardown code, which is a new
construct added to the test framework.

## Examples

Setting up the cluster is reported with a duration (with the test framework change only):

    [ok]: Setup start_cluster (10224 ms)

Adding the commit sending the early PING on the replication stream cuts the time:

    [ok]: Setup start_cluster (2324 ms)

If `start_cluster` times out when setting up the cluster, with this change:

    [err]: Setup start_cluster in tests/unit/cluster/faildet.tcl
    cluster config did not reach a consistent state

Without this change, a timeout while setting up the cluster is uncaught:

```
[exception]: Executing test client: assertion:cluster config did not reach a consistent state.
assertion:cluster config did not reach a consistent state
    while executing
"error "assertion:$msg""
    (procedure "fail" line 2)
    invoked from within
"fail "cluster config did not reach a consistent state""
    ("uplevel" body line 5)
    invoked from within
"uplevel 1 $elsescript"
    (procedure "wait_for_condition" line 15)
    invoked from within
"wait_for_condition 1000 50 {
        [cluster_config_consistent] eq 1
    } else {
        for {set j 0} {$j < [llength $::servers]} {incr j} {
      ..."
    (procedure "wait_for_cluster_propagation" line 2)
    invoked from within
"wait_for_cluster_propagation"
    (procedure "cluster_setup" line 50)
    invoked from within
"cluster_setup 2 2 4 continuous_slot_allocation default_replica_allocation {
```