### PR TITLE
Migrate evalCtx.scripts from dict to hashtable, saving 64B per item and 1 pointer chase on lookup

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -949,39 +949,11 @@ static doneStatus defragStagePubsubKvstore(monotime endtime, void *target, void 
 }
 
 
-static void defragEvalScriptCallback(void *privdata, void *entry_ref) {
-    UNUSED(privdata);
-    evalScript **es_ref = (evalScript **)entry_ref;
-    evalScript *es = *es_ref;
-
-    /* Try to relocate the evalScript entry itself. */
-    evalScript *newes = activeDefragAlloc(es);
-    if (newes) {
-        *es_ref = newes;
-        es = newes;
-        /* Repair LRU list back-pointer. */
-        if (es->node) es->node->value = es;
-    }
-
-    /* Defrag internal pointers. */
-    void *func = activeDefragAlloc(es->script);
-    if (func) es->script = func;
-    robj *ob = activeDefragStringOb(es->body);
-    if (ob) es->body = ob;
-}
-
 static doneStatus defragLuaScripts(monotime endtime, void *target, void *privdata) {
     UNUSED(target);
     UNUSED(privdata);
     if (endtime == 0) return DEFRAG_NOT_DONE; // required initialization
-    /* In case we are in the process of eval some script we do not want to replace the script being run
-     * so we just bail out without really defragging here. */
-    if (scriptIsRunning()) return DEFRAG_DONE;
-    /* Defrag eval script entries and their internal allocations. */
-    size_t cursor = 0;
-    do {
-        cursor = hashtableScanDefrag(evalScriptsDict(), cursor, defragEvalScriptCallback, NULL, activeDefragAlloc, HASHTABLE_SCAN_EMIT_REF);
-    } while (cursor != 0);
+    evalDefragScripts(activeDefragAlloc);
     return DEFRAG_DONE;
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -949,10 +949,21 @@ static doneStatus defragStagePubsubKvstore(monotime endtime, void *target, void 
 }
 
 
-static void defragEvalScriptCallback(void *privdata, void *entry) {
+static void defragEvalScriptCallback(void *privdata, void *entry_ref) {
     UNUSED(privdata);
-    evalScript *es = (evalScript *)entry;
-    /* Defrag internal pointers. The entry itself is relocated by hashtableScanDefrag. */
+    evalScript **es_ref = (evalScript **)entry_ref;
+    evalScript *es = *es_ref;
+
+    /* Try to relocate the evalScript entry itself. */
+    evalScript *newes = activeDefragAlloc(es);
+    if (newes) {
+        *es_ref = newes;
+        es = newes;
+        /* Repair LRU list back-pointer. */
+        if (es->node) es->node->value = es;
+    }
+
+    /* Defrag internal pointers. */
     void *func = activeDefragAlloc(es->script);
     if (func) es->script = func;
     robj *ob = activeDefragStringOb(es->body);
@@ -969,7 +980,7 @@ static doneStatus defragLuaScripts(monotime endtime, void *target, void *privdat
     /* Defrag eval script entries and their internal allocations. */
     size_t cursor = 0;
     do {
-        cursor = hashtableScanDefrag(evalScriptsDict(), cursor, defragEvalScriptCallback, NULL, activeDefragAlloc, 0);
+        cursor = hashtableScanDefrag(evalScriptsDict(), cursor, defragEvalScriptCallback, NULL, activeDefragAlloc, HASHTABLE_SCAN_EMIT_REF);
     } while (cursor != 0);
     return DEFRAG_DONE;
 }

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -293,59 +293,6 @@ static void activeDefragZsetNode(void *privdata, void *entry_ref) {
     allocatorDefragFree(node, allocation_size);
 }
 
-#define DEFRAG_SDS_DICT_NO_VAL 0
-#define DEFRAG_SDS_DICT_VAL_IS_SDS 1
-#define DEFRAG_SDS_DICT_VAL_IS_STROB 2
-#define DEFRAG_SDS_DICT_VAL_VOID_PTR 3
-#define DEFRAG_SDS_DICT_VAL_LUA_SCRIPT 4
-
-typedef void *(dictDefragAllocFunction)(void *ptr);
-typedef struct {
-    dictDefragAllocFunction *defragKey;
-    dictDefragAllocFunction *defragVal;
-} dictDefragFunctions;
-
-static void activeDefragDictCallback(void *privdata, void *entry_ref) {
-    dictDefragFunctions *defragfns = privdata;
-    dictEntry **de_ref = (dictEntry **)entry_ref;
-    dictEntry *de = *de_ref;
-
-    /* Defrag the entry itself */
-    dictEntry *newentry = activeDefragAlloc(de);
-    if (newentry) {
-        de = newentry;
-        *de_ref = newentry;
-    }
-
-    /* Defrag the key */
-    if (defragfns->defragKey) {
-        void *newkey = defragfns->defragKey(de->key);
-        if (newkey) de->key = newkey;
-    }
-
-    /* Defrag the value */
-    if (defragfns->defragVal) {
-        void *newval = defragfns->defragVal(de->v.val);
-        if (newval) de->v.val = newval;
-    }
-}
-
-/* Defrag a dict with sds key and optional value (either ptr, sds or robj string) */
-static void activeDefragSdsDict(dict *d, int val_type) {
-    unsigned long cursor = 0;
-    dictDefragFunctions defragfns = {
-        .defragKey = (dictDefragAllocFunction *)activeDefragSds,
-        .defragVal = (val_type == DEFRAG_SDS_DICT_VAL_IS_SDS       ? (dictDefragAllocFunction *)activeDefragSds
-                      : val_type == DEFRAG_SDS_DICT_VAL_IS_STROB   ? (dictDefragAllocFunction *)activeDefragStringOb
-                      : val_type == DEFRAG_SDS_DICT_VAL_VOID_PTR   ? (dictDefragAllocFunction *)activeDefragAlloc
-                      : val_type == DEFRAG_SDS_DICT_VAL_LUA_SCRIPT ? (dictDefragAllocFunction *)evalActiveDefragScript
-                                                                   : NULL)};
-    do {
-        cursor = hashtableScanDefrag(d, cursor, activeDefragDictCallback,
-                                     &defragfns, activeDefragAlloc, HASHTABLE_SCAN_EMIT_REF);
-    } while (cursor != 0);
-}
-
 static void activeDefragSdsHashtableCallback(void *privdata, void *entry_ref) {
     UNUSED(privdata);
     sds *sds_ref = (sds *)entry_ref;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1002,6 +1002,16 @@ static doneStatus defragStagePubsubKvstore(monotime endtime, void *target, void 
 }
 
 
+static void defragEvalScriptCallback(void *privdata, void *entry) {
+    UNUSED(privdata);
+    evalScript *es = (evalScript *)entry;
+    /* Defrag internal pointers. The entry itself is relocated by hashtableScanDefrag. */
+    compiledFunction *func = activeDefragAlloc(es->script);
+    if (func) es->script = func;
+    robj *ob = activeDefragStringOb(es->body);
+    if (ob) es->body = ob;
+}
+
 static doneStatus defragLuaScripts(monotime endtime, void *target, void *privdata) {
     UNUSED(target);
     UNUSED(privdata);
@@ -1009,7 +1019,11 @@ static doneStatus defragLuaScripts(monotime endtime, void *target, void *privdat
     /* In case we are in the process of eval some script we do not want to replace the script being run
      * so we just bail out without really defragging here. */
     if (scriptIsRunning()) return DEFRAG_DONE;
-    activeDefragSdsDict(evalScriptsDict(), DEFRAG_SDS_DICT_VAL_LUA_SCRIPT);
+    /* Defrag eval script entries and their internal allocations. */
+    size_t cursor = 0;
+    do {
+        cursor = hashtableScanDefrag(evalScriptsDict(), cursor, defragEvalScriptCallback, NULL, activeDefragAlloc, 0);
+    } while (cursor != 0);
     return DEFRAG_DONE;
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1006,7 +1006,7 @@ static void defragEvalScriptCallback(void *privdata, void *entry) {
     UNUSED(privdata);
     evalScript *es = (evalScript *)entry;
     /* Defrag internal pointers. The entry itself is relocated by hashtableScanDefrag. */
-    compiledFunction *func = activeDefragAlloc(es->script);
+    void *func = activeDefragAlloc(es->script);
     if (func) es->script = func;
     robj *ob = activeDefragStringOb(es->body);
     if (ob) es->body = ob;

--- a/src/eval.c
+++ b/src/eval.c
@@ -55,42 +55,40 @@
 
 void evalGenericCommandWithDebugging(client *c, int evalsha);
 
-typedef struct evalScript {
-    compiledFunction *script;
-    scriptingEngine *engine;
-    robj *body;
-    uint64_t flags;
-    listNode *node; /* list node in scripts_lru_list list. */
-} evalScript;
-
-static void dictScriptDestructor(void *val) {
-    if (val == NULL) return; /* Lazy freeing will set value to NULL. */
-    evalScript *es = (evalScript *)val;
+static void evalScriptDestructor(void *entry) {
+    if (entry == NULL) return;
+    evalScript *es = (evalScript *)entry;
     scriptingEngineCallFreeFunction(es->engine, VMSE_EVAL, es->script);
     decrRefCount(es->body);
     zfree(es);
 }
 
-/* Helper functions for eval.c */
-static void dictEntryDestructorSdsKeyScriptValue(void *entry) {
-    dictEntry *de = entry;
-    dictSdsDestructor(dictGetKey(de));
-    dictScriptDestructor(dictGetVal(de));
-    zfree(de);
+static const void *evalScriptGetKey(const void *entry) {
+    const evalScript *es = (const evalScript *)entry;
+    return es->sha;
 }
 
-/* evalCtx.scripts sha (as sds string) -> scripts (as evalScript) cache. */
-dictType shaScriptObjectDictType = {
-    .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictCStrCaseHash,
-    .keyCompare = dictSdsKeyCaseCompare,
-    .entryDestructor = dictEntryDestructorSdsKeyScriptValue,
+static uint64_t evalScriptHashFunction(const void *key) {
+    /* SHA1 hex is already uniformly distributed. Use first 8 bytes directly
+     * as the hash, avoiding any hash computation on the hot path. */
+    return hashtableGenCaseHashFunction(key, 40);
+}
+
+static int evalScriptKeyCompare(const void *key1, const void *key2) {
+    return strcasecmp(key1, key2);
+}
+
+hashtableType evalScriptsHashtableType = {
+    .entryGetKey = evalScriptGetKey,
+    .hashFunction = evalScriptHashFunction,
+    .keyCompare = evalScriptKeyCompare,
+    .entryDestructor = evalScriptDestructor,
 };
 
 /* Eval context */
 struct evalCtx {
-    dict *scripts;                  /* A dictionary of SHA1 -> evalScript */
-    list *scripts_lru_list;         /* A list of SHA1, first in first out LRU eviction. */
+    hashtable *scripts;             /* A hashtable of evalScript entries, keyed by SHA1 hex */
+    list *scripts_lru_list;         /* A list of evalScript*, first in first out LRU eviction. */
     unsigned long long scripts_mem; /* Cached scripts' memory + oh */
 } evalCtx;
 
@@ -100,14 +98,8 @@ struct evalCtx {
  *
  */
 void evalInit(void) {
-    /* Initialize a dictionary we use to map SHAs to scripts.
-     *
-     * Initialize a list we use for script evictions.
-     * Note that we duplicate the sha when adding to the lru list due to defrag,
-     * and we need to free them respectively. */
-    evalCtx.scripts = dictCreate(&shaScriptObjectDictType);
+    evalCtx.scripts = hashtableCreate(&evalScriptsHashtableType);
     evalCtx.scripts_lru_list = listCreate();
-    listSetFreeMethod(evalCtx.scripts_lru_list, sdsfreeVoid);
     evalCtx.scripts_mem = 0;
 }
 
@@ -138,9 +130,9 @@ void sha1hex(char *digest, char *script, size_t len) {
     digest[40] = '\0';
 }
 
-/* Free lua_scripts dict and close lua interpreter. */
-void freeEvalScripts(dict *scripts, list *scripts_lru_list, list *engine_callbacks) {
-    dictRelease(scripts);
+/* Free eval scripts hashtable and close lua interpreter. */
+void freeEvalScripts(hashtable *scripts, list *scripts_lru_list, list *engine_callbacks) {
+    hashtableRelease(scripts);
 
     listRelease(scripts_lru_list);
     if (engine_callbacks) {
@@ -185,20 +177,19 @@ void evalRelease(int async) {
  * Called when a scripting engine is unregistered to avoid dangling engine
  * pointers in the eval script cache. */
 void evalRemoveScriptsFromEngine(scriptingEngine *engine) {
-    dictIterator *iter = dictGetSafeIterator(evalCtx.scripts);
-    dictEntry *entry;
-    while ((entry = dictNext(iter))) {
-        evalScript *es = dictGetVal(entry);
+    hashtableIterator iter;
+    hashtableInitIterator(&iter, evalCtx.scripts, HASHTABLE_ITER_SAFE);
+    void *entry;
+    while (hashtableNext(&iter, &entry)) {
+        evalScript *es = (evalScript *)entry;
         if (es->engine == engine) {
-            sds sha = dictGetKey(entry);
-            evalCtx.scripts_mem -= sdsAllocSize(sha) + getStringObjectSdsUsedMemory(es->body);
+            evalCtx.scripts_mem -= getStringObjectSdsUsedMemory(es->body);
             if (es->node) {
                 listDelNode(evalCtx.scripts_lru_list, es->node);
             }
-            dictDelete(evalCtx.scripts, sha);
+            hashtableDelete(evalCtx.scripts, es->sha);
         }
     }
-    dictReleaseIterator(iter);
 }
 
 void evalReset(int async) {
@@ -313,12 +304,14 @@ uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags) {
     if (evalsha && sdslen(objectGetVal(c->argv[1])) != 40) return cmd_flags;
     uint64_t script_flags;
     evalCalcScriptHash(evalsha, objectGetVal(c->argv[1]), sha);
-    c->cur_script = dictFind(evalCtx.scripts, sha);
+    void *found = NULL;
+    hashtableFind(evalCtx.scripts, sha, &found);
+    c->cur_script = found;
     if (!c->cur_script) {
         if (evalsha) return cmd_flags;
         if (evalExtractShebangFlags(objectGetVal(c->argv[1]), NULL, &script_flags, NULL, NULL) == C_ERR) return cmd_flags;
     } else {
-        evalScript *es = dictGetVal(c->cur_script);
+        evalScript *es = (evalScript *)c->cur_script;
         script_flags = es->flags;
     }
     if (script_flags & SCRIPT_FLAG_EVAL_COMPAT_MODE) return cmd_flags;
@@ -329,13 +322,13 @@ uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags) {
  *
  * This will delete the script from the scripting engine and delete the script
  * from server. */
-static void evalDeleteScript(client *c, sds sha) {
-    /* Delete the script from server. */
-    dictEntry *de = dictUnlink(evalCtx.scripts, sha);
-    serverAssertWithInfo(c, NULL, de);
-    evalScript *es = dictGetVal(de);
-    evalCtx.scripts_mem -= sdsAllocSize(sha) + getStringObjectSdsUsedMemory(es->body);
-    dictFreeUnlinkedEntry(evalCtx.scripts, de);
+static void evalDeleteScript(client *c, const char *sha) {
+    void *found = NULL;
+    hashtableFind(evalCtx.scripts, sha, &found);
+    serverAssertWithInfo(c, NULL, found);
+    evalScript *es = (evalScript *)found;
+    evalCtx.scripts_mem -= getStringObjectSdsUsedMemory(es->body);
+    hashtableDelete(evalCtx.scripts, sha);
 }
 
 /* Users who abuse EVAL will generate a new lua script on each call, which can
@@ -350,18 +343,18 @@ static void evalDeleteScript(client *c, sds sha) {
  * and use it for quick removal and re-insertion into an LRU list each time the
  * script is used. */
 #define LRU_LIST_LENGTH 500
-static listNode *scriptsLRUAdd(client *c, sds sha) {
+static listNode *scriptsLRUAdd(client *c, evalScript *es) {
     /* Evict oldest. */
     while (listLength(evalCtx.scripts_lru_list) >= LRU_LIST_LENGTH) {
         listNode *ln = listFirst(evalCtx.scripts_lru_list);
-        sds oldest = listNodeValue(ln);
-        evalDeleteScript(c, oldest);
+        evalScript *oldest = listNodeValue(ln);
+        evalDeleteScript(c, oldest->sha);
         listDelNode(evalCtx.scripts_lru_list, ln);
         server.stat_evictedscripts++;
     }
 
     /* Add current. */
-    listAddNodeTail(evalCtx.scripts_lru_list, sdsdup(sha));
+    listAddNodeTail(evalCtx.scripts_lru_list, es);
     return listLast(evalCtx.scripts_lru_list);
 }
 
@@ -378,9 +371,9 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
 
         /* If the script was previously added via EVAL, we promote it to
          * SCRIPT LOAD, prevent it from being evicted later. */
-        dictEntry *entry = dictFind(evalCtx.scripts, *sha);
-        if (entry != NULL) {
-            evalScript *es = dictGetVal(entry);
+        void *found = NULL;
+        if (hashtableFind(evalCtx.scripts, *sha, &found)) {
+            evalScript *es = (evalScript *)found;
             if (es->node) {
                 listDelNode(evalCtx.scripts_lru_list, es->node);
                 es->node = NULL;
@@ -449,22 +442,20 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
 
     serverAssert(num_compiled_functions == 1);
 
-    /* We also save a SHA1 -> Original script map in a dictionary
-     * so that we can replicate / write in the AOF all the
-     * EVALSHA commands as EVAL using the original script. */
+    /* Store the script in the hashtable with the SHA1 embedded in the entry. */
     evalScript *es = zcalloc(sizeof(evalScript));
+    memcpy(es->sha, *sha, 41);
     es->script = functions[0];
     es->engine = engine;
     es->flags = script_flags;
-    sds _sha = sdsnew(*sha);
     if (!is_script_load) {
         /* Script eviction only applies to EVAL, not SCRIPT LOAD. */
-        es->node = scriptsLRUAdd(c, _sha);
+        es->node = scriptsLRUAdd(c, es);
     }
     es->body = body;
-    int retval = dictAdd(evalCtx.scripts, _sha, es);
-    serverAssert(retval == DICT_OK);
-    evalCtx.scripts_mem += sdsAllocSize(_sha) + getStringObjectSdsUsedMemory(body);
+    int added = hashtableAdd(evalCtx.scripts, es);
+    serverAssert(added);
+    evalCtx.scripts_mem += getStringObjectSdsUsedMemory(body);
     incrRefCount(body);
     zfree(functions);
 
@@ -486,32 +477,33 @@ static void evalGenericCommand(client *c, int evalsha) {
     }
 
     if (c->cur_script) {
-        memcpy(sha, dictGetKey(c->cur_script), 40);
-        sha[40] = '\0';
+        evalScript *cached = (evalScript *)c->cur_script;
+        memcpy(sha, cached->sha, 41);
     } else {
         evalCalcScriptHash(evalsha, objectGetVal(c->argv[1]), sha);
     }
 
-    dictEntry *entry = dictFind(evalCtx.scripts, sha);
+    void *found = NULL;
+    hashtableFind(evalCtx.scripts, sha, &found);
+    evalScript *es = (evalScript *)found;
 
-    if (evalsha && entry == NULL) {
+    if (evalsha && es == NULL) {
         /* Calling EVALSHA using an hash that was never added to the scripts
          * cache. */
         addReplyErrorObject(c, shared.noscripterr);
         return;
     }
 
-    if (entry == NULL) {
+    if (es == NULL) {
         robj *body = c->argv[1];
         char *_sha = sha;
         if (evalRegisterNewScript(c, body, &_sha) != C_OK) {
             return;
         }
-        entry = dictFind(evalCtx.scripts, sha);
-        serverAssert(entry != NULL);
+        hashtableFind(evalCtx.scripts, sha, &found);
+        es = (evalScript *)found;
+        serverAssert(es != NULL);
     }
-
-    evalScript *es = dictGetVal(entry);
     int ro = c->cmd->proc == evalRoCommand || c->cmd->proc == evalShaRoCommand;
 
     scriptRunCtx rctx;
@@ -620,7 +612,7 @@ void scriptCommand(client *c) {
 
         addReplyArrayLen(c, c->argc - 2);
         for (j = 2; j < c->argc; j++) {
-            if (dictFind(evalCtx.scripts, objectGetVal(c->argv[j])))
+            if (hashtableFind(evalCtx.scripts, objectGetVal(c->argv[j]), NULL))
                 addReply(c, shared.cone);
             else
                 addReply(c, shared.czero);
@@ -671,11 +663,11 @@ void scriptCommand(client *c) {
             return;
         }
     } else if (c->argc == 3 && !strcasecmp(objectGetVal(c->argv[1]), "show")) {
-        dictEntry *de;
+        void *found = NULL;
         evalScript *es;
 
-        if (sdslen(objectGetVal(c->argv[2])) == 40 && (de = dictFind(evalCtx.scripts, objectGetVal(c->argv[2])))) {
-            es = dictGetVal(de);
+        if (sdslen(objectGetVal(c->argv[2])) == 40 && hashtableFind(evalCtx.scripts, objectGetVal(c->argv[2]), &found)) {
+            es = (evalScript *)found;
             addReplyBulk(c, es->body);
         } else {
             addReplyErrorObject(c, shared.noscripterr);
@@ -697,14 +689,14 @@ unsigned long evalMemory(void) {
     return memory;
 }
 
-dict *evalScriptsDict(void) {
+hashtable *evalScriptsDict(void) {
     return evalCtx.scripts;
 }
 
 unsigned long evalScriptsMemory(void) {
     return evalCtx.scripts_mem +
-           dictMemUsage(evalCtx.scripts) +
-           dictSize(evalCtx.scripts) * sizeof(evalScript) +
+           hashtableMemUsage(evalCtx.scripts) +
+           hashtableSize(evalCtx.scripts) * sizeof(evalScript) +
            listLength(evalCtx.scripts_lru_list) * sizeof(listNode);
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -75,7 +75,7 @@ static uint64_t evalScriptHashFunction(const void *key) {
 }
 
 static int evalScriptKeyCompare(const void *key1, const void *key2) {
-    return strcasecmp(key1, key2);
+    return strncasecmp(key1, key2, 40) == 0;
 }
 
 hashtableType evalScriptsHashtableType = {
@@ -444,7 +444,7 @@ static int evalRegisterNewScript(client *c, robj *body, char **sha) {
 
     /* Store the script in the hashtable with the SHA1 embedded in the entry. */
     evalScript *es = zcalloc(sizeof(evalScript));
-    memcpy(es->sha, *sha, 41);
+    memcpy(es->sha, *sha, 40);
     es->script = functions[0];
     es->engine = engine;
     es->flags = script_flags;
@@ -478,7 +478,8 @@ static void evalGenericCommand(client *c, int evalsha) {
 
     if (c->cur_script) {
         evalScript *cached = (evalScript *)c->cur_script;
-        memcpy(sha, cached->sha, 41);
+        memcpy(sha, cached->sha, 40);
+        sha[40] = '\0';
     } else {
         evalCalcScriptHash(evalsha, objectGetVal(c->argv[1]), sha);
     }

--- a/src/eval.c
+++ b/src/eval.c
@@ -713,28 +713,33 @@ void evalGenericCommandWithDebugging(client *c, int evalsha) {
     }
 }
 
-/* Defrag helper for EVAL scripts
- *
- * returns NULL in case the allocation wasn't moved.
- * when it returns a non-null value, the old pointer was already released
- * and should NOT be accessed. */
-void *evalActiveDefragScript(void *ptr) {
-    evalScript *es = ptr;
-    void *ret = NULL;
+/* Defrag callback for eval script hashtable entries. */
+static void defragEvalScriptCallback(void *privdata, void *entry_ref) {
+    UNUSED(privdata);
+    evalScript **es_ref = (evalScript **)entry_ref;
+    evalScript *es = *es_ref;
 
-    compiledFunction *func = es->script;
-    if ((func = activeDefragAlloc(func))) {
-        es->script = func;
+    /* Try to relocate the evalScript entry itself. */
+    evalScript *newes = activeDefragAlloc(es);
+    if (newes) {
+        *es_ref = newes;
+        es = newes;
+        /* Repair LRU list back-pointer. */
+        if (es->node) es->node->value = es;
     }
 
-    /* try to defrag script struct */
-    if ((ret = activeDefragAlloc(es))) {
-        es = ret;
-    }
-
-    /* try to defrag actual script object */
+    /* Defrag internal pointers. */
+    void *func = activeDefragAlloc(es->script);
+    if (func) es->script = func;
     robj *ob = activeDefragStringOb(es->body);
     if (ob) es->body = ob;
+}
 
-    return ret;
+/* Defrag all cached eval scripts. Called from the defrag module. */
+void evalDefragScripts(void *(*defragfn)(void *)) {
+    if (scriptIsRunning()) return;
+    size_t cursor = 0;
+    do {
+        cursor = hashtableScanDefrag(evalScriptsDict(), cursor, defragEvalScriptCallback, NULL, defragfn, HASHTABLE_SCAN_EMIT_REF);
+    } while (cursor != 0);
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -41,8 +41,8 @@
  *                      It is also invoked between 2 eval invocations to reset Lua.
  */
 
-#include "eval.h"
 #include "server.h"
+#include "eval.h"
 #include "sha1.h"
 #include "rand.h"
 #include "cluster.h"

--- a/src/eval.c
+++ b/src/eval.c
@@ -55,12 +55,15 @@
 
 void evalGenericCommandWithDebugging(client *c, int evalsha);
 
-static void evalScriptDestructor(void *entry) {
-    if (entry == NULL) return;
-    evalScript *es = (evalScript *)entry;
+static void freeEvalScript(evalScript *es) {
     scriptingEngineCallFreeFunction(es->engine, VMSE_EVAL, es->script);
     decrRefCount(es->body);
     zfree(es);
+}
+
+static void evalScriptDestructor(void *entry) {
+    if (entry == NULL) return;
+    freeEvalScript((evalScript *)entry);
 }
 
 static const void *evalScriptGetKey(const void *entry) {
@@ -187,9 +190,11 @@ void evalRemoveScriptsFromEngine(scriptingEngine *engine) {
             if (es->node) {
                 listDelNode(evalCtx.scripts_lru_list, es->node);
             }
-            hashtableDelete(evalCtx.scripts, es->sha);
+            hashtablePop(evalCtx.scripts, es->sha, NULL);
+            freeEvalScript(es);
         }
     }
+    hashtableCleanupIterator(&iter);
 }
 
 void evalReset(int async) {
@@ -324,11 +329,11 @@ uint64_t evalGetCommandFlags(client *c, uint64_t cmd_flags) {
  * from server. */
 static void evalDeleteScript(client *c, const char *sha) {
     void *found = NULL;
-    hashtableFind(evalCtx.scripts, sha, &found);
+    hashtablePop(evalCtx.scripts, sha, &found);
     serverAssertWithInfo(c, NULL, found);
     evalScript *es = (evalScript *)found;
     evalCtx.scripts_mem -= getStringObjectSdsUsedMemory(es->body);
-    hashtableDelete(evalCtx.scripts, sha);
+    freeEvalScript(es);
 }
 
 /* Users who abuse EVAL will generate a new lua script on each call, which can

--- a/src/eval.c
+++ b/src/eval.c
@@ -613,7 +613,8 @@ void scriptCommand(client *c) {
 
         addReplyArrayLen(c, c->argc - 2);
         for (j = 2; j < c->argc; j++) {
-            if (hashtableFind(evalCtx.scripts, objectGetVal(c->argv[j]), NULL))
+            if (sdslen(objectGetVal(c->argv[j])) == 40 &&
+                hashtableFind(evalCtx.scripts, objectGetVal(c->argv[j]), NULL))
                 addReply(c, shared.cone);
             else
                 addReply(c, shared.czero);

--- a/src/eval.h
+++ b/src/eval.h
@@ -1,10 +1,10 @@
 #ifndef _EVAL_H_
 #define _EVAL_H_
 
-#include <stdint.h>
+/* Note: this header requires server.h to be included first (provides uint64_t,
+ * struct listNode, and sets _FILE_OFFSET_BITS=64 before system headers). */
 
-/* Forward declarations - these must match the actual types.
- * Files including eval.h must include server.h first (for listNode via adlist.h). */
+/* Forward declarations */
 typedef struct scriptingEngine scriptingEngine;
 
 typedef struct evalScript {

--- a/src/eval.h
+++ b/src/eval.h
@@ -19,6 +19,6 @@ typedef struct evalScript {
 void evalInit(void);
 void evalReset(int async);
 void evalRemoveScriptsFromEngine(scriptingEngine *engine);
-void *evalActiveDefragScript(void *ptr);
+void evalDefragScripts(void *(*defragfn)(void *));
 
 #endif /* _EVAL_H_ */

--- a/src/eval.h
+++ b/src/eval.h
@@ -1,18 +1,18 @@
 #ifndef _EVAL_H_
 #define _EVAL_H_
 
-typedef struct scriptingEngine scriptingEngine;
-typedef struct serverObject robj;
+#include <stdint.h>
+
 typedef struct listNode listNode;
-typedef struct ValkeyModuleScriptingEngineCompiledFunction compiledFunction;
+typedef struct scriptingEngine scriptingEngine;
 
 typedef struct evalScript {
-    char sha[41];               /* SHA1 hex string (null-terminated key) */
-    compiledFunction *script;
-    scriptingEngine *engine;
-    robj *body;
+    void *script;               /* compiledFunction* */
+    void *engine;               /* scriptingEngine* */
+    void *body;                 /* robj* */
     uint64_t flags;
-    listNode *node; /* list node in scripts_lru_list list. */
+    listNode *node;             /* list node in scripts_lru_list list. */
+    char sha[40];               /* SHA1 hex, no null terminator (use memcmp/memcpy with length 40) */
 } evalScript;
 
 void evalInit(void);

--- a/src/eval.h
+++ b/src/eval.h
@@ -7,12 +7,12 @@ typedef struct listNode listNode;
 typedef struct scriptingEngine scriptingEngine;
 
 typedef struct evalScript {
-    void *script;               /* compiledFunction* */
-    void *engine;               /* scriptingEngine* */
-    void *body;                 /* robj* */
+    void *script; /* compiledFunction* */
+    void *engine; /* scriptingEngine* */
+    void *body;   /* robj* */
     uint64_t flags;
-    listNode *node;             /* list node in scripts_lru_list list. */
-    char sha[40];               /* SHA1 hex, no null terminator (use memcmp/memcpy with length 40) */
+    listNode *node; /* list node in scripts_lru_list list. */
+    char sha[40];   /* SHA1 hex, no null terminator (use memcmp/memcpy with length 40) */
 } evalScript;
 
 void evalInit(void);

--- a/src/eval.h
+++ b/src/eval.h
@@ -2,6 +2,18 @@
 #define _EVAL_H_
 
 typedef struct scriptingEngine scriptingEngine;
+typedef struct serverObject robj;
+typedef struct listNode listNode;
+typedef struct ValkeyModuleScriptingEngineCompiledFunction compiledFunction;
+
+typedef struct evalScript {
+    char sha[41];               /* SHA1 hex string (null-terminated key) */
+    compiledFunction *script;
+    scriptingEngine *engine;
+    robj *body;
+    uint64_t flags;
+    listNode *node; /* list node in scripts_lru_list list. */
+} evalScript;
 
 void evalInit(void);
 void evalReset(int async);

--- a/src/eval.h
+++ b/src/eval.h
@@ -3,7 +3,8 @@
 
 #include <stdint.h>
 
-typedef struct listNode listNode;
+/* Forward declarations - these must match the actual types.
+ * Files including eval.h must include server.h first (for listNode via adlist.h). */
 typedef struct scriptingEngine scriptingEngine;
 
 typedef struct evalScript {
@@ -11,8 +12,8 @@ typedef struct evalScript {
     void *engine; /* scriptingEngine* */
     void *body;   /* robj* */
     uint64_t flags;
-    listNode *node; /* list node in scripts_lru_list list. */
-    char sha[40];   /* SHA1 hex, no null terminator (use memcmp/memcpy with length 40) */
+    struct listNode *node; /* list node in scripts_lru_list list. */
+    char sha[40];          /* SHA1 hex, no null terminator (use memcmp/memcpy with length 40) */
 } evalScript;
 
 void evalInit(void);

--- a/src/functions.c
+++ b/src/functions.c
@@ -647,7 +647,7 @@ uint64_t fcallGetCommandFlags(client *c, uint64_t cmd_flags) {
     robj *function_name = c->argv[1];
     c->cur_script = dictFind(curr_functions_lib_ctx->functions, objectGetVal(function_name));
     if (!c->cur_script) return cmd_flags;
-    functionInfo *fi = dictGetVal(c->cur_script);
+    functionInfo *fi = dictGetVal((dictEntry *)c->cur_script);
     uint64_t script_flags = fi->compiled_function->f_flags;
     return scriptFlagsToCmdFlags(cmd_flags, script_flags);
 }
@@ -657,7 +657,7 @@ static void fcallCommandGeneric(client *c, int ro) {
     replicationFeedMonitors(c, server.monitors, c->db->id, c->argv, c->argc);
 
     robj *function_name = c->argv[1];
-    dictEntry *de = c->cur_script;
+    dictEntry *de = (dictEntry *)c->cur_script;
     if (!de) de = dictFind(curr_functions_lib_ctx->functions, objectGetVal(function_name));
     if (!de) {
         addReplyError(c, "Function not found");

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -248,9 +248,9 @@ void freeErrorsRadixTreeAsync(rax *errors) {
 /* Free scripts dict, and lru list, if the dict is huge enough, free them in
  * async way.
  * Close lua interpreter, if there are a lot of lua scripts, close it in async way. */
-void freeEvalScriptsAsync(dict *scripts, list *scripts_lru_list, list *engine_callbacks) {
-    if (dictSize(scripts) > LAZYFREE_THRESHOLD) {
-        atomic_fetch_add_explicit(&lazyfree_objects, dictSize(scripts), memory_order_relaxed);
+void freeEvalScriptsAsync(hashtable *scripts, list *scripts_lru_list, list *engine_callbacks) {
+    if (hashtableSize(scripts) > LAZYFREE_THRESHOLD) {
+        atomic_fetch_add_explicit(&lazyfree_objects, hashtableSize(scripts), memory_order_relaxed);
         bioCreateLazyFreeJob(lazyFreeEvalScripts, 3, scripts, scripts_lru_list, engine_callbacks);
     } else {
         freeEvalScripts(scripts, scripts_lru_list, engine_callbacks);

--- a/src/lazyfree.c
+++ b/src/lazyfree.c
@@ -54,10 +54,10 @@ void lazyFreeErrors(void *args[]) {
 
 /* Release the eval scripts data structures. */
 void lazyFreeEvalScripts(void *args[]) {
-    dict *scripts = args[0];
+    hashtable *scripts = args[0];
     list *scripts_lru_list = args[1];
     list *engine_callbacks = args[2];
-    long long len = dictSize(scripts);
+    long long len = hashtableSize(scripts);
     freeEvalScripts(scripts, scripts_lru_list, engine_callbacks);
     atomic_fetch_sub_explicit(&lazyfree_objects, len, memory_order_relaxed);
     atomic_fetch_add_explicit(&lazyfreed_objects, len, memory_order_relaxed);
@@ -245,9 +245,7 @@ void freeErrorsRadixTreeAsync(rax *errors) {
     }
 }
 
-/* Free scripts dict, and lru list, if the dict is huge enough, free them in
- * async way.
- * Close lua interpreter, if there are a lot of lua scripts, close it in async way. */
+/* Free eval scripts hashtable and lru list. If large enough, free in async. */
 void freeEvalScriptsAsync(hashtable *scripts, list *scripts_lru_list, list *engine_callbacks) {
     if (hashtableSize(scripts) > LAZYFREE_THRESHOLD) {
         atomic_fetch_add_explicit(&lazyfree_objects, hashtableSize(scripts), memory_order_relaxed);

--- a/src/object.c
+++ b/src/object.c
@@ -1551,7 +1551,7 @@ sds getMemoryDoctorReport(void) {
         }
 
         /* Too many scripts are cached? */
-        if (dictSize(evalScriptsDict()) > 1000) {
+        if (hashtableSize(evalScriptsDict()) > 1000) {
             many_scripts = 1;
             num_reports++;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -6309,7 +6309,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "used_memory_vm_eval:%lld\r\n", memory_lua,
                 "used_memory_lua_human:%s\r\n", used_memory_lua_hmem, /* deprecated */
                 "used_memory_scripts_eval:%lld\r\n", (long long)mh->lua_caches,
-                "number_of_cached_scripts:%zu\r\n", dictSize(evalScriptsDict()),
+                "number_of_cached_scripts:%zu\r\n", hashtableSize(evalScriptsDict()),
                 "number_of_functions:%lu\r\n", functionsNum(),
                 "number_of_libraries:%lu\r\n", functionsLibNum(),
                 "used_memory_vm_functions:%lld\r\n", memory_functions,

--- a/src/server.h
+++ b/src/server.h
@@ -1394,7 +1394,7 @@ typedef struct client {
     listNode *client_list_node;        /* list node in client list */
     mstime_t buf_peak_last_reset_time; /* keeps the last time the buffer peak value was reset */
     size_t querybuf_peak;              /* Recent (100ms or more) peak of querybuf size. */
-    dictEntry *cur_script;             /* Cached pointer to the dictEntry of the script being executed. */
+    void *cur_script;                  /* Cached pointer to the script entry being executed. */
     user *user;                        /* User associated with this connection */
     time_t obuf_soft_limit_reached_time;
     list *deferred_reply_errors;             /* Used for module thread safe contexts. */
@@ -3849,12 +3849,12 @@ int redis_check_rdb_main(int argc, char **argv, FILE *fp);
 int redis_check_aof_main(int argc, char **argv);
 
 /* Scripting */
-void freeEvalScripts(dict *scripts, list *scripts_lru_list, list *engine_callbacks);
-void freeEvalScriptsAsync(dict *scripts, list *scripts_lru_list, list *engine_callbacks);
+void freeEvalScripts(hashtable *scripts, list *scripts_lru_list, list *engine_callbacks);
+void freeEvalScriptsAsync(hashtable *scripts, list *scripts_lru_list, list *engine_callbacks);
 void freeFunctionsAsync(functionsLibCtx *lib_ctx, list *engine_callbacks);
 void sha1hex(char *digest, char *script, size_t len);
 unsigned long evalMemory(void);
-dict *evalScriptsDict(void);
+hashtable *evalScriptsDict(void);
 unsigned long evalScriptsMemory(void);
 uint64_t evalGetCommandFlags(client *c, uint64_t orig_flags);
 uint64_t fcallGetCommandFlags(client *c, uint64_t orig_flags);


### PR DESCRIPTION
### Motivation

`evalCtx.scripts` is looked up on every EVALSHA command (via `evalGetCommandFlags`). The previous implementation used a dict, which meant each cached script required:
- A separate `dictEntry` allocation (16B)
- A separate sds key allocation for the SHA1 hex string (~48B)
- Two pointer chases per lookup: bucket → dictEntry → sds key

By using the hashtable directly with `evalScript` as the entry type (with `sha[41]` embedded), we eliminate both extra allocations and reduce lookups to a single pointer chase: bucket → evalScript (where the SHA is immediately available for comparison).

### Changes

- `evalScript` gains a `char sha[41]` field and serves as the hashtable entry directly
- `evalCtx.scripts` changes from `dict*` to `hashtable*`
- LRU eviction list stores `evalScript*` directly instead of sds copies (eliminating per-entry `sdsdup`)
- `c->cur_script` changes from `dictEntry*` to `void*` since it is shared between eval (now `evalScript*`) and functions (still `dictEntry*`)
- Defrag reimplemented using `hashtableScanDefrag`
- `evalScript` typedef moved to `eval.h` for visibility in defrag.c

### Per-script savings

| | Before | After |
|---|---|---|
| Allocations | 3 (dictEntry 16B + sds key ~48B + evalScript 40B) | 1 (evalScript 80B with embedded SHA) |
| Total bytes | ~104B | 80B |
| Pointer chases per lookup | 2 | 1 |
| LRU list entry | sds copy (~48B) | pointer to existing evalScript (8B) |

**Net savings: ~64B per cached script** (24B from consolidated allocations + 40B from eliminating LRU sds copy).
