### PR TITLE
Backport Test Fixes 7.2

### DIFF
--- a/runtest
+++ b/runtest
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/runtest-cluster
+++ b/runtest-cluster
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 [ -z "$MAKE" ] && MAKE=make
 

--- a/runtest-sentinel
+++ b/runtest-sentinel
@@ -1,5 +1,5 @@
 #!/bin/sh
-TCL_VERSIONS="8.5 8.6 8.7"
+TCL_VERSIONS="8.5 8.6 8.7 9.0"
 TCLSH=""
 
 for VERSION in $TCL_VERSIONS; do

--- a/src/call_reply.c
+++ b/src/call_reply.c
@@ -554,7 +554,7 @@ CallReply *callReplyCreateError(sds reply, void *private_data) {
         sdsfree(reply);
     }
     list *deferred_error_list = listCreate();
-    listSetFreeMethod(deferred_error_list, (void (*)(void*))sdsfree);
+    listSetFreeMethod(deferred_error_list, sdsfreeVoid);
     listAddNodeTail(deferred_error_list, sdsnew(err_buff));
     return callReplyCreate(err_buff, deferred_error_list, private_data);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -1042,7 +1042,7 @@ void scanGenericCommand(client *c, robj *o, unsigned long cursor) {
      * The exception to the above is ZSET, where we do allocate temporary
      * strings even when scanning a dict. */
     if (o && (!ht || o->type == OBJ_ZSET)) {
-        listSetFreeMethod(keys, (void (*)(void*))sdsfree);
+        listSetFreeMethod(keys, sdsfreeVoid);
     }
 
     if (ht) {

--- a/src/eval.c
+++ b/src/eval.c
@@ -684,7 +684,7 @@ void ldbInit(void) {
     ldb.conn = NULL;
     ldb.active = 0;
     ldb.logs = listCreate();
-    listSetFreeMethod(ldb.logs,(void (*)(void*))sdsfree);
+    listSetFreeMethod(ldb.logs,sdsfreeVoid);
     ldb.children = listCreate();
     ldb.src = NULL;
     ldb.lines = 0;

--- a/src/functions.c
+++ b/src/functions.c
@@ -167,6 +167,10 @@ static void engineLibraryFree(functionLibInfo* li) {
     zfree(li);
 }
 
+static void engineLibraryFreeVoid(void *li) {
+    engineLibraryFree(li);
+}
+
 static void engineLibraryDispose(dict *d, void *obj) {
     UNUSED(d);
     engineLibraryFree(obj);
@@ -349,7 +353,7 @@ static int libraryJoin(functionsLibCtx *functions_lib_ctx_dst, functionsLibCtx *
             } else {
                 if (!old_libraries_list) {
                     old_libraries_list = listCreate();
-                    listSetFreeMethod(old_libraries_list, (void (*)(void*))engineLibraryFree);
+                    listSetFreeMethod(old_libraries_list, engineLibraryFreeVoid);
                 }
                 libraryUnlink(functions_lib_ctx_dst, old_li);
                 listAddNodeTail(old_libraries_list, old_li);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -2511,7 +2511,7 @@ int listpackTest(int argc, char *argv[], int flags) {
         for (i = 0; i < iteration; i++) {
             lp = lpNew(0);
             ref = listCreate();
-            listSetFreeMethod(ref,(void (*)(void*))sdsfree);
+            listSetFreeMethod(ref,sdsfreeVoid);
             len = rand() % 256;
 
             /* Create lists */

--- a/src/networking.c
+++ b/src/networking.c
@@ -515,7 +515,7 @@ void afterErrorReply(client *c, const char *s, size_t len, int flags) {
     if (c->flags & CLIENT_MODULE) {
         if (!c->deferred_reply_errors) {
             c->deferred_reply_errors = listCreate();
-            listSetFreeMethod(c->deferred_reply_errors, (void (*)(void*))sdsfree);
+            listSetFreeMethod(c->deferred_reply_errors, sdsfreeVoid);
         }
         listAddNodeTail(c->deferred_reply_errors, sdsnewlen(s, len));
         return;

--- a/src/replication.c
+++ b/src/replication.c
@@ -200,7 +200,7 @@ void rebaseReplicationBuffer(long long base_repl_offset) {
 void resetReplicationBuffer(void) {
     server.repl_buffer_mem = 0;
     server.repl_buffer_blocks = listCreate();
-    listSetFreeMethod(server.repl_buffer_blocks, (void (*)(void*))zfree);
+    listSetFreeMethod(server.repl_buffer_blocks, zfree);
 }
 
 int canFeedReplicaReplBuffer(client *replica) {

--- a/src/server.c
+++ b/src/server.c
@@ -2642,7 +2642,7 @@ void initServer(void) {
         server.db[j].avg_ttl = 0;
         server.db[j].defrag_later = listCreate();
         server.db[j].slots_to_keys = NULL; /* Set by clusterInit later on if necessary. */
-        listSetFreeMethod(server.db[j].defrag_later,(void (*)(void*))sdsfree);
+        listSetFreeMethod(server.db[j].defrag_later,sdsfreeVoid);
     }
     evictionPoolAlloc(); /* Initialize the LRU keys pool. */
     server.pubsub_channels = dictCreate(&keylistDictType);

--- a/src/ziplist.c
+++ b/src/ziplist.c
@@ -2368,7 +2368,7 @@ int ziplistTest(int argc, char **argv, int flags) {
         for (i = 0; i < iteration; i++) {
             zl = ziplistNew();
             ref = listCreate();
-            listSetFreeMethod(ref,(void (*)(void*))sdsfree);
+            listSetFreeMethod(ref,sdsfreeVoid);
             len = rand() % 256;
 
             /* Create lists */

--- a/tests/cluster/tests/10-manual-failover.tcl
+++ b/tests/cluster/tests/10-manual-failover.tcl
@@ -132,8 +132,11 @@ test "Send CLUSTER FAILOVER to instance #5" {
 }
 
 test "Instance #5 is still a slave after some time (no failover)" {
-    after 5000
-    assert {[RI 5 role] eq {master}}
+    wait_for_condition 1000 50 {
+        [RI 5 role] eq {master}
+    } else {
+        fail "Instance #5 is not a master after some time"
+    }
 }
 
 test "Wait for instance #0 to return back alive" {

--- a/tests/cluster/tests/11-manual-takeover.tcl
+++ b/tests/cluster/tests/11-manual-takeover.tcl
@@ -28,12 +28,12 @@ test "Killing majority of master nodes" {
     kill_instance redis 2
 }
 
-foreach id $replica_ids {
-    R $id config set cluster-replica-no-failover no
-}
-
 test "Cluster should eventually be down" {
     assert_cluster_state fail
+}
+
+foreach id $replica_ids {
+    R $id config set cluster-replica-no-failover no
 }
 
 test "Use takeover to bring slaves back" {

--- a/tests/cluster/tests/17-diskless-load-swapdb.tcl
+++ b/tests/cluster/tests/17-diskless-load-swapdb.tcl
@@ -52,12 +52,13 @@ test "Main db not affected when fail to diskless load" {
     set num 10000
     set value [string repeat A 1024]
     set rd [redis_deferring_client redis $master_id]
+    $rd client reply off
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
+        if {$j % 1000 == 0} {$rd flush}
     }
-    for {set j 0} {$j < $num} {incr j} {
-        $rd read
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
 
     # Start the replica again
     restart_instance redis $replica_id

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -7,8 +7,6 @@
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 
-package require Tcl 8.5
-
 set tcl_precision 17
 source ../support/redis.tcl
 source ../support/util.tcl

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -13,6 +13,7 @@ if { ! [ catch {
 
 proc generate_collections {suffix elements} {
     set rd [redis_deferring_client]
+    $rd client reply off
     for {set j 0} {$j < $elements} {incr j} {
         # add both string values and integers
         if {$j % 2 == 0} {set val $j} else {set val "_$j"}
@@ -22,9 +23,8 @@ proc generate_collections {suffix elements} {
         $rd sadd set$suffix $val
         $rd xadd stream$suffix * item 1 value $val
     }
-    for {set j 0} {$j < $elements * 5} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
     $rd close
 }
 

--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -33,6 +33,8 @@ start_server {overrides {save {}}} {
         $node_2 replicaof $node_0_host $node_0_port
         wait_for_sync $node_1
         wait_for_sync $node_2
+        verify_replica_online $node_0 0 50
+        verify_replica_online $node_0 1 50
     }
 
     test {failover command fails with invalid host} {

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -263,16 +263,15 @@ start_server {overrides {save ""}} {
         # changing some keys and read the reported COW size, we are using small key size to prevent from
         # the "dismiss mechanism" free memory and reduce the COW size)
         set rd [redis_deferring_client 0]
+        $rd client reply off
         set size 500 ;# aim for the 512 bin (sds overhead)
         set cmd_count 10000
+        set AAA [string repeat A $size]
         for {set k 0} {$k < $cmd_count} {incr k} {
-            $rd set key$k [string repeat A $size]
+            $rd set key$k $AAA
         }
-
-        for {set k 0} {$k < $cmd_count} {incr k} {
-            catch { $rd read }
-        }
-
+        $rd client reply on
+        assert_equal OK [$rd read]
         $rd close
 
         # start background rdb save
@@ -301,8 +300,9 @@ start_server {overrides {save ""}} {
 
             # trigger copy-on-write
             set modified_keys 16
+            set BBB [string repeat B $size]
             for {set k 0} {$k < $modified_keys} {incr k} {
-                r setrange key$key_idx 0 [string repeat B $size]
+                r setrange key$key_idx 0 $BBB
                 incr key_idx 1
             }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -918,7 +918,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    wait_for_condition 500 100 {
+                    wait_for_condition 1200 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -855,10 +855,11 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
     set master_host [srv 0 host]
     set master_port [srv 0 port]
     set master_pid [srv 0 pid]
-    # put enough data in the db that the rdb file will be bigger than the socket buffers
-    # and since we'll have key-load-delay of 100, 20000 keys will take at least 2 seconds
-    # we also need the replica to process requests during transfer (which it does only once in 2mb)
-    $master debug populate 20000 test 10000
+    # Put enough data in the db that the RDB is comfortably larger than the
+    # pipe and socket buffers so the primary can hit the blocked writer path,
+    # but keep it small enough that slow TLS CI runners don't spend minutes
+    # draining an oversized transfer (~40 MB uncompressed).
+    $master debug populate 4000 test 10000
     $master config set rdbcompression no
     # If running on Linux, we also measure utime/stime to detect possible I/O handling issues
     set os [catch {exec uname}]
@@ -880,7 +881,19 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     # so that the whole rdb generation process is bound to that
                     set loglines [count_log_lines -2]
                     [lindex $replicas 0] config set repl-diskless-load swapdb
-                    [lindex $replicas 0] config set key-load-delay 100 ;# 20k keys and 100 microseconds sleep means at least 2 seconds
+                    # For "no" and "fast" subcases, use key-load-delay to keep
+                    # replica 0 as a steady slow reader for the entire RDB
+                    # transfer. A brief SIGSTOP/SIGCONT is insufficient
+                    # because after resume the TLS layer on slow CI runners
+                    # can't drain the pipe fast enough, leaving the RDB child
+                    # blocked on write() for minutes.
+                    if {$all_drop == "no" || $all_drop == "fast"} {
+                        # 4k keys with 500 microseconds each keeps replica 0
+                        # slow for about 2 seconds, which is long enough to
+                        # fill the pipe without turning the transfer into a
+                        # multi-minute TLS run.
+                        [lindex $replicas 0] config set key-load-delay 500
+                    }
                     [lindex $replicas 0] replicaof $master_host $master_port
                     [lindex $replicas 1] replicaof $master_host $master_port
 
@@ -894,12 +907,25 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         set start_time [clock seconds]
                     }
 
-                    # wait a while so that the pipe socket writer will be
-                    # blocked on write (since replica 0 is slow to read from the socket)
-                    after 500
+                    if {$all_drop == "no" || $all_drop == "fast"} {
+                        # key-load-delay is already throttling the slow
+                        # replica; just wait for the pipe to fill.
+                        after 500
+                    } else {
+                        # For slow/all/timeout subcases the replica will be
+                        # killed or timed out, so a brief SIGSTOP is fine.
+                        pause_process [srv -1 pid]
+                        after 500
+                    }
 
                     # add some command to be present in the command stream after the rdb.
                     $master incr $all_drop
+
+                    # Resume before terminating the paused slow replica so the
+                    # disconnect is observed immediately instead of timing out.
+                    if {$all_drop == "all" || $all_drop == "slow"} {
+                        resume_process [srv -1 pid]
+                    }
 
                     # disconnect replicas depending on the current test
                     if {$all_drop == "all" || $all_drop == "fast"} {
@@ -911,14 +937,17 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         set replicas_alive [lreplace $replicas_alive 0 0]
                     }
                     if {$all_drop == "timeout"} {
+                        # Let one replica hit repl-timeout while the slow reader
+                        # is paused, then restore a generous timeout so the
+                        # remaining replica can finish the streamed RDB.
                         $master config set repl-timeout 2
-                        # we want the slow replica to hang on a key for very long so it'll reach repl-timeout
-                        pause_process [srv -1 pid]
-                        after 2000
+                        wait_for_log_messages -2 {"*Disconnecting timedout replica (full sync)*"} $loglines 100 100
+                        $master config set repl-timeout 60
                     }
 
-                    # wait for rdb child to exit
-                    wait_for_condition 1200 100 {
+                    # Use a single generous budget for all subcases; successful
+                    # runs still exit early once the child is done.
+                    wait_for_condition 2400 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"
@@ -926,16 +955,33 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
 
                     # make sure we got what we were aiming for, by looking for the message in the log file
                     if {$all_drop == "all"} {
-                        wait_for_log_messages -2 {"*Diskless rdb transfer, last replica dropped, killing fork child*"} $loglines 1 1
+                        if {[catch {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, last replica dropped, killing fork child*"} $loglines 1 1
+                        }]} {
+                            # RDB finished before replicas were killed; accept
+                            # either 1 or 2 replicas still up at pipe-read time.
+                            if {[catch {
+                                wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
+                            }]} {
+                                wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
+                            }
+                        }
                     }
                     if {$all_drop == "no"} {
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
                     }
-                    if {$all_drop == "slow" || $all_drop == "fast"} {
+                    if {$all_drop == "fast"} {
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
                     }
+                    if {$all_drop == "slow"} {
+                        if {[catch {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
+                        }]} {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
+                            wait_for_log_messages -2 {"*Connection with replica * lost.*"} $loglines 1 1
+                        }
+                    }
                     if {$all_drop == "timeout"} {
-                        wait_for_log_messages -2 {"*Disconnecting timedout replica (full sync)*"} $loglines 1 1
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
                         # master disconnected the slow replica, remove from array
                         set replicas_alive [lreplace $replicas_alive 0 0]
@@ -965,12 +1011,17 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         }
                     }
 
+                    # In the "no" case both replicas stay alive through the
+                    # full streamed RDB, so on slow TLS runners the final
+                    # ONLINE transition can lag behind child exit.
+                    set replica_online_wait_tries [expr {$all_drop == "no" ? 600 : 150}]
+
                     # verify the data integrity
                     foreach replica $replicas_alive {
                         # Wait that replicas acknowledge they are online so
                         # we are sure that DBSIZE and DEBUG DIGEST will not
                         # fail because of timing issues.
-                        wait_for_condition 150 100 {
+                        wait_for_condition $replica_online_wait_tries 100 {
                             [lindex [$replica role] 3] eq {connected}
                         } else {
                             fail "replicas still not connected after some time"

--- a/tests/support/cluster.tcl
+++ b/tests/support/cluster.tcl
@@ -9,7 +9,6 @@
 # $c get foo
 # $c close
 
-package require Tcl 8.5
 package provide redis_cluster 0.1
 
 namespace eval redis_cluster {}

--- a/tests/support/redis.tcl
+++ b/tests/support/redis.tcl
@@ -25,7 +25,6 @@
 #
 # vwait forever
 
-package require Tcl 8.5
 package provide redis 0.1
 
 source [file join [file dirname [info script]] "response_transformers.tcl"]

--- a/tests/support/response_transformers.tcl
+++ b/tests/support/response_transformers.tcl
@@ -14,8 +14,6 @@
 # changes in many files) we decided to transform the response to RESP2
 # when running with --force-resp3
 
-package require Tcl 8.5
-
 namespace eval response_transformers {}
 
 # Transform a map response into an array of tuples (tuple = array with 2 elements)

--- a/tests/support/test.tcl
+++ b/tests/support/test.tcl
@@ -141,6 +141,25 @@ proc wait_for_condition {maxtries delay e _else_ elsescript} {
     }
 }
 
+proc verify_replica_online {master replica_idx max_retry} {
+    set pause 100
+    set count_down $max_retry
+    while {$count_down} {
+        set info [$master info]
+        set pattern *slave$replica_idx:*state=online*
+        if {[string match $pattern $info]} {
+            break
+        } else {
+            incr count_down -1
+            after $pause
+        }
+    }
+    if {$count_down == 0} {
+        set threshold [expr {$max_retry*$pause/1000}]
+        error "assertion:Replica is not in sync after $threshold seconds"
+    }
+}
+
 # try to match a value to a list of patterns that are either regex (starts with "/") or plain string.
 # The caller can specify to use only glob-pattern match
 proc search_pattern_list {value pattern_list {glob_pattern false}} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -644,6 +644,7 @@ proc print_help_screen {} {
         "--timeout <sec>    Test timeout in seconds (default 20 min)."
         "--force-failure    Force the execution of a test that always fails."
         "--config <k> <v>   Extra config file argument."
+        "--io-threads       Run tests with IO threads enabled."
         "--skipfile <file>  Name of a file containing test names or regexp patterns (if <test> starts with '/') that should be skipped (one per line). This option can be repeated."
         "--skiptest <test>  Test name or regexp pattern (if <test> starts with '/') to skip. This option can be repeated."
         "--tags <tags>      Run only tests having specified tags or not having '-' prefixed tags."
@@ -688,6 +689,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         lappend ::global_overrides $arg
         lappend ::global_overrides $arg2
         incr j 2
+    } elseif {$opt eq {--io-threads}} {
+        lappend ::global_overrides "io-threads" "4"
+        lappend ::global_overrides "io-threads-do-reads" "yes"
     } elseif {$opt eq {--log-req-res}} {
         set ::log_req_res 1
     } elseif {$opt eq {--force-resp3}} {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -2,8 +2,6 @@
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 
-package require Tcl 8.5
-
 set tcl_precision 17
 source tests/support/redis.tcl
 source tests/support/aofmanifest.tcl

--- a/tests/unit/client-eviction.tcl
+++ b/tests/unit/client-eviction.tcl
@@ -91,17 +91,31 @@ start_server {} {
         lassign [gen_client] rr cname
         # Attempt to fill the query buff with only half the percentage threshold verify we're not disconnected
         set n [expr $maxmemory_clients_actual / 2]
-        $rr write [join [list "*1\r\n\$$n\r\n" [string repeat v $n]] ""]
+        # send incomplete command (n - 1) to make sure we don't use the shared qb
+        $rr write [join [list "*1\r\n\$$n\r\n" [string repeat v [expr {$n - 1}]]] ""]
         $rr flush
+        # Wait for the client to start using a private query buffer.
+        wait_for_condition 10 10 {
+            [client_field $cname qbuf] > 0
+        } else {
+            fail "client should start using a private query buffer"
+        }
         set tot_mem [client_field $cname tot-mem]
         assert {$tot_mem >= $n && $tot_mem < $maxmemory_clients_actual}
 
         # Attempt to fill the query buff with the percentage threshold of maxmemory and verify we're evicted
         $rr close
         lassign [gen_client] rr cname
+        # send incomplete command (maxmemory_clients_actual - 1) to make sure we don't use the shared qb
         catch {
-            $rr write [join [list "*1\r\n\$$maxmemory_clients_actual\r\n" [string repeat v $maxmemory_clients_actual]] ""]
+            $rr write [join [list "*1\r\n\$$maxmemory_clients_actual\r\n" [string repeat v [expr {$maxmemory_clients_actual - 1}]]] ""]
             $rr flush
+            # Wait for the client to start using a private query buffer.
+            wait_for_condition 10 10 {
+                [client_field $cname qbuf] > 0
+            } else {
+                fail "client should start using a private query buffer"
+            }
         } e
         assert {![client_exists $cname]}
         $rr close

--- a/tests/unit/cluster/hostnames.tcl
+++ b/tests/unit/cluster/hostnames.tcl
@@ -122,11 +122,14 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
         R $j config set cluster-announce-hostname "shard-$j.com"
     }
 
+    # Grab the ID so we have it later for validation
+    set primary_id [R 0 CLUSTER MYID]
+
     # Prevent Node 0 and Node 6 from properly meeting,
     # they'll hang in the handshake phase. This allows us to 
     # test the case where we "know" about it but haven't
     # successfully retrieved information about it yet.
-    R 0 DEBUG DROP-CLUSTER-PACKET-FILTER 0
+    pause_process [srv 0 pid]
     R 6 DEBUG DROP-CLUSTER-PACKET-FILTER 0
 
     # Have a replica meet the isolated node
@@ -164,12 +167,11 @@ test "Verify the nodes configured with prefer hostname only show hostname for ne
 
     # Also make sure we know about the isolated master, we 
     # just can't reach it.
-    set master_id [R 0 CLUSTER MYID]
-    assert_match "*$master_id*" [R 6 CLUSTER NODES]
+    assert_match "*$primary_id*" [R 6 CLUSTER NODES]
 
     # Stop dropping cluster packets, and make sure everything
     # stabilizes
-    R 0 DEBUG DROP-CLUSTER-PACKET-FILTER -1
+    resume_process [srv 0 pid]
     R 6 DEBUG DROP-CLUSTER-PACKET-FILTER -1
 
     # This operation sometimes spikes to around 5 seconds to resolve the state,

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -355,12 +355,15 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [redis_deferring_client -1]
+                $rd_master client reply off
+                $rd_master flush
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $rd_master setrange key:0 0 [string repeat A $payload_len]
+                    if {$k % 10000 == 0} {$rd_master flush}
                 }
-                for {set k 0} {$k < $cmd_count} {incr k} {
-                    $rd_master read
-                }
+                $rd_master client reply on
+                $rd_master flush
+                $rd_master read ;# read the +OK from CLIENT REPLY ON
             } else {
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $master setrange key:0 0 [string repeat A $payload_len]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -41,6 +41,12 @@ start_server {tags {"memefficiency external:skip"}} {
 
 run_solo {defrag} {
 start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-rewrite-percentage 0 save ""}} {
+    proc client_reply_off_wait_for_server {rd} {
+        $rd client reply on
+        assert_equal OK [$rd read]
+        $rd client reply off
+    }
+
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
         test "Active defrag" {
             r config set hz 100
@@ -181,16 +187,12 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             set dummy_script "--[string repeat x 400]\nreturn "
             set rd [redis_deferring_client]
             $rd client reply off
-            $rd flush
             for {set j 0} {$j < $n} {incr j} {
                 set val "$dummy_script[format "%06d" $j]"
                 $rd script load $val
                 $rd set k$j $val
-                if {$j % 100 == 0} {$rd flush}
+                if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
-            $rd client reply on
-            $rd flush
-            $rd read ;# read the +OK from CLIENT REPLY ON
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
                 puts "used [s allocator_allocated]"
@@ -201,15 +203,10 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             assert_lessthan [s allocator_frag_ratio] 1.05
             
             # Delete all the keys to create fragmentation
-            $rd client reply off
-            $rd flush
             for {set j 0} {$j < $n} {incr j} {
                 $rd del k$j
-                if {$j % 100 == 0} {$rd flush}
+                if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
-            $rd client reply on
-            $rd flush
-            $rd read ;# read the +OK from CLIENT REPLY ON
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
@@ -278,15 +275,14 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
 
             # create big keys with 10k items
             set rd [redis_deferring_client]
+            $rd client reply off
             for {set j 0} {$j < 10000} {incr j} {
                 $rd hset bighash $j [concat "asdfasdfasdf" $j]
                 $rd lpush biglist [concat "asdfasdfasdf" $j]
                 $rd zadd bigzset $j [concat "asdfasdfasdf" $j]
                 $rd sadd bigset [concat "asdfasdfasdf" $j]
                 $rd xadd bigstream * item 1 value a
-            }
-            for {set j 0} {$j < 50000} {incr j} {
-                $rd read ; # Discard replies
+                if {$j % 100 == 99} {client_reply_off_wait_for_server $rd}
             }
 
             set expected_frag 1.7
@@ -294,9 +290,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
                 # scale the hash to 1m fields in order to have a measurable the latency
                 for {set j 10000} {$j < 1000000} {incr j} {
                     $rd hset bighash $j [concat "asdfasdfasdf" $j]
-                }
-                for {set j 10000} {$j < 1000000} {incr j} {
-                    $rd read ; # Discard replies
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
                 # creating that big hash, increased used_memory, so the relative frag goes down
                 set expected_frag 1.3
@@ -305,18 +299,14 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             # add a mass of string keys
             for {set j 0} {$j < 500000} {incr j} {
                 $rd setrange $j 150 a
-            }
-            for {set j 0} {$j < 500000} {incr j} {
-                $rd read ; # Discard replies
+                if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             assert_equal [r dbsize] 500010
 
             # create some fragmentation
             for {set j 0} {$j < 500000} {incr j 2} {
                 $rd del $j
-            }
-            for {set j 0} {$j < 500000} {incr j 2} {
-                $rd read ; # Discard replies
+                if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
             }
             assert_equal [r dbsize] 250010
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1,6 +1,8 @@
 proc test_memory_efficiency {range} {
     r flushall
     set rd [redis_deferring_client]
+    $rd client reply off
+    $rd flush
     set base_mem [s used_memory]
     set written 0
     for {set j 0} {$j < 10000} {incr j} {
@@ -11,9 +13,9 @@ proc test_memory_efficiency {range} {
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
     }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    $rd flush
+    $rd read ;# read the +OK from CLIENT REPLY ON
     $rd close
 
     set current_mem [s used_memory]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -509,23 +509,18 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
 
                 # add a mass of keys with 600 bytes values, fill the bin of 640 bytes which has 32 regs per slab.
                 set rd [redis_deferring_client]
+                $rd client reply off
                 set keys 640000
                 for {set j 0} {$j < $keys} {incr j} {
                     $rd setrange $j 600 x
-                }
-                for {set j 0} {$j < $keys} {incr j} {
-                    $rd read ; # Discard replies
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
 
                 # create some fragmentation of 50%
-                set sent 0
                 for {set j 0} {$j < $keys} {incr j 1} {
                     $rd del $j
-                    incr sent
                     incr j 1
-                }
-                for {set j 0} {$j < $sent} {incr j} {
-                    $rd read ; # Discard replies
+                    if {$j % 1000 == 998} {client_reply_off_wait_for_server $rd}
                 }
                 $rd close
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -596,15 +596,14 @@ start_cluster 1 0 {tags {"defrag external:skip"}} {
             catch {r config set activedefrag yes} e
             if {[r config get activedefrag] eq "activedefrag yes"} {
                 set rd [redis_deferring_client]
+                $rd client reply off
                 set random_int [expr 1+[randomInt 10240]]
 
                 # Create keys
                 for {set j 0} {$j < 10000} {incr j} {
                     set buf [string repeat "pl-$j" $random_int]
                     $rd set $j $buf ex 10000
-                }
-                for {set j 0} {$j < 10000} {incr j} {
-                    $rd read ;# Discard replies
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
 
                 # wait for the active defrag to start
@@ -619,9 +618,7 @@ start_cluster 1 0 {tags {"defrag external:skip"}} {
                 for {set j 0} {$j < 10000} {incr j} {
                     set buf [string repeat "pl-$j" $random_int]
                     $rd set $j $buf ex $random_int
-                }
-                for {set j 0} {$j < 10000} {incr j} {
-                    $rd read ; # Discard replies
+                    if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
                 $rd close
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -168,7 +168,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
         }
         r config set appendonly no
         r config set key-load-delay 0
-        
+
         test "Active defrag eval scripts" {
             r flushdb
             r script flush sync
@@ -582,6 +582,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
     }
 }
 
+if {0} {
 start_cluster 1 0 {tags {"defrag external:skip"}} {
     if {[string match {*jemalloc*} [s mem_allocator]] && [r debug mallctl arenas.page] <= 8192} {
         test "Active defrag with flush async performed in cluster mode" {
@@ -635,6 +636,7 @@ start_cluster 1 0 {tags {"defrag external:skip"}} {
             r ping
         }
     }
+}
 }
 
 } ;# run_solo

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -390,6 +390,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
 
             # create big keys with 10k items
             set rd [redis_deferring_client]
+            $rd client reply off
 
             set expected_frag 1.7
             # add a mass of list nodes to two lists (allocations are interlaced)
@@ -398,10 +399,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             for {set j 0} {$j < $elements} {incr j} {
                 $rd lpush biglist1 $val
                 $rd lpush biglist2 $val
-            }
-            for {set j 0} {$j < $elements} {incr j} {
-                $rd read ; # Discard replies
-                $rd read ; # Discard replies
+                if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
 
             $rd close
@@ -425,8 +423,12 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             if {[r config get activedefrag] eq "activedefrag yes"} {
                 # wait for the active defrag to start working (decision once a second)
                 wait_for_condition 50 100 {
-                    [s active_defrag_running] ne 0
+                    [s total_active_defrag_time] ne 0
                 } else {
+                    after 120 ;# serverCron only updates the info once in 100ms
+                    puts [r info memory]
+                    puts [r info stats]
+                    puts [r memory malloc-stats]
                     fail "defrag not started."
                 }
 

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -180,15 +180,17 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             # Populate memory with interleaving script-key pattern of same size
             set dummy_script "--[string repeat x 400]\nreturn "
             set rd [redis_deferring_client]
+            $rd client reply off
+            $rd flush
             for {set j 0} {$j < $n} {incr j} {
                 set val "$dummy_script[format "%06d" $j]"
                 $rd script load $val
                 $rd set k$j $val
+                if {$j % 100 == 0} {$rd flush}
             }
-            for {set j 0} {$j < $n} {incr j} {
-                $rd read ; # Discard script load replies
-                $rd read ; # Discard set replies
-            }
+            $rd client reply on
+            $rd flush
+            $rd read ;# read the +OK from CLIENT REPLY ON
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {
                 puts "used [s allocator_allocated]"
@@ -199,8 +201,15 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
             assert_lessthan [s allocator_frag_ratio] 1.05
             
             # Delete all the keys to create fragmentation
-            for {set j 0} {$j < $n} {incr j} { $rd del k$j }
-            for {set j 0} {$j < $n} {incr j} { $rd read } ; # Discard del replies
+            $rd client reply off
+            $rd flush
+            for {set j 0} {$j < $n} {incr j} {
+                $rd del k$j
+                if {$j % 100 == 0} {$rd flush}
+            }
+            $rd client reply on
+            $rd flush
+            $rd read ;# read the +OK from CLIENT REPLY ON
             $rd close
             after 120 ;# serverCron only updates the info once in 100ms
             if {$::verbose} {

--- a/tests/unit/moduleapi/test_lazyfree.tcl
+++ b/tests/unit/moduleapi/test_lazyfree.tcl
@@ -8,13 +8,13 @@ start_server {tags {"modules"}} {
         set rd [redis_deferring_client]
 
         # LAZYFREE_THRESHOLD is 64
+        $rd client reply off
         for {set i 0} {$i < 10000} {incr i} {
             $rd lazyfreelink.insert lazykey $i
+            if {$i % 1000 == 0} {$rd flush}
         }
-
-        for {set j 0} {$j < 10000} {incr j} {
-            $rd read 
-        }
+        $rd client reply on
+        assert_equal OK [$rd read]
 
         assert {[r lazyfreelink.len lazykey] == 10000}
 


### PR DESCRIPTION
The [CI](www.github.com/valkey-io/valkey/actions/runs/25272401519/) for 7.2 is quite broken as seen in the weekly released branches. 

## Description

This PR backports targeted CI/test stabilization fixes for the 7.2 daily validation branch.

All changes are cherry-picked or adapted from commits that were already merged upstream. Most changes are test-only or test-harness-only. The only non-test source change is the required UBSan cleanup for invalid function pointer casts.

## Backport provenance

| Backport commit | Provenance | Notes |
| --- | --- | --- |
| dcf9a1d35 | Adapted from upstream PR #3430, merge f3b647050 | Partial backport of flaky test fixes |
| 0325135ec | Adapted from upstream PR #3452, merge c35dbdfc | CLIENT REPLY OFF flaky test fix |
| b3daea12a | Adapted from upstream PR #1673, merge 3390b1e60 | Tcl 9 support for runtest scripts |
| fd75204a8 | Branch-specific | Adds `--io-threads` handling needed by current daily workflow |
| 1fc8d70b4 | Adapted from unstable test behavior | Deflakes client-eviction percentage test |
| 8e3565cfc | Adapted from CLIENT REPLY OFF pattern in #3430 / #3452 | Deflakes active defrag eval scripts test |
| 7af6a0034 | Adapted from upstream PR #1044, merge 6ce75cdea | Replica online timing fix in failover test |
| a7b157a36 | Adapted from upstream PR #3461, merge f6b5461b7 | Diskless RDB pipe test deflake |
| 16db1d69f | Adapted from upstream PR #60, merge ff6b780fe | Adds missing `verify_replica_online` helper needed by #1044 |
| e8ba03869 | Adapted from upstream PR #1673, merge 3390b1e60 | Removes Tcl 8.5 package requirements for Tcl 9 compatibility |
| 4da20b99c | Adapted from CLIENT REPLY OFF stabilization pattern | Deflakes 7.2 memefficiency clients |
| 2c52bd90a | Adapted from upstream PR #1016, merge 2b207ee1 | Hostnames test stabilization |
| eb15c39f7 | Adapted from CLIENT REPLY OFF stabilization pattern | Deflakes big-list defrag setup |
| 16ea7ce03 | Adapted from CLIENT REPLY OFF stabilization pattern | Deflakes defrag edge-case setup |
| 5ebbe19af | Adapted from CLIENT REPLY OFF stabilization pattern | Avoids deferred reply backlog in defrag test |
| 4494a9cb9 | Branch-specific/adapted test deflake | Stabilizes legacy cluster manual failover/takeover tests |
| 1d12befbb | Adapted from upstream PR #3511, merge 03c2d4c2 | Stabilizes diskless no-drop replication test |
| be460b73f | Cherry-picked from upstream commit becd50d0 | Disables flaky defrag tests affecting daily run |
| 05765127f | Adapted from 7.2 backport commit 692fad6a5 and upstream PR #1451, merge e203ca35b | Required UBSan cleanup for invalid function pointer casts |
