### PR TITLE
Fix sentinel crash: use angle-bracket include for dict.h in libvalkey

### DIFF
--- a/deps/libvalkey/src/async.c
+++ b/deps/libvalkey/src/async.c
@@ -44,7 +44,7 @@
 
 #include "async.h"
 #include "async_private.h"
-#include "dict.h"
+#include <dict.h>
 #include "net.h"
 #include "valkey_private.h"
 #include "vkutil.h"

--- a/deps/libvalkey/src/cluster.c
+++ b/deps/libvalkey/src/cluster.c
@@ -38,7 +38,7 @@
 #include "adlist.h"
 #include "alloc.h"
 #include "command.h"
-#include "dict.h"
+#include <dict.h>
 #include "vkutil.h"
 
 #include <dict.h>


### PR DESCRIPTION
libvalkey's `DICT_INCLUDE_DIR` feature allows embedders to substitute their own dict implementation. When valkey passes `DICT_INCLUDE_DIR=../../src/`, the `-I` flag is added to the compile command. However, `async.c` and `cluster.c` use `#include "dict.h"` which resolves to libvalkey's local `src/dict.h` first (C `"..."` semantics search the source file's directory before `-I` paths). This means these files compile against libvalkey's small 5-field `dictType`, but link against valkey's `dictCreate` which expects a 9-field `dictType`. Reading past the struct causes a crash.

On unstable this works by luck: `dict` is typedef'd to `hashtable`, and the `getMetadataSize` field happens to read as zero from memory following the static `callbackDict`. On 9.1 with the traditional dict implementation, the `dictMetadataBytes` offset reads garbage and crashes.

**Fix:** Change `#include "dict.h"` to `#include <dict.h>` so the `-I` path (`DICT_INCLUDE_DIR`) is used, picking up valkey's `dict.h`. The designated initializers in `callbackDict` zero-initialize unspecified fields, so `dictMetadataBytes` is NULL and `dictCreate` works correctly.

This should also be fixed upstream in libvalkey since the `DICT_INCLUDE_DIR` feature is broken without this change.

**Crash signature:**
```
signal 11, accessing address 0x90
sentinelReconnectInstance -> valkeyAsyncConnectBind -> dictCreate
```

**Verified locally:** distclean + full rebuild, sentinel starts and operates normally.