### PR TITLE
Fix weekly workflow startup_failure caused by permissions mismatch

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 6 * * 0'
   workflow_dispatch: {}
 permissions:
-  actions: read
+  actions: write
   contents: read
   pull-requests: read
 concurrency:
@@ -51,7 +51,7 @@ jobs:
     needs: determine-release-branches
     if: needs.determine-release-branches.outputs.has-branches == 'true' && github.repository == 'valkey-io/valkey'
     permissions:
-      actions: read
+      actions: write
       contents: read
       pull-requests: read
     strategy:


### PR DESCRIPTION
The weekly workflow has been broken since May 10: https://github.com/valkey-io/valkey/actions/runs/25622304450

#3358 added a `consolidate-test-failures` job to `daily.yml` that needs `actions: write` to delete per-job artifacts. `weekly.yml` calls `daily.yml` as a reusable workflow but only grants `actions: read`

Verified on my fork: https://github.com/sarthakaggarwal97/valkey/actions/runs/25760458519 `determine-release-branches` ran, the nested `daily.yml` matrix expanded, and the child jobs were started. Cancelled after that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable enhanced automation capabilities during release operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey/pull/3684)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->