### PR TITLE
Improved Tcl stacktraces

### DIFF
--- a/tests/support/stacktrace.tcl
+++ b/tests/support/stacktrace.tcl
@@ -76,23 +76,12 @@ set ::stacktrace_err ""
 if {[info commands tailcall] ne ""} {
     rename return orig_return
     proc return {args} {
-        set opts {}
-        set i 0
-        while {$i < [llength $args]} {
-            set arg [lindex $args $i]
-            switch -glob -- $arg {
-                -code - -errorcode - -errorinfo - -errorstack - -level - -options {
-                    dict set opts $arg [lindex $args $i+1]
-                    incr i 2
-                }
-                -- {
-                    incr i
-                    break
-                }
-                default {
-                    break
-                }
-            }
+        if {[llength $args] % 2 == 1} {
+            set opts [lrange $args 0 end-1]
+            set result [lindex $args end]
+        } else {
+            set opts $args
+            set result ""
         }
 
         # Intercept errors and capture the stacktrace, unless it's a re-raise
@@ -100,7 +89,7 @@ if {[info commands tailcall] ne ""} {
             set code [dict get $opts -code]
             if {$code eq "error" || $code == 1} {
                 set ::stacktrace [stacktrace 2]
-                set ::stacktrace_err [lindex $args $i]
+                set ::stacktrace_err $result
             }
         }
 

--- a/tests/support/stacktrace.tcl
+++ b/tests/support/stacktrace.tcl
@@ -1,0 +1,134 @@
+# Captures the stacktrace at the current stack frame.
+proc stacktrace {{skip 1}} {
+    set lines {}
+    set n [info frame]
+    incr n -$skip
+    set dir "[pwd]/"
+    set dirlen [string length $dir]
+    set prev_file ""
+    set prev_line 0
+    for {set i 1} {$i <= $n} {incr i} {
+        set frame [info frame $i]
+        set type [dict get $frame type]
+        set str ""
+
+        if {$type eq "eval" && [dict exists $frame line] && $prev_file ne ""} {
+            # Eval frame from uplevel - compute absolute line from last anchor
+            set abs_line [expr {$prev_line + [dict get $frame line] - 1}]
+            if {[dict exists $frame cmd]} {
+                set cmd [lindex [dict get $frame cmd] 0]
+            } else {
+                set cmd "?"
+            }
+            append str " in $cmd at $prev_file:$abs_line"
+            # Update anchor for further nested evals
+            set prev_line $abs_line
+            lappend lines $str
+            continue
+        } elseif {[dict exists $frame {proc}]} {
+            set ctx [dict get $frame {proc}]
+            if {[string match "::*" $ctx]} {
+                set ctx [string range $ctx 2 end]
+            }
+            # Skip internal handler frames
+            if {$ctx eq "unknown" || $ctx eq "error"} {
+                continue
+            }
+            append str " in $ctx"
+        } elseif {$type ne "source"} {
+            continue
+        } else {
+            # Non-proc source frame: show first word of cmd
+            if {[dict exists $frame cmd]} {
+                set cmd [lindex [dict get $frame cmd] 0]
+            } else {
+                set cmd "?"
+            }
+            append str " in $cmd"
+        }
+
+        if {$type eq {source}} {
+            set file [dict get $frame file]
+            if {[string length $file] >= $dirlen && [string equal -length $dirlen $dir $file]} {
+                set file [string range $file $dirlen end]
+            }
+            set line [dict get $frame line]
+            append str " at $file:$line"
+            # Update anchor, but not for uplevel frames
+            if {![dict exists $frame cmd] || ![string match "uplevel *" [dict get $frame cmd]]} {
+                set prev_file $file
+                set prev_line $line
+            }
+        } else {
+            continue
+        }
+
+        lappend lines $str
+    }
+    return [join [lreverse $lines] \n]\n
+}
+
+# The last captured stacktrace
+set ::stacktrace ""
+set ::stacktrace_err ""
+
+# Redefine 'return' to capture stacktraces
+rename return orig_return
+proc return {args} {
+    set opts {}
+    set i 0
+    while {$i < [llength $args]} {
+        set arg [lindex $args $i]
+        switch -glob -- $arg {
+            -code - -errorcode - -errorinfo - -errorstack - -level - -options {
+                dict set opts $arg [lindex $args $i+1]
+                incr i 2
+            }
+            -- {
+                incr i
+                break
+            }
+            default {
+                break
+            }
+        }
+    }
+
+    # Intercept errors and capture the stacktrace, unless it's a re-raise
+    if {[dict exists $opts -code] && ![dict exists $opts -errorinfo]} {
+        set code [dict get $opts -code]
+        if {$code eq "error" || $code == 1} {
+            set ::stacktrace [stacktrace 2]
+            set ::stacktrace_err [lindex $args $i]
+        }
+    }
+
+    # Bump -level by 1 to account for this wrapper's stack frame.
+    # Default -level for return is 1; we need it to be 2 to exit the caller.
+    if {[dict exists $opts -level]} {
+        set level [dict get $opts -level]
+    } else {
+        set level 1
+    }
+    incr level
+    # Rebuild args with the adjusted -level
+    dict set opts -level $level
+    # Reconstruct: flatten opts + result (if any)
+    if {$i < [llength $args]} {
+        orig_return {*}$opts [lindex $args $i]
+    } else {
+        orig_return {*}$opts
+    }
+}
+
+# Redefine 'error' to capture stacktraces
+rename error orig_error
+proc error {msg {errorinfo ""} {errorcode ""}} {
+    if {$errorinfo eq ""} {
+        # Fresh error - use return -code error to trigger stacktrace capture
+        return -code error $msg
+    } else {
+        # Re-raise - pass through with errorinfo
+        return -code error -errorinfo $errorinfo -errorcode $errorcode $msg
+    }
+}

--- a/tests/support/stacktrace.tcl
+++ b/tests/support/stacktrace.tcl
@@ -16,7 +16,7 @@ proc stacktrace {{skip 1}} {
             # Eval frame from uplevel - compute absolute line from last anchor
             set abs_line [expr {$prev_line + [dict get $frame line] - 1}]
             if {[dict exists $frame cmd]} {
-                set cmd [lindex [dict get $frame cmd] 0]
+                regexp {^\S+} [dict get $frame cmd] cmd
             } else {
                 set cmd "?"
             }
@@ -40,7 +40,7 @@ proc stacktrace {{skip 1}} {
         } else {
             # Non-proc source frame: show first word of cmd
             if {[dict exists $frame cmd]} {
-                set cmd [lindex [dict get $frame cmd] 0]
+                regexp {^\S+} [dict get $frame cmd] cmd
             } else {
                 set cmd "?"
             }
@@ -104,21 +104,15 @@ proc return {args} {
     }
 
     # Bump -level by 1 to account for this wrapper's stack frame.
-    # Default -level for return is 1; we need it to be 2 to exit the caller.
     if {[dict exists $opts -level]} {
         set level [dict get $opts -level]
+        incr level
+        set idx [lsearch -exact $args -level]
+        set args [lreplace $args $idx [expr {$idx+1}] -level $level]
     } else {
-        set level 1
+        set args [linsert $args 0 -level 2]
     }
-    incr level
-    # Rebuild args with the adjusted -level
-    dict set opts -level $level
-    # Reconstruct: flatten opts + result (if any)
-    if {$i < [llength $args]} {
-        orig_return {*}$opts [lindex $args $i]
-    } else {
-        orig_return {*}$opts
-    }
+    orig_return {*}$args
 }
 
 # Redefine 'error' to capture stacktraces

--- a/tests/support/stacktrace.tcl
+++ b/tests/support/stacktrace.tcl
@@ -72,57 +72,51 @@ proc stacktrace {{skip 1}} {
 set ::stacktrace ""
 set ::stacktrace_err ""
 
-# Redefine 'return' to capture stacktraces
-rename return orig_return
-proc return {args} {
-    set opts {}
-    set i 0
-    while {$i < [llength $args]} {
-        set arg [lindex $args $i]
-        switch -glob -- $arg {
-            -code - -errorcode - -errorinfo - -errorstack - -level - -options {
-                dict set opts $arg [lindex $args $i+1]
-                incr i 2
-            }
-            -- {
-                incr i
-                break
-            }
-            default {
-                break
+# Redefine 'return' to capture stacktraces (requires tailcall, Tcl 8.6+)
+if {[info commands tailcall] ne ""} {
+    rename return orig_return
+    proc return {args} {
+        set opts {}
+        set i 0
+        while {$i < [llength $args]} {
+            set arg [lindex $args $i]
+            switch -glob -- $arg {
+                -code - -errorcode - -errorinfo - -errorstack - -level - -options {
+                    dict set opts $arg [lindex $args $i+1]
+                    incr i 2
+                }
+                -- {
+                    incr i
+                    break
+                }
+                default {
+                    break
+                }
             }
         }
-    }
 
-    # Intercept errors and capture the stacktrace, unless it's a re-raise
-    if {[dict exists $opts -code] && ![dict exists $opts -errorinfo]} {
-        set code [dict get $opts -code]
-        if {$code eq "error" || $code == 1} {
-            set ::stacktrace [stacktrace 2]
-            set ::stacktrace_err [lindex $args $i]
+        # Intercept errors and capture the stacktrace, unless it's a re-raise
+        if {[dict exists $opts -code] && ![dict exists $opts -errorinfo]} {
+            set code [dict get $opts -code]
+            if {$code eq "error" || $code == 1} {
+                set ::stacktrace [stacktrace 2]
+                set ::stacktrace_err [lindex $args $i]
+            }
         }
-    }
 
-    # Bump -level by 1 to account for this wrapper's stack frame.
-    if {[dict exists $opts -level]} {
-        set level [dict get $opts -level]
-        incr level
-        set idx [lsearch -exact $args -level]
-        set args [lreplace $args $idx [expr {$idx+1}] -level $level]
-    } else {
-        set args [linsert $args 0 -level 2]
+        tailcall orig_return {*}$args
     }
-    orig_return {*}$args
 }
 
 # Redefine 'error' to capture stacktraces
 rename error orig_error
 proc error {msg {errorinfo ""} {errorcode ""}} {
     if {$errorinfo eq ""} {
-        # Fresh error - use return -code error to trigger stacktrace capture
-        return -code error $msg
+        set ::stacktrace [stacktrace 1]
+        set ::stacktrace_err $msg
+        orig_error $msg
     } else {
         # Re-raise - pass through with errorinfo
-        return -code error -errorinfo $errorinfo -errorcode $errorcode $msg
+        orig_error $msg $errorinfo $errorcode
     }
 }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -3,6 +3,7 @@
 # more information.
 
 set tcl_precision 17
+source tests/support/stacktrace.tcl
 source tests/support/valkey.tcl
 source tests/support/aofmanifest.tcl
 source tests/support/server.tcl
@@ -1059,7 +1060,14 @@ proc is_a_slow_computer {} {
 
 if {$::client} {
     if {[catch { test_client_main $::test_server_port } err]} {
-        set estr "Executing test client: $err.\n$::errorInfo"
+        if {$::stacktrace ne "" && $::stacktrace_err eq $err} {
+            # Pretty stacktraces from our stacktrace.tcl
+            set stacktrace $::stacktrace
+        } else {
+            # Fallback for Tcl builtin errors not raised via return or error.
+            set stacktrace $::errorInfo
+        }
+        set estr "Executing test client: $err.\n$stacktrace"
         if {[catch {send_data_packet $::test_server_fd exception $estr}]} {
             puts $estr
         }


### PR DESCRIPTION
Generate stack traces with filenames and absolute line numbers.

Examples, with exceptions inserted in the test suite:

```
% ./runtest --single tests/unit/auth.tcl
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 48510
Testing unit/auth
[ok]: AUTH fails if there is no password configured server side (0 ms)
[exception]: Executing test client: invalid command name "dummy_undefined_function".
 in dummy_undefined_function at tests/unit/auth.tcl:6
 in start_server at tests/support/server.tcl:766
 in execute_test_file at tests/unit/auth.tcl:1
 in execute_test_file at tests/test_helper.tcl:146
 in test_client_main at tests/test_helper.tcl:645
 in test_client_main at tests/test_helper.tcl:1062
 in catch at tests/test_helper.tcl:1062
 in if at tests/test_helper.tcl:1061

% ./runtest --single tests/unit/auth.tcl
Cleanup: may take some time... OK
Starting test server at port 21079
[ready]: 52538
Testing unit/auth
[exception]: Executing test client: Bad protocol, 'N' as reply type byte.
 in valkey::__dispatch__ at tests/support/valkey.tcl:116
 in $fd at tests/unit/auth.tcl:4
 in test at tests/support/test.tcl:262
 in test at tests/unit/auth.tcl:2
 in start_server at tests/support/server.tcl:766
 in execute_test_file at tests/unit/auth.tcl:1
 in execute_test_file at tests/test_helper.tcl:146
 in test_client_main at tests/test_helper.tcl:645
 in test_client_main at tests/test_helper.tcl:1062
 in catch at tests/test_helper.tcl:1062
 in if at tests/test_helper.tcl:1061
```