### PR TITLE
Add release notes entry for Valkey 8.0.8

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -10,6 +10,19 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
+Valkey 8.0.8  -  Tue 05 May 2026
+================================================================================
+
+Upgrade urgency SECURITY: This release includes security fixes we recommend you
+apply as soon as possible.
+
+Security fixes
+==============
+* (CVE-2026-23479) Use-After-Free in unblock client flow
+* (CVE-2026-25243) Invalid Memory Access in RESTORE command
+* (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution
+
+================================================================================
 Valkey 8.0.7  -  Released Mon 23 February 2026
 ================================================================================
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,8 +4,8 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "8.0.7"
-#define VALKEY_VERSION_NUM 0x00080007
+#define VALKEY_VERSION "8.0.8"
+#define VALKEY_VERSION_NUM 0x00080008
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
Add a release notes entry for **Valkey 8.0.8** covering the three security fixes being ported to the `8.0` branch:

- **CVE-2026-23479** — Use-After-Free in unblock client flow
- **CVE-2026-25243** — Invalid Memory Access in RESTORE command
- **CVE-2026-23631** — Use-after-free when full sync occurs during a yielding Lua/function execution

Only modifies `00-RELEASENOTES`. The actual code fixes are in separate PRs targeting `8.0`.
