### PR TITLE
fix(cluster): Remove per-call srand in valkey-cli (8.0 backport)

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -4169,7 +4169,6 @@ static void clusterManagerOptimizeAntiAffinity(clusterManagerNodeArray *ipnodes,
                           "for anti-affinity\n");
     int node_len = cluster_manager.nodes->len;
     int maxiter = 500 * node_len; // Effort is proportional to cluster size...
-    srand(time(NULL));
     while (maxiter > 0) {
         int offending_len = 0;
         if (offenders != NULL) {
@@ -5741,7 +5740,6 @@ static clusterManagerNode *clusterManagerNodePrimaryRandom(void) {
     }
 
     assert(primary_count > 0);
-    srand(time(NULL));
     idx = rand() % primary_count;
     listRewind(cluster_manager.nodes, &li);
     while ((ln = listNext(&li)) != NULL) {
@@ -8419,8 +8417,6 @@ static void pipeMode(void) {
     char magic[20]; /* Special reply we recognize. */
     time_t last_read_time = time(NULL);
 
-    srand(time(NULL));
-
     /* Use non blocking I/O. */
     if (anetNonBlock(aneterr, context->fd) == ANET_ERR) {
         fprintf(stderr, "Can't set the socket in non blocking mode: %s\n", aneterr);
@@ -9261,7 +9257,6 @@ static void LRUTestMode(void) {
     long long start_cycle;
     int j;
 
-    srand(time(NULL) ^ getpid());
     while (1) {
         /* Perform cycles of 1 second with 50% writes and 50% reads.
          * We use pipelining batching writes / reads N times per cycle in order
@@ -9481,6 +9476,7 @@ int main(int argc, char **argv) {
     int firstarg;
     struct timeval tv;
 
+    srand(time(NULL) ^ getpid());
     memset(&config.sslconfig, 0, sizeof(config.sslconfig));
     config.conn_info.hostip = sdsnew("127.0.0.1");
     config.conn_info.hostport = 6379;


### PR DESCRIPTION
Backport of #3586 to the 8.0 branch.

## Problem

`clusterManagerNodePrimaryRandom()` called `srand(time(NULL))` on every invocation, then immediately `rand() % primary_count`. When called in a tight loop for uncovered slots, all calls within the same wall-clock second produce the identical seed, causing every uncovered slot to be assigned to the same primary node.

The same issue existed in `clusterManagerOptimizeAntiAffinity`, `pipeMode`, and `LRUTestMode`.

## Solution

Remove all per-call `srand()` invocations and consolidate into a single `srand(time(NULL) ^ getpid())` at the start of `main()`. This allows `rand()` to advance its state across calls, distributing uncovered slots randomly across available primaries.

(cherry picked from commit 7e2a2f7c4a394cf27ebaa3dc7106a8337a8ddf72)