### PR TITLE
Use full hash-seed bytes when deriving SipHash seed

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -7654,7 +7654,7 @@ __attribute__((weak)) int main(int argc, char **argv) {
      * hashes) or use the random seed if not configured. */
     if (server.hash_seed) {
         uint8_t seed[16] = {0};
-        getHashSeedFromString(seed, sizeof(seed), server.hash_seed);
+        getHashSeedFromString(seed, sizeof(seed), server.hash_seed, sdslen(server.hash_seed));
         setConfigurableHashSeed(seed);
     } else {
         setConfigurableHashSeed(hashtableGetHashFunctionSeed());

--- a/src/util.c
+++ b/src/util.c
@@ -1054,18 +1054,17 @@ err:
 
 /* Populate the provided seed array by hashing the provided string with SHA256
  * and copying the first outlen bytes of the digest into the seed buffer. */
-void getHashSeedFromString(unsigned char *seed_array, size_t outlen, const char *value) {
+void getHashSeedFromString(unsigned char *seed_array, size_t outlen, const char *value, size_t value_len) {
     SHA256_CTX ctx;
     unsigned char digest[SHA256_BLOCK_SIZE];
 
     sha256_init(&ctx);
-    sha256_update(&ctx, (const BYTE *)value, strlen(value));
+    sha256_update(&ctx, (const BYTE *)value, value_len);
     sha256_final(&ctx, digest);
 
     if (outlen > SHA256_BLOCK_SIZE) outlen = SHA256_BLOCK_SIZE;
     memcpy(seed_array, digest, outlen);
 }
-
 
 /* Parses a version string on the form "major.minor.patch" and returns an
  * integer on the form 0xMMmmpp. Returns -1 on parse error. */

--- a/src/util.h
+++ b/src/util.h
@@ -92,7 +92,7 @@ int trimDoubleString(char *buf, size_t len);
 int d2string(char *buf, size_t len, double value);
 int fixedpoint_d2string(char *dst, size_t dstlen, double dvalue, int fractional_digits);
 int ld2string(char *buf, size_t len, long double value, ld2string_mode mode);
-void getHashSeedFromString(unsigned char *seed_array, size_t len, const char *value);
+void getHashSeedFromString(unsigned char *seed_array, size_t len, const char *value, size_t value_len);
 int double2ll(double d, long long *out);
 int version2num(const char *version);
 int yesnotoi(char *s);

--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -74,6 +74,10 @@ test {hash-seed uses full bytes including embedded NULL for seeding} {
             set primary [srv -1 client]
             set replica [srv 0 client]
 
+            set primary_seed [lindex [$primary config get hash-seed] 1]
+            set replica_seed [lindex [$replica config get hash-seed] 1]
+            assert_not_equal $primary_seed $replica_seed
+
             $replica replicaof [srv -1 host] [srv -1 port]
             wait_for_sync $replica
 

--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -64,3 +64,33 @@ test {scan family consistency with configured hash seed} {
         }
     }
 } {} {external:skip}
+
+test {hash-seed uses full bytes including embedded NULL for seeding} {
+    set seed_a {"valkey\x00AAAAA"}
+    set seed_b {"valkey\x00BBBBB"}
+
+    start_server [list overrides [list hash-seed $seed_a]] {
+        start_server [list overrides [list hash-seed $seed_b]] {
+            set primary [srv -1 client]
+            set replica [srv 0 client]
+
+            $replica replicaof [srv -1 host] [srv -1 port]
+            wait_for_sync $replica
+
+            set n 16384
+            for {set i 0} {$i < $n} {incr i} {
+                $primary set "k:$i" x
+            }
+
+            wait_for_condition 200 50 {
+                [$replica dbsize] == [$primary dbsize]
+            } else {
+                fail "replica did not catch up"
+            }
+
+            set keys [scan_interleaved $primary $replica scan]
+            set keys [lsort -unique $keys]
+            assert_not_equal $n [llength $keys]
+        }
+    }
+} {} {external:skip}

--- a/tests/integration/scan-family-consistency.tcl
+++ b/tests/integration/scan-family-consistency.tcl
@@ -95,6 +95,14 @@ test {hash-seed uses full bytes including embedded NULL for seeding} {
             set keys [scan_interleaved $primary $replica scan]
             set keys [lsort -unique $keys]
             assert_not_equal $n [llength $keys]
+
+            # Also use this opportunity to verify that the config rewrite works on NULL.
+            $primary config rewrite
+            restart_server -1 true false
+            assert_equal [lindex [[srv -1 client] config get hash-seed] 1] $primary_seed
+            $replica config rewrite
+            restart_server 0 true false
+            assert_equal [lindex [[srv 0 client] config get hash-seed] 1] $replica_seed
         }
     }
 } {} {external:skip}


### PR DESCRIPTION
The hash-seed config is an sds string and may contain embedded NUL
bytes (sdssplitargs preserves \xNN escapes inside double quotes).

In the old code getHashSeedFromString() used strlen() on it, so two
hash-seed values differing only after a \x00 byte collapsed to the
same SipHash seed, can break it.

hash-seed was added in #2608.