### PR TITLE
Fix grammatical typo "This functions" in code comments

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1906,7 +1906,7 @@ int removeExpire(serverDb *db, robj *key) {
  * to NULL. The 'when' parameter is the absolute unix time in milliseconds
  * after which the key will no longer be considered valid.
  *
- * This functions may reallocate the value. The new allocation is returned and
+ * This function may reallocate the value. The new allocation is returned and
  * the old object's reference counter is decremented and possibly freed. */
 robj *setExpire(client *c, serverDb *db, robj *key, long long when) {
     /* TODO: Add val as a parameter to this function, to avoid looking it up. */
@@ -2228,7 +2228,7 @@ static int dbExpandSkipSlot(int slot) {
 }
 
 /*
- * This functions increases size of the main/expires db to match desired number.
+ * This function increases size of the main/expires db to match desired number.
  * In cluster mode resizes all individual dictionaries for slots that this node owns.
  *
  * Based on the parameter `try_expand`, appropriate dict expand API is invoked.

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1021,7 +1021,7 @@ static void fillBucketHole(hashtable *ht, bucket *b, int pos_in_bucket, int tabl
 }
 
 /* When entries are deleted while rehashing is paused, they leave empty holes in
- * the buckets. This functions attempts to fill the holes by moving entries from
+ * the buckets. This function attempts to fill the holes by moving entries from
  * the end of the bucket chain to fill the holes and free any empty buckets in
  * the end of the chain. */
 static void compactBucketChain(hashtable *ht, size_t bucket_index, int table_index) {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -468,7 +468,7 @@ unsigned long long kvstoreScan(kvstore *kvs,
 }
 
 /*
- * This functions increases size of kvstore to match desired number.
+ * This function increases size of kvstore to match desired number.
  * It resizes all individual hash tables, unless predicate indicates otherwise.
  *
  * Based on the parameter `try_expand`, appropriate hashtable expand API is invoked.

--- a/src/object.c
+++ b/src/object.c
@@ -305,7 +305,7 @@ mstime_t objectGetExpire(const robj *o) {
     }
 }
 
-/* This functions may reallocate the value. The new allocation is returned and
+/* This function may reallocate the value. The new allocation is returned and
  * the old object's reference counter is decremented and possibly freed. Use the
  * returned object instead of 'o' after calling this function. */
 robj *objectSetExpire(robj *o, long long expire) {
@@ -349,7 +349,7 @@ void objectUnembedVal(robj *o) {
     o->val_ptr = new_val;
 }
 
-/* This functions may reallocate the value. The new allocation is returned and
+/* This function may reallocate the value. The new allocation is returned and
  * the old object's reference counter is decremented and possibly freed. Use the
  * returned object instead of 'o' after calling this function. */
 robj *objectSetKeyAndExpire(robj *o, const_sds key, long long expire) {

--- a/src/rand.c
+++ b/src/rand.c
@@ -1,7 +1,7 @@
 /* Pseudo random number generation functions derived from the drand48()
  * function obtained from pysam source code.
  *
- * This functions are used in order to replace the default math.random()
+ * These functions are used in order to replace the default math.random()
  * Lua implementation with something having exactly the same behavior
  * across different systems (by default Lua uses libc's rand() that is not
  * required to implement a specific PRNG generating the same sequence


### PR DESCRIPTION
Fix subject-verb agreement in 7 comment lines across 5 files.

In 6 places, the determiner "this" was followed by the plural noun
"functions" while the surrounding verb (`may`, `increases`, `attempts`)
is in third-person singular -- so the noun should be "function".

In `src/rand.c` the verb is plural (`are used`), so the fix there is
"This functions" -> "These functions".

No behavioral changes.