### PR TITLE
Revert "IO-Threads redesign cleanup work (#3544)"

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -581,7 +581,7 @@ ENGINE_SERVER_OBJ = \
     ziplist.o \
     zipmap.o \
     zmalloc.o \
-    queues.o
+	queues.o
 ENGINE_SERVER_OBJ+=$(ENGINE_TRACE_OBJ)
 ENGINE_CLI_NAME=$(ENGINE_NAME)-cli$(PROG_SUFFIX)
 ENGINE_CLI_OBJ = \

--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -8,10 +8,6 @@
 #include "queues.h"
 #include <sys/resource.h>
 
-#define IO_MPSC_QUEUE_SIZE 16384
-#define IO_SPMC_QUEUE_SIZE 4096
-#define IO_SPSC_QUEUE_SIZE 4096
-
 static _Thread_local int thread_id = 0;
 static _Thread_local mpscTicket io_thread_ticket = {0};
 /* Backlog of responses when io_shared_outbox is full. Should be rare. */
@@ -48,8 +44,8 @@ static inline void untagJob(void *tagged_ptr, void **ptr, int *type) {
 /* Handler prototypes */
 void ioThreadReadQueryFromClient(client *c);
 void ioThreadWriteToClient(client *c);
-void ioThreadFreeArgv(robj **argv);
-void ioThreadPoll(aeEventLoop *el);
+void IOThreadFreeArgv(robj **argv);
+void IOThreadPoll(aeEventLoop *el);
 static void ioThreadAccept(client *c);
 
 int inMainThread(void) {
@@ -111,6 +107,9 @@ void waitForClientIO(client *c) {
 }
 
 void IOThreadsBeforeSleep(long long current_time) {
+#ifndef RUSAGE_THREAD
+    UNUSED(current_time);
+#endif
     if (server.io_threads_num == 1) return;
     serverAssert(inMainThread());
 
@@ -127,23 +126,29 @@ void IOThreadsBeforeSleep(long long current_time) {
         }
     }
 
-    /* If threads are not active, track main-thread active time for ignition decision */
+#ifdef RUSAGE_THREAD
+    /* If threads are not active track main thread CPU time for ignition decision */
     if (server.active_io_threads_num == 1) {
         static long long last_measurement_time = 0;
         if (current_time - last_measurement_time < 50000) return; /* Sample once in 50ms */
         last_measurement_time = current_time;
-        trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_ACTIVE_TIME, server.stat_active_time, current_time, 1000000);
+        struct rusage ru;
+        if (getrusage(RUSAGE_THREAD, &ru) == 0) {
+            long long sys_time_us = ru.ru_stime.tv_sec * 1000000LL + ru.ru_stime.tv_usec;
+            long long user_time_us = ru.ru_utime.tv_sec * 1000000LL + ru.ru_utime.tv_usec;
+            trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_SYS, sys_time_us, current_time, 1000000);
+            trackInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_USER, user_time_us, current_time, 1000000);
+        }
     }
+#endif
 }
 
 #define IO_COOLDOWN_MS 1000
 #define IO_SAMPLE_RATE_MS 10
 #define IO_IGNITION_EVENTS 4
