### PR TITLE
Fix invalid memory access in RESTORE with malformed zipmap (CVE-2026-25243)

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2288,11 +2288,12 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
 
                         /* search for duplicate records */
                         sds field = sdstrynewlen(fstr, flen);
-                        if (!field || dictAdd(dupSearchDict, field, NULL) != DICT_OK ||
-                            !lpSafeToAdd(lp, (size_t)flen + vlen)) {
+                        if (!field || !lpSafeToAdd(lp, (size_t)flen + vlen) ||
+                            dictAdd(dupSearchDict, field, NULL) != DICT_OK) {
                             rdbReportCorruptRDB("Hash zipmap with dup elements, or big length (%u)", flen);
                             dictRelease(dupSearchDict);
                             sdsfree(field);
+                            lpFree(lp);
                             zfree(encoded);
                             o->ptr = NULL;
                             decrRefCount(o);
@@ -2761,7 +2762,6 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error) {
                                                 " loading a stream consumer "
                                                 "group");
                         decrRefCount(o);
-                        streamFreeNACK(nack);
                         return NULL;
                     }
                 }

--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -405,6 +405,10 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
 
         /* read the field name length */
         l = zipmapDecodeLength(p);
+        /* Sanity check: length < 254 must be encoded in 1 byte, not 5 bytes */
+        if (l < ZIPMAP_BIGLEN && s != 1)
+            return 0;
+
         p += s; /* skip the encoded field size */
         p += l; /* skip the field */
 
@@ -420,6 +424,9 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
 
         /* read the value length */
         l = zipmapDecodeLength(p);
+        /* Sanity check: length < 254 must be encoded in 1 byte, not 5 bytes */
+        if (l < ZIPMAP_BIGLEN && s != 1)
+            return 0;
         p += s; /* skip the encoded value size*/
         e = *p++; /* skip the encoded free space (always encoded in one byte) */
         p += l+e; /* skip the value and free space */

--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -407,4 +407,12 @@ start_server {tags {"dump"}} {
             assert_match {*WRONGPASS*} $err
         }
     } {} {external:skip}
+
+    test {RESTORE rejects zipmap with overlong field length encoding (CVE-2026-25243)} {
+        r debug set-skip-checksum-validation 1
+        set payload "\x09\x18\x02\xfe\x03\x00\x00\x00\x61\x62\x63\x03\x00\x64\x65\x66\x03\x67\x68\x69\x03\x00\x6a\x6b\x6c\xff\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        catch {r restore zipmap_test 0 $payload} err
+        r debug set-skip-checksum-validation 0
+        assert_match {*Bad data format*} $err
+    } {} {needs:debug}
 }


### PR DESCRIPTION
1. src/zipmap.c: Add sanity checks in zipmapValidateIntegrity() to reject entries where the decoded length < ZIPMAP_BIGLEN (254) but the encoding uses more than 1 byte. This prevents a pointer arithmetic mismatch between validation and zipmapNext() that leads to heap buffer over-reads.

2. src/rdb.c (hash zipmap conversion): Reorder the dictAdd()/lpSafeToAdd() checks so lpSafeToAdd() is evaluated before dictAdd() takes ownership of the field SDS. Add missing lpFree(lp) in the error path to fix a memory leak when the conversion fails.

3. src/rdb.c (stream consumer PEL): Remove erroneous streamFreeNACK(nack) in the "Duplicated consumer PEL entry" error path. The nack is a shared reference from the global PEL (obtained via raxFind), so freeing it here causes a double-free when the stream object is later destroyed.