### PR TITLE
Add release notes entry for Valkey 9.0.4

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -11,6 +11,18 @@ Upgrade urgency levels:
 | CRITICAL | There is a critical bug affecting MOST USERS. Upgrade ASAP.         |
 | SECURITY | There are security fixes in the release.                            |
 
+Valkey 9.0.4 - May 5, 2026
+--------------------------
+
+Upgrade urgency SECURITY: This release includes security fixes we recommend you
+apply as soon as possible.
+
+### Security fixes
+
+* (CVE-2026-23479) Use-After-Free in unblock client flow
+* (CVE-2026-25243) Invalid Memory Access in RESTORE command
+* (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution
+
 Valkey 9.0.3 - February 23, 2026
 ------------------
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,8 +4,8 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "9.0.3"
-#define VALKEY_VERSION_NUM 0x00090003
+#define VALKEY_VERSION "9.0.4"
+#define VALKEY_VERSION_NUM 0x00090004
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.


### PR DESCRIPTION
Add a release notes entry for **Valkey 9.0.4** covering the three security fixes being ported to the `9.0` branch:

- **CVE-2026-23479** — Use-After-Free in unblock client flow
- **CVE-2026-25243** — Invalid Memory Access in RESTORE command
- **CVE-2026-23631** — Use-after-free when full sync occurs during a yielding Lua/function execution

Only modifies `00-RELEASENOTES`. The actual code fixes are in separate PRs targeting `9.0`.
