### PR TITLE
Backport Test Fixes 8.0

### DIFF
--- a/src/unit/test_rax.c
+++ b/src/unit/test_rax.c
@@ -165,7 +165,7 @@ static uint32_t int2int(uint32_t input) {
         r = l ^ F;
         l = nl;
     }
-    return (r << 16) | l;
+    return ((uint32_t)r << 16) | l;
 }
 
 /* Turn an uint32_t integer into an alphanumerical key and return its

--- a/src/unit/test_sds.c
+++ b/src/unit/test_sds.c
@@ -259,43 +259,44 @@ int test_typesAndAllocSize(int argc, char **argv, int flags) {
 
     sds x = sdsnewlen(NULL, 31);
     TEST_ASSERT_MESSAGE("len 31 type", (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_5);
+    TEST_ASSERT_MESSAGE("len 31 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
     x = sdsnewlen(NULL, 32);
     TEST_ASSERT_MESSAGE("len 32 type", (x[-1] & SDS_TYPE_MASK) >= SDS_TYPE_8);
-    TEST_ASSERT_MESSAGE("len 32 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+    TEST_ASSERT_MESSAGE("len 32 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
     x = sdsnewlen(NULL, 252);
     TEST_ASSERT_MESSAGE("len 252 type", (x[-1] & SDS_TYPE_MASK) >= SDS_TYPE_8);
-    TEST_ASSERT_MESSAGE("len 252 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+    TEST_ASSERT_MESSAGE("len 252 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
     x = sdsnewlen(NULL, 253);
     TEST_ASSERT_MESSAGE("len 253 type", (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_16);
-    TEST_ASSERT_MESSAGE("len 253 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+    TEST_ASSERT_MESSAGE("len 253 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
     x = sdsnewlen(NULL, 65530);
     TEST_ASSERT_MESSAGE("len 65530 type", (x[-1] & SDS_TYPE_MASK) >= SDS_TYPE_16);
-    TEST_ASSERT_MESSAGE("len 65530 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+    TEST_ASSERT_MESSAGE("len 65530 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
     x = sdsnewlen(NULL, 65531);
     TEST_ASSERT_MESSAGE("len 65531 type", (x[-1] & SDS_TYPE_MASK) >= SDS_TYPE_32);
-    TEST_ASSERT_MESSAGE("len 65531 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+    TEST_ASSERT_MESSAGE("len 65531 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
     sdsfree(x);
 
 #if (LONG_MAX == LLONG_MAX)
     if (flags & UNIT_TEST_LARGE_MEMORY) {
         x = sdsnewlen(NULL, 4294967286);
         TEST_ASSERT_MESSAGE("len 4294967286 type", (x[-1] & SDS_TYPE_MASK) >= SDS_TYPE_32);
-        TEST_ASSERT_MESSAGE("len 4294967286 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+        TEST_ASSERT_MESSAGE("len 4294967286 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
         sdsfree(x);
 
         x = sdsnewlen(NULL, 4294967287);
         TEST_ASSERT_MESSAGE("len 4294967287 type", (x[-1] & SDS_TYPE_MASK) == SDS_TYPE_64);
-        TEST_ASSERT_MESSAGE("len 4294967287 sdsAllocSize", sdsAllocSize(x) == s_malloc_size(sdsAllocPtr(x)));
+        TEST_ASSERT_MESSAGE("len 4294967287 sdsAllocSize", sdsAllocSize(x) == s_malloc_usable_size(sdsAllocPtr(x)));
         sdsfree(x);
     }
 #endif

--- a/src/unit/test_zmalloc.c
+++ b/src/unit/test_zmalloc.c
@@ -6,8 +6,7 @@ int test_zmallocInitialUsedMemory(int argc, char **argv, int flags) {
     UNUSED(argv);
     UNUSED(flags);
 
-    TEST_ASSERT(zmalloc_used_memory() == 0);
-
+    TEST_PRINT_INFO("Initial used memory: %zu\n", zmalloc_used_memory());
     return 0;
 }
 
@@ -15,23 +14,27 @@ int test_zmallocAllocReallocCallocAndFree(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
-
+    size_t used_memory_before = zmalloc_used_memory();
     void *ptr, *ptr2;
 
     ptr = zmalloc(123);
-    TEST_PRINT_INFO("Allocated 123 bytes; used: %zu\n", zmalloc_used_memory());
+    TEST_PRINT_INFO("Allocated 123 bytes; used: %lld\n",
+                    (long long)zmalloc_used_memory() - used_memory_before);
 
     ptr = zrealloc(ptr, 456);
-    TEST_PRINT_INFO("Reallocated to 456 bytes; used: %zu\n", zmalloc_used_memory());
+    TEST_PRINT_INFO("Reallocated to 456 bytes; used: %lld\n",
+                    (long long)zmalloc_used_memory() - used_memory_before);
 
     ptr2 = zcalloc(123);
-    TEST_PRINT_INFO("Callocated 123 bytes; used: %zu\n", zmalloc_used_memory());
+    TEST_PRINT_INFO("Callocated 123 bytes; used: %lld\n",
+                    (long long)zmalloc_used_memory() - used_memory_before);
 
     zfree(ptr);
     zfree(ptr2);
-    TEST_PRINT_INFO("Freed pointers; used: %zu\n", zmalloc_used_memory());
+    TEST_PRINT_INFO("Freed pointers; used: %lld\n",
+                    (long long)zmalloc_used_memory() - used_memory_before);
 
-    TEST_ASSERT(zmalloc_used_memory() == 0);
+    TEST_ASSERT(zmalloc_used_memory() == used_memory_before);
 
     return 0;
 }
@@ -40,14 +43,14 @@ int test_zmallocAllocZeroByteAndFree(int argc, char **argv, int flags) {
     UNUSED(argc);
     UNUSED(argv);
     UNUSED(flags);
-
+    size_t used_memory_before = zmalloc_used_memory();
     void *ptr;
 
     ptr = zmalloc(0);
     TEST_PRINT_INFO("Allocated 0 bytes; used: %zu\n", zmalloc_used_memory());
     zfree(ptr);
 
-    TEST_ASSERT(zmalloc_used_memory() == 0);
+    TEST_ASSERT(zmalloc_used_memory() == used_memory_before);
 
     return 0;
 }

--- a/tests/cluster/tests/28-cluster-shards.tcl
+++ b/tests/cluster/tests/28-cluster-shards.tcl
@@ -117,7 +117,7 @@ test "Kill a node and tell the replica to immediately takeover" {
 
 # Primary 0 node should report as fail, wait until the new primary acknowledges it.
 test "Verify health as fail for killed node" {
-    wait_for_condition 50 100 {
+    wait_for_condition 1000 50 {
         "fail" eq [dict get [get_node_info_from_shard $node_0_id 4 "node"] "health"]
     } else {
         fail "New primary never detected the node failed"

--- a/tests/integration/corrupt-dump-fuzzer.tcl
+++ b/tests/integration/corrupt-dump-fuzzer.tcl
@@ -15,6 +15,7 @@ if { ! [ catch {
 
 proc generate_collections {suffix elements} {
     set rd [valkey_deferring_client]
+    $rd client reply off
     for {set j 0} {$j < $elements} {incr j} {
         # add both string values and integers
         if {$j % 2 == 0} {set val $j} else {set val "_$j"}
@@ -24,9 +25,8 @@ proc generate_collections {suffix elements} {
         $rd sadd set$suffix $val
         $rd xadd stream$suffix * item 1 value $val
     }
-    for {set j 0} {$j < $elements * 5} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
     $rd close
 }
 

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -626,7 +626,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica2 debug pause-after-fork 1
             test "Test dual-channel: primary tracking replica backlog refcount - start with empty backlog" {
                 $replica1 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 40 100]
                 set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
@@ -643,7 +643,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test dual-channel: primary tracking replica backlog refcount - start with backlog" {
                 $replica2 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 40 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -159,7 +159,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set load_handle1 [start_one_key_write_load $primary_host $primary_port 100 "mykey1"]
         set load_handle2 [start_one_key_write_load $primary_host $primary_port 100 "mykey2"]
         set load_handle3 [start_one_key_write_load $primary_host $primary_port 100 "mykey3"]
-        
+
         # wait for load handlers to start
         wait_for_condition 50 1000 {
             ([$primary get "mykey1"] != "") &&
@@ -802,7 +802,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set replica_port [srv 0 port]
         set replica_log [srv 0 stdout]
         set replica_pid  [srv 0 pid]
-        
+
         set load_handle0 [start_write_load $primary_host $primary_port 60]
         set load_handle1 [start_write_load $primary_host $primary_port 60]
         set load_handle2 [start_write_load $primary_host $primary_port 60]
@@ -810,7 +810,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
-        $replica config set repl-timeout 10
+        $replica config set repl-timeout 60
         $primary config set repl-backlog-size 1mb
 
         test "Test dual-channel-replication primary gets cob overrun before established psync" {
@@ -852,6 +852,37 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         } else {
             fail "Primary should abort sync"
         }
+        stop_write_load $load_handle0
+        stop_write_load $load_handle1
+        stop_write_load $load_handle2
+    }
+}
+
+start_server {tags {"dual-channel-replication external:skip"}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+    set loglines [count_log_lines 0]
+
+    $primary config set repl-diskless-sync yes
+    $primary config set dual-channel-replication-enabled yes
+    $primary config set client-output-buffer-limit "replica 1100k 0 0"
+    $primary config set loglevel debug
+    start_server {} {
+        set replica [srv 0 client]
+        set replica_host [srv 0 host]
+        set replica_port [srv 0 port]
+        set replica_log [srv 0 stdout]
+        set replica_pid  [srv 0 pid]
+
+        set load_handle0 [start_write_load $primary_host $primary_port 60]
+        set load_handle1 [start_write_load $primary_host $primary_port 60]
+        set load_handle2 [start_write_load $primary_host $primary_port 60]
+
+        $replica config set dual-channel-replication-enabled yes
+        $replica config set loglevel debug
+        $replica config set repl-timeout 60
+        $primary config set repl-backlog-size 1mb
         
         $replica debug pause-after-fork 1
         $primary debug populate 1000 primary 100000

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -806,6 +806,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         set load_handle0 [start_write_load $primary_host $primary_port 60]
         set load_handle1 [start_write_load $primary_host $primary_port 60]
         set load_handle2 [start_write_load $primary_host $primary_port 60]
+        set replica_loglines [count_log_lines 0]
 
         $replica config set dual-channel-replication-enabled yes
         $replica config set loglevel debug
@@ -834,6 +835,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # In this way, in the subsequent replicaof no one, we won't get the LOADING error if the replica reconnects
             # too quickly and enters the loading state.
             $primary debug pause-after-fork 1
+            set replica_loglines [count_log_lines 0]
             resume_process $replica_pid
             set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
             set loglines [lindex $res 1]

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -516,7 +516,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         test "Test dual-channel-replication sync- psync established after rdb load" {
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages -1 {"*Done loading RDB*"} 0 2000 1
+            wait_for_log_messages -1 {"*Done loading RDB*"} 0 20 100
             wait_and_resume_process 0
 
             verify_replica_online $primary 0 500
@@ -527,7 +527,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
             wait_for_value_to_propagate_to_replica $primary $replica "key1"
             # Confirm the occurrence of a race condition.
-            wait_for_log_messages -1 {"*Dual channel sync - psync established after rdb load*"} 0 2000 1
+            wait_for_log_messages -1 {"*Dual channel sync - psync established after rdb load*"} 0 20 100
         }
     }
 }
@@ -626,8 +626,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $replica2 debug pause-after-fork 1
             test "Test dual-channel: primary tracking replica backlog refcount - start with empty backlog" {
                 $replica1 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 2000 1]
-                set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 2000 1]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * no repl-backlog to track*"} $loglines 20 100]
+                set res [wait_for_log_messages 0 {"*Attach replica rdb client*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -2
@@ -643,7 +643,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
             test "Test dual-channel: primary tracking replica backlog refcount - start with backlog" {
                 $replica2 replicaof $primary_host $primary_port
-                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 2000 1]
+                set res [wait_for_log_messages 0 {"*Add rdb replica * tracking repl-backlog tail*"} $loglines 20 100]
                 set loglines [lindex $res 1]
                 incr $loglines
                 wait_and_resume_process -1
@@ -701,7 +701,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 5. Replica resumes operation.
             # Expected outcome: Primary maintains RDB channel until replica establishes PSYNC connection.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 5
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -762,7 +762,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # 4. Primary resumes operation and detects closed RDB channel.
             # Expected outcome: Primary drops the RDB channel after grace period is done.
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 2000 1
+            wait_for_log_messages 0 {"*Done loading RDB*"} $loglines 100 100
             pause_process $replica_pid
             wait_and_resume_process -1
             wait_for_condition 50 100 {
@@ -772,7 +772,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             }
 
             # Sync should fail once the replica ask for PSYNC using main channel
-            set res [wait_for_log_messages -1 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 4000 1]
+            set res [wait_for_log_messages -1 {"*Replica main channel failed to establish PSYNC within the grace period*"} 0 40 100]
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
@@ -817,7 +817,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Pause primary main process after fork
             $primary debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 5000 10
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 100 100
 
             # At this point rdb is loaded but psync hasn't been established yet. 
             # Pause the replica so the primary main process will wake up while the
@@ -825,7 +825,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             pause_process $replica_pid
             wait_and_resume_process -1
             $primary debug pause-after-fork 0
-            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 100 100
             wait_for_condition 50 100 {
                 [string match {*replicas_waiting_psync:0*} [$primary info replication]]
             } else {
@@ -837,12 +837,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary debug pause-after-fork 1
             set replica_loglines [count_log_lines 0]
             resume_process $replica_pid
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 200 100]
             set loglines [lindex $res 1]
         }
         # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
         wait_process_paused -1
-        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
+        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 100 100
         $replica replicaof no one
         # Resume the primary and make sure the sync is dropped.
         resume_process [srv -1 pid]
@@ -910,7 +910,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             $primary config set repl-diskless-sync-delay 100
             wait_and_resume_process 0
             $replica debug pause-after-fork 0
-            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1]
+            set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 200 100]
             set loglines [lindex $res 0]
         }
         stop_write_load $load_handle0
@@ -1063,7 +1063,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after main conn kill" {
@@ -1092,7 +1092,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set loglines [count_log_lines -1]
             $primary client kill id $replica_rdb_channel_id
             # Wait for primary to abort the sync
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
         }
 
         test "Test dual channel replication slave of no one after rdb conn kill" {
@@ -1234,7 +1234,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            $primary config set repl-diskless-sync-delay 0
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&
@@ -1272,7 +1273,8 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
-            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 1000 10
+            $primary config set repl-diskless-sync-delay 0
+            wait_for_log_messages -1 {"*Background RDB transfer error*"} $loglines 100 100
             # Replica should retry
             wait_for_condition 500 1000 {
                 [string match "*slave*,state=wait_bgsave*,type=rdb-channel*" [$primary info replication]] &&

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -884,7 +884,6 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         $replica config set repl-timeout 60
         $primary config set repl-backlog-size 1mb
         
-        $replica debug pause-after-fork 1
         $primary debug populate 1000 primary 100000
         # Set primary with a slow rdb generation, so that we can easily intercept loading
         # 10ms per key, with 1000 keys is 10 seconds
@@ -892,6 +891,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
 
         test "Test dual-channel-replication primary gets cob overrun during replica rdb load" {
             set cur_client_closed_count [s -1 client_output_buffer_limit_disconnections]
+            $replica debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
             wait_for_condition 500 1000 {
                 [s -1 client_output_buffer_limit_disconnections] > $cur_client_closed_count
@@ -904,7 +904,12 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
+
+            # Increase the delay to make sure the replica doesn't start another sync
+            # after it resumes after the first one.
+            $primary config set repl-diskless-sync-delay 100
             wait_and_resume_process 0
+            $replica debug pause-after-fork 0
             set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 20000 1]
             set loglines [lindex $res 0]
         }

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -810,7 +810,7 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             # Pause primary main process after fork
             $primary debug pause-after-fork 1
             $replica replicaof $primary_host $primary_port
-            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 5000 10
 
             # At this point rdb is loaded but psync hasn't been established yet. 
             # Pause the replica so the primary main process will wake up while the
@@ -828,6 +828,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
             set loglines [lindex $res 1]
         }
+        # Waiting for the primary to enter the paused state, that is, make sure that bgsave is triggered.
+        wait_process_paused -1
+        wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
         $replica replicaof no one
         wait_for_condition 500 1000 {
             [s -1 rdb_bgsave_in_progress] eq 0

--- a/tests/integration/dual-channel-replication.tcl
+++ b/tests/integration/dual-channel-replication.tcl
@@ -23,14 +23,20 @@ proc get_client_id_by_last_cmd {r cmd} {
     return $client_id
 }
 
-# Wait until the process enters a paused state, then resume the process.
-proc wait_and_resume_process idx {
+# Wait until the process enters a paused state.
+proc wait_process_paused idx {
     set pid [srv $idx pid]
     wait_for_condition 50 1000 {
         [string match "T*" [exec ps -o state= -p $pid]]
     } else {
         fail "Process $pid didn't stop, current state is [exec ps -o state= -p $pid]"
     }
+}
+
+# Wait until the process enters a paused state, then resume the process.
+proc wait_and_resume_process idx {
+    set pid [srv $idx pid]
+    wait_process_paused $idx
     resume_process $pid
 }
 
@@ -824,6 +830,10 @@ start_server {tags {"dual-channel-replication external:skip"}} {
             } else {
                 fail "Primary did not free repl buf block after sync failure"
             }
+            # Full sync will be triggered after the replica is reconnected, pause primary main process after fork.
+            # In this way, in the subsequent replicaof no one, we won't get the LOADING error if the replica reconnects
+            # too quickly and enters the loading state.
+            $primary debug pause-after-fork 1
             resume_process $replica_pid
             set res [wait_for_log_messages -1 {"*Unable to partial resync with replica * for lack of backlog*"} $loglines 2000 10]
             set loglines [lindex $res 1]
@@ -832,6 +842,9 @@ start_server {tags {"dual-channel-replication external:skip"}} {
         wait_process_paused -1
         wait_for_log_messages 0 {"*Done loading RDB*"} $replica_loglines 5000 10
         $replica replicaof no one
+        # Resume the primary and make sure the sync is dropped.
+        resume_process [srv -1 pid]
+        $primary debug pause-after-fork 0
         wait_for_condition 500 1000 {
             [s -1 rdb_bgsave_in_progress] eq 0
         } else {

--- a/tests/integration/failover.tcl
+++ b/tests/integration/failover.tcl
@@ -33,6 +33,8 @@ start_server {overrides {save {}}} {
         $node_2 replicaof $node_0_host $node_0_port
         wait_for_sync $node_1
         wait_for_sync $node_2
+        verify_replica_online $node_0 0 50
+        verify_replica_online $node_0 1 50
     }
 
     test {failover command fails with invalid host} {

--- a/tests/integration/rdb.tcl
+++ b/tests/integration/rdb.tcl
@@ -263,16 +263,15 @@ start_server {overrides {save ""}} {
         # changing some keys and read the reported COW size, we are using small key size to prevent from
         # the "dismiss mechanism" free memory and reduce the COW size)
         set rd [valkey_deferring_client 0]
+        $rd client reply off
         set size 500 ;# aim for the 512 bin (sds overhead)
         set cmd_count 10000
+        set AAA [string repeat A $size]
         for {set k 0} {$k < $cmd_count} {incr k} {
-            $rd set key$k [string repeat A $size]
+            $rd set key$k $AAA
         }
-
-        for {set k 0} {$k < $cmd_count} {incr k} {
-            catch { $rd read }
-        }
-
+        $rd client reply on
+        assert_equal OK [$rd read]
         $rd close
 
         # start background rdb save
@@ -301,8 +300,9 @@ start_server {overrides {save ""}} {
 
             # trigger copy-on-write
             set modified_keys 16
+            set BBB [string repeat B $size]
             for {set k 0} {$k < $modified_keys} {incr k} {
-                r setrange key$key_idx 0 [string repeat B $size]
+                r setrange key$key_idx 0 $BBB
                 incr key_idx 1
             }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -915,7 +915,14 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     # so that the whole rdb generation process is bound to that
                     set loglines [count_log_lines -2]
                     [lindex $replicas 0] config set repl-diskless-load swapdb
-                    [lindex $replicas 0] config set key-load-delay 100 ;# 20k keys and 100 microseconds sleep means at least 2 seconds
+                    # For "no" and "fast" subcases, use key-load-delay to keep
+                    # replica 0 as a steady slow reader for the entire RDB
+                    # transfer. A brief SIGSTOP/SIGCONT is insufficient on
+                    # slow CI runners because the TLS layer cannot always drain
+                    # the pipe fast enough after resume.
+                    if {$all_drop == "no" || $all_drop == "fast"} {
+                        [lindex $replicas 0] config set key-load-delay 100
+                    }
                     [lindex $replicas 0] replicaof $master_host $master_port
                     [lindex $replicas 1] replicaof $master_host $master_port
 
@@ -929,12 +936,26 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         set start_time [clock seconds]
                     }
 
-                    # wait a while so that the pipe socket writer will be
-                    # blocked on write (since replica 0 is slow to read from the socket)
-                    after 500
+                    if {$all_drop == "no" || $all_drop == "fast"} {
+                        # key-load-delay is already throttling the slow
+                        # replica; just wait for the pipe to fill.
+                        after 500
+                    } else {
+                        # For slow/all/timeout subcases the replica will be
+                        # killed or timed out, so a brief SIGSTOP is fine.
+                        set slow_replica_pid [srv -1 pid]
+                        pause_process $slow_replica_pid
+                        after 500
+                    }
 
                     # add some command to be present in the command stream after the rdb.
                     $master incr $all_drop
+
+                    # Resume before terminating the paused slow replica so the
+                    # disconnect is observed immediately instead of timing out.
+                    if {$all_drop == "all" || $all_drop == "slow"} {
+                        resume_process $slow_replica_pid
+                    }
 
                     # disconnect replicas depending on the current test
                     if {$all_drop == "all" || $all_drop == "fast"} {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -953,7 +953,7 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     }
 
                     # wait for rdb child to exit
-                    wait_for_condition 500 100 {
+                    wait_for_condition 1200 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -890,10 +890,11 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
     set master_host [srv 0 host]
     set master_port [srv 0 port]
     set master_pid [srv 0 pid]
-    # put enough data in the db that the rdb file will be bigger than the socket buffers
-    # and since we'll have key-load-delay of 100, 20000 keys will take at least 2 seconds
-    # we also need the replica to process requests during transfer (which it does only once in 2mb)
-    $master debug populate 20000 test 10000
+    # Put enough data in the db that the RDB is comfortably larger than the
+    # pipe and socket buffers so the primary can hit the blocked writer path,
+    # but keep it small enough that slow TLS CI runners don't spend minutes
+    # draining an oversized transfer (~40 MB uncompressed).
+    $master debug populate 4000 test 10000
     $master config set rdbcompression no
     # If running on Linux, we also measure utime/stime to detect possible I/O handling issues
     set os [catch {exec uname}]
@@ -917,11 +918,17 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     [lindex $replicas 0] config set repl-diskless-load swapdb
                     # For "no" and "fast" subcases, use key-load-delay to keep
                     # replica 0 as a steady slow reader for the entire RDB
-                    # transfer. A brief SIGSTOP/SIGCONT is insufficient on
-                    # slow CI runners because the TLS layer cannot always drain
-                    # the pipe fast enough after resume.
+<<<<<<< HEAD
+                    # transfer. A brief SIGSTOP/SIGCONT is insufficient
+                    # because after resume the TLS layer on slow CI runners
+                    # can't drain the pipe fast enough, leaving the RDB child
+                    # blocked on write() for minutes.
                     if {$all_drop == "no" || $all_drop == "fast"} {
-                        [lindex $replicas 0] config set key-load-delay 100
+                        # 4k keys with 500 microseconds each keeps replica 0
+                        # slow for about 2 seconds, which is long enough to
+                        # fill the pipe without turning the transfer into a
+                        # multi-minute TLS run.
+                        [lindex $replicas 0] config set key-load-delay 500
                     }
                     [lindex $replicas 0] replicaof $master_host $master_port
                     [lindex $replicas 1] replicaof $master_host $master_port
@@ -967,14 +974,17 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         set replicas_alive [lreplace $replicas_alive 0 0]
                     }
                     if {$all_drop == "timeout"} {
+                        # Let one replica hit repl-timeout while the slow reader
+                        # is paused, then restore a generous timeout so the
+                        # remaining replica can finish the streamed RDB.
                         $master config set repl-timeout 2
-                        # we want the slow replica to hang on a key for very long so it'll reach repl-timeout
-                        pause_process [srv -1 pid]
-                        after 2000
+                        wait_for_log_messages -2 {"*Disconnecting timedout replica (full sync)*"} $loglines 100 100
+                        $master config set repl-timeout 60
                     }
 
-                    # wait for rdb child to exit
-                    wait_for_condition 1200 100 {
+                    # Use a single generous budget for all subcases; successful
+                    # runs still exit early once the child is done.
+                    wait_for_condition 2400 100 {
                         [s -2 rdb_bgsave_in_progress] == 0
                     } else {
                         fail "rdb child didn't terminate"
@@ -982,16 +992,33 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
 
                     # make sure we got what we were aiming for, by looking for the message in the log file
                     if {$all_drop == "all"} {
-                        wait_for_log_messages -2 {"*Diskless rdb transfer, last replica dropped, killing fork child*"} $loglines 1 1
+                        if {[catch {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, last replica dropped, killing fork child*"} $loglines 1 1
+                        }]} {
+                            # RDB finished before replicas were killed; accept
+                            # either 1 or 2 replicas still up at pipe-read time.
+                            if {[catch {
+                                wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
+                            }]} {
+                                wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
+                            }
+                        }
                     }
                     if {$all_drop == "no"} {
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
                     }
-                    if {$all_drop == "slow" || $all_drop == "fast"} {
+                    if {$all_drop == "fast"} {
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
                     }
+                    if {$all_drop == "slow"} {
+                        if {[catch {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
+                        }]} {
+                            wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 2 replicas still up*"} $loglines 1 1
+                            wait_for_log_messages -2 {"*Connection with replica * lost.*"} $loglines 1 1
+                        }
+                    }
                     if {$all_drop == "timeout"} {
-                        wait_for_log_messages -2 {"*Disconnecting timedout replica (full sync)*"} $loglines 1 1
                         wait_for_log_messages -2 {"*Diskless rdb transfer, done reading from pipe, 1 replicas still up*"} $loglines 1 1
                         # master disconnected the slow replica, remove from array
                         set replicas_alive [lreplace $replicas_alive 0 0]
@@ -1021,12 +1048,17 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                         }
                     }
 
+                    # In the "no" case both replicas stay alive through the
+                    # full streamed RDB, so on slow TLS runners the final
+                    # ONLINE transition can lag behind child exit.
+                    set replica_online_wait_tries [expr {$all_drop == "no" ? 600 : 150}]
+
                     # verify the data integrity
                     foreach replica $replicas_alive {
                         # Wait that replicas acknowledge they are online so
                         # we are sure that DBSIZE and DEBUG DIGEST will not
                         # fail because of timing issues.
-                        wait_for_condition 150 100 {
+                        wait_for_condition $replica_online_wait_tries 100 {
                             [lindex [$replica role] 3] eq {connected}
                         } else {
                             fail "replicas still not connected after some time"

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -918,7 +918,6 @@ start_server {tags {"repl external:skip"} overrides {save ""}} {
                     [lindex $replicas 0] config set repl-diskless-load swapdb
                     # For "no" and "fast" subcases, use key-load-delay to keep
                     # replica 0 as a steady slow reader for the entire RDB
-<<<<<<< HEAD
                     # transfer. A brief SIGSTOP/SIGCONT is insufficient
                     # because after resume the TLS layer on slow CI runners
                     # can't drain the pipe fast enough, leaving the RDB child

--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -42,7 +42,7 @@ start_cluster 3 3 {tags {external:skip cluster}} {
     }
 
     test "Verify health as fail for killed node" {
-        wait_for_condition 50 100 {
+        wait_for_condition 1000 50 {
             "fail" eq [dict get [get_node_info_from_shard $node_0_id $validation_node "node"] "health"]
         } else {
             fail "New primary never detected the node failed"

--- a/tests/unit/cluster/diskless-load-swapdb.tcl
+++ b/tests/unit/cluster/diskless-load-swapdb.tcl
@@ -48,12 +48,13 @@ test "Main db not affected when fail to diskless load" {
     set num 10000
     set value [string repeat A 1024]
     set rd [valkey_deferring_client valkey $master_id]
+    $rd client reply off
     for {set j 0} {$j < $num} {incr j} {
         $rd set $j $value
+        if {$j % 1000 == 0} {$rd flush}
     }
-    for {set j 0} {$j < $num} {incr j} {
-        $rd read
-    }
+    $rd client reply on
+    assert_equal OK [$rd read]
 
     # Start the replica again
     resume_process [srv $replica_id pid]

--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -182,17 +182,17 @@ proc test_replica_config_epoch_failover {type} {
 
         # Make sure both the automatic and the manual failover will fail in the first time.
         if {$type == "automatic"} {
-            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1000 10
+            wait_for_log_messages -3 {"*Failover attempt expired*"} 0 1200 50
         } elseif {$type == "manual"} {
             R 3 cluster failover force
-            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1000 10
+            wait_for_log_messages -3 {"*Manual failover timed out*"} 0 1200 50
         }
 
         # Make sure the primaries prints the relevant logs.
-        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
-        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1000 10
-        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1000 10
+        wait_for_log_messages -1 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -1 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
+        wait_for_log_messages -2 {"*Failover auth denied to* epoch * > reqConfigEpoch*"} 0 1200 50
+        wait_for_log_messages -2 {"*has old slots configuration, sending an UPDATE message about*"} 0 1200 50
 
         # Make sure the replica has updated the config epoch.
         wait_for_condition 1000 10 {

--- a/tests/unit/cluster/half-migrated-slot.tcl
+++ b/tests/unit/cluster/half-migrated-slot.tcl
@@ -81,10 +81,11 @@ test "Move key back" {
     assert_equal "xyz" [$cluster get aga]
 }
 
+reset_cluster
+
 test "Half-finish importing" {
     # Now we half finish 'importing' node
     assert_equal {OK} [$nodeto(link) cluster setslot 609 node $nodeto(id)]
-    fix_cluster $nodefrom(addr)
     assert_equal "xyz" [$cluster get aga]
 }
 

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -104,13 +104,15 @@ proc test_migrated_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 
@@ -198,11 +200,13 @@ proc test_nonempty_replica {type} {
         # Make sure the key exists and is consistent.
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 4 get key_991803] == 1024 &&
-            [R 7 get key_991803] == 1024
+            [catch {expr {
+                [R 4 get key_991803] == 1024 &&
+                [R 7 get key_991803] == 1024
+            }} result] == 0 && $result
         } else {
-            puts "R 4: [R 4 get key_991803]"
-            puts "R 7: [R 7 get key_991803]"
+            catch {puts "R 4: [R 4 get key_991803]"}
+            catch {puts "R 7: [R 7 get key_991803]"}
             fail "Key not consistent"
         }
 
@@ -320,13 +324,15 @@ proc test_sub_replica {type} {
         R 3 readonly
         R 7 readonly
         wait_for_condition 1000 50 {
-            [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
-            [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
-            [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            [catch {expr {
+                [R 3 get key_991803] == 1024 && [R 3 get key_977613] == 10240 &&
+                [R 4 get key_991803] == 1024 && [R 4 get key_977613] == 10240 &&
+                [R 7 get key_991803] == 1024 && [R 7 get key_977613] == 10240
+            }} result] == 0 && $result
         } else {
-            puts "R 3: [R 3 keys *]"
-            puts "R 4: [R 4 keys *]"
-            puts "R 7: [R 7 keys *]"
+            catch {puts "R 3: [R 3 keys *]"}
+            catch {puts "R 4: [R 4 keys *]"}
+            catch {puts "R 7: [R 7 keys *]"}
             fail "Key not consistent"
         }
 

--- a/tests/unit/cluster/replica-migration.tcl
+++ b/tests/unit/cluster/replica-migration.tcl
@@ -90,6 +90,8 @@ proc test_migrated_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 3 cluster slots] eq [R 4 cluster slots] &&
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 3 cluster_state] eq "ok" &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"
@@ -189,6 +191,7 @@ proc test_nonempty_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"
         } else {
@@ -310,6 +313,8 @@ proc test_sub_replica {type} {
 
         # Wait for the cluster to be ok.
         wait_for_condition 1000 50 {
+            [R 3 cluster slots] eq [R 4 cluster slots] &&
+            [R 4 cluster slots] eq [R 7 cluster slots] &&
             [CI 3 cluster_state] eq "ok" &&
             [CI 4 cluster_state] eq "ok" &&
             [CI 7 cluster_state] eq "ok"

--- a/tests/unit/maxmemory.tcl
+++ b/tests/unit/maxmemory.tcl
@@ -371,12 +371,15 @@ proc test_slave_buffers {test_name cmd_count payload_len limit_memory pipeline} 
             # send some 10mb worth of commands that don't increase the memory usage
             if {$pipeline == 1} {
                 set rd_master [valkey_deferring_client -1]
+                $rd_master client reply off
+                $rd_master flush
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $rd_master setrange key:0 0 [string repeat A $payload_len]
+                    if {$k % 10000 == 0} {$rd_master flush}
                 }
-                for {set k 0} {$k < $cmd_count} {incr k} {
-                    $rd_master read
-                }
+                $rd_master client reply on
+                $rd_master flush
+                $rd_master read ;# read the +OK from CLIENT REPLY ON
             } else {
                 for {set k 0} {$k < $cmd_count} {incr k} {
                     $master setrange key:0 0 [string repeat A $payload_len]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -1,6 +1,8 @@
 proc test_memory_efficiency {range} {
     r flushall
     set rd [valkey_deferring_client]
+    $rd client reply off
+    $rd flush
     set base_mem [s used_memory]
     set written 0
     for {set j 0} {$j < 10000} {incr j} {
@@ -11,9 +13,9 @@ proc test_memory_efficiency {range} {
         incr written [string length $val]
         incr written 2 ;# A separator is the minimum to store key-value data.
     }
-    for {set j 0} {$j < 10000} {incr j} {
-        $rd read ; # Discard replies
-    }
+    $rd client reply on
+    $rd flush
+    $rd read ;# read the +OK from CLIENT REPLY ON
     $rd close
     set current_mem [s used_memory]
     set used [expr {$current_mem-$base_mem}]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -206,10 +206,12 @@ run_solo {defrag} {
             set dummy_script "--[string repeat x 400]\nreturn "
             set rd [valkey_deferring_client]
             $rd client reply off
+            $rd flush
             for {set j 0} {$j < $n} {incr j} {
                 set val "$dummy_script[format "%06d" $j]"
                 $rd script load $val
                 $rd set k$j $val
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             after 120 ;# serverCron only updates the info once in 100ms
@@ -224,6 +226,7 @@ run_solo {defrag} {
             # Delete all the keys to create fragmentation
             for {set j 0} {$j < $n} {incr j} {
                 $rd del k$j
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             $rd close
@@ -321,6 +324,7 @@ run_solo {defrag} {
                 # scale the hash to 1m fields in order to have a measurable the latency
                 for {set j 10000} {$j < 1000000} {incr j} {
                     $rd hset bighash $j [concat "asdfasdfasdf" $j]
+                    if {$j % 100 == 0} {$rd flush}
                     if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
                 }
                 # creating that big hash, increased used_memory, so the relative frag goes down
@@ -448,6 +452,7 @@ run_solo {defrag} {
             $rd client reply off
             for {set j 0} {$j < $n} {incr j} {
                 $rd del k$j
+                if {$j % 100 == 0} {$rd flush}
                 if {$j % 1000 == 999} {client_reply_off_wait_for_server $rd}
             }
             $rd close

--- a/tests/unit/moduleapi/test_lazyfree.tcl
+++ b/tests/unit/moduleapi/test_lazyfree.tcl
@@ -8,13 +8,13 @@ start_server {tags {"modules"}} {
         set rd [valkey_deferring_client]
 
         # LAZYFREE_THRESHOLD is 64
+        $rd client reply off
         for {set i 0} {$i < 10000} {incr i} {
             $rd lazyfreelink.insert lazykey $i
+            if {$i % 1000 == 0} {$rd flush}
         }
-
-        for {set j 0} {$j < 10000} {incr j} {
-            $rd read 
-        }
+        $rd client reply on
+        assert_equal OK [$rd read]
 
         assert {[r lazyfreelink.len lazykey] == 10000}
 

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -281,20 +281,14 @@ start_server {tags {"tracking network logreqres:skip"}} {
     }
 
     test {RESP3 Client gets tracking-redir-broken push message after cached key changed when rediretion client is terminated} {
+        # make sure r is working resp 3
+        r HELLO 3
         r CLIENT TRACKING on REDIRECT $redir_id
         $rd_sg SET key1 1
         r GET key1
         $rd_redirection QUIT
         assert_equal OK [$rd_redirection read]
         $rd_sg SET key1 2
-        set MAX_TRIES 100
-        set res -1
-        for {set i 0} {$i <= $MAX_TRIES && $res < 0} {incr i} {
-            set res [lsearch -exact [r PING] "tracking-redir-broken"]
-        }
-        assert {$res >= 0}
-        # Consume PING reply
-        assert_equal PONG [r read]
 
         # Reinstantiating after QUIT
         set rd_redirection [valkey_deferring_client]
@@ -302,6 +296,15 @@ start_server {tags {"tracking network logreqres:skip"}} {
         set redir_id [$rd_redirection read]
         $rd_redirection SUBSCRIBE __redis__:invalidate
         $rd_redirection read ; # Consume the SUBSCRIBE reply
+
+        # Wait to read the tracking-redir-broken
+        wait_for_condition 1000 50 {
+            [lsearch -exact [r PING] "tracking-redir-broken"]
+        } else {
+            fail "Failed to get redirect broken indication"
+        }
+         # Consume PING reply
+        assert_equal PONG [r read]
     }
 
     test {Different clients can redirect to the same connection} {

--- a/tests/unit/tracking.tcl
+++ b/tests/unit/tracking.tcl
@@ -23,7 +23,9 @@ start_server {tags {"tracking network logreqres:skip"}} {
             # info which will not be consumed.
             r CLIENT TRACKING off
             $rd QUIT
+            $rd close
             $rd_redirection QUIT
+            $rd_redirection close
             set rd [valkey_deferring_client]
             set rd_redirection [valkey_deferring_client]
             $rd_redirection client id
@@ -288,6 +290,7 @@ start_server {tags {"tracking network logreqres:skip"}} {
         r GET key1
         $rd_redirection QUIT
         assert_equal OK [$rd_redirection read]
+        $rd_redirection close
         $rd_sg SET key1 2
 
         # Reinstantiating after QUIT

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -291,7 +291,9 @@ catch {
 }
 if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
 
-    set str_length 5000000000
+    # Reduced from 5GB to fit in 16GB CI runners with ASAN overhead
+    # Must exceed 2^32 (4294967296) to test >4GiB (32-bit boundary) behavior
+    set str_length 4300000000
 
     # repeating all the plain nodes basic checks with 5gb values
     test {Test LPUSH and LPOP on plain nodes over 4GB} {

--- a/tests/unit/type/set.tcl
+++ b/tests/unit/type/set.tcl
@@ -1281,7 +1281,9 @@ catch {
 }
 if {[lindex [r config get proto-max-bulk-len] 1] == 10000000000} {
 
-    set str_length 4400000000 ;#~4.4GB
+    # Reduced from 4.4GB to fit in 16GB CI runners with ASAN overhead
+    # Must exceed 2^32 (4294967296) to test >4GiB (32-bit boundary) behavior
+    set str_length 4300000000 ;#~4GiB, >2^32
 
     test {SADD, SCARD, SISMEMBER - large data} {
         r flushdb

--- a/tests/unit/violations.tcl
+++ b/tests/unit/violations.tcl
@@ -1,4 +1,5 @@
-# One XADD with one huge 5GB field
+# One XADD with one huge >4GiB field (reduced from 5GB for CI memory limits)
+# Must exceed 2^32 to require more than 32 bits to address
 # Expected to fail resulting in an empty stream
 run_solo {violations} {
 start_server [list overrides [list save ""] ] {
@@ -8,7 +9,7 @@ start_server [list overrides [list save ""] ] {
         r write "*5\r\n\$4\r\nXADD\r\n\$2\r\nS1\r\n\$1\r\n*\r\n"
         r write "\$1\r\nA\r\n"
         catch {
-            write_big_bulk 5000000000 ;#5gb
+            write_big_bulk 4300000000 ;#~4GiB, >2^32
         } err
         assert_match {*too large*} $err
         r xlen S1
@@ -33,15 +34,16 @@ start_server [list overrides [list save ""] ] {
 }
 
 # Gradually add big stream fields using repeated XADD calls
+# Reduced from 10 to 3 iterations to fit in 16GB CI runners with ASAN overhead
 start_server [list overrides [list save ""] ] {
     test {several XADD big fields} {
         r config set stream-node-max-bytes 0
-        for {set j 0} {$j<10} {incr j} {
+        for {set j 0} {$j<3} {incr j} {
             r xadd stream * 1 $::str500 2 $::str500
         }
         r ping
         r xlen stream
-    } {10} {large-memory}
+    } {3} {large-memory}
 }
 
 # Add over 4GB to a single stream listpack (one XADD command)
@@ -75,6 +77,7 @@ start_server [list overrides [list save ""] ] {
 
 # Add over 4GB to a single hash field (one HSET command)
 # Object will be converted to hashtable encoding
+# Reduced from 5GB; must exceed 2^32 to test >4GiB (32-bit boundary) behavior
 start_server [list overrides [list save ""] ] {
     test {hash with one huge field} {
         catch {r config set hash-max-ziplist-value 10000000000} ;#10gb
@@ -82,7 +85,7 @@ start_server [list overrides [list save ""] ] {
         r config set client-query-buffer-limit 10000000000 ;#10gb
         r write "*4\r\n\$4\r\nHSET\r\n\$2\r\nH1\r\n"
         r write "\$1\r\nA\r\n"
-        write_big_bulk 5000000000 ;#5gb
+        write_big_bulk 4300000000 ;#~4GiB, >2^32
         r object encoding H1
     } {hashtable} {large-memory}
 }


### PR DESCRIPTION
## Description

This PR backports targeted CI/test stabilization fixes for the 8.0 daily validation branch.

## Backport provenance

| Backport commit | Provenance | Notes |
| --- | --- | --- |
| 90ef3bb78 | Adapted from upstream PR #3430, merge f3b647050 | Partial backport of flaky test fixes |
| 3680cf993 | Adapted from upstream PR #3452, merge c35dbdfc | CLIENT REPLY OFF flaky test fix |
| 25ac91955 | Adapted from upstream PR #3263, merge c9ce3e09 | Partial backport for large-memory ASAN test sizing |
| f40ee25cb | Adapted from upstream PR #1122, merge dcac3e149 | Fixes UBSan left-shift overflow in `test_rax.c` |
| b57fe713f | Adapted from CLIENT REPLY OFF stabilization pattern | Deflakes active defrag eval scripts test |
| 274a60e4d | Adapted from upstream PR #1044, merge 6ce75cdea | Replica online timing fix in failover test |
| 28760014f | Adapted from upstream PR #3461, merge f6b5461b7 | Diskless RDB pipe test deflake |
| 42637f10a | Adapted from upstream PR #2304, merge 9c45cf334 | Makes zmalloc unit checks baseline-safe |
| 795c6e0d0 | Branch-specific/adapted test deflake | Stabilizes diskless no-replicas RDB pipe test |
| 0c8be103d | Adapted from upstream PR #3242, merge 4dee322e | Dual-channel replication COB overrun deflake |
| b3b5ec6fb | Adapted from upstream PR #1314, merge d07674fc0 | Uses usable size in SDS unit checks |
| 6e3cfea90 | Adapted from upstream PR #1288, merge 4aacffa3 | Avoids LOADING error in dual replication test |
| 23845d09f | Adapted from upstream PR #1979, merge 0b94ca683 | Restores dual-channel replica log marker |
| e34b0914c | Adapted from upstream PR #1374, merge 7043ef0b | Splits dual-channel COB overrun tests |
| 973adb088 | Adapted from upstream PR #1612, merge 88a68303 | Disables pause-after-fork cleanup issue in dual-channel test |
| d05d138f9 | Adapted from upstream PR #2748, merge 2288657a | Deflakes psync-established-after-RDB-load test |
| 0bd5d04e9 | Adapted from upstream PR #3511, merge 03c2d4c2 | Stabilizes diskless no-drop replication test |
| ab9c47aef | Branch-specific cleanup | Removes a backport conflict artifact |
| f9b7168cd | Adapted from upstream PR #2827, merge b7a3fc98 | Dual-channel tracking replica backlog refcount deflake |
| f0eff3da6 | Adapted from upstream PR #1628, merge 230efa4f | Deflakes tracking redirection test |
| 9df0916ca | Adapted from upstream PR #1719, merge 2f2b8d15 | Avoids leaking Tcl connections in tracking tests |
| 7a1249e1d | Branch-specific/adapted test deflake | Resets cluster state before half-finish importing test |
| 0b710e5b1 | Adapted from upstream PR #1243, merge a102852d | Cluster-shards timing fix |
| 71f6df888 | Adapted from upstream PR #1311, merge aa2dd3ec | Replica migration cluster config consistency fix |
