### PR TITLE
Fix crash in connectWithPrimary when primary_host is NULL with TLS

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -4335,6 +4335,10 @@ void syncWithPrimary(connection *conn) {
 }
 
 int connectWithPrimary(void) {
+    if (server.primary_host == NULL) {
+        serverLog(LL_WARNING, "Unable to connect to PRIMARY: primary_host is NULL");
+        return C_ERR;
+    }
     server.repl_transfer_s = connCreate(connTypeOfReplication());
     if (connConnect(server.repl_transfer_s, server.primary_host, server.primary_port, server.bind_source_addr,
                     server.repl_mptcp, syncWithPrimary) == C_ERR) {
@@ -5268,8 +5272,12 @@ void replicationCron(void) {
 
     /* Check if we should connect to a PRIMARY */
     if (server.repl_state == REPL_STATE_CONNECT) {
-        serverLog(LL_NOTICE, "Connecting to PRIMARY %s:%d", server.primary_host, server.primary_port);
-        connectWithPrimary();
+        if (server.primary_host) {
+            serverLog(LL_NOTICE, "Connecting to PRIMARY %s:%d", server.primary_host, server.primary_port);
+            connectWithPrimary();
+        } else {
+            server.repl_state = REPL_STATE_NONE;
+        }
     }
 
     /* Send ACK to primary from time to time.

--- a/src/tls.c
+++ b/src/tls.c
@@ -1603,6 +1603,7 @@ static int connTLSConnect(connection *conn_,
     unsigned char addr_buf[sizeof(struct in6_addr)];
 
     if (conn->c.state != CONN_STATE_NONE) return C_ERR;
+    if (addr == NULL) return C_ERR;
     ERR_clear_error();
 
     /* Check whether addr is an IP address, if not, use the value for Server Name Indication */

--- a/tests/unit/wait.tcl
+++ b/tests/unit/wait.tcl
@@ -343,7 +343,7 @@ tags {"wait aof network external:skip"} {
                 set rd [valkey_deferring_client -1]
                 $rd incr foo
                 $rd read
-                $rd waitaof 0 1 0
+                $rd waitaof 0 1 10000
                 wait_for_blocked_client -1
                 $replica replicaof $master_host $master_port
                 assert_equal [$rd read] {1 1}


### PR DESCRIPTION
## Summary

This fix addresses a SIGSEGV crash in `connectWithPrimary()` that occurs when TLS and IO threads are both enabled. The crash was identified while triaging the recurring `test-ubuntu-tls-io-threads` daily CI failure in `tests/unit/wait.tcl` (test: "WAITAOF master without backlog, wait is released when the replica finishes full-sync").

## Root Cause

When a replica executes `REPLICAOF NO ONE`, `replicationUnsetPrimary()` performs the following sequence:

1. Sets `server.primary_host = NULL`
2. Calls `freeClient(server.primary)`

The `freeClient` call chains through `replicationCachePrimary()` which calls `replicationHandlePrimaryDisconnection()`. This function unconditionally sets `server.repl_state = REPL_STATE_CONNECT`, creating a window where `repl_state == REPL_STATE_CONNECT` while `primary_host == NULL`.

With TLS and IO threads enabled, `replicationCron` can observe this transient inconsistent state and call `connectWithPrimary()`, which passes `NULL` to `connTLSConnect()`. Inside `connTLSConnect`, `inet_pton(AF_INET, NULL, ...)` dereferences the NULL pointer, causing the SIGSEGV.

CI crash evidence (from daily run on 2026-05-10):
```
10981:M * Connecting to PRIMARY (null):28117
10981:M # valkey 255.255.255 crashed by signal: 11, si_code: 1
10981:M # Accessing address: (nil)
```

Stack trace:
```
#3 connTLSConnect at src/tls.c:1609
#5 connectWithPrimary at src/replication.c:4339
#6 replicationCron at src/replication.c:5278
```

## Reproduction

Reproduced locally using fault injection that simulates the race condition. After establishing TLS replication between master and replica, `REPLICAOF NO ONE` triggers the injected call to `connectWithPrimary()` with `primary_host == NULL`:

- Without fix: server crashes with signal 11, accessing address 0x0
- With fix: server logs "Unable to connect to PRIMARY: primary_host is NULL" and continues operating normally

## Fix

1. `src/replication.c` - `connectWithPrimary()`: Return `C_ERR` early if `server.primary_host` is NULL.
2. `src/replication.c` - `replicationCron`: Check `server.primary_host` before calling `connectWithPrimary()`. If NULL, reset `repl_state` to `REPL_STATE_NONE` to recover from the inconsistent state.
3. `src/tls.c` - `connTLSConnect()`: Return `C_ERR` if `addr` is NULL (defense in depth).
4. `tests/unit/wait.tcl`: Change `waitaof 0 1 0` (infinite timeout) to `waitaof 0 1 10000` (10 second timeout) to prevent the test from hanging indefinitely when the replica cannot complete sync.

## Testing

- Full `unit/wait` test suite passes (40/40) with IO threads enabled, run 3 consecutive times
- Crash reproduction confirmed with fault injection over TLS (SIGSEGV without fix, graceful handling with fix)