### PR TITLE
Use wait_for_condition instead of hardcoding in dump.tcl test

### DIFF
--- a/tests/unit/dump.tcl
+++ b/tests/unit/dump.tcl
@@ -163,8 +163,11 @@ start_server {tags {"dump"}} {
     } {} {external:skip}
 
     test {MIGRATE cached connections are released after some time} {
-        after 15000
-        assert_match {*migrate_cached_sockets:0*} [r info]
+        wait_for_condition 20 1000 {
+            [string match {*migrate_cached_sockets:0*} [r info]]
+        } else {
+            fail "MIGRATE cached connections were not released after some time"
+        }
     }
 
     test {MIGRATE is able to migrate a key between two instances} {


### PR DESCRIPTION
This after causes the test to take 15 seconds, but it might only
require just over 10 seconds since the MIGRATE_SOCKET_CACHE_TTL
is 10 seconds.
```
/* Cleanup expired MIGRATE cached sockets. */
run_with_period(1000) {
    migrateCloseTimedoutSockets();
}
```