### PR TITLE
[Performance] Revert `tryOffloadFreeObjToIOThreads` to offload entire robj

### DIFF
--- a/src/io_threads.c
+++ b/src/io_threads.c
@@ -343,7 +343,7 @@ static void *IOThreadMain(void *myid) {
                 ioThreadWriteToClient((client *)data);
                 break;
             case JOB_REQ_FREE_OBJ:
-                zfree(data);
+                decrRefCount(data);
                 break;
             case JOB_REQ_ACCEPT:
                 ioThreadAccept((client *)data);
@@ -689,12 +689,8 @@ int tryOffloadFreeObjToIOThreads(robj *obj) {
 
     if (obj->encoding != OBJ_ENCODING_RAW || obj->type != OBJ_STRING) return C_ERR;
 
-    /* We offload only the free of the ptr that may be allocated by the I/O thread.
-     * The object itself was allocated by the main thread and will be freed by the main thread. */
-    void *job = tagJob(sdsAllocPtr(objectGetVal(obj)), JOB_REQ_FREE_OBJ);
+    void *job = tagJob(obj, JOB_REQ_FREE_OBJ);
     if (unlikely(spmcEnqueue(&io_shared_inbox, job) == false)) return C_ERR;
-    objectSetVal(obj, NULL);
-    decrRefCount(obj);
     io_jobs_submitted++;
     server.stat_io_freed_objects++;
     return C_OK;


### PR DESCRIPTION
### Problem:

PR #3544 changed `tryOffloadFreeObjToIOThreads` to only offload the SDS buffer free to IO threads, while freeing the robj shell on the main thread via `decrRefCount(obj) → zfree()`. This moved allocator work from 8 IO threads back to the single main thread, causing ~20% SET throughput regression when IO threads are active (128B+ values, pipelined workloads).

### Fix:

Restore the original behavior: offload the entire `decrRefCount(obj)` to the IO thread. Cross-thread `zfree` is safe with jemalloc's tcache mechanism and the original design has been running without correctness issues since the IO threads redesign.