### PR TITLE
cmake: Fix missing release_header dependency for cli, benchmark, and gtest

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ list(APPEND CLI_LIBS "ffc")
 valkey_build_and_install_bin(valkey-cli "${VALKEY_CLI_SRCS}" "${VALKEY_SERVER_LDFLAGS}" "${CLI_LIBS}" "redis-cli")
 add_dependencies(valkey-cli generate_commands_def)
 add_dependencies(valkey-cli generate_fmtargs_h)
+add_dependencies(valkey-cli release_header)
 
 # Target: valkey-benchmark
 list(APPEND BENCH_LIBS "fpconv")
@@ -83,6 +84,7 @@ valkey_build_and_install_bin(valkey-benchmark "${VALKEY_BENCHMARK_SRCS}" "${VALK
                              "redis-benchmark")
 add_dependencies(valkey-benchmark generate_commands_def)
 add_dependencies(valkey-benchmark generate_fmtargs_h)
+add_dependencies(valkey-benchmark release_header)
 
 # Targets: valkey-sentinel, valkey-check-aof and valkey-check-rdb are just symbolic links
 valkey_create_symlink("valkey-server" "valkey-sentinel")

--- a/src/unit/CMakeLists.txt
+++ b/src/unit/CMakeLists.txt
@@ -40,6 +40,7 @@ FetchContent_MakeAvailable(googletest)
 
 # Build Valkey sources as a static library for the test (C code compiled with C compiler)
 add_library(valkeylib-gtest STATIC ${VALKEY_SERVER_SRCS})
+add_dependencies(valkeylib-gtest release_header)
 target_compile_options(valkeylib-gtest PRIVATE -Og -g -fno-lto)
 target_compile_definitions(valkeylib-gtest PRIVATE "${COMPILE_DEFINITIONS}")
 target_include_directories(valkeylib-gtest PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/deps)


### PR DESCRIPTION
release.c is compiled into valkey-cli, valkey-benchmark, and the valkeylib-gtest static library, but only valkey-server declared a dependency on the release_header custom target that runs mkreleasehdr.sh to generate src/release.h. On a clean build (no stale release.h on disk) or under high parallelism, those targets could attempt to compile release.c before the header was generated and fail with "release.h: No such file or directory".

Add the missing add_dependencies(... release_header) for all three.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system dependencies to ensure proper generation order during compilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey/pull/3683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->