### PR TITLE
[backport] Weekly backport sweep for 9.1

### DIFF
--- a/deps/libvalkey/.github/workflows/build.yml
+++ b/deps/libvalkey/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build in FreeBSD
-        uses: vmactions/freebsd-vm@c9f815bc7aa0d34c9fdd0619b034a32d6ca7b57e # v1.4.2
+        uses: vmactions/freebsd-vm@d1e65811565151536c0c894fff74f06351ed26e6 # v1.4.5
         with:
           prepare: pkg install -y gmake cmake
           run: |
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build on Solaris
-        uses: vmactions/solaris-vm@69d382b4a775b25ea5955e6c1730e9d05047ca0d # v1.3.1
+        uses: vmactions/solaris-vm@c20562b2c69737b06be9e828915761703e487373 # v1.3.3
         with:
           prepare: pkgutil -y -i gmake gcc5core openssl_utils
           run: USE_TLS=1 gmake
@@ -108,7 +108,7 @@ jobs:
              > pkg.oracle.com.key.pem
 
        - name: Build on Solaris
-         uses: vmactions/solaris-vm@69d382b4a775b25ea5955e6c1730e9d05047ca0d # v1.3.1
+         uses: vmactions/solaris-vm@c20562b2c69737b06be9e828915761703e487373 # v1.3.3
          with:
            usesh: true
            prepare: |

--- a/deps/libvalkey/.github/workflows/ci.yml
+++ b/deps/libvalkey/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       matrix:
         include:
           # New compilers
-          - compiler: 'clang-20'
-            cmake-version: '4.0'
+          - compiler: 'clang-22'
+            cmake-version: '4.2'
             cmake-build-type: Release
-          - compiler: 'gcc-14'
-            cmake-version: '4.0'
+          - compiler: 'gcc-15'
+            cmake-version: '4.2'
             cmake-build-type: Release
           # Old compilers
           - compiler: 'clang-14'
@@ -45,10 +45,12 @@ jobs:
             cmake-version: '3.13'
             cmake-build-type: Release
         # Sanitizers enabled
-        compiler: ['gcc-14', 'clang-20']
-        cmake-version: ['4.0']
+        compiler: ['clang-22', 'gcc-15']
+        cmake-version: ['4.2']
         cmake-build-type: [RelWithDebInfo]
         sanitizer: [thread, undefined, leak, address]
+    env:
+      CC: ${{ matrix.compiler }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Prepare
@@ -57,13 +59,27 @@ jobs:
         packages: libevent-dev libuv1-dev libev-dev libglib2.0-dev valkey-server
         version: 1.0
     - name: Setup compiler
-      uses: aminya/setup-cpp@1f17f92d6a52bfcb1a25348e2c526c2e5cbb1134 # v1.8.0
-      with:
-        compiler: ${{ matrix.compiler }}
+      run: |
+        COMP="${{ matrix.compiler }}"
+        TYPE="${COMP%%-*}"
+        VERSION="${COMP##*-}"
+        echo "Installing $TYPE version $VERSION"
+
+        if [ "$TYPE" = "clang" ]; then
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          # Temporary fix to install clang-22
+          sed -i 's/LLVM_VERSION_PATTERNS\[22\]=\"\"/LLVM_VERSION_PATTERNS[22]=\"-22\"/' llvm.sh
+          sudo apt-get install -y "${{ matrix.compiler }}" || sudo ./llvm.sh "$VERSION"
+        else
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y "${{ matrix.compiler }}"
+        fi
     - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
+      uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
       with:
-        cmake-version: ${{ matrix.cmake-version }}
+        cmakeVersion: ${{ matrix.cmake-version }}
     - name: Generate makefiles
       run: |
         if [ -n "${{ matrix.sanitizer }}" ]; then
@@ -207,9 +223,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
+        uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
         with:
-          cmake-version: '3.7.0'
+          cmakeVersion: '3.7.0'
       - name: Generate makefiles
         run: |
           mkdir build && cd build
@@ -251,7 +267,7 @@ jobs:
         run: |
           choco install -y memurai-developer
       - name: Install dependencies (vcpkg)
-        uses: johnwason/vcpkg-action@caa1c94fbb94d8b023a0cc93edf10cd3791349a7 # v7.0.1
+        uses: johnwason/vcpkg-action@04c68c847bf5196ecaa72331ecf51208583916ef # v8.0.0
         with:
           pkgs: pkgconf libevent openssl
           triplet: x64-windows
@@ -293,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up MinGW
-        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: mingw64
           install: |

--- a/deps/libvalkey/.github/workflows/release-drafter.yml
+++ b/deps/libvalkey/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6.2.0
+      - uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/deps/libvalkey/.github/workflows/spellcheck.yml
+++ b/deps/libvalkey/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run spellcheck
-        uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # 0.58.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e # 0.60.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install typos
-        uses: taiki-e/install-action@288875dd3d64326724fa6d9593062d9f8ba0b131 # v2.67.30
+        uses: taiki-e/install-action@db5fb34fa772531a3ece57ca434f579eb334e0fb # v2.75.30
         with:
           tool: typos
       - name: Run typos

--- a/deps/libvalkey/Makefile
+++ b/deps/libvalkey/Makefile
@@ -18,7 +18,7 @@ TEST_BINS = $(patsubst $(TEST_DIR)/%.c,$(TEST_DIR)/%,$(TEST_SRCS))
 SOURCES = $(filter-out $(SRC_DIR)/tls.c $(SRC_DIR)/rdma.c, $(wildcard $(SRC_DIR)/*.c))
 HEADERS = $(filter-out $(INCLUDE_DIR)/tls.h $(INCLUDE_DIR)/rdma.h, $(wildcard $(INCLUDE_DIR)/*.h))
 
-# Allow the libvalkey provided sds and dict types to be replaced by
+# Allow the libvalkey provided sds type to be replaced by
 # compatible implementations (like Valkey's).
 # A replaced type is not included in a built archive or shared library.
 SDS_INCLUDE_DIR ?= $(SRC_DIR)

--- a/deps/libvalkey/docs/standalone.md
+++ b/deps/libvalkey/docs/standalone.md
@@ -43,6 +43,8 @@ valkeyContext *valkeyConnectWithOptions(valkeyOptions *opt);
 
 When connecting to a server, libvalkey will return `NULL` in the event that we can't allocate the context, and set the `err` member if we can connect but there are issues. So when connecting it's simple to handle error states.
 
+When a hostname resolves to multiple addresses, libvalkey will try each address in order until one succeeds or all have failed. Note that the `connect_timeout` applies per address, so the total connection time may be up to N × timeout when multiple addresses are unreachable.
+
 ```c
 valkeyContext *ctx = valkeyConnect("localhost", 6379);
 if (ctx == NULL || ctx->err) {

--- a/deps/libvalkey/include/valkey/read.h
+++ b/deps/libvalkey/include/valkey/read.h
@@ -117,6 +117,8 @@ typedef struct valkeyReader {
 LIBVALKEY_API valkeyReader *valkeyReaderCreateWithFunctions(valkeyReplyObjectFunctions *fn);
 LIBVALKEY_API void valkeyReaderFree(valkeyReader *r);
 LIBVALKEY_API int valkeyReaderFeed(valkeyReader *r, const char *buf, size_t len);
+LIBVALKEY_API int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minbytes);
+LIBVALKEY_API void valkeyReaderCommitRead(valkeyReader *r, size_t nread);
 LIBVALKEY_API int valkeyReaderGetReply(valkeyReader *r, void **reply);
 
 #define valkeyReaderSetPrivdata(_r, _p) (int)(((valkeyReader *)(_r))->privdata = (_p))

--- a/deps/libvalkey/include/valkey/valkey.h
+++ b/deps/libvalkey/include/valkey/valkey.h
@@ -50,7 +50,7 @@ typedef SSIZE_T ssize_t;
 #include <stdint.h> /* uintXX_t, etc */
 
 #define LIBVALKEY_VERSION_MAJOR 0
-#define LIBVALKEY_VERSION_MINOR 4
+#define LIBVALKEY_VERSION_MINOR 5
 #define LIBVALKEY_VERSION_PATCH 0
 
 /* Connection type can be blocking or non-blocking and is set in the

--- a/deps/libvalkey/src/async.c
+++ b/deps/libvalkey/src/async.c
@@ -44,6 +44,7 @@
 
 #include "async.h"
 #include "async_private.h"
+#include "dict.h"
 #include "net.h"
 #include "valkey_private.h"
 #include "vkutil.h"
@@ -520,9 +521,9 @@ static int valkeyGetSubscribeCallback(valkeyAsyncContext *ac, valkeyReply *reply
                 c->flags &= ~VALKEY_SUBSCRIBED;
 
                 /* Move ongoing regular command callbacks. */
-                valkeyCallback cb;
-                while (valkeyShiftCallback(&ac->sub.replies, &cb) == VALKEY_OK) {
-                    valkeyPushCallback(&ac->replies, &cb);
+                valkeyCallback reply_cb;
+                while (valkeyShiftCallback(&ac->sub.replies, &reply_cb) == VALKEY_OK) {
+                    valkeyPushCallback(&ac->replies, &reply_cb);
                 }
             }
         }
@@ -941,9 +942,9 @@ void valkeySsubscribeCallback(struct valkeyAsyncContext *ac, void *reply, void *
             }
         }
 
-        valkeyCallback cb = {0};
-        valkeyGetSubscribeCallback(ac, reply, &cb);
-        valkeyRunCallback(ac, &cb, reply);
+        valkeyCallback sub_cb = {0};
+        valkeyGetSubscribeCallback(ac, reply, &sub_cb);
+        valkeyRunCallback(ac, &sub_cb, reply);
         vk_free(data->command);
         vk_free(privdata);
         return;

--- a/deps/libvalkey/src/cluster.c
+++ b/deps/libvalkey/src/cluster.c
@@ -38,6 +38,7 @@
 #include "adlist.h"
 #include "alloc.h"
 #include "command.h"
+#include "dict.h"
 #include "vkutil.h"
 
 #include <dict.h>
@@ -212,13 +213,13 @@ static replyErrorType getReplyErrorType(valkeyReply *reply) {
 
     if (reply->type != VALKEY_REPLY_ERROR)
         return CLUSTER_NO_ERROR;
-    if (memcmp(reply->str, "MOVED", 5) == 0)
+    if (reply->len >= 5 && memcmp(reply->str, "MOVED", 5) == 0)
         return CLUSTER_ERR_MOVED;
-    if (memcmp(reply->str, "ASK", 3) == 0)
+    if (reply->len >= 3 && memcmp(reply->str, "ASK", 3) == 0)
         return CLUSTER_ERR_ASK;
-    if (memcmp(reply->str, "TRYAGAIN", 8) == 0)
+    if (reply->len >= 8 && memcmp(reply->str, "TRYAGAIN", 8) == 0)
         return CLUSTER_ERR_TRYAGAIN;
-    if (memcmp(reply->str, "CLUSTERDOWN", 11) == 0)
+    if (reply->len >= 11 && memcmp(reply->str, "CLUSTERDOWN", 11) == 0)
         return CLUSTER_ERR_CLUSTERDOWN;
     return CLUSTER_ERR_OTHER;
 }

--- a/deps/libvalkey/src/net.c
+++ b/deps/libvalkey/src/net.c
@@ -72,7 +72,7 @@ static ssize_t valkeyNetRead(valkeyContext *c, char *buf, size_t bufcap) {
             valkeySetError(c, VALKEY_ERR_TIMEOUT, "recv timeout");
             return -1;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     } else if (nread == 0) {
@@ -92,23 +92,12 @@ static ssize_t valkeyNetWrite(valkeyContext *c) {
             /* Try again */
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }
 
     return nwritten;
-}
-
-static void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix) {
-    int errorno = errno; /* snprintf() may change errno */
-    char buf[128] = {0};
-    size_t len = 0;
-
-    if (prefix != NULL)
-        len = snprintf(buf, sizeof(buf), "%s: ", prefix);
-    strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
-    valkeySetError(c, type, buf);
 }
 
 static int valkeySetReuseAddr(valkeyContext *c) {
@@ -180,7 +169,7 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
 
 #ifndef _WIN32
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
@@ -188,13 +177,13 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
 
 #if defined(__APPLE__) && defined(__MACH__)
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 #else
 #if defined(__GLIBC__) && !defined(__FreeBSD_kernel__)
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
@@ -202,13 +191,13 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
     if (val == 0)
         val = 1;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
     val = 3;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 #endif
@@ -486,6 +475,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
             continue;
 
         c->fd = s;
+        /* Use non-blocking connect to be able to enforce connect timeout. */
         if (valkeySetBlocking(c, 0) != VALKEY_OK)
             goto error;
         if (c->tcp.source_addr) {
@@ -515,9 +505,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
             }
             freeaddrinfo(bservinfo);
             if (!bound) {
-                char buf[128];
-                snprintf(buf, sizeof(buf), "Can't bind socket: %s", strerror(errno));
-                valkeySetError(c, VALKEY_ERR_OTHER, buf);
+                valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, "Can't bind socket");
                 goto error;
             }
         }
