### PR TITLE
Add check to disallow `CLUSTER SETSLOT` to target self

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -7660,6 +7660,10 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
             addReplyErrorFormat(c, "I don't know about node %s", (char *)objectGetVal(c->argv[4]));
             return 0;
         }
+        if (n == myself) {
+            addReplyError(c, "Target node is myself");
+            return 0;
+        }
         if (nodeIsReplica(n)) {
             addReplyError(c, "Target node is not a master");
             return 0;
@@ -7674,6 +7678,10 @@ int clusterParseSetSlotCommand(client *c, int *slot_out, clusterNode **node_out,
         n = clusterLookupNode(objectGetVal(c->argv[4]), sdslen(objectGetVal(c->argv[4])));
         if (n == NULL) {
             addReplyErrorFormat(c, "I don't know about node %s", (char *)objectGetVal(c->argv[4]));
+            return 0;
+        }
+        if (n == myself) {
+            addReplyError(c, "Target node is myself");
             return 0;
         }
         if (nodeIsReplica(n)) {

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -419,6 +419,16 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
         catch {R 0 CLUSTER SETSLOT 609 TIMEOUT 100 MIGRATING $R1_id} e
         assert_equal $e "ERR Invalid CLUSTER SETSLOT action or number of arguments. Try CLUSTER HELP"
     }
+
+    test "CLUSTER SETSLOT MIGRATING/IMPORTING should not be allowed to target self" {
+        set R0_id [R 0 CLUSTER MYID]
+        set slot 1
+
+        set result [catch {assert_error [R 0 CLUSTER SETSLOT $slot MIGRATING $R0_id]} err]
+        assert_match "ERR Target node is myself" $err
+        set result [catch {assert_error [R 1 CLUSTER SETSLOT $slot IMPORTING $R1_id]} err]
+        assert_match "ERR Target node is myself" $err
+    }
 }
 
 start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica-migration no cluster-node-timeout 1000} } {
@@ -657,17 +667,4 @@ start_cluster 3 3 {tags {external:skip cluster} } {
 
     }
 
-}
-
-start_cluster 3 0 {tags {external:skip cluster} } {
-    test "CLUSTER SETSLOT MIGRATING/IMPORTING should not be allowed to target self" {
-        set R0_id [R 0 CLUSTER MYID]
-        set R1_id [R 1 CLUSTER MYID]
-        set slot 1
-
-        set result [catch {assert_error [R 0 CLUSTER SETSLOT $slot MIGRATING $R0_id]} err]
-        assert_match "ERR Target node is myself" $err
-        set result [catch {assert_error [R 1 CLUSTER SETSLOT $slot IMPORTING $R1_id]} err]
-        assert_match "ERR Target node is myself" $err
-    }
 }

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -658,3 +658,16 @@ start_cluster 3 3 {tags {external:skip cluster} } {
     }
 
 }
+
+start_cluster 3 0 {tags {external:skip cluster} } {
+    test "CLUSTER SETSLOT MIGRATING/IMPORTING should not be allowed to target self" {
+        set R0_id [R 0 CLUSTER MYID]
+        set R1_id [R 1 CLUSTER MYID]
+        set slot 1
+
+        set result [catch {assert_error [R 0 CLUSTER SETSLOT $slot MIGRATING $R0_id]} err]
+        assert_match "ERR Target node is myself" $err
+        set result [catch {assert_error [R 1 CLUSTER SETSLOT $slot IMPORTING $R1_id]} err]
+        assert_match "ERR Target node is myself" $err
+    }
+}

--- a/tests/unit/cluster/slot-migration.tcl
+++ b/tests/unit/cluster/slot-migration.tcl
@@ -421,13 +421,8 @@ start_cluster 3 3 {tags {external:skip cluster} overrides {cluster-allow-replica
     }
 
     test "CLUSTER SETSLOT MIGRATING/IMPORTING should not be allowed to target self" {
-        set R0_id [R 0 CLUSTER MYID]
-        set slot 1
-
-        set result [catch {assert_error [R 0 CLUSTER SETSLOT $slot MIGRATING $R0_id]} err]
-        assert_match "ERR Target node is myself" $err
-        set result [catch {assert_error [R 1 CLUSTER SETSLOT $slot IMPORTING $R1_id]} err]
-        assert_match "ERR Target node is myself" $err
+        assert_error {ERR Target node is myself} {R 0 CLUSTER SETSLOT 609 MIGRATING [R 0 CLUSTER MYID]}
+        assert_error {ERR Target node is myself} {R 1 CLUSTER SETSLOT 609 IMPORTING [R 1 CLUSTER MYID]}
     }
 }
 


### PR DESCRIPTION
Currently, the `CLUSTER SETSLOT MIGRATING/IMPORTING` commands only check the ownership of the slot. So if the user mistyped node IDs while writing these commands, it will be pretty confusing to debug, since the `valkey-cli --cluster check` command will still report the correct status.

This PR adds a simple check to verify if the node ID in the command points to itself, reducing confusion when doing manual hash slot migration