### PR TITLE
More cluster refactoring: move common logic from cluster_legacy.c

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -155,8 +155,61 @@ void clusterBeforeSleep(void) {
     }
     clusterCurrentBus->beforeSleep();
 }
+static void clusterAutoFailoverOnShutdown(void) {
+    if (!nodeIsPrimary(myself)) return;
+
+    /* Find the best replica, that is, the replica with the largest offset. */
+    int legacy_replica = 0;
+    client *best_replica = NULL;
+    listIter replicas_iter;
+    listNode *replicas_list_node;
+    listRewind(server.replicas, &replicas_iter);
+    while ((replicas_list_node = listNext(&replicas_iter)) != NULL) {
+        client *replica = listNodeValue(replicas_list_node);
+        if (replica->repl_data->replica_version < 0x90000) {
+            legacy_replica = 1;
+            best_replica = NULL;
+            break;
+        }
+        if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE &&
+            replica->repl_data->repl_ack_off == server.primary_repl_offset &&
+            replica->repl_data->replica_nodeid && sdslen(replica->repl_data->replica_nodeid) == CLUSTER_NAMELEN) {
+            best_replica = replica;
+        }
+    }
+
+    if (best_replica == NULL) {
+        if (legacy_replica) {
+            serverLog(LL_NOTICE, "Unable to perform auto failover on shutdown since there are legacy replicas.");
+        } else {
+            serverLog(LL_NOTICE, "Unable to find a replica to perform the auto failover on shutdown.");
+        }
+        return;
+    }
+
+    char buf[128];
+    size_t buflen = snprintf(buf, sizeof(buf),
+                             "*5\r\n$7\r\nCLUSTER\r\n"
+                             "$8\r\nFAILOVER\r\n"
+                             "$5\r\nFORCE\r\n"
+                             "$9\r\nREPLICAID\r\n"
+                             "$%d\r\n%.*s\r\n",
+                             CLUSTER_NAMELEN,
+                             CLUSTER_NAMELEN,
+                             best_replica->repl_data->replica_nodeid);
+    serverAssert(buflen <= 128);
+    prepareReplicasToWrite();
+    feedReplicationBuffer(buf, buflen);
+    serverLog(LL_NOTICE, "Perform auto failover to replica %s on shutdown.", best_replica->repl_data->replica_nodeid);
+}
+
+void clusterPrepareShutdown(void) {
+    if (clusterCurrentBus->prepareShutdown) clusterCurrentBus->prepareShutdown();
+}
+
 void clusterHandleServerShutdown(bool auto_failover) {
-    clusterCurrentBus->handleServerShutdown(auto_failover);
+    if (auto_failover) clusterAutoFailoverOnShutdown();
+    clusterCurrentBus->handleServerShutdown();
 }
 static void clusterNotifyMyselfUpdated(int old_flags);
 
@@ -256,13 +309,14 @@ int clusterAllowFailoverCmd(client *c) {
     return 0;
 }
 unsigned long getClusterConnectionsCount(void) {
-    return clusterCurrentBus->getConnectionsCount();
+    return server.cluster_enabled ? ((dictSize(server.cluster->nodes) - 1) * 2) : 0;
 }
 /* Resets transient cluster stats that we expose via INFO or other means that we want
  * to reset via CONFIG RESETSTAT. The function is also used in order to
  * initialize these fields in clusterInit() at server startup. */
 void resetClusterStats(void) {
     if (!server.cluster_enabled) return;
+    clusterSlotStatResetAll();
     server.cluster->stat_cluster_links_buffer_limit_exceeded = 0;
     clusterCurrentBus->resetStats();
 }
@@ -333,6 +387,25 @@ void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required) {
     /* Perform needed slot migration state transitions */
     clusterUpdateSlotExportsOnOwnershipChange();
     clusterUpdateSlotImportsOnOwnershipChange();
+}
+
+/* Called by cluster internals when a node has lost its last slot. Triggers
+ * replica migration. */
+void clusterHandleLostLastSlot(clusterNode *target) {
+    clusterNode *my_primary = clusterNodeGetPrimary(myself);
+    serverAssert(my_primary->numslots == 0 && target != my_primary);
+    if (server.cluster_allow_replica_migration) {
+        serverLog(LL_NOTICE,
+                  "Lost my last slot during slot migration. "
+                  "Reconfiguring myself as a replica of %.40s (%s) in shard %.40s",
+                  target->name, humanNodename(target), target->shard_id);
+        clusterCurrentBus->setReplicaOf(target, NULL, NULL);
+    } else if (nodeIsPrimary(myself)) {
+        serverLog(LL_NOTICE,
+                  "My last slot was migrated to node %.40s (%s) "
+                  "in shard %.40s. I am now an empty primary.",
+                  target->name, humanNodename(target), target->shard_id);
+    }
 }
 
 /* -----------------------------------------------------------------------------
@@ -1227,37 +1300,9 @@ static void clusterSetSlotNodeCallback(void *ctx, const char *error) {
     if (!c) return;
     if (error) {
         addReplyError(c, error);
-        unblockClientAsync(c);
-        return;
+    } else {
+        addReply(c, shared.ok);
     }
-
-    /* If this shard lost its last slot, reconfigure as a replica of the
-     * new owner. This is a local decision, not a cluster-wide change. */
-    clusterNode *myself = getMyClusterNode();
-    clusterNode *my_primary = clusterNodeGetPrimary(myself);
-    if (my_primary->numslots == 0) {
-        /* Find who got our slots — look at argv for the target node. */
-        clusterNode *target = clusterLookupNode(objectGetVal(c->argv[4]),
-                                                sdslen(objectGetVal(c->argv[4])));
-        if (target && target != my_primary) {
-            if (server.cluster_allow_replica_migration) {
-                serverLog(LL_NOTICE,
-                          "Lost my last slot during slot migration. Reconfiguring myself "
-                          "as a replica of %.40s (%s) in shard %.40s",
-                          target->name, humanNodename(target), target->shard_id);
-                if (nodeIsReplica(myself)) protectClient(c);
-                clusterSetPrimary(target, 1, 1);
-                if (nodeIsReplica(myself)) unprotectClient(c);
-            } else if (nodeIsPrimary(myself)) {
-                serverLog(LL_NOTICE,
-                          "My last slot was migrated to node %.40s (%s) in shard %.40s. "
-                          "I am now an empty primary.",
-                          target->name, humanNodename(target), target->shard_id);
-            }
-        }
-    }
-
-    addReply(c, shared.ok);
     unblockClientAsync(c);
 }
 
@@ -1515,8 +1560,13 @@ void clusterCommandSetSlot(client *c) {
         }
 
         slotRange range = {slot, slot};
-        void *h = blockClientAsync(c);
-        clusterSlotChange(&range, 1, n, h, clusterSetSlotNodeCallback);
+        if (c == server.primary) {
+            /* Replicated CLUSTER SETSLOT. Don't block and don't send a reply. */
+            clusterSlotChange(&range, 1, n, NULL, NULL);
+        } else {
+            void *h = blockClientAsync(c);
+            clusterSlotChange(&range, 1, n, h, clusterSetSlotNodeCallback);
+        }
         return;
     }
 
@@ -1926,8 +1976,13 @@ void clusterCommand(client *c) {
             serverLog(LL_NOTICE, "Manual failover user request accepted (user request from '%s').", cl);
         }
         sdsfree(cl);
