### PR TITLE
Skip deferred_reply test in req/res log validation

### DIFF
--- a/tests/unit/moduleapi/deferred_reply.tcl
+++ b/tests/unit/moduleapi/deferred_reply.tcl
@@ -1,6 +1,6 @@
 set testmodule [file normalize tests/modules/deferred_reply.so]
 
-start_server {tags {"modules"}} {
+start_server {tags {"modules logreqres:skip"}} {
     r module load $testmodule
 
     test {Deferred reply with postponed array length during active deferred reply buffer} {


### PR DESCRIPTION
Introduced in test here #3578

I saw it fail here: https://github.com/valkey-io/valkey/actions/runs/25465801442/job/74718737672?pr=3468#step:12:1604

The `deferred_reply` module regression test can emit two top-level RESP replies for a single client command: the normal `SET` reply followed by the module callback reply.

The req/res log validator assumes each logged argv is followed by one response.