### PR TITLE
Fix flaky block_keyspace_notification test for HGETDEL notify race

### DIFF
--- a/tests/unit/moduleapi/block_keyspace_notification.tcl
+++ b/tests/unit/moduleapi/block_keyspace_notification.tcl
@@ -139,8 +139,14 @@ start_server {tags {"modules"}} {
         # HGETDEL
         r b_keyspace.clear
         assert_equal "v2" [r hgetdel h1 FIELDS 1 f2]
-        # "hdel" and "del" notifications can be recorded in either order
-        # because they run on independent background threads.
+        # "hdel" and "del" notifications run on independent background threads.
+        # The client is unblocked by the "hdel" thread, so by the time HGETDEL
+        # returns the "del" thread may not have logged yet — wait for both.
+        wait_for_condition 50 100 {
+            [llength [r b_keyspace.events]] >= 2
+        } else {
+            fail "Did not see both hdel and del events: [r b_keyspace.events]"
+        }
         assert_equal [lsort {{event hdel key h1} {event del key h1}}] [lsort [r b_keyspace.events]]
         assert_equal "0" [r exists h1]
 


### PR DESCRIPTION
The HFE-blocking-keyspace-notify test added in #3743 is racy and intermittently fails with:

```
Expected '{event del key h1} {event hdel key h1}' to be equal to '{event hdel key h1}'
(context: ... cmd {assert_equal [lsort {{event hdel key h1} {event del key h1}}] [lsort [r b_keyspace.events]]} proc ::test)
```

## Why it races

When `HGETDEL` empties the hash, `hgetdelCommand` fires two notifications back-to-back on the main thread:

1. `notifyKeyspaceEvent(NOTIFY_HASH, "hdel", ...)`
2. `notifyKeyspaceEvent(NOTIFY_GENERIC, "del", ...)` (the key was removed)

The `block_keyspace_notification` test module's callback always spawns a background thread that sleeps 1s, appends to the event log, and optionally unblocks the client. For the second notification, `RM_BlockClient` returns `NULL` (the client is already blocked by the first), so the second thread never unblocks anyone — it only appends `"del"` to the log.

The first thread is the one that unblocks the client, so `HGETDEL` returns as soon as that thread has logged `"hdel"`. The test client then immediately reads `b_keyspace.events`, racing the second thread which has not yet acquired the event-log mutex. On a loaded host or under valgrind the second thread routinely loses the race, leaving only `"hdel"` visible.

## Fix

`wait_for_condition` until both events have been logged before asserting on their contents. This matches the pattern already used by the four other event-log assertions in this file (e.g. the `Server-created keyspace notification` and `Event that fires twice` blocks).

```tcl
wait_for_condition 50 100 {
    [llength [r b_keyspace.events]] >= 2
} else {
    fail "Did not see both hdel and del events: [r b_keyspace.events]"
}
assert_equal [lsort {{event hdel key h1} {event del key h1}}] [lsort [r b_keyspace.events]]
```

## Verification

On a quiet macOS host:
- Without the fix: 2 of 5 runs fail with the exact error above (and intermittently in larger batches).
- With the fix: 30 of 30 runs pass (10-run + 20-run batches, plus a 15-run rerun directly off `origin/unstable`).

Test-only change; no server code is touched.