-        void *h = blockClientAsync(c);
-        clusterCurrentBus->failover(force, takeover, h, clusterCommandFailoverCompletion);
+        if (c == server.primary) {
+            /* CLUSTER FAILOVER send by the primary over the replication stream. */
+            clusterCurrentBus->failover(force, takeover, NULL, NULL);
+        } else {
+            void *h = blockClientAsync(c);
+            clusterCurrentBus->failover(force, takeover, h, clusterCommandFailoverCompletion);
+        }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "replicate") &&
                (c->argc == 3 || c->argc == 4)) {
         /* CLUSTER REPLICATE (<NODE ID> | NO ONE) */
@@ -3037,10 +3092,6 @@ void clusterscanCommand(client *c) {
 /* -----------------------------------------------------------------------------
  * Cluster state evaluation
  * -------------------------------------------------------------------------- */
-
-#define CLUSTER_MAX_REJOIN_DELAY 5000
-#define CLUSTER_MIN_REJOIN_DELAY 500
-#define CLUSTER_WRITABLE_DELAY 2000
 
 void clusterLogFailReason(int reason) {
     if (reason == CLUSTER_FAIL_NONE) return;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -55,6 +55,7 @@ extern clusterBusType clusterLegacyBus;
 clusterBusType *clusterCurrentBus = &clusterLegacyBus;
 
 static void clusterCommandFlushslot(client *c);
+static void clusterCheckReplicaMigration(void);
 
 /* -----------------------------------------------------------------------------
  * Cluster bus dispatchers
@@ -147,6 +148,7 @@ void clusterInitLast(void) {
 void clusterCron(void) {
     clusterSlotMigrationCron();
     clusterCurrentBus->cron();
+    clusterCheckReplicaMigration();
 }
 void clusterBeforeSleep(void) {
     if (server.cluster->before_sleep_handle_slot_migration) {
@@ -406,6 +408,139 @@ void clusterHandleLostLastSlot(clusterNode *target) {
                   "in shard %.40s. I am now an empty primary.",
                   target->name, humanNodename(target), target->shard_id);
     }
+}
+
+/* -----------------------------------------------------------------------------
+ * CLUSTER replica migration
+ *
+ * Replica migration is the process that allows a replica of a primary that is
+ * already covered by at least another replica, to "migrate" to a primary that
+ * is orphaned, that is, left with no working replicas.
+ * -------------------------------------------------------------------------- */
+
+#define CLUSTER_REPLICA_MIGRATION_DELAY 5000 /* Delay for replica migration. */
+
+/* This function is responsible to decide if this replica should be migrated
+ * to a different (orphaned) primary. It is called by the clusterCron() function
+ * only if:
+ *
+ * 1) We are a replica node.
+ * 2) It was detected that there is at least one orphaned primary in
+ *    the cluster.
+ * 3) We are a replica of one of the primaries with the greatest number of
+ *    replicas.
+ *
+ * This checks are performed by the caller since it requires to iterate
+ * the nodes anyway, so we spend time into clusterHandleReplicaMigration()
+ * if definitely needed.
+ *
+ * The function is called with a pre-computed max_replicas, that is the max
+ * number of working (not in FAIL state) replicas for a single primary.
+ *
+ * Additional conditions for migration are examined inside the function.
+ */
+static void clusterHandleReplicaMigration(int max_replicas) {
+    int j, ok_replicas = 0;
+    clusterNode *my_primary = myself->replicaof, *target = NULL, *candidate = NULL;
+    dictIterator *di;
+    dictEntry *de;
+
+    /* Step 1: Don't migrate if the cluster state is not ok. */
+    if (server.cluster->state != CLUSTER_OK) return;
+
+    /* Step 2: Don't migrate if my primary will not be left with at least
+     *         'migration-barrier' replicas after my migration. */
+    if (my_primary == NULL) return;
+    for (j = 0; j < my_primary->num_replicas; j++)
+        if (!nodeFailed(my_primary->replicas[j]) && !nodeTimedOut(my_primary->replicas[j])) ok_replicas++;
+    if (ok_replicas <= server.cluster_migration_barrier) return;
+
+    /* Step 3: Identify a candidate for migration, and check if among the
+     * primaries with the greatest number of ok replicas, I'm the one with the
+     * smallest node ID (the "candidate replica").
+     *
+     * Note: this means that eventually a replica migration will occur
+     * since replicas that are reachable again always have their FAIL flag
+     * cleared, so eventually there must be a candidate.
+     * There is a possible race condition causing multiple
+     * replicas to migrate at the same time, but this is unlikely to
+     * happen and relatively harmless when it does. */
+    candidate = myself;
+    di = dictGetSafeIterator(server.cluster->nodes);
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        int ok_replicas = 0, is_orphaned = 1;
+
+        /* We want to migrate only if this primary is working, orphaned, and
+         * used to have replicas or if failed over a primary that had replicas
+         * (MIGRATE_TO flag). This way we only migrate to instances that were
+         * supposed to have replicas. */
+        if (nodeIsReplica(node) || nodeFailed(node)) is_orphaned = 0;
+        if (!(node->flags & CLUSTER_NODE_MIGRATE_TO)) is_orphaned = 0;
+
+        /* Check number of working replicas. */
+        if (clusterNodeIsPrimary(node)) ok_replicas = clusterCountNonFailingReplicas(node);
+        if (ok_replicas > 0) is_orphaned = 0;
+
+        if (is_orphaned) {
+            if (!target && node->numslots > 0) target = node;
+
+            /* Track the starting time of the orphaned condition for this
+             * primary. */
+            if (!node->orphaned_time) node->orphaned_time = mstime();
+        } else {
+            node->orphaned_time = 0;
+        }
+
+        /* Check if I'm the replica candidate for the migration: attached
+         * to a primary with the maximum number of replicas and with the smallest
+         * node ID. */
+        if (ok_replicas == max_replicas) {
+            for (j = 0; j < node->num_replicas; j++) {
+                if (memcmp(node->replicas[j]->name, candidate->name, CLUSTER_NAMELEN) < 0) {
+                    candidate = node->replicas[j];
+                }
+            }
+        }
+    }
+    dictReleaseIterator(di);
+
+    /* Step 4: perform the migration if there is a target, and if I'm the
+     * candidate, but only if the primary is continuously orphaned for a
+     * couple of seconds, so that during failovers, we give some time to
+     * the natural replicas of this instance to advertise their switch from
+     * the old primary to the new one. */
+    if (target && candidate == myself && (mstime() - target->orphaned_time) > CLUSTER_REPLICA_MIGRATION_DELAY &&
+        !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) {
+        serverLog(LL_NOTICE, "Migrating to orphaned primary %.40s (%s) in shard %.40s", target->name,
+                  humanNodename(target), target->shard_id);
+        clusterCurrentBus->setReplicaOf(target, NULL, NULL);
+    }
+}
+
+/* Called periodically to check if this replica should migrate to an orphaned
+ * primary. Computes orphaned-primary stats and calls clusterHandleReplicaMigration
+ * if conditions are met. */
+static void clusterCheckReplicaMigration(void) {
+    if (!nodeIsReplica(myself) || !server.cluster_allow_replica_migration) return;
+
+    int orphaned_primaries = 0, max_replicas = 0, this_replicas = 0;
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) continue;
+        if (clusterNodeIsPrimary(node) && !nodeFailed(node)) {
+            int ok_replicas = clusterCountNonFailingReplicas(node);
+            if (ok_replicas == 0 && node->numslots > 0 && node->flags & CLUSTER_NODE_MIGRATE_TO)
+                orphaned_primaries++;
+            if (ok_replicas > max_replicas) max_replicas = ok_replicas;
+            if (myself->replicaof == node) this_replicas = ok_replicas;
+        }
+    }
+    dictReleaseIterator(di);
+    if (orphaned_primaries && max_replicas >= 2 && this_replicas == max_replicas)
+        clusterHandleReplicaMigration(max_replicas);
 }
 
 /* -----------------------------------------------------------------------------
@@ -1279,10 +1414,17 @@ void clusterKeySlotCommand(client *c) {
     addReplyLongLong(c, keyHashSlot(key, sdslen(key)));
 }
 
-/* Callback for CLUSTER ADDSLOTS/DELSLOTS/ADDSLOTSRANGE/DELSLOTSRANGE.
- * Called after the slot change is applied. This may be called inline
- * or asynchronously if the change goes through cluster consensus. */
-static void clusterAddDelSlotsCallback(void *ctx, const char *error) {
+/* Completion callback for async-capable cluster admin subcommands: ADDSLOTS,
+ * DELSLOTS, ADDSLOTSRANGE, DELSLOTSRANGE, SETSLOT NODE, MEET, FORGET,
+ * REPLICATE, FAILOVER.
+ *
+ * Called after the change is fully applied. This may be called inline or
+ * asynchronously if the change goes through cluster consensus.
+ *
+ * The ctx is the blocked client handle. If the client is still connected when
+ * the callback fires, an error reply is sent if error is non-NULL and an OK
+ * reply is sent otherwise. */
+static void clusterCommandCompletion(void *ctx, const char *error) {
     client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
     if (!c) return;
     if (error) {
@@ -1293,16 +1435,20 @@ static void clusterAddDelSlotsCallback(void *ctx, const char *error) {
     unblockClientAsync(c);
 }
 
-/* Callback for CLUSTER SETSLOT NODE after the slot change is applied.
- * Handles replica migration if this shard lost its last slot. */
-static void clusterSetSlotNodeCallback(void *ctx, const char *error) {
+/* Completion callback for CLUSTER REPLICATE NO ONE. Ctx is blocked client handle. */
+static void clusterCommandPromoteCompletion(void *ctx, const char *error) {
     client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
     if (!c) return;
     if (error) {
         addReplyError(c, error);
-    } else {
-        addReply(c, shared.ok);
+        unblockClientAsync(c);
+        return;
     }
+    flushAllDataAndResetRDB(server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
+    verifyClusterConfigWithData();
+    clusterCloseAllSlots();
+    clusterCancelManualFailover();
+    addReply(c, shared.ok);
     unblockClientAsync(c);
 }
 
@@ -1565,77 +1711,12 @@ void clusterCommandSetSlot(client *c) {
             clusterSlotChange(&range, 1, n, NULL, NULL);
         } else {
             void *h = blockClientAsync(c);
-            clusterSlotChange(&range, 1, n, h, clusterSetSlotNodeCallback);
+            clusterSlotChange(&range, 1, n, h, clusterCommandCompletion);
         }
         return;
     }
 
     addReply(c, shared.ok);
-}
-
-
-/* Completion callbacks for async-capable cluster commands. The ctx is the
- * client. On error, an error reply is sent. On success, the command-specific
- * post-action work is done and an OK reply is sent. */
-
-static void clusterCommandMeetCompletion(void *ctx, const char *error) {
-    client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
-    if (!c) return;
-    if (error) {
-        addReplyError(c, error);
-    } else {
-        addReply(c, shared.ok);
-    }
-    unblockClientAsync(c);
-}
-
-static void clusterCommandForgetCompletion(void *ctx, const char *error) {
-    client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
-    if (!c) return;
-    if (error) {
-        addReplyError(c, error);
-    } else {
-        addReply(c, shared.ok);
-    }
-    unblockClientAsync(c);
-}
-
-static void clusterCommandReplicateCompletion(void *ctx, const char *error) {
-    client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
-    if (!c) return;
-    if (error) {
-        addReplyError(c, error);
-    } else {
-        addReply(c, shared.ok);
-    }
-    unblockClientAsync(c);
-}
-
-static void clusterCommandPromoteCompletion(void *ctx, const char *error) {
-    client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
-    if (!c) return;
-    if (error) {
-        addReplyError(c, error);
-        unblockClientAsync(c);
-        return;
-    }
-    flushAllDataAndResetRDB(server.repl_replica_lazy_flush ? EMPTYDB_ASYNC : EMPTYDB_NO_FLAGS);
-    verifyClusterConfigWithData();
-    clusterCloseAllSlots();
-    clusterCancelManualFailover();
-    addReply(c, shared.ok);
-    unblockClientAsync(c);
-}
-
-static void clusterCommandFailoverCompletion(void *ctx, const char *error) {
-    client *c = consumeBlockedClientAsyncHandle((blockedAsyncHandle *)ctx);
-    if (!c) return;
-    if (error) {
-        addReplyError(c, error);
-    } else {
-        addReply(c, shared.ok);
-    }
-    unblockClientAsync(c);
 }
 
 void clusterCommand(client *c) {
@@ -1755,7 +1836,7 @@ void clusterCommand(client *c) {
         void *h = blockClientAsync(c);
         clusterSlotChange(ranges, numslots,
                           del ? NULL : getMyClusterNode(),
-                          h, clusterAddDelSlotsCallback);
+                          h, clusterCommandCompletion);
         zfree(ranges);
     } else if ((!strcasecmp(objectGetVal(c->argv[1]), "addslotsrange") || !strcasecmp(objectGetVal(c->argv[1]), "delslotsrange")) &&
                c->argc >= 4) {
@@ -1802,7 +1883,7 @@ void clusterCommand(client *c) {
         void *h = blockClientAsync(c);
         clusterSlotChange(ranges, numranges,
                           del ? NULL : getMyClusterNode(),
-                          h, clusterAddDelSlotsCallback);
+                          h, clusterCommandCompletion);
         zfree(ranges);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "flushslots") && c->argc == 2) {
         /* CLUSTER FLUSHSLOTS */
@@ -1832,7 +1913,7 @@ void clusterCommand(client *c) {
             if (in_range) numranges++;
             void *h = blockClientAsync(c);
             clusterSlotChange(ranges, numranges, NULL,
-                              h, clusterAddDelSlotsCallback);
+                              h, clusterCommandCompletion);
             zfree(ranges);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "setslot") && c->argc >= 4) {
@@ -1894,7 +1975,7 @@ void clusterCommand(client *c) {
                   (char *)objectGetVal(c->argv[2]), port, cl);
         sdsfree(cl);
         void *h = blockClientAsync(c);
-        clusterCurrentBus->meet(objectGetVal(c->argv[2]), port, cport, h, clusterCommandMeetCompletion);
+        clusterCurrentBus->meet(objectGetVal(c->argv[2]), port, cport, h, clusterCommandCompletion);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "reset") && (c->argc == 2 || c->argc == 3)) {
         /* CLUSTER RESET [SOFT|HARD] */
         int hard = 0;
@@ -1981,7 +2062,7 @@ void clusterCommand(client *c) {
             clusterCurrentBus->failover(force, takeover, NULL, NULL);
         } else {
             void *h = blockClientAsync(c);
-            clusterCurrentBus->failover(force, takeover, h, clusterCommandFailoverCompletion);
+            clusterCurrentBus->failover(force, takeover, h, clusterCommandCompletion);
         }
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "replicate") &&
                (c->argc == 3 || c->argc == 4)) {
@@ -2036,7 +2117,7 @@ void clusterCommand(client *c) {
             return;
         }
         void *h = blockClientAsync(c);
-        clusterCurrentBus->setReplicaOf(n, h, clusterCommandReplicateCompletion);
+        clusterCurrentBus->setReplicaOf(n, h, clusterCommandCompletion);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "forget") && c->argc == 3) {
         /* CLUSTER FORGET <NODE ID> */
         const char *node_id = objectGetVal(c->argv[2]);
@@ -2059,7 +2140,7 @@ void clusterCommand(client *c) {
             sdsfree(cl);
         }
         void *h = blockClientAsync(c);
-        clusterCurrentBus->forgetNode(node_id, id_len, h, clusterCommandForgetCompletion);
+        clusterCurrentBus->forgetNode(node_id, id_len, h, clusterCommandCompletion);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "count-failure-reports") && c->argc == 3) {
         /* CLUSTER COUNT-FAILURE-REPORTS <NODE ID> */
         clusterNode *n = clusterLookupNode(objectGetVal(c->argv[2]),

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -56,6 +56,7 @@ void clusterInitLast(void);
 void clusterCron(void);
 void clusterBeforeSleep(void);
 int verifyClusterConfigWithData(void);
+void clusterPrepareShutdown(void);
 void clusterHandleServerShutdown(bool auto_failover);
 
 int clusterSendModuleMessageToTarget(const char *target,
@@ -156,6 +157,7 @@ int clusterDecodeOpenSlotsAuxField(int rdbflags, sds s);
 void clusterSlotChange(slotRange *ranges, int numranges, clusterNode *target, void *ctx, void (*callback)(void *ctx, const char *error));
 void clusterCancelManualFailover(void);
 void clusterSetPrimary(clusterNode *n, int closeSlots, int full_sync_required);
+void clusterHandleLostLastSlot(clusterNode *target);
 void clusterScheduleHandleSlotMigration(void);
 mstime_t clusterComputeMfPauseEnd(void);
 

--- a/src/cluster_bus.h
+++ b/src/cluster_bus.h
@@ -21,7 +21,8 @@ typedef struct clusterBusType {
     void (*initLast)(void);
     void (*cron)(void);
     void (*beforeSleep)(void);
-    void (*handleServerShutdown)(bool auto_failover);
+    void (*prepareShutdown)(void); /* Called early in shutdown to allow graceful handoff. */
+    void (*handleServerShutdown)(void);
 
     /* Cluster link message handling — called from cluster_link.c */
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -55,8 +55,8 @@
 #define LEGACY_STATE() ((clusterLegacyState *)server.cluster->protocol_data)
 
 /* Legacy-specific defines. */
-#define CLUSTER_FAIL_REPORT_VALIDITY_MULT 2  /* Fail report validity. */
-#define CLUSTER_FAIL_UNDO_TIME_MULT 2        /* Undo fail if primary is back. */
+#define CLUSTER_FAIL_REPORT_VALIDITY_MULT 2 /* Fail report validity. */
+#define CLUSTER_FAIL_UNDO_TIME_MULT 2       /* Undo fail if primary is back. */
 
 /* clusterState todo_before_sleep flags. */
 #define CLUSTER_TODO_HANDLE_FAILOVER (1 << 0)

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -677,73 +677,11 @@ static void clusterLegacyResetStats(void) {
     LEGACY_STATE()->stats_bus_module_bytes_received = 0;
 }
 
-
 static void clusterLegacyInitLast(void) {
     clusterListenerInit();
 }
 
-void clusterAutoFailoverOnShutdown(void) {
-    if (!nodeIsPrimary(myself)) return;
-
-    /* Find the first best replica, that is, the replica with the largest offset. */
-    int legacy_replica = 0;
-    client *best_replica = NULL;
-    listIter replicas_iter;
-    listNode *replicas_list_node;
-    listRewind(server.replicas, &replicas_iter);
-    while ((replicas_list_node = listNext(&replicas_iter)) != NULL) {
-        client *replica = listNodeValue(replicas_list_node);
-        /* This is done only when the replica offset is caught up, to avoid data loss.
-         * And 0x90000 is 9.0.0, we only support this feature in this version. */
-        if (replica->repl_data->replica_version < 0x90000) {
-            legacy_replica = 1;
-            best_replica = NULL;
-            break;
-        }
-        if (replica->repl_data->repl_state == REPLICA_STATE_ONLINE &&
-            replica->repl_data->repl_ack_off == server.primary_repl_offset &&
-            replica->repl_data->replica_nodeid && sdslen(replica->repl_data->replica_nodeid) == CLUSTER_NAMELEN) {
-            best_replica = replica;
-        }
-    }
-
-    /* We are not able to find the replica to do the auto failover. */
-    if (best_replica == NULL) {
-        if (legacy_replica) {
-            serverLog(LL_NOTICE, "Unable to perform auto failover on shutdown since there are legacy replicas.");
-        } else {
-            serverLog(LL_NOTICE, "Unable to find a replica to perform the auto failover on shutdown.");
-        }
-        return;
-    }
-
-    /* Send the CLUSTER FAILOVER FORCE REPLICAID node-id to all replicas since
-     * it is a shared replication buffer, but only the replica with the matching
-     * node-id will execute it. The caller will call flushReplicasOutputBuffers,
-     * so in here it is a best effort. */
-    char buf[128];
-    size_t buflen = snprintf(buf, sizeof(buf),
-                             "*5\r\n$7\r\nCLUSTER\r\n"
-                             "$8\r\nFAILOVER\r\n"
-                             "$5\r\nFORCE\r\n"
-                             "$9\r\nREPLICAID\r\n"
-                             "$%d\r\n%.*s\r\n",
-                             CLUSTER_NAMELEN,
-                             CLUSTER_NAMELEN,
-                             best_replica->repl_data->replica_nodeid);
-    serverAssert(buflen <= 128);
-    /* Must install write handler for all replicas first before feeding
-     * replication stream. */
-    prepareReplicasToWrite();
-    feedReplicationBuffer(buf, buflen);
-    serverLog(LL_NOTICE, "Perform auto failover to replica %s on shutdown.", best_replica->repl_data->replica_nodeid);
-}
-
-/* Called when a cluster node receives SHUTDOWN. */
-static void clusterLegacyHandleServerShutdown(bool auto_failover) {
-    /* Check if we are able to do the auto failover on shutdown. */
-    if (auto_failover) clusterAutoFailoverOnShutdown();
-
+static void clusterLegacyHandleServerShutdown(void) {
     /* The error logs have been logged in the save function if the save fails. */
     serverLog(LL_NOTICE, "Saving the cluster configuration file before exiting.");
     clusterSaveConfig(1);
@@ -4651,95 +4589,24 @@ static int nodeExceedsHandshakeTimeout(clusterNode *node, mstime_t now) {
     return now - node->ctime > getHandshakeTimeout() ? 1 : 0;
 }
 
-#define NODE_CONNECTION_RETRIES_PER_TIMEOUT 10
-
-/* Check if the node is disconnected and re-establish the connection.
- * Also update a few stats while we are here, that can be used to make
- * better decisions in other part of the code. */
-static int clusterNodeCronHandleReconnect(clusterNode *node, mstime_t now, long long *cluster_conn_attempts) {
-    /* Not interested in reconnecting the link with myself or nodes
-     * for which we have no address. */
-    if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) return 1;
+/* Gossip-specific per-node maintenance: count PFAIL nodes and send MEET
+ * to peers that have an outbound link but no inbound link. */
+static void clusterNodeCronGossipMaintenance(clusterNode *node, mstime_t now) {
+    if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) return;
 
     if (node->flags & CLUSTER_NODE_PFAIL) LEGACY_STATE()->stats_pfail_nodes++;
 
-    /* A Node in HANDSHAKE state has a limited lifespan equal to the
-     * configured node timeout. */
-    if (nodeInHandshake(node) && nodeExceedsHandshakeTimeout(node, now)) {
-        serverLog(LL_WARNING, "Clusterbus handshake timeout %s:%d", node->ip, node->cport);
-        clusterDelNode(node);
-        return 1;
-    }
+    /* If we have an outbound link but no inbound link for longer than the
+     * handshake timeout, the peer probably doesn't know us. Send MEET. */
     if (nodeInNormalState(node) && node->link != NULL && node->inbound_link == NULL &&
         now - node->inbound_link_freed_time > getHandshakeTimeout() &&
         now - LEGACY_DATA(node)->meet_sent > getHandshakeTimeout() &&
         nodeSupportsMultiMeet(node)) {
-        /* Node has an outbound link, but no inbound link for more than the handshake timeout.
-         * This probably means this node does not know us yet, whereas we know it.
-         * So we send it a MEET packet to do a handshake with it and correct the inconsistent cluster view.
-         * We make sure to not re-send a MEET packet more than once every handshake timeout period, so as to
-         * leave the other node time to complete the handshake. */
         node->flags |= CLUSTER_NODE_MEET;
         serverLog(LL_NOTICE, "Sending MEET packet to node %.40s (%s) because there is no inbound link for it",
                   node->name, humanNodename(node));
         clusterSendPing(node->link, CLUSTERMSG_TYPE_MEET);
     }
-
-    if (node->link == NULL) {
-        mstime_t reconnect_interval = server.cluster_node_timeout / 2;
-        /* Skip this outbound connection attempt when all these conditions are true:
-         *  1. No inbound link from the peer exists.
-         *  2. The back‑off window since the last try is still active
-         *  3. The node has already exceeded its retry budget for this cron cycle
-         */
-        if (!node->inbound_link && (now - node->outbound_link_attempt_time < reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT && *cluster_conn_attempts == 0)) {
-            return 1;
-        }
-        node->outbound_link_attempt_time = now;
-        (*cluster_conn_attempts)--;
-        clusterLink *link = createClusterLink(node);
-        link->conn = connCreate(connTypeOfCluster());
-        connSetPrivateData(link->conn, link);
-        if (connConnect(link->conn, node->ip, node->cport, server.bind_source_addr, 0, clusterLinkConnectHandler) ==
-            C_ERR) {
-            /* We got a synchronous error from connect before
-             * clusterSendPing() had a chance to be called.
-             * If LEGACY_DATA(node)->ping_sent is zero, failure detection can't work,
-             * so we claim we actually sent a ping now (that will
-             * be really sent as soon as the link is obtained). */
-            if (LEGACY_DATA(node)->ping_sent == 0) LEGACY_DATA(node)->ping_sent = mstime();
-            serverLog(LL_DEBUG,
-                      "Unable to connect to "
-                      "Cluster Node [%s]:%d -> %s",
-                      node->ip, node->cport, server.neterr);
-
-            freeClusterLink(link);
-            return 0;
-        }
-    }
-    return 0;
-}
-
-/* Free outbound link to a node if its send buffer size exceeded limit. */
-static void clusterNodeCronFreeLinkOnBufferLimitReached(clusterNode *node) {
-    freeClusterLinkOnBufferLimitReached(node->link);
-    freeClusterLinkOnBufferLimitReached(node->inbound_link);
-}
-
-/* Compute the maximum number of connection attempts the clusterLegacyCron
- * loop should schedule in a single cron.
- *
- * We want to guarantee that every node is contacted 10 times within node timeout. */
-static long long maxConnectionAttemptsPerCron(void) {
-    long long reconnect_interval = server.cluster_node_timeout / 2;
-    if (reconnect_interval <= 0)
-        return 0;
-    /* We run the cron loop every 100 ms.  To reach 100 % of the nodes
-     * within the timeout, we need: ceil(nodes * 100 / reconnect_interval) */
-    const long long min_nodes_for_coverage = dictSize(server.cluster->nodes) * CLUSTER_CRON_PERIOD_MS / reconnect_interval;
-    /* Increase the coverage budget so each node can be probed 10 times
-     * inside the timeout. */
-    return min_nodes_for_coverage * NODE_CONNECTION_RETRIES_PER_TIMEOUT;
 }
 
 /* This is executed 10 times every second */
@@ -4755,22 +4622,18 @@ static void clusterLegacyCron(void) {
     static unsigned long long iteration = 0;
     iteration++; /* Number of times this function was called so far. */
 
-    /* Clear so clusterNodeCronHandleReconnect can count the number of nodes in PFAIL. */
+    /* Clear pfail counter before iterating. */
     LEGACY_STATE()->stats_pfail_nodes = 0;
     /* Run through some of the operations we want to do on each cluster node. */
     di = dictGetSafeIterator(server.cluster->nodes);
-    long long cluster_node_conn_attempts = maxConnectionAttemptsPerCron();
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
-        /* We free the inbound or outbound link to the node if the link has an
-         * oversized message send queue and immediately try reconnecting. */
-        clusterNodeCronFreeLinkOnBufferLimitReached(node);
-        /* The protocol is that function(s) below return non-zero if the node was
-         * terminated.
-         */
-        if (!server.debug_cluster_disable_reconnection && clusterNodeCronHandleReconnect(node, now, &cluster_node_conn_attempts)) continue;
+        clusterNodeCronGossipMaintenance(node, now);
     }
     dictReleaseIterator(di);
+
+    /* Reconnect nodes with no outbound link (shared with raft). */
+    if (!server.debug_cluster_disable_reconnection) clusterConnectNodes();
 
     /* Ping some random node 1 time every 10 iterations, so that we usually ping
      * one random node every second. */
@@ -4990,6 +4853,8 @@ static void clusterLegacySlotChange(slotRange *ranges, int numranges, clusterNod
 
     if (claiming) clusterBumpConfigEpochWithoutConsensus();
 
+    clusterNode *my_primary = clusterNodeGetPrimary(myself);
+    int num_slots_before = my_primary->numslots;
     for (int i = 0; i < numranges; i++) {
         for (int j = ranges[i].start_slot; j <= ranges[i].end_slot; j++) {
             if (target) {
@@ -5004,6 +4869,14 @@ static void clusterLegacySlotChange(slotRange *ranges, int numranges, clusterNod
                 clusterDelSlot(j);
             }
         }
+    }
+    if (num_slots_before > 0 && my_primary->numslots == 0 && target) {
+        /* Lost the last slot. If this is a replicated SETSLOT command, protect
+         * the primary client so it doesn't get freed by the replica migration. */
+        int is_replicated = server.primary && (server.current_client == server.primary);
+        if (is_replicated) protectClient(server.primary);
+        clusterHandleLostLastSlot(target);
+        if (is_replicated) unprotectClient(server.primary);
     }
 
     if (claiming) {
@@ -5397,7 +5270,7 @@ static void clusterLegacySetReplicaOf(clusterNode *primary, void *ctx, void (*ca
     clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE |
                          CLUSTER_TODO_SAVE_CONFIG |
                          CLUSTER_TODO_BROADCAST_ALL);
-    callback(ctx, NULL);
+    if (callback) callback(ctx, NULL);
 }
 
 static void clusterLegacyForgetNode(const char *node_id, size_t id_len, void *ctx, void (*callback)(void *ctx, const char *error)) {
@@ -5467,7 +5340,7 @@ static void clusterLegacyFailover(int force, int takeover, void *ctx, void (*cal
     } else {
         clusterSendMFStart(myself->replicaof);
     }
-    callback(ctx, NULL);
+    if (callback) callback(ctx, NULL);
 }
 
 

--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -57,7 +57,6 @@
 /* Legacy-specific defines. */
 #define CLUSTER_FAIL_REPORT_VALIDITY_MULT 2  /* Fail report validity. */
 #define CLUSTER_FAIL_UNDO_TIME_MULT 2        /* Undo fail if primary is back. */
-#define CLUSTER_REPLICA_MIGRATION_DELAY 5000 /* Delay for replica migration. */
 
 /* clusterState todo_before_sleep flags. */
 #define CLUSTER_TODO_HANDLE_FAILOVER (1 << 0)
@@ -98,7 +97,6 @@ typedef struct clusterNodeLegacyData {
     mstime_t pong_received;                 /* Unix time we received the pong */
     mstime_t meet_sent;                     /* Unix time we sent latest meet packet */
     mstime_t fail_time;                     /* Unix time when FAIL flag was set */
-    mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
     rax *fail_reports;                      /* Radix tree for failure reports with sorted order by timestamp */
 } clusterNodeLegacyData;
 
@@ -438,7 +436,6 @@ void clusterSendFail(char *nodename);
 void clusterSendFailoverAuthIfNeeded(clusterNode *node, clusterMsg *request);
 void clusterMoveNodeSlots(clusterNode *from_node, clusterNode *to_node, int *slots, int *importing_slots, int *migrating_slots);
 void clusterHandleReplicaFailover(void);
-void clusterHandleReplicaMigration(int max_replicas);
 void clusterSendUpdate(clusterLink *link, clusterNode *node);
 static void clusterLegacyCancelManualFailover(void);
 void clusterSetNodeAsPrimary(clusterNode *n);
@@ -1029,7 +1026,6 @@ static void clusterLegacyInitNodeData(clusterNode *node) {
     legacy->pong_received = 0;
     legacy->meet_sent = 0;
     legacy->fail_time = 0;
-    legacy->orphaned_time = 0;
     legacy->fail_reports = raxNew();
 }
 
@@ -4361,115 +4357,6 @@ void clusterHandleReplicaFailover(void) {
 }
 
 /* -----------------------------------------------------------------------------
- * CLUSTER replica migration
- *
- * Replica migration is the process that allows a replica of a primary that is
- * already covered by at least another replica, to "migrate" to a primary that
- * is orphaned, that is, left with no working replicas.
- * ------------------------------------------------------------------------- */
-
-/* This function is responsible to decide if this replica should be migrated
- * to a different (orphaned) primary. It is called by the clusterLegacyCron() function
- * only if:
- *
- * 1) We are a replica node.
- * 2) It was detected that there is at least one orphaned primary in
- *    the cluster.
- * 3) We are a replica of one of the primaries with the greatest number of
- *    replicas.
- *
- * This checks are performed by the caller since it requires to iterate
- * the nodes anyway, so we spend time into clusterHandleReplicaMigration()
- * if definitely needed.
- *
- * The function is called with a pre-computed max_replicas, that is the max
- * number of working (not in FAIL state) replicas for a single primary.
- *
- * Additional conditions for migration are examined inside the function.
- */
-void clusterHandleReplicaMigration(int max_replicas) {
-    int j, ok_replicas = 0;
-    clusterNode *my_primary = myself->replicaof, *target = NULL, *candidate = NULL;
-    dictIterator *di;
-    dictEntry *de;
-
-    /* Step 1: Don't migrate if the cluster state is not ok. */
-    if (server.cluster->state != CLUSTER_OK) return;
-
-    /* Step 2: Don't migrate if my primary will not be left with at least
-     *         'migration-barrier' replicas after my migration. */
-    if (my_primary == NULL) return;
-    for (j = 0; j < my_primary->num_replicas; j++)
-        if (!nodeFailed(my_primary->replicas[j]) && !nodeTimedOut(my_primary->replicas[j])) ok_replicas++;
-    if (ok_replicas <= server.cluster_migration_barrier) return;
-
-    /* Step 3: Identify a candidate for migration, and check if among the
-     * primaries with the greatest number of ok replicas, I'm the one with the
-     * smallest node ID (the "candidate replica").
-     *
-     * Note: this means that eventually a replica migration will occur
-     * since replicas that are reachable again always have their FAIL flag
-     * cleared, so eventually there must be a candidate.
-     * There is a possible race condition causing multiple
-     * replicas to migrate at the same time, but this is unlikely to
-     * happen and relatively harmless when it does. */
-    candidate = myself;
-    di = dictGetSafeIterator(server.cluster->nodes);
-    while ((de = dictNext(di)) != NULL) {
-        clusterNode *node = dictGetVal(de);
-        int ok_replicas = 0, is_orphaned = 1;
-
-        /* We want to migrate only if this primary is working, orphaned, and
-         * used to have replicas or if failed over a primary that had replicas
-         * (MIGRATE_TO flag). This way we only migrate to instances that were
-         * supposed to have replicas. */
-        if (nodeIsReplica(node) || nodeFailed(node)) is_orphaned = 0;
-        if (!(node->flags & CLUSTER_NODE_MIGRATE_TO)) is_orphaned = 0;
-
-        /* Check number of working replicas. */
-        if (clusterNodeIsPrimary(node)) ok_replicas = clusterCountNonFailingReplicas(node);
-        if (ok_replicas > 0) is_orphaned = 0;
-
-        if (is_orphaned) {
-            if (!target && node->numslots > 0) target = node;
-
-            /* Track the starting time of the orphaned condition for this
-             * primary. */
-            if (!LEGACY_DATA(node)->orphaned_time) LEGACY_DATA(node)->orphaned_time = mstime();
-        } else {
-            LEGACY_DATA(node)->orphaned_time = 0;
-        }
-
-        /* Check if I'm the replica candidate for the migration: attached
-         * to a primary with the maximum number of replicas and with the smallest
-         * node ID. */
-        if (ok_replicas == max_replicas) {
-            for (j = 0; j < node->num_replicas; j++) {
-                if (memcmp(node->replicas[j]->name, candidate->name, CLUSTER_NAMELEN) < 0) {
-                    candidate = node->replicas[j];
-                }
-            }
-        }
-    }
-    dictReleaseIterator(di);
-
-    /* Step 4: perform the migration if there is a target, and if I'm the
-     * candidate, but only if the primary is continuously orphaned for a
-     * couple of seconds, so that during failovers, we give some time to
-     * the natural replicas of this instance to advertise their switch from
-     * the old primary to the new one. */
-    if (target && candidate == myself && (mstime() - LEGACY_DATA(target)->orphaned_time) > CLUSTER_REPLICA_MIGRATION_DELAY &&
-        !(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) {
-        serverLog(LL_NOTICE, "Migrating to orphaned primary %.40s (%s) in shard %.40s", target->name,
-                  humanNodename(target), target->shard_id);
-        /* We are migrating to a different shard that has a completely different
-         * replication history, so a full sync is required. */
-        clusterSetPrimary(target, 1, 1);
-        clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_FSYNC_CONFIG | CLUSTER_TODO_BROADCAST_ALL);
-    }
-}
-
-/* -----------------------------------------------------------------------------
  * CLUSTER manual failover
  *
  * This are the important steps performed by replicas during a manual failover:
@@ -4614,9 +4501,6 @@ static void clusterLegacyCron(void) {
     dictIterator *di;
     dictEntry *de;
     int update_state = 0;
-    int orphaned_primaries; /* How many primaries there are without ok replicas. */
-    int max_replicas;       /* Max number of ok replicas for a single primary. */
-    int this_replicas;      /* Number of ok replicas for our primary (if we are replica). */
     mstime_t min_pong = 0, now = mstime();
     clusterNode *min_pong_node = NULL;
     static unsigned long long iteration = 0;
@@ -4660,36 +4544,13 @@ static void clusterLegacyCron(void) {
         }
     }
 
-    /* Iterate nodes to check if we need to flag something as failing.
-     * This loop is also responsible to:
-     * 1) Check if there are orphaned primaries (primaries without non failing
-     *    replicas).
-     * 2) Count the max number of non failing replicas for a single primary.
-     * 3) Count the number of replicas for our primary, if we are a replica. */
-    orphaned_primaries = 0;
-    max_replicas = 0;
-    this_replicas = 0;
+    /* Iterate nodes to check if we need to flag something as failing. */
     di = dictGetSafeIterator(server.cluster->nodes);
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         now = mstime(); /* Use an updated time at every iteration. */
 
         if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR | CLUSTER_NODE_HANDSHAKE)) continue;
-
-        /* Orphaned primary check, useful only if the current instance
-         * is a replica that may migrate to another primary. */
-        if (nodeIsReplica(myself) && clusterNodeIsPrimary(node) && !nodeFailed(node)) {
-            int ok_replicas = clusterCountNonFailingReplicas(node);
-
-            /* A primary is orphaned if it is serving a non-zero number of
-             * slots, have no working replicas, but used to have at least one
-             * replica, or failed over a primary that used to have replicas. */
-            if (ok_replicas == 0 && node->numslots > 0 && node->flags & CLUSTER_NODE_MIGRATE_TO) {
-                orphaned_primaries++;
-            }
-            if (ok_replicas > max_replicas) max_replicas = ok_replicas;
-            if (myself->replicaof == node) this_replicas = ok_replicas;
-        }
 
         /* If we are not receiving any data for more than half the cluster
          * timeout, reconnect the link: maybe there is a connection
@@ -4768,14 +4629,6 @@ static void clusterLegacyCron(void) {
     if (nodeIsReplica(myself)) {
         clusterHandleManualFailover();
         if (!(server.cluster_module_flags & CLUSTER_MODULE_FLAG_NO_FAILOVER)) clusterHandleReplicaFailover();
-        /* If there are orphaned replicas, and we are a replica among the primaries
-         * with the max number of non-failing replicas, consider migrating to
-         * the orphaned primaries. Note that it does not make sense to try
-         * a migration if there is no primary with at least *two* working
-         * replicas. */
-        if (orphaned_primaries && max_replicas >= 2 && this_replicas == max_replicas &&
-            server.cluster_allow_replica_migration)
-            clusterHandleReplicaMigration(max_replicas);
     }
 
     if (update_state || server.cluster->state == CLUSTER_FAIL) clusterUpdateState();

--- a/src/cluster_link.c
+++ b/src/cluster_link.c
@@ -409,12 +409,22 @@ void clusterConnectNodes(void) {
     mstime_t reconnect_interval = server.cluster_node_timeout / 2;
     if (reconnect_interval <= 0) reconnect_interval = 1;
 
+    /* Budget: try to contact every node NODE_CONNECTION_RETRIES_PER_TIMEOUT
+     * times within node_timeout. Each cron tick gets a proportional share. */
+    long long budget = (long long)dictSize(server.cluster->nodes) *
+                       CLUSTER_CRON_PERIOD_MS / reconnect_interval *
+                       NODE_CONNECTION_RETRIES_PER_TIMEOUT;
+    if (budget < 1) budget = 1;
+
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
     dictEntry *de;
     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
-        if (node == myself) continue;
-        if (node->link) continue;
+        if (node->flags & (CLUSTER_NODE_MYSELF | CLUSTER_NODE_NOADDR)) continue;
+
+        /* Free links that exceeded the send buffer limit. */
+        freeClusterLinkOnBufferLimitReached(node->link);
+        freeClusterLinkOnBufferLimitReached(node->inbound_link);
 
         /* Remove handshake nodes that have timed out. */
         if (nodeInHandshake(node) && now - node->ctime > handshake_timeout) {
@@ -422,9 +432,16 @@ void clusterConnectNodes(void) {
             continue;
         }
 
-        /* Throttle reconnection attempts. */
-        if (now - node->outbound_link_attempt_time < reconnect_interval) continue;
+        if (node->link) continue;
+
+        /* Throttle reconnection attempts. If an inbound link exists the peer
+         * already knows us, so reconnect immediately without throttling. */
+        if (!node->inbound_link) {
+            mstime_t backoff = reconnect_interval / NODE_CONNECTION_RETRIES_PER_TIMEOUT;
+            if (now - node->outbound_link_attempt_time < backoff && budget <= 0) continue;
+        }
         node->outbound_link_attempt_time = now;
+        budget--;
 
         clusterLink *link = createClusterLink(node);
         link->conn = connCreate(connTypeOfCluster());

--- a/src/cluster_link.h
+++ b/src/cluster_link.h
@@ -10,6 +10,9 @@ typedef struct clusterNode clusterNode;
 #define RCVBUF_MIN_READ_LEN 14
 #define RCVBUF_MAX_PREALLOC (1 << 20) /* 1MB */
 
+/* How many times per node_timeout we attempt to reconnect to each node. */
+#define NODE_CONNECTION_RETRIES_PER_TIMEOUT 10
+
 /* A refcounted block of bytes queued for sending on a cluster link.
  * The data member is uint64_t to ensure alignment for protocol
  * implementations that cast it to message structs with uint64_t fields. */

--- a/src/cluster_nodes.c
+++ b/src/cluster_nodes.c
@@ -327,6 +327,103 @@ static sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pa
     return ci;
 }
 
+/* Append the address+aux string for a node to an sds: ip:port@cport[,hostname][,aux=val]*
+ * This is the same format used in the second column of nodes.conf. */
+sds clusterNodeAppendAddressString(sds s, clusterNode *node, int tls_primary) {
+    int port = tls_primary ? node->tls_port : node->tcp_port;
+    s = sdscatfmt(s, "%s:%i@%i", node->ip, port, node->cport);
+    if (sdslen(node->hostname) != 0) {
+        s = sdscatfmt(s, ",%s", node->hostname);
+    } else {
+        s = sdscatlen(s, ",", 1);
+    }
+    for (int i = af_count - 1; i >= 0; i--) {
+        if ((tls_primary && i == af_tls_port) || (!tls_primary && i == af_tcp_port)) continue;
+        if (auxFieldHandlers[i].isPresent(node)) {
+            s = sdscatfmt(s, ",%s=", auxFieldHandlers[i].field);
+            s = auxFieldHandlers[i].getter(node, s);
+        }
+    }
+    return s;
+}
+
+/* Parse an address+aux string onto a node. The string format is:
+ * ip:port@cport[,hostname][,aux=val]*
+ * Returns C_OK on success, C_ERR on parse error. The input string is modified. */
+int clusterNodeParseAddressString(clusterNode *n, char *str) {
+    int aux_argc;
+    sds *aux_argv = sdssplitlen(str, strlen(str), ",", 1, &aux_argc);
+    if (aux_argv == NULL) return C_ERR;
+
+    /* Hostname */
+    if (aux_argc > 1 && sdslen(aux_argv[1]) > 0) {
+        n->hostname = sdscpy(n->hostname, aux_argv[1]);
+    } else if (sdslen(n->hostname) != 0) {
+        sdsclear(n->hostname);
+    }
+
+    /* Aux fields */
+    int aux_tcp_port = 0, aux_tls_port = 0;
+    for (int i = 2; i < aux_argc; i++) {
+        int field_argc;
+        sds *field_argv = sdssplitlen(aux_argv[i], sdslen(aux_argv[i]), "=", 1, &field_argc);
+        if (field_argv == NULL || field_argc != 2) {
+            if (field_argv) sdsfreesplitres(field_argv, field_argc);
+            goto err;
+        }
+        if (!isValidAuxString(field_argv[0], sdslen(field_argv[0])) ||
+            !isValidAuxString(field_argv[1], sdslen(field_argv[1]))) {
+            sdsfreesplitres(field_argv, field_argc);
+            goto err;
+        }
+        int found = 0;
+        for (unsigned j = 0; j < af_count; j++) {
+            if (sdslen(field_argv[0]) != strlen(auxFieldHandlers[j].field) ||
+                memcmp(field_argv[0], auxFieldHandlers[j].field, sdslen(field_argv[0])) != 0)
+                continue;
+            found = 1;
+            aux_tcp_port |= j == af_tcp_port;
+            aux_tls_port |= j == af_tls_port;
+            if (auxFieldHandlers[j].setter(n, field_argv[1], sdslen(field_argv[1])) != C_OK) {
+                sdsfreesplitres(field_argv, field_argc);
+                goto err;
+            }
+        }
+        sdsfreesplitres(field_argv, field_argc);
+        if (!found) goto err;
+    }
+
+    /* ip:port@cport */
+    char *p = strrchr(aux_argv[0], ':');
+    if (!p) goto err;
+    *p = '\0';
+    memcpy(n->ip, aux_argv[0], strlen(aux_argv[0]) + 1);
+    char *port = p + 1;
+    char *busp = strchr(port, '@');
+    if (busp) {
+        *busp = '\0';
+        busp++;
+    }
+    if (!aux_tcp_port && !aux_tls_port) {
+        if (server.tls_cluster)
+            n->tls_port = atoi(port);
+        else
+            n->tcp_port = atoi(port);
+    } else if (!aux_tcp_port) {
+        n->tcp_port = atoi(port);
+    } else if (!aux_tls_port) {
+        n->tls_port = atoi(port);
+    }
+    n->cport = busp ? atoi(busp) : (getNodeDefaultClientPort(n) + CLUSTER_PORT_INCR);
+
+    sdsfreesplitres(aux_argv, aux_argc);
+    return C_OK;
+
+err:
+    sdsfreesplitres(aux_argv, aux_argc);
+    return C_ERR;
+}
+
 /* Generate a csv-alike representation of the specified cluster node.
  * See clusterGenNodesDescription() top comment for more information.
  *
@@ -337,29 +434,20 @@ static sds representSlotInfo(sds ci, uint16_t *slot_info_pairs, int slot_info_pa
 sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary) {
     int j, start;
     sds ci;
-    int port = clusterNodeClientPort(node, tls_primary, c);
-    char *ip = clusterNodeIp(node, c);
 
     /* Node coordinates */
     ci = sdscatlen(sdsempty(), node->name, CLUSTER_NAMELEN);
-    ci = sdscatfmt(ci, " %s:%i@%i", ip, port, node->cport);
-    if (sdslen(node->hostname) != 0) {
-        ci = sdscatfmt(ci, ",%s", node->hostname);
-    }
-    /* Don't expose aux fields to any clients yet but do allow them
-     * to be persisted to nodes.conf */
+    ci = sdscatlen(ci, " ", 1);
     if (c == NULL) {
-        if (sdslen(node->hostname) == 0) {
-            ci = sdscatfmt(ci, ",", 1);
-        }
-        for (int i = af_count - 1; i >= 0; i--) {
-            if ((tls_primary && i == af_tls_port) || (!tls_primary && i == af_tcp_port)) {
-                continue;
-            }
-            if (auxFieldHandlers[i].isPresent(node)) {
-                ci = sdscatfmt(ci, ",%s=", auxFieldHandlers[i].field);
-                ci = auxFieldHandlers[i].getter(node, ci);
-            }
+        /* nodes.conf: use the canonical address+aux format */
+        ci = clusterNodeAppendAddressString(ci, node, tls_primary);
+    } else {
+        /* CLUSTER NODES reply: use client-facing IP/port, no aux fields */
+        int port = clusterNodeClientPort(node, tls_primary, c);
+        char *ip = clusterNodeIp(node, c);
+        ci = sdscatfmt(ci, "%s:%i@%i", ip, port, node->cport);
+        if (sdslen(node->hostname) != 0) {
+            ci = sdscatfmt(ci, ",%s", node->hostname);
         }
     }
 
@@ -553,8 +641,8 @@ int clusterLoadConfig(char *filename) {
     line = zmalloc(maxline);
     tmp_cluster_nodes = dictCreate(&clusterNodesDictType);
     while (fgets(line, maxline, fp) != NULL) {
-        int argc, aux_argc;
-        sds *argv, *aux_argv;
+        int argc;
+        sds *argv;
         clusterNode *n, *primary;
         char *p, *s;
 
@@ -611,116 +699,10 @@ int clusterLoadConfig(char *filename) {
         }
         /* Format for the node address and auxiliary argument information:
          * ip:port[@cport][,hostname][,aux=val]*] */
-
-        aux_argv = sdssplitlen(argv[1], sdslen(argv[1]), ",", 1, &aux_argc);
-        if (aux_argv == NULL) {
+        if (clusterNodeParseAddressString(n, argv[1]) == C_ERR) {
             sdsfreesplitres(argv, argc);
             goto fmterr;
         }
-
-        /* Hostname is an optional argument that defines the endpoint
-         * that can be reported to clients instead of IP. */
-        if (aux_argc > 1 && sdslen(aux_argv[1]) > 0) {
-            n->hostname = sdscpy(n->hostname, aux_argv[1]);
-        } else if (sdslen(n->hostname) != 0) {
-            sdsclear(n->hostname);
-        }
-
-        /* All fields after hostname are auxiliary and they take on
-         * the format of "aux=val" where both aux and val can contain
-         * characters that pass the isValidAuxChar check only. The order
-         * of the aux fields is insignificant. */
-        int aux_tcp_port = 0;
-        int aux_tls_port = 0;
-        for (int i = 2; i < aux_argc; i++) {
-            int field_argc;
-            sds *field_argv;
-            field_argv = sdssplitlen(aux_argv[i], sdslen(aux_argv[i]), "=", 1, &field_argc);
-            if (field_argv == NULL || field_argc != 2) {
-                /* Invalid aux field format */
-                if (field_argv != NULL) sdsfreesplitres(field_argv, field_argc);
-                sdsfreesplitres(aux_argv, aux_argc);
-                sdsfreesplitres(argv, argc);
-                goto fmterr;
-            }
-
-            /* Validate that both aux and value contain valid characters only */
-            for (unsigned j = 0; j < 2; j++) {
-                if (!isValidAuxString(field_argv[j], sdslen(field_argv[j]))) {
-                    /* Invalid aux field format */
-                    sdsfreesplitres(field_argv, field_argc);
-                    sdsfreesplitres(aux_argv, aux_argc);
-                    sdsfreesplitres(argv, argc);
-                    goto fmterr;
-                }
-            }
-
-            /* Note that we don't expect lots of aux fields in the foreseeable
-             * future so a linear search is completely fine. */
-            int field_found = 0;
-            for (unsigned j = 0; j < af_count; j++) {
-                if (sdslen(field_argv[0]) != strlen(auxFieldHandlers[j].field) ||
-                    memcmp(field_argv[0], auxFieldHandlers[j].field, sdslen(field_argv[0])) != 0) {
-                    continue;
-                }
-                field_found = 1;
-                aux_tcp_port |= j == af_tcp_port;
-                aux_tls_port |= j == af_tls_port;
-                if (auxFieldHandlers[j].setter(n, field_argv[1], sdslen(field_argv[1])) != C_OK) {
-                    /* Invalid aux field format */
-                    sdsfreesplitres(field_argv, field_argc);
-                    sdsfreesplitres(aux_argv, aux_argc);
-                    sdsfreesplitres(argv, argc);
-                    goto fmterr;
-                }
-            }
-
-            if (field_found == 0) {
-                /* Invalid aux field format */
-                sdsfreesplitres(field_argv, field_argc);
-                sdsfreesplitres(aux_argv, aux_argc);
-                sdsfreesplitres(argv, argc);
-                goto fmterr;
-            }
-
-            sdsfreesplitres(field_argv, field_argc);
-        }
-        /* Address and port */
-        if ((p = strrchr(aux_argv[0], ':')) == NULL) {
-            sdsfreesplitres(aux_argv, aux_argc);
-            sdsfreesplitres(argv, argc);
-            goto fmterr;
-        }
-        *p = '\0';
-        memcpy(n->ip, aux_argv[0], strlen(aux_argv[0]) + 1);
-        char *port = p + 1;
-        char *busp = strchr(port, '@');
-        if (busp) {
-            *busp = '\0';
-            busp++;
-        }
-        /* If neither TCP or TLS port is found in aux field, it is considered
-         * an old version of nodes.conf file.*/
-        if (!aux_tcp_port && !aux_tls_port) {
-            if (server.tls_cluster) {
-                n->tls_port = atoi(port);
-            } else {
-                n->tcp_port = atoi(port);
-            }
-        } else if (!aux_tcp_port) {
-            n->tcp_port = atoi(port);
-        } else if (!aux_tls_port) {
-            n->tls_port = atoi(port);
-        }
-        /* In older versions of nodes.conf the "@busport" part is missing.
-         * In this case we set it to the default offset of 10000 from the
-         * base port. */
-        n->cport = busp ? atoi(busp) : (getNodeDefaultClientPort(n) + CLUSTER_PORT_INCR);
-
-        /* The plaintext port for client in a TLS cluster (n->pport) is not
-         * stored in nodes.conf. It is received later over the bus protocol. */
-
-        sdsfreesplitres(aux_argv, aux_argc);
 
         /* Parse flags */
         p = s = argv[2];

--- a/src/cluster_nodes.h
+++ b/src/cluster_nodes.h
@@ -3,6 +3,10 @@
 
 #include "cluster.h"
 
+/* Node address string: ip:port@cport[,hostname][,aux=val]* */
+sds clusterNodeAppendAddressString(sds s, clusterNode *node, int tls_primary);
+int clusterNodeParseAddressString(clusterNode *n, char *str);
+
 /* Node description / serialization. */
 sds clusterGenNodeDescription(client *c, clusterNode *node, int tls_primary);
 sds clusterGenNodesDescription(client *c, int filter, int tls_primary);

--- a/src/cluster_state.h
+++ b/src/cluster_state.h
@@ -67,6 +67,7 @@ struct clusterNode {
     clusterLink *inbound_link;              /* TCP/IP link accepted from this node */
     int is_node_healthy;                    /* Boolean indicating the cached node health.
                                                Update with updateAndCountChangedNodeHealth(). */
+    mstime_t orphaned_time;                 /* Starting time of orphaned primary condition */
     void *protocol_data;                    /* Protocol-specific data (e.g. clusterNodeLegacyData) */
 };
 

--- a/src/server.c
+++ b/src/server.c
@@ -4763,6 +4763,9 @@ int prepareForShutdown(client *c, int flags) {
     }
     if (server.supervised_mode == SUPERVISED_SYSTEMD) serverCommunicateSystemd("STOPPING=1\n");
 
+    /* Allow the cluster protocol to initiate graceful handoff (e.g. leader transfer). */
+    if (server.cluster_enabled) clusterPrepareShutdown();
+
     /* If we have any replicas, let them catch up the replication offset before
      * we shut down, to avoid data loss. */
     if (!(flags & SHUTDOWN_NOW) && server.shutdown_timeout != 0 && !isReadyToShutdown()) {


### PR DESCRIPTION
This refactoring is done as a preparation for, and in parallel to, implementing another cluster protocol, so the line between common logic and gossip-specific code is becomming clearer.

Refactor replica migration code in cluster.c: New function clusterHandleLostLastSlot(target) — called when a node loses its last slot in slot migration. Triggers replica migration and does some logging. This code is now called from the protocol-specific code (cluster_legacy.c) when the CLUSTER SETSLOT NODE command has completed removing the last slot from a node.

Replicated CLUSTER SETSLOT / CLUSTER FAILOVER handling (cluster.c). These commands are sometimes received from the primary over the replication stream. Added c == server.primary checks before blocking the client.

Shutdown refactoring (cluster.c, cluster_bus.h, server.c): clusterAutoFailoverOnShutdown moved from cluster_legacy.c to cluster.c (common code). New clusterBus callback prepareShutdown — called early in shutdown for graceful handoff (intended to trigger Raft leader transfer if the leader is shutting down).

Node reconnection logic extracted to cluster_link.c and cluster_link.h. Reconnect code called by common clusterCron. clusterConnectNodes() handles buffer limit checks, handshake timeout removal, reconnection with budget/throttling, and backoff logic.

Node address parsing/serialization extracted (cluster_nodes.c) - parse and build the ip:port@cport,hostname,aux=val string. (To be reused for cluster V2).

getClusterConnectionsCount() simplified. It's not protocol specific.

reset cluster stats code moved to common code.