### PR TITLE
tests: Add CVE-2025-46817 regression test (Lua integer overflow)

### DIFF
--- a/tests/unit/scripting.tcl
+++ b/tests/unit/scripting.tcl
@@ -368,6 +368,44 @@ start_server {tags {"scripting"}} {
         set e
     } {*against a key*}
 
+    test {EVAL - Test table unpack with invalid indexes} {
+        catch {run_script { return {unpack({1,2,3}, -2, 2147483647)} } 0} e
+        assert_match {*too many results to unpack*} $e
+        catch {run_script { return {unpack({1,2,3}, 0, 2147483647)} } 0} e
+        assert_match {*too many results to unpack*} $e
+        catch {run_script { return {unpack({1,2,3}, -2147483648, -2)} } 0} e
+        assert_match {*too many results to unpack*} $e
+        set res [run_script { return {unpack({1,2,3}, -1, -2)} } 0]
+        assert_match {} $res
+        set res [run_script { return {unpack({1,2,3}, 1, -1)} } 0]
+        assert_match {} $res
+
+        # unpack with range -1 to 5, verify nil indexes
+        set res [run_script {
+             local function unpack_to_list(t, i, j)
+               local n, v = select('#', unpack(t, i, j)), {unpack(t, i, j)}
+               for i = 1, n do v[i] = v[i] or '_NIL_' end
+               v.n = n
+               return v
+             end
+
+            return unpack_to_list({1,2,3}, -1, 5)
+        } 0]
+        assert_match {_NIL_ _NIL_ 1 2 3 _NIL_ _NIL_} $res
+
+        # unpack with negative range, verify nil indexes
+        set res [run_script {
+             local function unpack_to_list(t, i, j)
+               local n, v = select('#', unpack(t, i, j)), {unpack(t, i, j)}
+               for i = 1, n do v[i] = v[i] or '_NIL_' end
+               v.n = n
+               return v
+             end
+
+            return unpack_to_list({1,2,3}, -2147483648, -2147483646)
+        } 0]
+        assert_match {_NIL_ _NIL_ _NIL_} $res
+    } {}
 
     test {EVAL - JSON numeric decoding} {
         # We must return the table as a string because otherwise


### PR DESCRIPTION
Adds the upstream regression test for CVE-2025-46817 to valkey.

### Source-code fix status
**Already present in valkey** (no source change in this PR).

Valkey's `deps/lua/src/lbaselib.c` and `deps/lua/src/ltable.c` already contain the upstream redis security fix — cherry-picking redis commit `fc9abc775e` auto-merges silently for those two files, producing zero source-line diff. Only the regression test in `tests/unit/scripting.tcl` was missing.

### What this PR adds
`tests/unit/scripting.tcl | 38 ++++` — only the regression test, mirrored from the upstream redis commit.

### References
- Upstream commit: https://github.com/redis/redis/commit/fc9abc775e308374f667fdf3e723ef4b7eb0e3ca
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-46817

### Caveat
I have not run the full valkey test suite locally; the new test block was lifted from upstream by `git cherry-pick -x` with minor conflict resolution on `tests/unit/scripting.tcl`.
