### PR TITLE
Add release notes entry for Valkey 7.2.13

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -12,6 +12,19 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
+Valkey 7.2.13  -  Tue 05 May 2026
+================================================================================
+
+Upgrade urgency SECURITY: This release includes security fixes we recommend you
+apply as soon as possible.
+
+Security fixes
+==============
+* (CVE-2026-23479) Use-After-Free in unblock client flow
+* (CVE-2026-25243) Invalid Memory Access in RESTORE command
+* (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution
+
+================================================================================
 Valkey 7.2.12  -  Released Mon 23 February 2026
 ================================================================================
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #define SERVER_NAME "valkey"
-#define VALKEY_VERSION "7.2.12"
-#define VALKEY_VERSION_NUM 0x0007020C
+#define VALKEY_VERSION "7.2.13"
+#define VALKEY_VERSION_NUM 0x0007020D
 
 /* Redis compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
Add a release notes entry for **Valkey 7.2.13** covering the three security fixes being ported to the `7.2` branch:

- **CVE-2026-23479** — Use-After-Free in unblock client flow
- **CVE-2026-25243** — Invalid Memory Access in RESTORE command
- **CVE-2026-23631** — Use-after-free when full sync occurs during a yielding Lua/function execution

Only modifies `00-RELEASENOTES`. The actual code fixes are in separate PRs targeting `7.2`.
