### PR TITLE
Trigger cluster state update immediately when cluster-require-full-coverage changes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2745,7 +2745,7 @@ static int applyBind(const char **err) {
 
 static int updateClusterState(const char **err) {
     UNUSED(err);
-    clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE);
+    if (server.cluster_enabled) clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE);
     return 1;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -2743,6 +2743,12 @@ static int applyBind(const char **err) {
     return 1;
 }
 
+static int updateClusterState(const char **err) {
+    UNUSED(err);
+    clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE);
+    return 1;
+}
+
 int updateClusterFlags(const char **err) {
     UNUSED(err);
     clusterUpdateMyselfFlags();
@@ -3275,7 +3281,7 @@ standardConfig static_configs[] = {
     createBoolConfig("dual-channel-replication-enabled", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.dual_channel_replication, 0, NULL, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("no-appendfsync-on-rewrite", NULL, MODIFIABLE_CONFIG, server.aof_no_fsync_on_rewrite, 0, NULL, NULL),
-    createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),
+    createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, updateClusterState),
     createBoolConfig("rdb-save-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.rdb_save_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("aof-load-truncated", NULL, MODIFIABLE_CONFIG, server.aof_load_truncated, 1, NULL, NULL),
     createBoolConfig("aof-use-rdb-preamble", NULL, MODIFIABLE_CONFIG, server.aof_use_rdb_preamble, 1, NULL, NULL),

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -106,3 +106,32 @@ start_cluster 1 1 {tags {external:skip cluster} overrides {cluster-config-save-b
         assert_equal [count_log_message -1 "Cluster config updated even though writing the cluster config file to disk failed"] 1
     }
 }
+
+# Test that changing cluster-require-full-coverage triggers an immediate
+# cluster state update. Use 3 primaries with no replicas so that pausing
+# one primary leaves a slot range uncovered without automatic failover.
+start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-require-full-coverage yes}} {
+    test "Cluster state transitions when toggling cluster-require-full-coverage" {
+        # Pause one primary so part of the slots is uncovered.
+        pause_process [srv 0 pid]
+        wait_for_cluster_state fail
+
+        # With cluster-require-full-coverage set to no, the R1 should
+        # stay in the OK state even though some slots are uncovered.
+        R 1 config set cluster-require-full-coverage no
+        assert_equal [CI 1 cluster_state] "ok"
+        assert_equal [CI 2 cluster_state] "fail"
+
+        # Now change cluster-require-full-coverage back to yes. The R1
+        # should immediately transition to FAIL because slots are uncovered.
+        # Without the fix, the cluster would remain stuck in OK because
+        # clusterUpdateState was only called when cluster is FAIL in clusterCron.
+        R 1 config set cluster-require-full-coverage yes
+        assert_equal [CI 1 cluster_state] "fail"
+        assert_equal [CI 2 cluster_state] "fail"
+
+        # Resume the paused primary to bring the cluster back to OK.
+        resume_process [srv 0 pid]
+        wait_for_cluster_state ok
+    }
+}


### PR DESCRIPTION
Previously, changing the cluster-require-full-coverage config via
CONFIG SET would not trigger an immediate cluster state update, requiring
the cluster to wait for the next clusterCron cycle to reflect the change.

Furthermore, there was a bug when flipping cluster-require-full-coverage
from "no" to "yes" while the cluster was in the OK state. Because
clusterCron only called clusterUpdateState() when:
```
    if (update_state || server.cluster->state == CLUSTER_FAIL)
```

The cluster would remain stuck in the OK state despite having uncovered
slots, since neither condition was true (state was OK and update_state
was not set).

The fix schedules CLUSTER_TODO_UPDATE_STATE in beforeSleep whenever
the config changes, so the state is re-evaluated promptly in both
directions (FAIL -> OK and OK -> FAIL).

Add a test that verifies both transitions by pausing a primary with
cluster-require-full-coverage set to "no" (cluster stays OK), then
flipping it back to "yes" (cluster immediately transitions to FAIL).