### PR TITLE
fix: duplicated words in networking/server/function_lua comments

### DIFF
--- a/src/modules/lua/function_lua.c
+++ b/src/modules/lua/function_lua.c
@@ -112,7 +112,7 @@ static void freeCompiledFunc(lua_State *lua,
 
 /*
  * Compile a given script code by generating a set of compiled functions. These
- * functions are also saved into the the registry of the Lua environment.
+ * functions are also saved into the registry of the Lua environment.
  *
  * Returns an array of compiled functions. The `compileFunction` struct stores a
  * Lua ref that allows to later retrieve the function from the registry.

--- a/src/networking.c
+++ b/src/networking.c
@@ -4038,7 +4038,7 @@ void discardCommandQueue(client *c) {
     queue->off = queue->len = queue->cap = 0;
 }
 
-/* Returns the number of keys in the the incr_states array after adding keys. */
+/* Returns the number of keys in the incr_states array after adding keys. */
 static int addKeysToIncrFindBatch(client *c,
                                   struct serverCommand *cmd,
                                   robj **argv,

--- a/src/server.c
+++ b/src/server.c
@@ -807,7 +807,7 @@ dictType migrateCacheDictType = {
     .entryDestructor = dictEntryDestructorSdsKey,
 };
 
-/* Dict for for case-insensitive search using null terminated C strings.
+/* Dict for case-insensitive search using null terminated C strings.
  * The keys stored in dict are sds though. */
 dictType stringSetDictType = {
     .entryGetKey = dictEntryGetKey,


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in source comments:
- `src/networking.c` — "/* Returns the number of keys in the the incr_states array after adding keys. */" → "...in the incr_states array..."
- `src/modules/lua/function_lua.c` — "* functions are also saved into the the registry of the Lua environment." → "... into the registry of the Lua environment."
- `src/server.c` — "/* Dict for for case-insensitive search using null terminated C strings." → "/* Dict for case-insensitive search using null terminated C strings."

No code/behavior change.

Signed-off-by: Aiden Park <275402320+vip892766gma@users.noreply.github.com>