@@ -532,43 +520,39 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
         c->addrlen = p->ai_addrlen;
 
         if (connect(s, p->ai_addr, p->ai_addrlen) == -1) {
-            if (errno == EHOSTUNREACH) {
-                valkeyNetClose(c);
-                continue;
-            } else if (errno == EINPROGRESS) {
-                if (blocking) {
-                    goto wait_for_ready;
-                }
-                /* This is ok.
-                 * Note that even when it's in blocking mode, we unset blocking
-                 * for `connect()`
-                 */
-            } else if (errno == EADDRNOTAVAIL && reuseaddr) {
-                if (++reuses >= VALKEY_CONNECT_RETRIES) {
-                    goto error;
-                } else {
+            if (errno == EINPROGRESS) {
+                if (blocking && valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK) {
                     valkeyNetClose(c);
+                    continue;
+                }
+                /* Non-blocking: EINPROGRESS is expected, continue to success. */
+            } else if (errno == EADDRNOTAVAIL && reuseaddr) {
+                valkeyNetClose(c);
+                if (++reuses >= VALKEY_CONNECT_RETRIES) {
+                    continue;
+                } else {
                     goto addrretry;
                 }
             } else {
-            wait_for_ready:
-                if (valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK)
-                    goto error;
-                if (valkeySetTcpNoDelay(c) != VALKEY_OK)
-                    goto error;
+                valkeyNetClose(c);
+                continue;
             }
         }
+        /* TCP_NODELAY is set here for blocking connections only. For non-blocking,
+         * it's deferred to valkeyAsyncHandleConnect() after connect completes,
+         * since some systems reject setsockopt on in-progress sockets. */
+        if (blocking && valkeySetTcpNoDelay(c) != VALKEY_OK)
+            goto error;
         if (blocking && valkeySetBlocking(c, 1) != VALKEY_OK)
             goto error;
 
         c->flags |= VALKEY_CONNECTED;
         rv = VALKEY_OK;
+        valkeyClearError(c);
         goto end;
     }
     if (p == NULL) {
-        char buf[128];
-        snprintf(buf, sizeof(buf), "Can't create socket: %s", strerror(errno));
-        valkeySetError(c, VALKEY_ERR_OTHER, buf);
+        valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
         goto error;
     }
 

--- a/deps/libvalkey/src/rdma.c
+++ b/deps/libvalkey/src/rdma.c
@@ -48,6 +48,8 @@
 #include <poll.h>
 #include <rdma/rdma_cma.h>
 #include <stdint.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -258,6 +260,7 @@ typedef struct RdmaContext {
     struct ibv_comp_channel *comp_channel;
     struct ibv_cq *cq;
     struct ibv_pd *pd;
+    int evfd;
 
     /* TX */
     char *tx_addr;
@@ -306,6 +309,52 @@ static int valkeyRdmaSetFdBlocking(valkeyContext *c, int fd, int blocking) {
     }
 
     return 0;
+}
+
+static int valkeyRdmaAddEpoll(int epfd, int fd) {
+    struct epoll_event event = {0};
+
+    /* EPOLLIN only by default */
+    event.events = EPOLLIN | EPOLLET;
+    event.data.fd = fd;
+
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event)) {
+        return VALKEY_ERR;
+    }
+
+    return VALKEY_OK;
+}
+
+static inline int rdmaEventKick(int evfd) {
+    uint64_t u = 1;
+    ssize_t ret;
+
+    ret = write(evfd, &u, sizeof(u));
+    if (ret == sizeof(uint64_t)) {
+        return VALKEY_OK;
+    } else {
+        if (errno == EAGAIN) {
+            return VALKEY_OK;
+        }
+    }
+
+    return VALKEY_ERR;
+}
+
+static inline int rdmaEventAck(int evfd) {
+    uint64_t u = 1;
+    ssize_t ret;
+
+    ret = read(evfd, &u, sizeof(u));
+    if (ret == sizeof(uint64_t)) {
+        return VALKEY_OK;
+    } else {
+        if (errno == EAGAIN) {
+            return VALKEY_OK;
+        }
+    }
+
+    return VALKEY_ERR;
 }
 
 static int rdmaPostRecv(RdmaContext *ctx, struct rdma_cm_id *cm_id, valkeyRdmaCmd *cmd) {
@@ -609,48 +658,63 @@ pollcq:
     return VALKEY_OK;
 }
 