-/* Start using I/O threads when the main thread is active for more than the below
- * defined percentage of the time. This number is picked somewhat arbitrarily but
- * needed to be low enough to make sure we start the next thread quickly while not
- * starting too many threads unnecessarily to avoid contention. */
-#define IO_IGNITION_MAIN_THREAD_ACTIVE_PERCENT 30
+#define IO_IGNITION_CPU_SYS 30.0
+#define IO_IGNITION_CPU_SYS_LOW 5.0
+#define IO_IGNITION_CPU_USER 50.0
 #define BATCH_SIZE 32
 
 void IOThreadsAfterSleep(int numevents) {
@@ -166,9 +171,15 @@ void IOThreadsAfterSleep(int numevents) {
     /* Ignition Policy */
     if (server.active_io_threads_num == 1) {
         int should_ignite = 0;
-        float main_thread_active_time = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_ACTIVE_TIME) / 10000.0;
-        /* Ignite IO threads when main-thread active time exceeds the threshold (30%) */
-        should_ignite = (main_thread_active_time > (float)IO_IGNITION_MAIN_THREAD_ACTIVE_PERCENT);
+#ifdef RUSAGE_THREAD
+        float cpu_sys = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_SYS) / 10000.0;
+        float cpu_user = (float)getInstantaneousMetric(STATS_METRIC_MAIN_THREAD_CPU_USER) / 10000.0;
+        /* Ignite IO threads if sys CPU > 30%, or if sys CPU > 5% and user CPU > 50% */
+        should_ignite = (cpu_sys > IO_IGNITION_CPU_SYS) ||
+                        (cpu_sys > IO_IGNITION_CPU_SYS_LOW && cpu_user > IO_IGNITION_CPU_USER);
+#else
+        should_ignite = (numevents >= IO_IGNITION_EVENTS);
+#endif
         if (should_ignite) {
             pthread_mutex_unlock(&io_threads_mutex[1]);
             server.active_io_threads_num++;
@@ -232,7 +243,7 @@ void IOThreadsAfterSleep(int numevents) {
 
 /* This function performs polling on the given event loop and updates the server's
  * IO fired events count and poll state. */
-void ioThreadPoll(aeEventLoop *el) {
+void IOThreadPoll(aeEventLoop *el) {
     struct timeval tvp = {0, 0};
     int num_events = aePoll(el, &tvp);
     server.io_ae_fired_events = num_events;
@@ -315,10 +326,10 @@ static void *IOThreadMain(void *myid) {
 
                 switch (type) {
                 case JOB_REQ_FREE_ARGV:
-                    ioThreadFreeArgv((robj **)data);
+                    IOThreadFreeArgv((robj **)data);
                     break;
                 case JOB_REQ_POLL:
-                    ioThreadPoll((aeEventLoop *)data);
+                    IOThreadPoll((aeEventLoop *)data);
                     break;
                 default:
                     serverPanic("Invalid SPSC job type: %d", type);
@@ -327,8 +338,10 @@ static void *IOThreadMain(void *myid) {
             processed += batch_count;
         }
 
-        /* PRIORITY 2: Shared Global Queue (SPMC)
-         * Only checked after SPSC is drained. */
+        /*
+         * PRIORITY 2: Shared Global Queue (SPMC)
+         * Only checked after SPSC is drained.
+         */
         void *tagged_job = spmcDequeue(&io_shared_inbox);
         if (tagged_job) {
             void *data;
@@ -343,13 +356,13 @@ static void *IOThreadMain(void *myid) {
                 ioThreadWriteToClient((client *)data);
                 break;
             case JOB_REQ_FREE_OBJ:
-                zfree(data);
+                decrRefCount(data);
                 break;
             case JOB_REQ_ACCEPT:
                 ioThreadAccept((client *)data);
                 break;
             case JOB_REQ_POLL:
-                ioThreadPoll((aeEventLoop *)data);
+                IOThreadPoll((aeEventLoop *)data);
                 break;
             default:
                 serverPanic("Invalid SPMC job type: %d", type);
@@ -385,7 +398,7 @@ static void createIOThread(int id) {
     serverAssert(id > 0 && id < server.io_threads_num);
 
     /* Initialize the private SPSC queue for this thread */
-    spscInit(&io_private_inbox[id], IO_SPSC_QUEUE_SIZE);
+    spscInit(&io_private_inbox[id]);
 
     pthread_t tid;
     pthread_mutex_init(&io_threads_mutex[id], NULL);
@@ -445,7 +458,7 @@ int updateIOThreads(const char **err) {
      * in that state, we will deadlock (Main thread waits for worker, Worker waits for queue space). */
     size_t pending = getPendingIOResponsesCount();
 
-    if (pending > io_shared_outbox.queue_size) {
+    if (pending > MPSC_QUEUE_SIZE) {
         if (err) *err = "Can't update IO threads under load, try again later";
         return 0;
     }
@@ -484,8 +497,8 @@ void initIOThreads(int prev_threads_num) {
         server.active_io_threads_num = 1; /* We start with threads not active. */
         server.io_poll_state = AE_IO_STATE_NONE;
         server.io_ae_fired_events = 0;
-        spmcInit(&io_shared_inbox, IO_SPMC_QUEUE_SIZE);
-        mpscInit(&io_shared_outbox, IO_MPSC_QUEUE_SIZE);
+        spmcInit(&io_shared_inbox);
+        mpscInit(&io_shared_outbox);
         io_jobs_submitted = 0;
         atomic_init(&io_jobs_finished, 0);
         prefetchCommandsBatchInit();
@@ -547,7 +560,6 @@ int trySendWriteToIOThreads(client *c) {
     if (c->flag.lua_debug) return C_ERR;
 
     int is_replica = getClientType(c) == CLIENT_TYPE_REPLICA;
-    clientReplyBlock *block = NULL;
     if (is_replica) {
         c->io_last_reply_block = listLast(server.repl_buffer_blocks);
         replBufBlock *o = listNodeValue(c->io_last_reply_block);
@@ -559,10 +571,14 @@ int trySendWriteToIOThreads(client *c) {
          * threads from reading data that might be invalid in their local CPU cache. */
         c->io_last_reply_block = listLast(c->reply);
         if (c->io_last_reply_block) {
-            block = (clientReplyBlock *)listNodeValue(c->io_last_reply_block);
+            clientReplyBlock *block = (clientReplyBlock *)listNodeValue(c->io_last_reply_block);
             c->io_last_bufpos = block->used;
+            /* If buffer is encoded force new header */
+            if (block->flag.buf_encoded) block->last_header = NULL;
         } else {
             c->io_last_bufpos = (size_t)c->bufpos;
+            /* If buffer is encoded force new header */
+            if (c->flag.buf_encoded) c->last_header = NULL;
         }
     }
 
@@ -581,15 +597,7 @@ int trySendWriteToIOThreads(client *c) {
         c->io_last_bufpos = 0;
         return C_ERR;
     }
-    /* Force new header after successful enqueue so the main thread doesn't
-     * extend a header the I/O thread is currently reading. */
-    if (!is_replica) {
-        if (block) {
-            if (block->flag.buf_encoded) block->last_header = NULL;
-        } else {
-            if (c->flag.buf_encoded) c->last_header = NULL;
-        }
-    }
+
     if (c->flag.pending_write) {
         listUnlinkNode(server.clients_pending_write, &c->clients_pending_write_node);
         c->flag.pending_write = 0;
@@ -601,7 +609,7 @@ int trySendWriteToIOThreads(client *c) {
 }
 
 /* Internal function to free the client's argv in an IO thread. */
-void ioThreadFreeArgv(robj **argv) {
+void IOThreadFreeArgv(robj **argv) {
     int last_arg = 0;
     for (int i = 0;; i++) {
         robj *o = argv[i];
@@ -689,12 +697,8 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
 
     if (obj->encoding != OBJ_ENCODING_RAW || obj->type != OBJ_STRING) return C_ERR;
 
-    /* We offload only the free of the ptr that may be allocated by the I/O thread.
-     * The object itself was allocated by the main thread and will be freed by the main thread. */
-    void *job = tagJob(sdsAllocPtr(objectGetVal(obj)), JOB_REQ_FREE_OBJ);
+    void *job = tagJob(obj, JOB_REQ_FREE_OBJ);
     if (unlikely(spmcEnqueue(&io_shared_inbox, job) == false)) return C_ERR;
-    objectSetVal(obj, NULL);
-    decrRefCount(obj);
     io_jobs_submitted++;
     server.stat_io_freed_objects++;
     return C_OK;

--- a/src/io_threads.h
+++ b/src/io_threads.h
@@ -12,14 +12,16 @@ typedef enum {
     JOB_REQ_ACCEPT,
     JOB_REQ_COUNT
 } JobRequest;
-_Static_assert(JOB_REQ_COUNT <= 8, "JOB_REQ_COUNT must not exceed 8 for pointer arithmetic");
+_Static_assert(JOB_REQ_COUNT <= 8, "JOB_REQ_COUNT must not exceed 7 for pointer arithmetic");
 
 typedef enum {
     JOB_RES_READ_CLIENT = 0,
     JOB_RES_WRITE_CLIENT,
     JOB_RES_COUNT
 } JobResult;
-_Static_assert(JOB_RES_COUNT <= 8, "JOB_RES_COUNT must not exceed 8 for pointer arithmetic");
+_Static_assert(JOB_RES_COUNT <= 8, "JOB_RES_COUNT must not exceed 7 for pointer arithmetic");
+
+typedef void (*job_handler)(void *);
 
 void initIOThreads(int prev_threads_num);
 void killIOThreads(void);

--- a/src/networking.c
+++ b/src/networking.c
@@ -6528,16 +6528,31 @@ void evictClients(void) {
     size_t client_eviction_limit = getClientEvictionLimit();
     if (client_eviction_limit == 0) return;
 
+    /* Variable to track memory of clients marked for close but not yet freed */
+    size_t pending_freed = 0;
+
     while (server.stat_clients_type_memory[CLIENT_TYPE_NORMAL] +
-               server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] >
+               server.stat_clients_type_memory[CLIENT_TYPE_PUBSUB] -
+               pending_freed >
            client_eviction_limit) {
         listNode *ln = listNext(&bucket_iter);
         if (ln) {
             client *c = ln->value;
+            if (c->flag.close_asap) {
+                /* Already scheduled to close. Count memory as freed and skip. */
+                pending_freed += getClientMemoryUsage(c, NULL);
+                continue;
+            }
             sds ci = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log);
             serverLog(LL_NOTICE, "Evicting client: %s", ci);
-            if (freeClient(c)) server.stat_evictedclients++;
             sdsfree(ci);
+            server.stat_evictedclients++;
+
+            if (freeClient(c) == 0) {
+                /* Protected client (async close). Count memory as freed and skip. */
+                pending_freed += getClientMemoryUsage(c, NULL);
+                continue;
+            }
         } else {
             curr_bucket--;
             if (curr_bucket < 0) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -4,27 +4,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Implementation of MPSC, SPMC, and SPSC queues
+ *
  */
 
 #include "queues.h"
 #include "zmalloc.h"
-
-void mpscInit(mpscQueue *q, size_t queue_size) {
-    /* Queue size must be a power of 2 (the masking logic relies on it) */
-    assert((queue_size & (queue_size - 1)) == 0);
-    q->buffer = (_Atomic(void *) *)zmalloc(sizeof(_Atomic(void *)) * queue_size);
-    q->queue_size = queue_size;
+inline void mpscInit(mpscQueue *q) {
+    q->buffer = (_Atomic(void *) *)zmalloc(sizeof(_Atomic(void *)) * MPSC_QUEUE_SIZE);
     atomic_init(&q->head, 0);
     atomic_init(&q->tail, 0);
     atomic_init(&q->head_cache, 0);
     q->tail_cache = 0;
 
-    for (size_t i = 0; i < q->queue_size; ++i) {
+    for (size_t i = 0; i < MPSC_QUEUE_SIZE; ++i) {
         atomic_init(&q->buffer[i], NULL);
     }
 }
 
-void mpscFree(mpscQueue *q) {
+inline void mpscFree(mpscQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -35,7 +32,7 @@ void mpscFree(mpscQueue *q) {
     q->tail_cache = 0;
 }
 
-bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
+inline bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
     size_t tail;
     assert(data);
 
@@ -48,12 +45,12 @@ bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
 
     /* Check limits (Fullness check) */
     size_t head = atomic_load_explicit(&q->head_cache, memory_order_acquire);
-    if ((tail - head) >= q->queue_size) {
+    if ((tail - head) >= MPSC_QUEUE_SIZE) {
         /* Cached limit reached, refresh from actual head */
         head = atomic_load_explicit(&q->head, memory_order_acquire);
         atomic_store_explicit(&q->head_cache, head, memory_order_release);
 
-        if (unlikely((tail - head) >= q->queue_size)) {
+        if (unlikely((tail - head) >= MPSC_QUEUE_SIZE)) {
             /* Queue is full - Persist reservation for retry */
             ticket->index = tail;
             ticket->has_reservation = true;
@@ -62,13 +59,13 @@ bool mpscEnqueue(mpscQueue *q, void *data, mpscTicket *ticket) {
     }
 
     /* Commit data */
-    atomic_store_explicit(&q->buffer[tail & (q->queue_size - 1)], data, memory_order_release);
+    atomic_store_explicit(&q->buffer[tail & MPSC_QUEUE_MASK], data, memory_order_release);
 
     ticket->has_reservation = false;
     return true;
 }
 
-size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
+inline size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
     size_t popped_count = 0;
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     size_t tail = q->tail_cache;
@@ -84,13 +81,13 @@ size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
     if (limit > max_jobs) limit = max_jobs;
 
     for (size_t i = 0; i < limit; ++i) {
-        void *data = atomic_load_explicit(&q->buffer[head & (q->queue_size - 1)], memory_order_relaxed);
+        void *data = atomic_load_explicit(&q->buffer[head & MPSC_QUEUE_MASK], memory_order_relaxed);
 
         /* Stop if slot is reserved but data not yet written */
         if (!data) break;
 
         jobs_out[popped_count++] = data;
-        atomic_store_explicit(&q->buffer[head & (q->queue_size - 1)], NULL, memory_order_relaxed);
+        atomic_store_explicit(&q->buffer[head & MPSC_QUEUE_MASK], NULL, memory_order_relaxed);
         head++;
     }
 
@@ -106,22 +103,19 @@ size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs) {
  * SPMC QUEUE (Single-Producer Multi-Consumer)
  * ========================================================================== */
 
-inline void spmcInit(spmcQueue *q, size_t queue_size) {
-    /* Queue size must be a power of 2 (the masking logic relies on it) */
-    assert((queue_size & (queue_size - 1)) == 0);
-    q->buffer = (spmcCell *)zmalloc_cache_aligned(sizeof(spmcCell) * queue_size);
-    q->queue_size = queue_size;
+inline void spmcInit(spmcQueue *q) {
+    q->buffer = (spmcCell *)zmalloc_cache_aligned(sizeof(spmcCell) * SPMC_QUEUE_SIZE);
     atomic_init(&q->head, 0);
     q->tail = 0;
     q->head_cache = 0;
 
-    for (size_t i = 0; i < q->queue_size; i++) {
+    for (size_t i = 0; i < SPMC_QUEUE_SIZE; i++) {
         atomic_init(&q->buffer[i].sequence, i);
         q->buffer[i].data = NULL;
     }
 }
 
-void spmcFree(spmcQueue *q) {
+inline void spmcFree(spmcQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -131,7 +125,7 @@ void spmcFree(spmcQueue *q) {
     q->head_cache = 0;
 }
 
-bool spmcIsEmpty(spmcQueue *q) {
+inline bool spmcIsEmpty(spmcQueue *q) {
     /* Fast path: Check against cached consumer position */
     if (q->tail == q->head_cache) {
         return true;
@@ -144,13 +138,13 @@ bool spmcIsEmpty(spmcQueue *q) {
     return q->tail == curr_head;
 }
 
-size_t spmcSize(spmcQueue *q) {
+inline size_t spmcSize(spmcQueue *q) {
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     return (q->tail >= head) ? (q->tail - head) : 0;
 }
 
-bool spmcEnqueue(spmcQueue *q, void *data) {
-    spmcCell *cell = &q->buffer[q->tail & (q->queue_size - 1)];
+inline bool spmcEnqueue(spmcQueue *q, void *data) {
+    spmcCell *cell = &q->buffer[q->tail & SPMC_QUEUE_MASK];
     size_t seq = atomic_load_explicit(&cell->sequence, memory_order_acquire);
 
     /* Sequence Check:
@@ -169,13 +163,13 @@ bool spmcEnqueue(spmcQueue *q, void *data) {
     return true;
 }
 
-void *spmcDequeue(spmcQueue *q) {
+inline void *spmcDequeue(spmcQueue *q) {
     size_t head = atomic_load_explicit(&q->head, memory_order_relaxed);
     spmcCell *cell;
     void *data;
 
     while (1) {
-        cell = &q->buffer[head & (q->queue_size - 1)];
+        cell = &q->buffer[head & SPMC_QUEUE_MASK];
         size_t seq = atomic_load_explicit(&cell->sequence, memory_order_acquire);
 
         intptr_t diff = (intptr_t)seq - (intptr_t)(head + 1);
@@ -188,7 +182,7 @@ void *spmcDequeue(spmcQueue *q) {
                 data = cell->data;
 
                 /* Mark slot empty for next generation (pos + size) */
-                atomic_store_explicit(&cell->sequence, head + q->queue_size, memory_order_release);
+                atomic_store_explicit(&cell->sequence, head + SPMC_QUEUE_SIZE, memory_order_release);
                 return data;
             }
         } else if (diff < 0) {
@@ -205,11 +199,8 @@ void *spmcDequeue(spmcQueue *q) {
  * SPSC QUEUE (Single-Producer Single-Consumer)
  * ========================================================================== */
 
-void spscInit(spscQueue *q, size_t queue_size) {
-    /* Queue size must be a power of 2 (the masking logic relies on it) */
-    assert((queue_size & (queue_size - 1)) == 0);
-    q->buffer = (void **)zmalloc(sizeof(void *) * queue_size);
-    q->queue_size = queue_size;
+inline void spscInit(spscQueue *q) {
+    q->buffer = (void **)zmalloc(sizeof(void *) * SPSC_QUEUE_SIZE);
     atomic_init(&q->head, 0);
     atomic_init(&q->tail, 0);
     q->head_cache = 0;
@@ -217,7 +208,7 @@ void spscInit(spscQueue *q, size_t queue_size) {
     q->tail_local = 0;
 }
 
-void spscFree(spscQueue *q) {
+inline void spscFree(spscQueue *q) {
     if (q->buffer) {
         zfree(q->buffer);
         q->buffer = NULL;
@@ -229,13 +220,13 @@ void spscFree(spscQueue *q) {
     q->tail_local = 0;
 }
 
-bool spscIsFull(spscQueue *q) {
+inline bool spscIsFull(spscQueue *q) {
     const size_t curr_tail = q->tail_local;
 
-    if (curr_tail - q->head_cache >= q->queue_size) {
+    if (curr_tail - q->head_cache >= SPSC_QUEUE_SIZE) {
         q->head_cache = atomic_load_explicit(&q->head, memory_order_acquire);
 
-        if (curr_tail - q->head_cache >= q->queue_size) {
+        if (curr_tail - q->head_cache >= SPSC_QUEUE_SIZE) {
             /* Flush any local changes before reporting full */
             if (q->tail_local != q->tail) {
                 atomic_store_explicit(&q->tail, q->tail_local, memory_order_release);
@@ -246,8 +237,8 @@ bool spscIsFull(spscQueue *q) {
     return false;
 }
 
-void spscEnqueue(spscQueue *q, void *data, bool commit) {
-    q->buffer[q->tail_local & (q->queue_size - 1)] = data;
+inline void spscEnqueue(spscQueue *q, void *data, bool commit) {
+    q->buffer[q->tail_local & SPSC_QUEUE_MASK] = data;
     q->tail_local++;
 
     if (commit) {
@@ -255,13 +246,13 @@ void spscEnqueue(spscQueue *q, void *data, bool commit) {
     }
 }
 
-void spscCommit(spscQueue *q) {
+inline void spscCommit(spscQueue *q) {
     size_t tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
     if (q->tail_local == tail) return;
     atomic_store_explicit(&q->tail, q->tail_local, memory_order_release);
 }
 
-size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
+inline size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
     size_t curr_head = atomic_load_explicit(&q->head, memory_order_relaxed);
     size_t curr_tail_cache = q->tail_cache;
 
@@ -275,13 +266,13 @@ size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs) {
     size_t count = (num_jobs < available) ? num_jobs : available;
 
     for (size_t i = 0; i < count; ++i) {
-        jobs_out[i] = q->buffer[(curr_head + i) & (q->queue_size - 1)];
+        jobs_out[i] = q->buffer[(curr_head + i) & SPSC_QUEUE_MASK];
     }
     atomic_store_explicit(&q->head, curr_head + count, memory_order_release);
     return count;
 }
 
-bool spscIsEmpty(spscQueue *q) {
+inline bool spscIsEmpty(spscQueue *q) {
     /* Fast path */
     if (q->tail_local == q->head_cache) {
         return true;

--- a/src/queues.h
+++ b/src/queues.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Implements different types of queues
  *
  * 1. SPMC - Single Producer Multi Consumer
@@ -33,6 +37,12 @@
  * MPSC QUEUE (Multi-Producer Single-Consumer)
  * ========================================================================== */
 
+#define MPSC_QUEUE_SIZE 16384
+#define MPSC_QUEUE_MASK (MPSC_QUEUE_SIZE - 1)
+#ifndef __cplusplus
+static_assert((MPSC_QUEUE_SIZE & (MPSC_QUEUE_SIZE - 1)) == 0, "MPSC_QUEUE_SIZE must be power of 2");
+#endif
+
 typedef struct mpscTicket {
     size_t index;
     bool has_reservation;
@@ -49,12 +59,9 @@ typedef struct mpscQueue {
 
     /* Data buffer */
     _Alignas(CACHE_LINE_SIZE) _Atomic(void *) *buffer;
-    size_t queue_size;
 } mpscQueue;
 
-/* Initializes an MPSC queue with a size that must be a power of 2 */
-void mpscInit(mpscQueue *q, size_t queue_size);
-/* Frees the MPSC queue's internal buffer and resets its state */
+void mpscInit(mpscQueue *q);
 void mpscFree(mpscQueue *q);
 
 /* Pushes an item into the queue and returns true if the queue is not full.
@@ -69,6 +76,12 @@ size_t mpscDequeueBatch(mpscQueue *q, void **jobs_out, size_t max_jobs);
 /* ==========================================================================
  * SPMC QUEUE (Single-Producer Multi-Consumer)
  * ========================================================================== */
+
+#define SPMC_QUEUE_SIZE 4096
+#define SPMC_QUEUE_MASK (SPMC_QUEUE_SIZE - 1)
+#ifndef __cplusplus
+static_assert((SPMC_QUEUE_SIZE & (SPMC_QUEUE_SIZE - 1)) == 0, "SPMC_QUEUE_SIZE must be power of 2");
+#endif
 
 typedef struct spmcCell {
     _Alignas(CACHE_LINE_SIZE) _Atomic(size_t) sequence;
@@ -85,25 +98,24 @@ typedef struct spmcQueue {
 
     /* Data buffer */
     _Alignas(CACHE_LINE_SIZE) spmcCell *buffer;
-    size_t queue_size;
 } spmcQueue;
 
-/* Initializes an SPMC queue with a size that must be a power of 2 */
-void spmcInit(spmcQueue *q, size_t queue_size);
-/* Frees the SPMC queue's internal buffer and resets its state */
+void spmcInit(spmcQueue *q);
 void spmcFree(spmcQueue *q);
-/* Returns true if the SPMC queue has no items */
 bool spmcIsEmpty(spmcQueue *q);
-/* Returns an approximate number of items currently in the queue */
 size_t spmcSize(spmcQueue *q);
-/* Pushes an item to the SPMC queue. Returns true on success, false if the queue is full. */
 bool spmcEnqueue(spmcQueue *q, void *data);
-/* Pops and returns the next item from the queue, or NULL if the queue is empty */
 void *spmcDequeue(spmcQueue *q);
 
 /* ==========================================================================
  * SPSC QUEUE (Single-Producer Single-Consumer)
  * ========================================================================== */
+
+#define SPSC_QUEUE_SIZE 4096
+#define SPSC_QUEUE_MASK (SPSC_QUEUE_SIZE - 1)
+#ifndef __cplusplus
+static_assert((SPSC_QUEUE_SIZE & (SPSC_QUEUE_SIZE - 1)) == 0, "SPSC_QUEUE_SIZE must be power of 2");
+#endif
 
 typedef struct spscQueue {
     /* Consumer cache line */
@@ -117,22 +129,16 @@ typedef struct spscQueue {
 
     /* Dynamic buffer */
     _Alignas(CACHE_LINE_SIZE) void **buffer;
-    size_t queue_size;
 } spscQueue;
 
-/* Initializes an SPSC queue with a size that must be a power of 2 */
-void spscInit(spscQueue *q, size_t queue_size);
-/* Frees the SPSC queue's internal buffer and resets its state */
+void spscInit(spscQueue *q);
 void spscFree(spscQueue *q);
-/* Returns true if the queue is full, or false otherwise */
 bool spscIsFull(spscQueue *q);
 /* Push data to the queue. Caller must ensure queue is not full via spscIsFull().
  * If commit is true, the tail pointer is updated immediately (visible to consumer) else,
  * only local index is updated (batching). */
 void spscEnqueue(spscQueue *q, void *data, bool commit);
-/* Publishes any pending batched enqueues by advancing the shared tail pointer */
 void spscCommit(spscQueue *q);
-/* Pops up to num_jobs items from the queue and returns the actual number popped */
 size_t spscDequeueBatch(spscQueue *q, void **jobs_out, size_t num_jobs);
 /* Check if queue is empty from producer's perspective. */
 bool spscIsEmpty(spscQueue *q);

--- a/src/server.h
+++ b/src/server.h
@@ -195,16 +195,17 @@ struct ValkeyModule;
 /* Instantaneous metrics tracking. */
 #define STATS_METRIC_SAMPLES 16 /* Number of samples per metric. */
 typedef enum {
-    STATS_METRIC_COMMAND = 0,             /* Number of commands executed. */
-    STATS_METRIC_NET_INPUT,               /* Bytes read from network. */
-    STATS_METRIC_NET_OUTPUT,              /* Bytes written to network. */
-    STATS_METRIC_NET_INPUT_REPLICATION,   /* Bytes read from network during replication. */
-    STATS_METRIC_NET_OUTPUT_REPLICATION,  /* Bytes written to network during replication. */
-    STATS_METRIC_EL_CYCLE,                /* Number of eventloop cycled. */
-    STATS_METRIC_EL_DURATION,             /* Eventloop duration. */
-    STATS_METRIC_IO_WAIT,                 /* IO queue size */
-    STATS_METRIC_MAIN_THREAD_ACTIVE_TIME, /* Main-thread active time */
-    STATS_METRIC_COUNT                    /* Total count */
+    STATS_METRIC_COMMAND = 0,            /* Number of commands executed. */
+    STATS_METRIC_NET_INPUT,              /* Bytes read from network. */
+    STATS_METRIC_NET_OUTPUT,             /* Bytes written to network. */
+    STATS_METRIC_NET_INPUT_REPLICATION,  /* Bytes read from network during replication. */
+    STATS_METRIC_NET_OUTPUT_REPLICATION, /* Bytes written to network during replication. */
+    STATS_METRIC_EL_CYCLE,               /* Number of eventloop cycled. */
+    STATS_METRIC_EL_DURATION,            /* Eventloop duration. */
+    STATS_METRIC_IO_WAIT,                /* IO queue size */
+    STATS_METRIC_MAIN_THREAD_CPU_SYS,    /* Main thread CPU sys time */
+    STATS_METRIC_MAIN_THREAD_CPU_USER,   /* Main thread CPU user time */
+    STATS_METRIC_COUNT                   /* Total count */
 } instantaneous_metric_type;
 
 /* Protocol and I/O related defines */

--- a/src/unit/test_queues.cpp
+++ b/src/unit/test_queues.cpp
@@ -22,7 +22,6 @@ extern "C" {
 class SpscQueueTest : public ::testing::Test {
   protected:
     spscQueue q;
-    static constexpr size_t SPSC_QUEUE_SIZE = 4096;
 
     struct ConsumerArg {
         spscQueue *q;
@@ -30,7 +29,7 @@ class SpscQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        spscInit(&q, SPSC_QUEUE_SIZE);
+        spscInit(&q);
     }
 
     void TearDown() override {
@@ -140,7 +139,6 @@ TEST_F(SpscQueueTest, TestSpscConcurrent) {
 class SpmcQueueTest : public ::testing::Test {
   protected:
     spmcQueue q;
-    static constexpr size_t SPMC_QUEUE_SIZE = 4096;
 
     struct ConsumerArg {
         spmcQueue *q;
@@ -149,7 +147,7 @@ class SpmcQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        spmcInit(&q, SPMC_QUEUE_SIZE);
+        spmcInit(&q);
         ASSERT_NE(q.buffer, nullptr);
         EXPECT_EQ(reinterpret_cast<uintptr_t>(q.buffer) % CACHE_LINE_SIZE, 0u);
     }
@@ -253,7 +251,6 @@ TEST_F(SpmcQueueTest, TestSpmcConcurrent) {
 class MpscQueueTest : public ::testing::Test {
   protected:
     mpscQueue q;
-    static constexpr size_t MPSC_QUEUE_SIZE = 16384;
 
     struct ProducerArg {
         mpscQueue *q;
@@ -262,7 +259,7 @@ class MpscQueueTest : public ::testing::Test {
     };
 
     void SetUp() override {
-        mpscInit(&q, MPSC_QUEUE_SIZE);
+        mpscInit(&q);
     }
 
     void TearDown() override {


### PR DESCRIPTION
This reverts the [commit](https://github.com/valkey-io/valkey/commit/fdd90393073881cefb26520c7826ca8991ad9269) that was merged as part of the PR #3544 due to a performance regression observed [here](https://github.com/valkey-io/valkey/issues/3750)