### PR TITLE
Delay full sync during yielding Lua scripts to prevent use-after-free (CVE-2026-23631)

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2615,6 +2615,11 @@ int replicaLoadPrimaryRDBFromDisk(rdbSaveInfo *rsi) {
 /* Asynchronously read the SYNC payload we receive from a primary, parse it,
  * and load it directly to memory without going through the disk */
 void replicaReceiveRDBFromPrimaryToMemory(connection *conn) {
+    /* During full sync, the functions engine is freed right before loading
+     * the RDB. To avoid this happening while a function is still running,
+     * delay full sync processing until it finishes. */
+    if (isInsideYieldingLongCommand()) return;
+
     char buf[PROTO_IOBUF_LEN];
     int ret;
     rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;


### PR DESCRIPTION
During a full sync, the functions/scripting engine is freed right before loading the RDB from the primary. If a Lua script is still running and yielding via the long-command mechanism at that moment, the freed engine can be accessed when the script resumes, causing a use-after-free.

Add a guard at the top of replicaReceiveRDBFromPrimaryToMemory() to check isInsideYieldingLongCommand() and return early, deferring the sync processing until the script completes.