### PR TITLE
Fix buffered_reply assert in HFE commands with module keyspace notifications

### DIFF
--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -1175,6 +1175,8 @@ void hgetdelCommand(client *c) {
     bool hash_volatile_items = hashTypeHasVolatileFields(o);
     if (o && o->encoding == OBJ_ENCODING_HASHTABLE) hashtablePauseAutoShrink(objectGetVal(o));
 
+    initDeferredReplyBuffer(c);
+
     /* Reply with array of values and delete at the same time */
     addReplyArrayLen(c, num_fields);
     for (i = fields_index; i < c->argc; i++) {
@@ -1203,6 +1205,8 @@ void hgetdelCommand(client *c) {
         if (keyremoved) notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         server.dirty += deleted;
     }
+
+    commitDeferredReplyBuffer(c, 1);
 }
 
 void hlenCommand(client *c) {
@@ -1915,6 +1919,8 @@ void hexpireGenericCommand(client *c, mstime_t basetime, int unit) {
 
     bool has_volatile_fields = hashTypeHasVolatileFields(obj);
 
+    initDeferredReplyBuffer(c);
+
     /* From this point we would return array reply */
     addReplyArrayLen(c, num_fields);
 
@@ -1972,6 +1978,8 @@ void hexpireGenericCommand(client *c, mstime_t basetime, int unit) {
             notifyKeyspaceEvent(NOTIFY_GENERIC, "del", c->argv[1], c->db->id);
         }
     }
+
+    commitDeferredReplyBuffer(c, 1);
 }
 
 void hexpireCommand(client *c) {
@@ -2023,6 +2031,8 @@ void hpersistCommand(client *c) {
     if (checkType(c, hash, OBJ_HASH))
         return;
 
+    initDeferredReplyBuffer(c);
+
     /* From this point we would return array reply */
     addReplyArrayLen(c, num_fields);
 
@@ -2043,6 +2053,8 @@ void hpersistCommand(client *c) {
         notifyKeyspaceEvent(NOTIFY_HASH, "hpersist", c->argv[1], c->db->id);
         signalModifiedKey(c, c->db, c->argv[1]);
     }
+
+    commitDeferredReplyBuffer(c, 1);
 }
 
 /* High-Level Algorithm of HTTL / HPTTL / HEXPIRETIME / HPEXPIRETIME Commands:

--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -129,18 +129,28 @@ start_server {tags {"modules"}} {
         wait_for_blocked_clients_count 0
 
         # HEXPIRE: updated + expired(del)
+        r b_keyspace.clear
         assert_equal "1" [r hexpire h1 100 FIELDS 1 f1]
+        assert_equal {{event hexpire key h1}} [r b_keyspace.events]
+        r b_keyspace.clear
         assert_equal "2" [r hexpire h1 0 FIELDS 1 f1]
+        assert_equal {{event hexpired key h1}} [r b_keyspace.events]
 
         # HGETDEL
+        r b_keyspace.clear
         assert_equal "v2" [r hgetdel h1 FIELDS 1 f2]
+        # "hdel" and "del" notifications can be recorded in either order
+        # because they run on independent background threads.
+        assert_equal [lsort {{event hdel key h1} {event del key h1}}] [lsort [r b_keyspace.events]]
         assert_equal "0" [r exists h1]
 
         # HPERSIST
         r hset h1 f1 v1
         r hexpire h1 100 FIELDS 1 f1
         wait_for_blocked_clients_count 0
+        r b_keyspace.clear
         assert_equal "1" [r hpersist h1 FIELDS 1 f1]
+        assert_equal {{event hpersist key h1}} [r b_keyspace.events]
 
         r del h1
     }

--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -121,6 +121,8 @@ start_server {tags {"modules"}} {
     }
 
     test {HFE commands with blocking keyspace notify} {
+        r del h1
+
         wait_for_blocked_clients_count 0
         r b_keyspace.clear
         r hset h1 f1 v1 f2 v2

--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -119,6 +119,30 @@ start_server {tags {"modules"}} {
             fail "Expired event not propagated within 5 seconds"
         }
     }
+
+    test {HFE commands with blocking keyspace notify} {
+        wait_for_blocked_clients_count 0
+        r b_keyspace.clear
+        r hset h1 f1 v1 f2 v2
+        wait_for_blocked_clients_count 0
+
+        # HEXPIRE: updated + expired(del)
+        assert_equal "1" [r hexpire h1 100 FIELDS 1 f1]
+        assert_equal "2" [r hexpire h1 0 FIELDS 1 f1]
+
+        # HGETDEL
+        assert_equal "v2" [r hgetdel h1 FIELDS 1 f2]
+        assert_equal "0" [r exists h1]
+
+        # HPERSIST
+        r hset h1 f1 v1
+        r hexpire h1 100 FIELDS 1 f1
+        wait_for_blocked_clients_count 0
+        assert_equal "1" [r hpersist h1 FIELDS 1 f1]
+
+        r del h1
+    }
+
     test "Unload the module - testblockingkeyspacenotif" {
         assert_equal {OK} [r module unload testblockingkeyspacenotif]
     }


### PR DESCRIPTION
When a module subscribes to NOTIFY_HASH keyspace events and blocks the
client in the notification callback, hexpireGenericCommand, hgetdelCommand,
and hpersistCommand would trigger debugServerAssert in notifyKeyspaceEvent()
because addReplyArrayLen() sets buffered_reply=1 before the notification
fires. This debug assert was added in #1819.

Affected commands: HEXPIRE, HPEXPIRE, HEXPIREAT, HPEXPIREAT, HGETDEL,
HPERSIST.