-/* There are two FD(s) in use:
+/* There are three FD(s) in epollfd:
  * - fd of CM channel: handle CM event. Return error on Disconnected.
  * - fd of completion channel: handle CQ event.
- * Return OK on CQ event ready, then CQ event should be handled outside.
+ * - fd of eventfd: handle event EPOLLIN event.
+ * Return VALKEY_ERR on failure
  */
-static int valkeyRdmaPollCqCm(valkeyContext *c, long timed) {
-#define VALKEY_RDMA_POLLFD_CM 0
-#define VALKEY_RDMA_POLLFD_CQ 1
-#define VALKEY_RDMA_POLLFD_MAX 2
-    struct pollfd pfd[VALKEY_RDMA_POLLFD_MAX];
+static int valkeyRdmaWaitEvent(valkeyContext *c, long timed) {
     RdmaContext *ctx = c->privctx;
-    long now = vk_msec_now();
+    struct epoll_event events[3];
+    int nevent, i, fd;
     int ret;
 
-    if (now >= timed) {
-        valkeySetError(c, VALKEY_ERR_IO, "RDMA: IO timeout");
+    while (1) {
+        nevent = epoll_wait(c->fd, events, sizeof(events) / sizeof(events[0]), timed);
+        if (nevent > 0) {
+            break;
+        }
+
+        if (!nevent) {
+            if (!timed) {
+                return VALKEY_OK;
+            } else {
+                valkeySetError(c, VALKEY_ERR_IO, "Resource temporarily unavailable");
+                return VALKEY_ERR;
+            }
+        }
+
+        if (errno == EINTR) {
+            continue;
+        }
+
+        valkeySetError(c, VALKEY_ERR_IO, "RDMA: epoll wait failed");
         return VALKEY_ERR;
     }
 
-    /* pfd[0] for CM event */
-    pfd[VALKEY_RDMA_POLLFD_CM].fd = ctx->cm_channel->fd;
-    pfd[VALKEY_RDMA_POLLFD_CM].events = POLLIN;
-    pfd[VALKEY_RDMA_POLLFD_CM].revents = 0;
+    for (i = 0; i < nevent; i++) {
+        fd = events[i].data.fd;
 
-    /* pfd[1] for CQ event */
-    pfd[VALKEY_RDMA_POLLFD_CQ].fd = ctx->comp_channel->fd;
-    pfd[VALKEY_RDMA_POLLFD_CQ].events = POLLIN;
-    pfd[VALKEY_RDMA_POLLFD_CQ].revents = 0;
-    ret = poll(pfd, VALKEY_RDMA_POLLFD_MAX, timed - now);
-    if (ret < 0) {
-        valkeySetError(c, VALKEY_ERR_IO, "RDMA: Poll CQ/CM failed");
-        return VALKEY_ERR;
-    } else if (ret == 0) {
-        valkeySetError(c, VALKEY_ERR_IO, "Resource temporarily unavailable");
-        return VALKEY_ERR;
-    }
-
-    if (pfd[VALKEY_RDMA_POLLFD_CM].revents & POLLIN) {
-        valkeyRdmaCM(c, 0);
-        if (!(c->flags & VALKEY_CONNECTED)) {
-            valkeySetError(c, VALKEY_ERR_EOF, "Server closed the connection");
-            return VALKEY_ERR;
+        if (fd == ctx->comp_channel->fd) {
+            ret = connRdmaHandleCq(c);
+            if (ret == VALKEY_ERR) {
+                return VALKEY_ERR;
+            }
+        } else if (fd == ctx->evfd) {
+            ret = rdmaEventAck(ctx->evfd);
+            if (ret == VALKEY_ERR) {
+                valkeySetError(c, VALKEY_ERR_IO, "Failed to ACK eventfd");
+                return VALKEY_ERR;
+            }
+        } else if (fd == ctx->cm_channel->fd) {
+            valkeyRdmaCM(c, 0);
+            if (!(c->flags & VALKEY_CONNECTED)) {
+                valkeySetError(c, VALKEY_ERR_EOF, "Server closed the connection");
+                return VALKEY_ERR;
+            }
+        } else {
+            assert(0); /* this should never happed */
         }
     }
 
@@ -659,33 +723,38 @@ static int valkeyRdmaPollCqCm(valkeyContext *c, long timed) {
 
 static ssize_t valkeyRdmaReadZC(valkeyContext *c, char **buf) {
     RdmaContext *ctx = c->privctx;
-    long timed, end;
+    long start = vk_msec_now(), timed, elapsed;
     uint32_t remained;
 
     if (valkeyCommandTimeoutMsec(c, &timed)) {
         return VALKEY_ERR;
     }
 
-    end = vk_msec_now() + timed;
-
-pollcq:
-    /* try to poll a CQ first */
-    if (connRdmaHandleCq(c) == VALKEY_ERR) {
+    /* typically invoked by POLLIN/EPOLLIN event, handle events */
+    if (valkeyRdmaWaitEvent(c, 0) == VALKEY_ERR) {
         return VALKEY_ERR;
     }
 
-    if (ctx->recv_offset < ctx->rx_offset) {
-        remained = ctx->rx_offset - ctx->recv_offset;
-        *buf = ctx->recv_buf + ctx->recv_offset;
-        ctx->recv_offset = ctx->rx_offset;
-        return remained;
+    while (1) {
+        if (ctx->recv_offset < ctx->rx_offset) {
+            remained = ctx->rx_offset - ctx->recv_offset;
+            *buf = ctx->recv_buf + ctx->recv_offset;
+            ctx->recv_offset = ctx->rx_offset;
+            return remained;
+        }
+
+        elapsed = vk_msec_now() - start;
+        if (elapsed >= timed) {
+            valkeySetError(c, VALKEY_ERR_IO, "RDMA: IO timeout");
+            break;
+        }
+
+        if (valkeyRdmaWaitEvent(c, timed - elapsed) == VALKEY_ERR) {
+            return VALKEY_ERR;
+        }
     }
 
-    if (valkeyRdmaPollCqCm(c, end) == VALKEY_OK) {
-        goto pollcq;
-    } else {
-        return VALKEY_ERR;
-    }
+    return VALKEY_ERR;
 }
 
 static ssize_t valkeyRdmaReadZCDone(valkeyContext *c) {
@@ -735,7 +804,7 @@ static ssize_t valkeyRdmaWrite(valkeyContext *c) {
     RdmaContext *ctx = c->privctx;
     struct rdma_cm_id *cm_id = ctx->cm_id;
     size_t data_len = sdslen(c->obuf);
-    long timed, end;
+    long start = vk_msec_now(), timed, elapsed;
     uint32_t towrite, wrote = 0;
     size_t ret;
 
@@ -743,36 +812,41 @@ static ssize_t valkeyRdmaWrite(valkeyContext *c) {
         return VALKEY_ERR;
     }
 
-    end = vk_msec_now() + timed;
-
-pollcq:
-    if (connRdmaHandleCq(c) == VALKEY_ERR) {
+    if (valkeyRdmaWaitEvent(c, 0) == VALKEY_ERR) {
         return VALKEY_ERR;
     }
 
-    assert(ctx->tx_offset <= ctx->tx_length);
-    if (ctx->tx_offset == ctx->tx_length) {
-        /* wait a new TX buffer */
-        goto waitcq;
+    do {
+        assert(ctx->tx_offset <= ctx->tx_length);
+        if (ctx->tx_offset == ctx->tx_length) {
+            /* wait a new TX buffer */
+            elapsed = vk_msec_now() - start;
+            if (elapsed >= timed) {
+                valkeySetError(c, VALKEY_ERR_IO, "RDMA: IO timeout");
+                return VALKEY_ERR;
+            }
+
+            if (valkeyRdmaWaitEvent(c, timed - elapsed) == VALKEY_ERR) {
+                return VALKEY_ERR;
+            }
+
+            continue;
+        }
+
+        towrite = valkeyMin(ctx->tx_length - ctx->tx_offset, data_len - wrote);
+        ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite);
+        if (ret == (size_t)VALKEY_ERR) {
+            return VALKEY_ERR;
+        }
+
+        wrote += ret;
+    } while (wrote < data_len);
+
+    if (ctx->recv_offset < ctx->rx_offset) {
+        rdmaEventKick(ctx->evfd); /* schedule a new EPOLLIN/POLLIN event to wake up read handler */
     }
 
-    towrite = valkeyMin(ctx->tx_length - ctx->tx_offset, data_len - wrote);
-    ret = connRdmaSend(ctx, cm_id, c->obuf + wrote, towrite);
-    if (ret == (size_t)VALKEY_ERR) {
-        return VALKEY_ERR;
-    }
-
-    wrote += ret;
-    if (wrote == data_len) {
-        return data_len;
-    }
-
-waitcq:
-    if (valkeyRdmaPollCqCm(c, end) == VALKEY_OK) {
-        goto pollcq;
-    } else {
-        return VALKEY_ERR;
-    }
+    return data_len;
 }
 
 /* RDMA has no POLLOUT event supported, so it couldn't work well with valkey async mechanism */
@@ -803,6 +877,8 @@ static void valkeyRdmaClose(valkeyContext *c) {
     rdma_destroy_id(cm_id);
 
     rdma_destroy_event_channel(ctx->cm_channel);
+    close(ctx->evfd);
+    close(c->fd);
 }
 
 static void valkeyRdmaFree(void *privctx) {
@@ -834,6 +910,11 @@ static int valkeyRdmaConnect(valkeyContext *c, struct rdma_cm_id *cm_id) {
 
     if (valkeyRdmaSetFdBlocking(c, comp_channel->fd, 0) != VALKEY_OK) {
         valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: set recv comp channel fd non-block failed");
+        goto error;
+    }
+
+    if (valkeyRdmaAddEpoll(c->fd, comp_channel->fd)) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: failed to add comp channel fd into epollfd");
         goto error;
     }
 
@@ -897,12 +978,9 @@ error:
 }
 
 static int valkeyRdmaEstablished(valkeyContext *c, struct rdma_cm_id *cm_id) {
-    RdmaContext *ctx = c->privctx;
-
-    /* it's time to tell redis we have already connected */
+    /* it's time to tell upper layer we have already connected */
     c->flags |= VALKEY_CONNECTED;
     c->funcs = &valkeyContextRdmaFuncs;
-    c->fd = ctx->comp_channel->fd;
 
     return connRdmaRegisterRx(c, cm_id);
 }
@@ -956,9 +1034,10 @@ static int valkeyRdmaCM(valkeyContext *c, long timeout) {
 }
 
 static int valkeyRdmaWaitConn(valkeyContext *c, long timeout) {
-    struct pollfd pfd;
     long now, end;
     RdmaContext *ctx = c->privctx;
+    struct epoll_event events[1], *event;
+    int nevent;
 
     assert(timeout >= 0);
     end = vk_msec_now() + timeout;
@@ -969,13 +1048,22 @@ static int valkeyRdmaWaitConn(valkeyContext *c, long timeout) {
             break;
         }
 
-        pfd.fd = ctx->cm_channel->fd;
-        pfd.events = POLLIN;
-        pfd.revents = 0;
-        if (poll(&pfd, 1, end - now) < 0) {
+        nevent = epoll_wait(c->fd, events, sizeof(events) / sizeof(events[0]), end - now);
+        if (!nevent) {
+            break;
+        }
+
+        if (nevent < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+
+            valkeySetError(c, VALKEY_ERR_IO, "RDMA: epoll wait failed");
             return VALKEY_ERR;
         }
 
+        event = &events[0];
+        assert(event->data.fd == ctx->cm_channel->fd); /* CM channel fd wakes up only now */
         if (valkeyRdmaCM(c, end - now) == VALKEY_ERR) {
             return VALKEY_ERR;
         }
@@ -1003,6 +1091,7 @@ static int valkeyContextConnectRdma(valkeyContext *c, const valkeyOptions *optio
     c->connection_type = VALKEY_CONN_RDMA;
     c->tcp.port = port;
     c->flags &= ~VALKEY_CONNECTED;
+    c->fd = -1;
 
     if (port < 0 || port > UINT16_MAX) {
         valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: Port number must be between 0-65535");
@@ -1104,6 +1193,28 @@ static int valkeyContextConnectRdma(valkeyContext *c, const valkeyOptions *optio
         goto error;
     }
 
+    ctx->evfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (ctx->evfd == -1) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: failed to create eventfd");
+        goto error;
+    }
+
+    c->fd = epoll_create1(0);
+    if (c->fd == -1) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: failed to create epollfd");
+        goto error;
+    }
+
+    if (valkeyRdmaAddEpoll(c->fd, ctx->evfd)) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: failed to add eventfd into epollfd");
+        goto error;
+    }
+
+    if (valkeyRdmaAddEpoll(c->fd, ctx->cm_channel->fd)) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "RDMA: failed to add RDMA CM channel FD into epollfd");
+        goto error;
+    }
+
     timed = vk_msec_now() - start;
     if (timed >= timeout_msec) {
         valkeySetError(c, VALKEY_ERR_TIMEOUT, "RDMA: resolving timeout");
@@ -1125,8 +1236,16 @@ error:
             rdma_destroy_event_channel(ctx->cm_channel);
         }
 
+        if (ctx->evfd > 0) {
+            close(ctx->evfd);
+        }
+
         vk_free(ctx);
         c->privctx = NULL;
+    }
+
+    if (c->fd > 0) {
+        close(c->fd);
     }
 
 end:

--- a/deps/libvalkey/src/read.c
+++ b/deps/libvalkey/src/read.c
@@ -556,8 +556,23 @@ static int processAggregateItem(valkeyReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == VALKEY_REPLY_MAP || cur->type == VALKEY_REPLY_ATTR)
+            if (cur->type == VALKEY_REPLY_MAP ||
+                cur->type == VALKEY_REPLY_ATTR) {
+
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                                         "Multi-bulk length out of range");
+                    return VALKEY_ERR;
+                }
+
                 elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur, elements);
@@ -732,36 +747,83 @@ void valkeyReaderFree(valkeyReader *r) {
 }
 
 int valkeyReaderFeed(valkeyReader *r, const char *buf, size_t len) {
-    sds newbuf;
-
     /* Return early when this reader is in an erroneous state. */
     if (r->err)
         return VALKEY_ERR;
 
-    /* Copy the provided buffer. */
     if (buf != NULL && len >= 1) {
-        /* Destroy internal buffer when it is empty and is quite large. */
-        if (r->len == 0 && r->maxbuf != 0 && sdsavail(r->buf) > r->maxbuf) {
-            sdsfree(r->buf);
-            r->buf = sdsempty();
-            if (r->buf == 0)
-                goto oom;
-
-            r->pos = 0;
-        }
-
-        newbuf = sdscatlen(r->buf, buf, len);
-        if (newbuf == NULL)
-            goto oom;
-
-        r->buf = newbuf;
-        r->len = sdslen(r->buf);
+        char *dest;
+        size_t cap;
+        if (valkeyReaderGetReadBuf(r, &dest, &cap, len) != VALKEY_OK)
+            return VALKEY_ERR;
+        memcpy(dest, buf, len);
+        valkeyReaderCommitRead(r, len);
     }
 
     return VALKEY_OK;
+}
+
+/* Prepare the reader's internal buffer for a direct read. This compacts
+ * consumed data, ensures at least 'minbytes' of writable space, and returns
+ * a pointer and available capacity. The caller can then read() directly into
+ * *buf and call valkeyReaderCommitRead() with the number of bytes read.
+ * Returns VALKEY_OK on success, VALKEY_ERR on allocation failure. */
+int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minbytes) {
+    if (r->err)
+        return VALKEY_ERR;
+
+    if (minbytes > SSIZE_MAX) {
+        valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                             "Requested buffer size too large");
+        return VALKEY_ERR;
+    }
+
+    /* Destroy internal buffer when it is empty and is quite large. */
+    if (r->len == 0 && r->maxbuf != 0 && sdsavail(r->buf) > r->maxbuf) {
+        sdsfree(r->buf);
+        r->buf = sdsempty();
+        if (r->buf == NULL)
+            goto oom;
+        r->pos = 0;
+    }
+
+    /* Compact consumed data. */
+    if (r->pos > 0) {
+        if (sdslen(r->buf) > SSIZE_MAX) {
+            valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                                 "Reader buffer is too large");
+            return VALKEY_ERR;
+        }
+        sdsrange(r->buf, r->pos, -1);
+        r->pos = 0;
+        r->len = sdslen(r->buf);
+    }
+
+    /* Ensure enough writable space. */
+    if (sdsavail(r->buf) < minbytes) {
+        sds newbuf = sdsMakeRoomFor(r->buf, minbytes);
+        if (newbuf == NULL)
+            goto oom;
+        r->buf = newbuf;
+    }
+
+    *buf = r->buf + sdslen(r->buf);
+    *cap = sdsavail(r->buf);
+    if (*cap > SSIZE_MAX)
+        *cap = SSIZE_MAX;
+    return VALKEY_OK;
+
 oom:
     valkeyReaderSetErrorOOM(r);
     return VALKEY_ERR;
+}
+
+/* Commit bytes that were written directly into the buffer obtained from
+ * valkeyReaderGetReadBuf(). */
+void valkeyReaderCommitRead(valkeyReader *r, size_t nread) {
+    assert(nread <= SSIZE_MAX);
+    sdsIncrLen(r->buf, (ssize_t)nread);
+    r->len = sdslen(r->buf);
 }
 
 int valkeyReaderGetReply(valkeyReader *r, void **reply) {
@@ -796,17 +858,6 @@ int valkeyReaderGetReply(valkeyReader *r, void **reply) {
     /* Return ASAP when an error occurred. */
     if (r->err)
         return VALKEY_ERR;
-
-    /* Discard part of the buffer when we've consumed at least 1k, to avoid
-     * doing unnecessary calls to memmove() in sds.c. */
-    if (r->pos >= 1024) {
-        /* No length check in Valkeys sdsrange() */
-        if (sdslen(r->buf) > SSIZE_MAX)
-            return VALKEY_ERR;
-        sdsrange(r->buf, r->pos, -1);
-        r->pos = 0;
-        r->len = sdslen(r->buf);
-    }
 
     /* Emit a reply when there is one. */
     if (r->ridx == -1) {

--- a/deps/libvalkey/src/sds.c
+++ b/deps/libvalkey/src/sds.c
@@ -84,7 +84,7 @@ static inline char sdsReqType(size_t string_size) {
  * end of the string. However the string is binary safe and can contain
  * \0 characters in the middle, as the length is stored in the sds header. */
 sds sdsnewlen(const void *init, size_t initlen) {
-    void *sh;
+    void *s_hdr;
     sds s;
     char type = sdsReqType(initlen);
     /* Empty strings are usually created in order to append. Use type 8
@@ -96,12 +96,12 @@ sds sdsnewlen(const void *init, size_t initlen) {
 
     if (hdrlen + initlen + 1 <= initlen)
         return NULL; /* Catch size_t overflow */
-    sh = s_malloc(hdrlen + initlen + 1);
-    if (sh == NULL)
+    s_hdr = s_malloc(hdrlen + initlen + 1);
+    if (s_hdr == NULL)
         return NULL;
     if (!init)
-        memset(sh, 0, hdrlen + initlen + 1);
-    s = (char *)sh + hdrlen;
+        memset(s_hdr, 0, hdrlen + initlen + 1);
+    s = (char *)s_hdr + hdrlen;
     fp = ((unsigned char *)s) - 1;
     switch (type) {
     case SDS_TYPE_5: {
@@ -329,7 +329,7 @@ void *sdsAllocPtr(sds s) {
  * ... check for nread <= 0 and handle it ...
  * sdsIncrLen(s, nread);
  */
-void sdsIncrLen(sds s, int incr) {
+void sdsIncrLen(sds s, ssize_t incr) {
     unsigned char flags = s[-1];
     size_t len;
     switch (flags & SDS_TYPE_MASK) {

--- a/deps/libvalkey/src/sds.h
+++ b/deps/libvalkey/src/sds.h
@@ -261,7 +261,7 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
-void sdsIncrLen(sds s, int incr);
+void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);
 void *sdsAllocPtr(sds s);

--- a/deps/libvalkey/src/tls.c
+++ b/deps/libvalkey/src/tls.c
@@ -392,15 +392,15 @@ static int valkeyTLSConnect(valkeyContext *c, SSL *ssl) {
     }
 
     if (c->err == 0) {
-        char err[512];
         if (rv == SSL_ERROR_SYSCALL)
-            snprintf(err, sizeof(err) - 1, "SSL_connect failed: %s", strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, "SSL_connect failed");
         else {
             unsigned long e = ERR_peek_last_error();
-            snprintf(err, sizeof(err) - 1, "SSL_connect failed: %s",
+            char err[512];
+            snprintf(err, sizeof(err), "SSL_connect failed: %s",
                      ERR_reason_error_string(e));
+            valkeySetError(c, VALKEY_ERR_IO, err);
         }
-        valkeySetError(c, VALKEY_ERR_IO, err);
     }
 
     vk_free(rssl);
@@ -508,12 +508,11 @@ static ssize_t valkeyTLSRead(valkeyContext *c, char *buf, size_t bufcap) {
              */
             if (errno == EINTR) {
                 return 0;
+            } else if (errno == EAGAIN) {
+                valkeySetError(c, VALKEY_ERR_IO, "Resource temporarily unavailable");
+                return -1;
             } else {
-                const char *msg = NULL;
-                if (errno == EAGAIN) {
-                    msg = "Resource temporarily unavailable";
-                }
-                valkeySetError(c, VALKEY_ERR_IO, msg);
+                valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
                 return -1;
             }
         }
@@ -524,7 +523,7 @@ static ssize_t valkeyTLSRead(valkeyContext *c, char *buf, size_t bufcap) {
         if (maybeCheckWant(rssl, err)) {
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, NULL);
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }
@@ -545,7 +544,7 @@ static ssize_t valkeyTLSWrite(valkeyContext *c) {
         if ((c->flags & VALKEY_BLOCK) == 0 && maybeCheckWant(rssl, err)) {
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, NULL);
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }

--- a/deps/libvalkey/src/valkey.c
+++ b/deps/libvalkey/src/valkey.c
@@ -697,16 +697,26 @@ void valkeySetError(valkeyContext *c, int type, const char *str) {
     size_t len;
 
     c->err = type;
-    if (str != NULL) {
-        len = strlen(str);
-        len = len < (sizeof(c->errstr) - 1) ? len : (sizeof(c->errstr) - 1);
-        memcpy(c->errstr, str, len);
-        c->errstr[len] = '\0';
-    } else {
-        /* Only VALKEY_ERR_IO may lack a description! */
-        assert(type == VALKEY_ERR_IO);
-        strerror_r(errno, c->errstr, sizeof(c->errstr));
-    }
+    len = strlen(str);
+    len = len < (sizeof(c->errstr) - 1) ? len : (sizeof(c->errstr) - 1);
+    memcpy(c->errstr, str, len);
+    c->errstr[len] = '\0';
+}
+
+void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix) {
+    int errorno = errno; /* snprintf() may change errno */
+    char buf[128] = {0};
+    size_t len = 0;
+
+    if (prefix != NULL)
+        len = snprintf(buf, sizeof(buf), "%s: ", prefix);
+    strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
+    valkeySetError(c, type, buf);
+}
+
+void valkeyClearError(valkeyContext *c) {
+    c->err = 0;
+    memset(c->errstr, '\0', strlen(c->errstr));
 }
 
 valkeyReader *valkeyReaderCreate(void) {
@@ -774,8 +784,7 @@ valkeyFD valkeyFreeKeepFd(valkeyContext *c) {
 int valkeyReconnect(valkeyContext *c) {
     valkeyOptions options = {.connect_timeout = c->connect_timeout};
 
-    c->err = 0;
-    memset(c->errstr, '\0', strlen(c->errstr));
+    valkeyClearError(c);
 
     assert(c->funcs);
     if (c->funcs && c->funcs->close)
@@ -1002,8 +1011,7 @@ valkeyPushFn *valkeySetPushCallback(valkeyContext *c, valkeyPushFn *fn) {
  * After this function is called, you may use valkeyGetReplyFromReader to
  * see if there is a reply available. */
 int valkeyBufferRead(valkeyContext *c) {
-    char buf[1024 * 16];
-    int nread;
+    ssize_t nread;
 
     /* Return early when the context has seen an error. */
     if (c->err)
@@ -1021,13 +1029,20 @@ int valkeyBufferRead(valkeyContext *c) {
         }
         return c->funcs->read_zc_done(c);
     }
-    nread = c->funcs->read(c, buf, sizeof(buf));
+
+    /* Read directly into the reader's buffer to avoid a memcpy. */
+    char *buf;
+    size_t cap;
+    if (valkeyReaderGetReadBuf(c->reader, &buf, &cap, 1024 * 16) != VALKEY_OK) {
+        valkeySetError(c, c->reader->err, c->reader->errstr);
+        return VALKEY_ERR;
+    }
+    nread = c->funcs->read(c, buf, cap);
     if (nread < 0) {
         return VALKEY_ERR;
     }
-    if (nread > 0 && valkeyReaderFeed(c->reader, buf, nread) != VALKEY_OK) {
-        valkeySetError(c, c->reader->err, c->reader->errstr);
-        return VALKEY_ERR;
+    if (nread > 0) {
+        valkeyReaderCommitRead(c->reader, nread);
     }
     return VALKEY_OK;
 }

--- a/deps/libvalkey/src/valkey_private.h
+++ b/deps/libvalkey/src/valkey_private.h
@@ -42,6 +42,8 @@
 #include <string.h>
 
 LIBVALKEY_API void valkeySetError(valkeyContext *c, int type, const char *str);
+LIBVALKEY_API void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix);
+void valkeyClearError(valkeyContext *c);
 
 /* Helper function. Convert struct timeval to millisecond. */
 static inline int valkeyContextTimeoutMsec(const struct timeval *timeout, long *result) {

--- a/deps/libvalkey/tests/CMakeLists.txt
+++ b/deps/libvalkey/tests/CMakeLists.txt
@@ -97,6 +97,13 @@ target_include_directories(ut_slotmap_update PRIVATE "${PROJECT_SOURCE_DIR}/src"
 target_link_libraries(ut_slotmap_update valkey_unittest)
 add_test(NAME ut_slotmap_update COMMAND "$<TARGET_FILE:ut_slotmap_update>")
 
+if(NOT WIN32 AND NOT CYGWIN)
+  add_executable(ut_connect_fallback ut_connect_fallback.c)
+  target_compile_options(ut_connect_fallback PRIVATE -Wno-pedantic)
+  target_link_libraries(ut_connect_fallback valkey_unittest dl)
+  add_test(NAME ut_connect_fallback COMMAND "$<TARGET_FILE:ut_connect_fallback>")
+endif()
+
 # Cluster tests
 add_executable(ct_commands ct_commands.c test_utils.c)
 target_link_libraries(ct_commands valkey ${TLS_LIBRARY})
@@ -279,6 +286,13 @@ endif()
 
 if(GLIB_LIBRARY_FOUND)
   add_executable(ct_async_glib ct_async_glib.c)
+  # From clang-22 and https://github.com/llvm/llvm-project/pull/162662 the
+  # use of `__COUNTER__` in glib-2.0 causes warnings, e.g. in glib/gmacros.h:1243.
+  # Disabling the c2y-extensions warning until corrected in GLib.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND
+     CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+    target_compile_options(ct_async_glib PRIVATE -Wno-c2y-extensions)
+  endif()
   target_link_libraries(ct_async_glib valkey ${TLS_LIBRARY} PkgConfig::GLIB_LIBRARY)
   add_test(NAME ct_async_glib COMMAND "$<TARGET_FILE:ct_async_glib>")
 else()

--- a/deps/libvalkey/tests/client_test.c
+++ b/deps/libvalkey/tests/client_test.c
@@ -872,6 +872,16 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     valkeyReaderFree(reader);
 
+    /* RESP3 MAP/ATTR types double the element count being key-value pairs */
+    test("A RESP3 MAP/ATTR can't overflow: ");
+    reader = valkeyReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    valkeyReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = valkeyReaderGetReply(reader, &reply);
+    test_cond(ret == VALKEY_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    valkeyReaderFree(reader);
+
     test("Can parse RESP3 attribute: ");
     reader = valkeyReaderCreate();
     valkeyReaderFeed(reader, "|2\r\n+foo\r\n:123\r\n+bar\r\n#t\r\n", 26);

--- a/deps/libvalkey/tests/clusterclient.c
+++ b/deps/libvalkey/tests/clusterclient.c
@@ -27,6 +27,8 @@
 void printReply(const valkeyReply *reply) {
     switch (reply->type) {
     case VALKEY_REPLY_ERROR:
+        printf("Error: %s\n", reply->str);
+        break;
     case VALKEY_REPLY_STATUS:
     case VALKEY_REPLY_STRING:
     case VALKEY_REPLY_VERB:

--- a/deps/libvalkey/tests/clusterclient_async.c
+++ b/deps/libvalkey/tests/clusterclient_async.c
@@ -64,6 +64,8 @@ void sendNextCommand(evutil_socket_t, short, void *);
 void printReply(const valkeyReply *reply) {
     switch (reply->type) {
     case VALKEY_REPLY_ERROR:
+        printf("Error: %s\n", reply->str);
+        break;
     case VALKEY_REPLY_STATUS:
     case VALKEY_REPLY_STRING:
     case VALKEY_REPLY_VERB:

--- a/deps/libvalkey/tests/ct_out_of_memory_handling.c
+++ b/deps/libvalkey/tests/ct_out_of_memory_handling.c
@@ -11,18 +11,9 @@
  * Tests will call a libvalkeycluster API-function while iterating on a number,
  * the number of successful allocations during the call before it hits an OOM.
  * The result and the error code is then checked to show "Out of memory".
- * As a last step the correct number of allocations is prepared to get a
- * successful API-function call.
- *
- * Tip:
- * When this testcase fails after code changes in the library, run the testcase
- * in `gdb` to find which API call that failed, and in which iteration.
- * - Go to the correct stack frame to find which API that triggered a failure.
- * - Use the gdb command `print i` to find which iteration.
- * - Investigate if a failure or a success is expected after the code change.
- * - Set correct `i` in for-loop and the `prepare_allocation_test()` for the test.
- *   Correct `i` can be hard to know, finding the correct number might require trial
- *   and error of running with increased/decreased `i` until the edge is found.
+ * The required number of allocations for a successful call is discovered at
+ * runtime rather than hardcoded, making the tests resilient to changes in
+ * internal allocation patterns.
  */
 #define _XOPEN_SOURCE 600 /* For strdup() */
 #include "adapters/libevent.h"
@@ -148,15 +139,16 @@ void test_alloc_failure_handling(void) {
         valkeyReply *reply;
         const char *cmd = "SET key value";
 
-        for (int i = 0; i < 33; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover the number of allocations required for a successful call. */
+        int n;
+        for (n = 0; n < 1000; n++) {
+            prepare_allocation_test(cc, n);
             reply = (valkeyReply *)valkeyClusterCommand(cc, cmd);
-            assert(reply == NULL);
+            if (reply != NULL)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
-
-        prepare_allocation_test(cc, 33);
-        reply = (valkeyReply *)valkeyClusterCommand(cc, cmd);
+        assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -169,17 +161,15 @@ void test_alloc_failure_handling(void) {
         valkeyClusterNode *node = valkeyClusterGetNodeByKey(cc, (char *)"key");
         assert(node);
 
-        // OOM failing commands
-        for (int i = 0; i < 32; ++i) {
-            prepare_allocation_test(cc, i);
+        int n;
+        for (n = 0; n < 1000; n++) {
+            prepare_allocation_test(cc, n);
             reply = valkeyClusterCommandToNode(cc, node, cmd);
-            assert(reply == NULL);
+            if (reply != NULL)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
-
-        // Successful command
-        prepare_allocation_test(cc, 32);
-        reply = valkeyClusterCommandToNode(cc, node, cmd);
+        assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -189,37 +179,35 @@ void test_alloc_failure_handling(void) {
         valkeyReply *reply;
         const char *cmd = "SET foo one";
 
-        for (int i = 0; i < 33; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover allocations needed for a successful append. */
+        int na;
+        for (na = 0; na < 1000; na++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommand(cc, cmd);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
+        assert(na < 1000);
 
-        for (int i = 0; i < 4; ++i) {
-            // Appended command lost when receiving error from valkey
-            // during a GetReply, needs a new append for each test loop
-            prepare_allocation_test(cc, 33);
+        /* Discover allocations needed for a successful GetReply. */
+        int ng;
+        for (ng = 0; ng < 1000; ng++) {
+            /* Appended command lost when receiving error during a GetReply,
+             * needs a new append for each test loop. */
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommand(cc, cmd);
             assert(result == VALKEY_OK);
 
-            prepare_allocation_test(cc, i);
+            prepare_allocation_test(cc, ng);
             result = valkeyClusterGetReply(cc, (void *)&reply);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
-
-        prepare_allocation_test(cc, 34);
-        result = valkeyClusterAppendCommand(cc, cmd);
-        assert(result == VALKEY_OK);
-
-        prepare_allocation_test(cc, 4);
-        result = valkeyClusterGetReply(cc, (void *)&reply);
-        assert(result == VALKEY_OK);
+        assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -232,39 +220,33 @@ void test_alloc_failure_handling(void) {
         valkeyClusterNode *node = valkeyClusterGetNodeByKey(cc, (char *)"foo");
         assert(node);
 
-        // OOM failing appends
-        for (int i = 0; i < 34; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover allocations needed for a successful append to node. */
+        int na;
+        for (na = 0; na < 1000; na++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommandToNode(cc, node, cmd);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
+        assert(na < 1000);
 
-        // OOM failing GetResults
-        for (int i = 0; i < 4; ++i) {
-            // First a successful append
-            prepare_allocation_test(cc, 34);
+        /* Discover allocations needed for a successful GetReply. */
+        int ng;
+        for (ng = 0; ng < 1000; ng++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommandToNode(cc, node, cmd);
             assert(result == VALKEY_OK);
 
-            prepare_allocation_test(cc, i);
+            prepare_allocation_test(cc, ng);
             result = valkeyClusterGetReply(cc, (void *)&reply);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
-
-        // Successful append and GetReply
-        prepare_allocation_test(cc, 35);
-        result = valkeyClusterAppendCommandToNode(cc, node, cmd);
-        assert(result == VALKEY_OK);
-
-        prepare_allocation_test(cc, 4);
-        result = valkeyClusterGetReply(cc, (void *)&reply);
-        assert(result == VALKEY_OK);
+        assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -318,18 +300,19 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test ASK reply handling with OOM */
-        for (int i = 0; i < 45; ++i) {
-            prepare_allocation_test(cc, i);
-            reply = valkeyClusterCommand(cc, "GET foo");
-            assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        {
+            int n;
+            for (n = 0; n < 1000; n++) {
+                prepare_allocation_test(cc, n);
+                reply = valkeyClusterCommand(cc, "GET foo");
+                if (reply != NULL)
+                    break;
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            }
+            assert(n < 1000);
+            CHECK_REPLY_STR(cc, reply, "one");
+            freeReplyObject(reply);
         }
-
-        /* Test ASK reply handling without OOM */
-        prepare_allocation_test(cc, 45);
-        reply = valkeyClusterCommand(cc, "GET foo");
-        CHECK_REPLY_STR(cc, reply, "one");
-        freeReplyObject(reply);
 
         /* Finalize the migration. Skip OOM testing during these steps by
          * allowing a high number of allocations. */
@@ -347,18 +330,19 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test MOVED reply handling with OOM */
-        for (int i = 0; i < 32; ++i) {
-            prepare_allocation_test(cc, i);
-            reply = valkeyClusterCommand(cc, "GET foo");
-            assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        {
+            int n;
+            for (n = 0; n < 1000; n++) {
+                prepare_allocation_test(cc, n);
+                reply = valkeyClusterCommand(cc, "GET foo");
+                if (reply != NULL)
+                    break;
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            }
+            assert(n < 1000);
+            CHECK_REPLY_STR(cc, reply, "one");
+            freeReplyObject(reply);
         }
-
-        /* Test MOVED reply handling without OOM */
-        prepare_allocation_test(cc, 32);
-        reply = valkeyClusterCommand(cc, "GET foo");
-        CHECK_REPLY_STR(cc, reply, "one");
-        freeReplyObject(reply);
 
         /* MOVED triggers a slotmap update which currently replaces all cluster_node
          * objects. We can get the new objects by searching for its server ports.

--- a/deps/libvalkey/tests/scripts/client-disconnect-test.sh
+++ b/deps/libvalkey/tests/scripts/client-disconnect-test.sh
@@ -69,7 +69,7 @@ fi
 
 expected="Event: connect to 127.0.0.1:7401
 OK
-MOVED 12182 127.0.0.1:7402
+Error: MOVED 12182 127.0.0.1:7402
 Event: disconnect from 127.0.0.1:7401
 error: disconnecting"
 

--- a/deps/libvalkey/tests/scripts/moved-redirect-test.sh
+++ b/deps/libvalkey/tests/scripts/moved-redirect-test.sh
@@ -38,6 +38,10 @@ EXPECT CLOSE
 EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND "bar"
+
+# Test 3: Handle truncated errors (no heap-buffer-overflow).
+EXPECT ["GET", "foo"]
+SEND -MO
 EXPECT CLOSE
 EOF
 server1=$!
@@ -69,6 +73,8 @@ GET foo
 GET foo
 !sleep
 GET foo
+# Test 3
+GET foo
 EOF
 clientexit=$?
 
@@ -98,6 +104,7 @@ Event: slotmap-updated
 bar
 Event: slotmap-updated
 bar
+Error: MO
 Event: free-context"
 
 echo "$expected" | diff -u - "$testname.out" || exit 99

--- a/deps/libvalkey/tests/ut_connect_fallback.c
+++ b/deps/libvalkey/tests/ut_connect_fallback.c
@@ -1,0 +1,137 @@
+/*
+ * Unit test for TCP connect fallback behavior.
+ *
+ * Verifies that valkeyContextConnectTcp iterates through all addresses in the
+ * DNS response when earlier ones fail. We override getaddrinfo() to return three
+ * entries for 127.0.0.1 and override connect() to fail with ECONNREFUSED on the
+ * first two. The third entry points to a real listening socket and should
+ * succeed.
+ */
+
+#define _GNU_SOURCE
+#include "fmacros.h"
+
+#include "sockcompat.h"
+#include "valkey.h"
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int port_listen;
+
+#define PORT_ECONNREFUSED 10000 /* Simulates failed non-blocking connect */
+#define PORT_EHOSTUNREACH 10001 /* Simulates immediate routing failure */
+static struct addrinfo *make_entry(int port, struct addrinfo *next);
+
+/* --- Overridden system calls --- */
+
+/*
+ * Override getaddrinfo(3) to return a crafted address list instead of doing
+ * real DNS resolution. Linked before libc due to static library ordering.
+ */
+int getaddrinfo(const char *node, const char *service,
+                const struct addrinfo *hints, struct addrinfo **res) {
+    (void)node;
+    (void)service;
+    (void)hints;
+    struct addrinfo *third = make_entry(port_listen, NULL);
+    struct addrinfo *second = make_entry(PORT_EHOSTUNREACH, third);
+    struct addrinfo *first = make_entry(PORT_ECONNREFUSED, second);
+    *res = first;
+    return 0;
+}
+
+/* Override freeaddrinfo(3) to match the crafted getaddrinfo above. */
+void freeaddrinfo(struct addrinfo *res) {
+    while (res) {
+        struct addrinfo *next = res->ai_next;
+        free(res->ai_addr);
+        free(res);
+        res = next;
+    }
+}
+
+/*
+ * Override connect(2) to simulate connect failures for the fake addresses.
+ * Port 10000 returns EINPROGRESS then ECONNREFUSED (failed non-blocking connect).
+ * Port 10001 returns EHOSTUNREACH (immediate routing failure).
+ * Falls through to the real connect via dlsym(RTLD_NEXT) for other addresses.
+ */
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
+    static int refused_attempts = 0;
+    static int (*real_connect)(int, const struct sockaddr *, socklen_t) = NULL;
+    if (!real_connect)
+        real_connect = dlsym(RTLD_NEXT, "connect");
+
+    assert(addr->sa_family == AF_INET);
+    const struct sockaddr_in *sa = (const struct sockaddr_in *)addr;
+    int port = ntohs(sa->sin_port);
+    if (port == PORT_ECONNREFUSED) {
+        errno = (refused_attempts++ == 0) ? EINPROGRESS : ECONNREFUSED;
+        return -1;
+    }
+    if (port == PORT_EHOSTUNREACH) {
+        errno = EHOSTUNREACH;
+        return -1;
+    }
+    return real_connect(sockfd, addr, addrlen);
+}
+
+/* --- Helpers --- */
+
+/* Build a single addrinfo entry for 127.0.0.1 on the given port. */
+static struct addrinfo *make_entry(int port, struct addrinfo *next) {
+    struct addrinfo *ai = calloc(1, sizeof(*ai));
+    struct sockaddr_in *sa = calloc(1, sizeof(*sa));
+    assert(ai && sa);
+    sa->sin_family = AF_INET;
+    sa->sin_port = htons(port);
+    sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ai->ai_family = AF_INET;
+    ai->ai_socktype = SOCK_STREAM;
+    ai->ai_addrlen = sizeof(*sa);
+    ai->ai_addr = (struct sockaddr *)sa;
+    ai->ai_next = next;
+    return ai;
+}
+
+/* Create a TCP listener on 127.0.0.1 with an OS-assigned port. */
+static int create_listener(int *out_port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(fd >= 0);
+    struct sockaddr_in addr = {.sin_family = AF_INET,
+                               .sin_addr.s_addr = htonl(INADDR_LOOPBACK)};
+    assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    assert(listen(fd, 1) == 0);
+    socklen_t len = sizeof(addr);
+    assert(getsockname(fd, (struct sockaddr *)&addr, &len) == 0);
+    *out_port = ntohs(addr.sin_port);
+    return fd;
+}
+
+int main(void) {
+    int listen_fd = create_listener(&port_listen);
+
+    printf("Test: connect falls back to next address after ECONNREFUSED\n");
+
+    /* Arguments are ignored by our getaddrinfo override. */
+    valkeyContext *c = valkeyConnect("localhost", 0);
+    assert(c != NULL);
+    if (c->err) {
+        fprintf(stderr, "FAIL: %s\n", c->errstr);
+        valkeyFree(c);
+        close(listen_fd);
+        return 1;
+    }
+    assert(c->err == 0);
+    assert(c->errstr[0] == '\0');
+
+    printf("PASS\n");
+    valkeyFree(c);
+    close(listen_fd);
+    return 0;
+}


### PR DESCRIPTION
# Weekly backport sweep for 9.1

Automated cherry-picks from PRs marked "To be backported".

## Applied

| Source PR | Title | Detail |
|---|---|---|
| `#3697` | Update deps/libvalkey to version 0.5.0 |  |

<details><summary>Skipped / unresolved (45)</summary>

| Source PR | Title | Reason |
|---|---|---|
| `#2227` | Do the failover immediately if the replica is the best ranked replica | skipped-existing: resolution was already satisfied on target branch |
| `#3122` | Adds new (hidden) ValkeyModule_CallArgv API functions | skipped-existing: resolution was already satisfied on target branch |
| `#2936` | Module command result callback addition | skipped-existing: resolution was already satisfied on target branch |
| `#2811` | Enhance cluster stale packet detection to prevent sub-replica and empty primary | skipped-existing: already applied or empty cherry-pick |
| `#3306` | Improve COB memory tracking with copy avoidance | skipped-existing: already applied or empty cherry-pick |
| `#3359` | Fix incorrect memory overhead calculation for watched keys | skipped-conflict: unresolved: src/multi.c |
| `#3368` | Make scripting debug test skippable | skipped-existing: already applied or empty cherry-pick |
| `#3372` | Add cluster-config-save-behavior option to control nodes.conf save behavior | skipped-existing: already applied or empty cherry-pick |
| `#3281` | Fix use zfree in cli --eval path  | skipped-existing: already applied or empty cherry-pick |
| `#3209` | Fix `valkey-cli --cluster del-node` for unreachable nodes | skipped-existing: already applied or empty cherry-pick |
| `#3392` | Add Static Module Support | skipped-conflict: unresolved: src/server.c |
| `#3033` | ARM NEON SIMD optimization for pvFind() in vset.c | skipped-existing: already applied or empty cherry-pick |
| `#3401` | Big endian bitmap byte order mismatch fix | skipped-existing: resolution was already satisfied on target branch |
| `#3360` | Optimize WATCH duplicate key check from O(N) to O(1) using per-db hashtable | skipped-existing: already applied or empty cherry-pick |
| `#3443` | Fix slot-migration-max-failover-repl-bytes unable to accept -1 | skipped-existing: resolution was already satisfied on target branch |
| `#3420` | Avoid having server.h being included by cli and benchmark | skipped-existing: already applied or empty cherry-pick |
| `#3397` | Increase embedded string threshold from 64 to 128 bytes | skipped-existing: already applied or empty cherry-pick |
| `#3391` | CLUSTERSCAN range bounded scanning across contiguous slots | skipped-existing: already applied or empty cherry-pick |
| `#3380` | CLUSTERSCAN MATCH pattern maps to a specific slot optimizations | skipped-existing: resolution was already satisfied on target branch |
| `#3444` | Skip faster-failover test under TLS  | skipped-existing: resolution was already satisfied on target branch |
| `#3452` | Fix some flaky tests using CLIENT REPLY OFF | skipped-existing: already applied or empty cherry-pick |
| `#3461` | Attempt to deflake 'diskless no replicas drop during rdb pipe' | skipped-existing: resolution was already satisfied on target branch |
| `#3471` | Defer argument redaction by storing indices instead of rewriting argv | skipped-existing: already applied or empty cherry-pick |
| `#3440` | Fix config rewrite producing negative values for unsigned memory configs | skipped-existing: already applied or empty cherry-pick |
| `#3458` | Fix race condition during async client freeing with IO threading enabled | skipped-existing: already applied or empty cherry-pick |
| `#3498` | Fix double free in stream consumer PEL loading with corrupt RDB data | skipped-existing: already applied or empty cherry-pick |
| `#3448` | Fixes server crash when RDMA benchmark clients disconnect | skipped-existing: already applied or empty cherry-pick |
| `#3516` | Fix HPERSIST RESP protocol violation on wrong-type key | skipped-existing: already applied or empty cherry-pick |
| `#3541` | Fix FD leak in connSocketBlockingConnect on timeout | skipped-existing: already applied or empty cherry-pick |
| `#3548` | Fix lua-enable-insecure-api default value cannot be changed to yes | skipped-existing: already applied or empty cherry-pick |
| `#3554` | Ensure client slot migration pointer is cleared during reset | skipped-existing: already applied or empty cherry-pick |
| `#3544` | IO-Threads redesign cleanup work | skipped-existing: already applied or empty cherry-pick |
| `#3503` | Fix remove cached eval scripts on engine unregister | skipped-existing: already applied or empty cherry-pick |
| `#3568` | Fix GEOSEARCH BYPOLYGON leak on invalid COUNT | skipped-existing: already applied or empty cherry-pick |
| `#3580` | fix(syncio): Set errno on EOF in syncRead and propagate to conn->last… | skipped-existing: already applied or empty cherry-pick |
| `#3586` | fix(cluster): Remove per-call srand in clusterManagerNodePrimaryRandom | skipped-existing: resolution was already satisfied on target branch |
| `#3591` | Handle NULL pointer in streamTrim listpack delta calculation | skipped-existing: already applied or empty cherry-pick |
| `#3596` | Fix: prevent NULL dereference crash in connectSlotExportJob when target node disappears | skipped-existing: already applied or empty cherry-pick |
| `#3578` | Fix Deferred Reply Placeholders in Active Deferred Buffers | skipped-existing: resolution was already satisfied on target branch |
| `#3610` | Fix SIGSEGV in VM_GetLRU/SetLRU/GetLFU/SetLFU on NULL key | skipped-existing: already applied or empty cherry-pick |
| `#3641` | Add null check in updateSSLPendingFlag | skipped-existing: already applied or empty cherry-pick |
| `#3613` | Fix UAF in unblockClientOnKey when reprocessed command frees the client (CVE-2026-23479) | skipped-existing: already applied or empty cherry-pick |
| `#3625` | Delay full sync during yielding Lua scripts to prevent use-after-free (CVE-2026-23631) | skipped-existing: already applied or empty cherry-pick |
| `#3619` | Fix invalid memory access in RESTORE with malformed zipmap (CVE-2026-25243) | skipped-conflict: unresolved: tests/unit/dump.tcl |
| `#3679` | Fix CLUSTERSCAN fingerprint to use configurable_hash_seed | skipped-conflict: unresolved: src/server.c |

</details>

---
*Generated by valkey-ci-agent using Claude Code.*