### PR TITLE
Release Valkey 8.0.9 and revoke 8.0.8

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -19,7 +19,7 @@ security fixes we recommend you apply as soon as possible.
 Notes
 =====
 * Valkey 8.0.8 has been revoked. The 8.0.8 tag was placed on a commit that is
-  not part of the 8.0 release branch, so checking out v8.0.8 yields a tree
+  not part of the 8.0 release branch, so checking out 8.0.8 yields a tree
   that does not correspond to the 8.0 line. Do not use 8.0.8. Users should
   upgrade directly from 8.0.7 to 8.0.9, which contains the intended security
   fixes on the 8.0 branch.
@@ -36,12 +36,6 @@ Valkey 8.0.8  -  Tue 05 May 2026  [REVOKED -- do not use; see 8.0.9]
 
 This release has been revoked. The 8.0.8 tag was placed on a commit that is
 not part of the 8.0 release branch. Users should upgrade to 8.0.9 instead.
-
-Security fixes (shipped in 8.0.9)
-=================================
-* (CVE-2026-23479) Use-After-Free in unblock client flow
-* (CVE-2026-25243) Invalid Memory Access in RESTORE command
-* (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution
 
 ================================================================================
 Valkey 8.0.7  -  Released Mon 23 February 2026

--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -10,14 +10,35 @@ SECURITY: There are security fixes in the release.
 --------------------------------------------------------------------------------
 
 ================================================================================
-Valkey 8.0.8  -  Tue 05 May 2026
+Valkey 8.0.9  -  Wed 06 May 2026
 ================================================================================
 
-Upgrade urgency SECURITY: This release includes security fixes we recommend you
-apply as soon as possible.
+Upgrade urgency SECURITY: This release supersedes 8.0.8 (revoked) and includes
+security fixes we recommend you apply as soon as possible.
+
+Notes
+=====
+* Valkey 8.0.8 has been revoked. The 8.0.8 tag was placed on a commit that is
+  not part of the 8.0 release branch, so checking out v8.0.8 yields a tree
+  that does not correspond to the 8.0 line. Do not use 8.0.8. Users should
+  upgrade directly from 8.0.7 to 8.0.9, which contains the intended security
+  fixes on the 8.0 branch.
 
 Security fixes
 ==============
+* (CVE-2026-23479) Use-After-Free in unblock client flow
+* (CVE-2026-25243) Invalid Memory Access in RESTORE command
+* (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution
+
+================================================================================
+Valkey 8.0.8  -  Tue 05 May 2026  [REVOKED -- do not use; see 8.0.9]
+================================================================================
+
+This release has been revoked. The 8.0.8 tag was placed on a commit that is
+not part of the 8.0 release branch. Users should upgrade to 8.0.9 instead.
+
+Security fixes (shipped in 8.0.9)
+=================================
 * (CVE-2026-23479) Use-After-Free in unblock client flow
 * (CVE-2026-25243) Invalid Memory Access in RESTORE command
 * (CVE-2026-23631) Use-after-free when full sync occurs during a yielding Lua/function execution

--- a/src/version.h
+++ b/src/version.h
@@ -4,8 +4,8 @@
  * similar. */
 #define SERVER_NAME "valkey"
 #define SERVER_TITLE "Valkey"
-#define VALKEY_VERSION "8.0.8"
-#define VALKEY_VERSION_NUM 0x00080008
+#define VALKEY_VERSION "8.0.9"
+#define VALKEY_VERSION_NUM 0x00080009
 
 /* Redis OSS compatibility version, should never
  * exceed 7.2.x. */


### PR DESCRIPTION
## Summary

Cuts Valkey 8.0.9 and revokes 8.0.8.

## Why

The `8.0.8` tag was placed on a commit that is not part of the `8.0` release branch — it points at a commit on `unstable` (`fea0b4064`). As a result, `git checkout v8.0.8` yields a tree derived from `unstable`, not from the `8.0` line. Users who build from `v8.0.8` get code substantially different from what the `8.0` branch contains.

The three security fixes intended for 8.0.8 were also cherry-picked onto the `8.0` branch as separate commits (`fdc142c65`, `e058d4690`, and the UAF unblock fix) and already exist on `upstream/8.0` HEAD. 8.0.9 is their correct release on the `8.0` branch.

## Changes

- **`00-RELEASENOTES`**: new 8.0.9 section at the top listing the three CVEs; existing 8.0.8 section marked `[REVOKED -- do not use; see 8.0.9]` with a short explanation.
- **`src/version.h`**: `VALKEY_VERSION "8.0.8"` → `"8.0.9"`, `VALKEY_VERSION_NUM 0x00080008` → `0x00080009`.

## Security fixes carried forward in 8.0.9

- CVE-2026-23479 — Use-After-Free in unblock client flow
- CVE-2026-25243 — Invalid Memory Access in RESTORE command
- CVE-2026-23631 — Use-after-free when full sync occurs during a yielding Lua/function execution

## Follow-ups (not in this PR)

- GitHub release for `v8.0.8` needs to be retracted / annotated.
- Downstream package registries / container images that shipped `8.0.8` need coordinating.
- The tag itself may need to be explicitly marked on the webpage as REVOKED
