### PR TITLE
Fix CLUSTERSCAN fingerprint to use configurable_hash_seed

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1661,7 +1661,7 @@ void clusterCommandFlushslot(client *c) {
  * but additional factors (e.g., hash table type) can be mixed in later.
  *
  * Fingerprint is encoded using consecutive ASCII values starting from '0'
- * (48 to 111), each represenenting 6 bits. This encoding avoids '-', '{', '}'
+ * (48 to 111), each representing 6 bits. This encoding avoids '-', '{', '}'
  * which are part of the cursor.
  *
  * Returns a non zero 32-bit fingerprint. 0 is reserved for cross-node cursor */
@@ -1669,7 +1669,10 @@ static const char *clusterscanFingerprint(void) {
     static char cached_fp[7];
     if (cached_fp[0]) return cached_fp;
 
-    uint64_t *seed = (uint64_t *)hashtableGetHashFunctionSeed();
+    /* Use configurable_hash_seed (derived from hash-seed config) so that nodes
+     * sharing the same hash-seed produce the same fingerprint, allowing cursors
+     * to survive failover without restarting the scan. */
+    uint64_t *seed = (uint64_t *)getConfigurableHashSeed();
     uint64_t hash = wangHash64(seed[0] ^ seed[1]);
 
     /* Truncating to 32 bit instead of 64 bit */

--- a/src/server.c
+++ b/src/server.c
@@ -425,6 +425,10 @@ void setConfigurableHashSeed(uint8_t *seed) {
     memcpy(configurable_hash_seed, seed, sizeof(configurable_hash_seed));
 }
 
+uint8_t *getConfigurableHashSeed(void) {
+    return configurable_hash_seed;
+}
+
 uint64_t genHashFunctionConfigurableSeed(const char *buf, size_t len) {
     return siphash((const uint8_t *)buf, len, configurable_hash_seed);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -3910,6 +3910,7 @@ int performEvictions(void);
 void startEvictionTimeProc(void);
 
 /* Keys hashing/comparison functions for dict.c and hashtable.c hash tables. */
+uint8_t *getConfigurableHashSeed(void);
 uint64_t dictSdsHash(const void *key);
 uint64_t dictSdsCaseHash(const void *key);
 uint64_t dictCStrHash(const void *key);

--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -609,3 +609,103 @@ start_cluster 2 0 {tags {external:skip cluster}} {
         }
     }
 }
+
+proc scan_interleaved_clusterscan {primary replica args} {
+    set cursor "0-{06S}-0"
+    set keys {}
+    set toggle [randomInt 2]
+    while {1} {
+        if {$toggle == 0} {
+            set res [$primary clusterscan $cursor {*}$args]
+        } else {
+            set res [$replica clusterscan $cursor {*}$args]
+        }
+        lappend keys {*}[lindex $res 1]
+        set cursor [lindex $res 0]
+        if {$cursor eq "0"} break
+        set toggle [expr {1 - $toggle}]
+    }
+    return $keys
+}
+
+# Nodes with the same hash-seed produce the same fingerprint, so
+# CLUSTERSCAN cursors can be exchanged between primary and replica.
+start_cluster 1 1 {tags {external:skip cluster} overrides {hash-seed "fingerprint-seed"}} {
+    test "CLUSTERSCAN fingerprint is consistent across nodes with same hash-seed" {
+        set n 500
+        for {set i 0} {$i < $n} {incr i} {
+            R 0 set "{06S}:fp:$i" "val"
+        }
+        wait_for_condition 200 50 {
+            [R 1 dbsize] == $n
+        } else {
+            fail "Replica did not sync"
+        }
+
+        R 1 readonly
+
+        # Verify fingerprints match directly.
+        set primary_res [R 0 clusterscan "0-{06S}-0" SLOT 0 COUNT 1]
+        set replica_res [R 1 clusterscan "0-{06S}-0" SLOT 0 COUNT 1]
+        set primary_fp [string range [lindex $primary_res 0] 0 [expr {[string first "-" [lindex $primary_res 0]] - 1}]]
+        set replica_fp [string range [lindex $replica_res 0] 0 [expr {[string first "-" [lindex $replica_res 0]] - 1}]]
+        assert_equal $primary_fp $replica_fp
+
+        # Verify fingerprints match when interleaving primary and replica scans.
+        set keys [scan_interleaved_clusterscan [srv 0 client] [srv -1 client] SLOT 0]
+        set keys [lsort -unique $keys]
+        assert_equal $n [llength $keys]
+    }
+
+    test "CLUSTERSCAN cursor survives failover with same hash-seed" {
+        R 0 flushall
+        set n 500
+        for {set i 0} {$i < $n} {incr i} {
+            R 0 set "{06S}:fo:$i" "val"
+        }
+        wait_for_condition 200 50 {
+            [R 1 dbsize] == $n
+        } else {
+            fail "Replica did not sync"
+        }
+
+        # Partial scan on old primary.
+        set cursor "0-{06S}-0"
+        set keys_before {}
+        while {1} {
+            set res [R 0 clusterscan $cursor SLOT 0 COUNT 10]
+            set cursor [lindex $res 0]
+            lappend keys_before {*}[lindex $res 1]
+            if {[llength $keys_before] > 0 && $cursor ne "0"} break
+        }
+
+        # Extract fingerprint from old primary's cursor.
+        set old_primary_fp [string range $cursor 0 [expr {[string first "-" $cursor] - 1}]]
+
+        # Failover: replica becomes new primary.
+        R 1 cluster failover
+        wait_for_condition 1000 50 {
+            [s 0 role] == "slave" &&
+            [s -1 role] == "master"
+        } else {
+            fail "Failover did not happen"
+        }
+
+        # Verify new primary produces the same fingerprint.
+        set res [R 1 clusterscan "0-{06S}-0" SLOT 0 COUNT 1]
+        set new_primary_fp [string range [lindex $res 0] 0 [expr {[string first "-" [lindex $res 0]] - 1}]]
+        assert_equal $old_primary_fp $new_primary_fp
+
+        # Continue on new primary with the old cursor.
+        set keys_after {}
+        while {$cursor ne "0"} {
+            set res [R 1 clusterscan $cursor SLOT 0 COUNT 100]
+            set cursor [lindex $res 0]
+            lappend keys_after {*}[lindex $res 1]
+        }
+
+        # Verify all keys are present.
+        set all_keys [lsort -unique [concat $keys_before $keys_after]]
+        assert_equal $n [llength $all_keys]
+    }
+}


### PR DESCRIPTION
This bug was introduced in #3366.

Before PR #3366, hash-seed config was applied directly via
hashtableSetHashFunctionSeed(), so clusterscanFingerprint() correctly
used hash_function_seed to derive the fingerprint.
```c
if (server.hash_seed != NULL) {
    memset(hashseed, 0, sizeof(hashseed));
    getHashSeedFromString(hashseed, sizeof(hashseed), server.hash_seed);
    hashtableSetHashFunctionSeed(hashseed);
}
```

PR #3366 introduced a separate configurable_hash_seed for data
hashtables and kept hash_function_seed as a random per-process value.
```c
/* Set the configured hash seed used by data hashtables (keys, sets, zsets,
 * hashes) or use the random seed if not configured. */
if (server.hash_seed) {
    uint8_t seed[16] = {0};
    getHashSeedFromString(seed, sizeof(seed), server.hash_seed);
    setConfigurableHashSeed(seed);
} else {
    setConfigurableHashSeed(hashtableGetHashFunctionSeed());
}
```

However, clusterscanFingerprint() was not updated accordingly — it
still reads hash_function_seed, which is now random on every node.
This makes fingerprints differ across nodes even when they share the
same hash-seed config, causing cursors to restart on failover.

CLUSTERSCAN was introduced in #2934.