### PR TITLE
Change default of commandlog-reply-larger-than to disable tracking

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3446,7 +3446,7 @@ standardConfig static_configs[] = {
     createLongLongConfig("cluster-ping-interval", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 0, LLONG_MAX, server.cluster_ping_interval, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("commandlog-execution-slower-than", "slowlog-log-slower-than", MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_SLOW].threshold, 10000, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("commandlog-request-larger-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_LARGE_REQUEST].threshold, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
-    createLongLongConfig("commandlog-reply-larger-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold, 1024 * 1024, INTEGER_CONFIG, NULL, NULL),
+    createLongLongConfig("commandlog-reply-larger-than", NULL, MODIFIABLE_CONFIG, -1, LLONG_MAX, server.commandlog[COMMANDLOG_TYPE_LARGE_REPLY].threshold, -1, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("latency-monitor-threshold", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.latency_monitor_threshold, 0, INTEGER_CONFIG, NULL, NULL),
     createLongLongConfig("proto-max-bulk-len", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, 1024 * 1024, LONG_MAX, server.proto_max_bulk_len, 512ll * 1024 * 1024, MEMORY_CONFIG, NULL, NULL), /* Bulk request max size */
     createLongLongConfig("stream-node-max-entries", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.stream_node_max_entries, 100, INTEGER_CONFIG, NULL, NULL),

--- a/valkey.conf
+++ b/valkey.conf
@@ -2209,8 +2209,7 @@ commandlog-large-request-max-len 128
 # Note that -1 disables the large reply log, while 0 forces logging of every command.
 # Enabling this feature (values other than -1) has performance implications
 # when I/O threads are used due to additional tracking overhead.
-# Consider using -1 to disable if large reply monitoring is not needed.
-commandlog-reply-larger-than 1048576
+commandlog-reply-larger-than -1
 # Record the number of commands.
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the large reply log with COMMANDLOG RESET LARGE-REPLY.


### PR DESCRIPTION
Change default of `commandlog-reply-larger-than` config to -1 because enabling tracking noticeably reduces performance with copy avoidance feature enabled. This is a breaking change and should be included only in major version.
Related Issue/PRs with more details about reasoning and benchmarks:
https://github.com/valkey-io/valkey/issues/2926 https://github.com/valkey-io/valkey/pull/2652 https://github.com/valkey-io/valkey/pull/3086