### PR TITLE
Delay full sync during yielding Lua scripts to prevent use-after-free (CVE-2026-23631)

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -1863,6 +1863,11 @@ void replicationAttachToNewMaster(void) {
 /* Asynchronously read the SYNC payload we receive from a master */
 #define REPL_MAX_WRITTEN_BEFORE_FSYNC (1024*1024*8) /* 8 MB */
 void readSyncBulkPayload(connection *conn) {
+    /* During full sync, the functions engine is freed right before loading
+     * the RDB. To avoid this happening while a function is still running,
+     * delay full sync processing until it finishes. */
+    if (isInsideYieldingLongCommand()) return;
+
     char buf[PROTO_IOBUF_LEN];
     ssize_t nread, readlen, nwritten;
     int use_diskless_load = useDisklessLoad();


### PR DESCRIPTION
During a full sync, the functions/scripting engine is freed right before loading the RDB from the primary. If a Lua script is still running and yielding via the long-command mechanism at that moment, the freed engine can be accessed when the script resumes, causing a use-after-free.

Add a guard at the top of readSyncBulkPayload() to check isInsideYieldingLongCommand() and return early, deferring the sync processing until the script completes.