### PR TITLE
Remove references to closed Discord channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: Questions?
     url: https://github.com/valkey-io/valkey/discussions
     about: Ask and answer questions on GitHub Discussions.
-  - name: Chat with us on Discord?
-    url: https://discord.gg/zbcPa5umUB
-    about: We are on Discord!
   - name: Chat with us on Matrix?
     url: https://matrix.to/#/#valkey:matrix.org
     about: We are on Matrix too!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ The Valkey project is led by a Technical Steering Committee, whose responsibilit
 
 * Have a question? Ask it on
   [GitHub Discussions](https://github.com/valkey-io/valkey/discussions)
-  or [Valkey's Discord](https://discord.gg/zbcPa5umUB)
   or [Valkey's Matrix](https://matrix.to/#/#valkey:matrix.org)
 * Found a bug? [Report it here](https://github.com/valkey-io/valkey/issues/new?template=bug_report.md&title=%5BBUG%5D)
 * Valkey crashed? [Submit a crash report here](https://github.com/valkey-io/valkey/issues/new?template=crash_report.md&title=%5BCRASH%5D+%3Cshort+description%3E)


### PR DESCRIPTION
Closes #3220

The Valkey Discord server has been closed. This changes the entry from the GitHub issue template and the contributing guide.