### PR TITLE
Fix UAF in unblockClientOnKey when reprocessed command frees the client (CVE-2026-23479)

### DIFF
--- a/src/blocked.c
+++ b/src/blocked.c
@@ -682,7 +682,13 @@ static void unblockClientOnKey(client *c, robj *key) {
         client *old_client = server.current_client;
         server.current_client = c;
         enterExecutionUnit(1, 0);
-        processCommandAndResetClient(c);
+        if (processCommandAndResetClient(c) == C_ERR) {
+            /* Client was freed during command processing, exit immediately */
+            exitExecutionUnit();
+            server.current_client = old_client;
+            return;
+        }
+
         if (!(c->flags & CLIENT_BLOCKED)) {
             if (c->flags & CLIENT_MODULE) {
                 moduleCallCommandUnblockedHandler(c);


### PR DESCRIPTION
When a blocked client is woken up on a key, unblockClientOnKey() re-executes its pending command via processCommandAndResetClient(). That function returns C_ERR when the client was freed as a side effect of the re-execution (it detects this by server.current_client becoming NULL inside freeClient()).

The pre-fix code ignored the return value and unconditionally accessed c->flags & CLIENT_BLOCKED / c->flags & CLIENT_MODULE afterwards -- a use-after-free on the freed client.

The fix mirrors the existing dead-client handling in processPendingCommandAndInputBuffer() (src/networking.c): on C_ERR, unwind the execution unit, restore server.current_client, and return without touching c.