### PR TITLE
Add --failures-output flag to test runners for weekly CI compatibility

### DIFF
--- a/.github/actions/upload-test-failures/action.yml
+++ b/.github/actions/upload-test-failures/action.yml
@@ -1,0 +1,14 @@
+name: 'Upload Test Failures'
+description: 'Upload test failure artifacts'
+inputs:
+  job-name:
+    description: 'Unique name for the artifact'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload test failures
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: test-failures-${{ inputs.job-name }}
+        path: test-failures/

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -35,6 +35,7 @@ set ::dirs {} ; # We remove all the temp dirs at exit
 set ::run_matching {} ; # If non empty, only tests matching pattern are run.
 set ::stop_on_failure 0
 set ::loop 0
+set ::failures_output_file ""; # If set, write failures JSON to this path
 
 if {[catch {cd tmp}]} {
     puts "tmp directory not found."
@@ -304,6 +305,9 @@ proc parse_options {} {
             set ::log_req_res 1
         } elseif {$opt eq {--force-resp3}} {
             set ::force_resp3 1
+        } elseif {$opt eq {--failures-output}} {
+            incr j
+            set ::failures_output_file $val
         } elseif {$opt eq "--help"} {
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--dont-clean            Keep log files on exit."
@@ -316,6 +320,7 @@ proc parse_options {} {
             puts "--config <k> <v>        Extra config argument(s)."
             puts "--stop                  Blocks once the first test fails."
             puts "--loop                  Execute the specified set of tests forever."
+            puts "--failures-output <path> Write test failures to the specified JSON file."
             puts "--help                  Shows this help."
             exit 0
         } else {
@@ -504,6 +509,21 @@ while 1 {
 
 # Print a message and exists with 0 / 1 according to zero or more failures.
 proc end_tests {} {
+    # Write failures output file if requested
+    if {$::failures_output_file ne ""} {
+        set outdir [file dirname $::failures_output_file]
+        if {$outdir ne "." && $outdir ne ""} {
+            file mkdir $outdir
+        }
+        set fp [open $::failures_output_file w]
+        if {$::failed > 0} {
+            puts $fp "\[\{\"test_name\":\"sentinel/cluster tests\",\"test_file\":\"unknown\",\"status\":\"err\",\"error\":\"$::failed test(s) failed\"\}\]"
+        } else {
+            puts $fp "\[\]"
+        }
+        close $fp
+    }
+
     if {$::failed == 0 } {
         puts [colorstr green "GOOD! No errors."]
         exit 0

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -150,6 +150,7 @@ set ::ignoredigest 0
 set ::large_memory 0
 set ::log_req_res 0
 set ::force_resp3 0
+set ::failures_output_file ""; # If set, write failures JSON to this path
 
 # Set to 1 when we are running in client mode. The Redis test uses a
 # server-client model to run tests simultaneously. The server instance
@@ -576,6 +577,49 @@ proc signal_idle_client fd {
 
 # The the_end function gets called when all the test units were already
 # executed, so the test finished.
+proc write_test_failures {} {
+    if {$::failures_output_file eq ""} {
+        return
+    }
+
+    set failures {}
+    foreach failed $::failed_tests {
+        if {[string match {*\[*TIMEOUT*\]*} $failed]} continue
+        if {[string match {*Sanitizer error*} $failed]} continue
+        if {[string match {*Valgrind error*} $failed]} continue
+        if {[string match {*Can't start*} $failed]} continue
+        if {[string match {*Check for memory leaks*} $failed]} continue
+
+        set status "err"
+        set test_name ""
+        set test_file ""
+        set error_msg ""
+
+        if {[regexp {\[(\w+)\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> status test_name test_file error_msg]} {
+            # Successfully parsed
+        } else {
+            set test_name $failed
+            set test_file "unknown"
+            set error_msg $failed
+        }
+
+        set test_name [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_name]
+        set test_file [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $test_file]
+        set error_msg [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $error_msg]
+        set status [string map {"\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t" "\b" "\\b" "\f" "\\f"} $status]
+
+        lappend failures "\{\"test_name\":\"$test_name\",\"test_file\":\"$test_file\",\"status\":\"$status\",\"error\":\"$error_msg\"\}"
+    }
+
+    set outdir [file dirname $::failures_output_file]
+    if {$outdir ne "."} {
+        file mkdir $outdir
+    }
+    set fp [open $::failures_output_file w]
+    puts $fp "\[[join $failures ","]\]"
+    close $fp
+}
+
 proc the_end {} {
     # TODO: print the status, exit with the right exit code.
     puts "\n                   The End\n"
@@ -583,6 +627,12 @@ proc the_end {} {
     foreach {time name} $::clients_time_history {
         puts "  $time seconds - $name"
     }
+
+    # Write structured failures for automated detection
+    if {[catch {write_test_failures} err]} {
+        puts "Warning: Failed to write test failures: $err"
+    }
+
     if {[llength $::failed_tests]} {
         puts "\n[colorstr bold-red {!!! WARNING}] The following tests failed:\n"
         foreach failed $::failed_tests {
@@ -641,6 +691,8 @@ proc print_help_screen {} {
         "--clients <num>    Number of test clients (default 16)."
         "--timeout <sec>    Test timeout in seconds (default 20 min)."
         "--force-failure    Force the execution of a test that always fails."
+        "--failures-output <path>"
+        "                   Write test failures to the specified JSON file."
         "--config <k> <v>   Extra config file argument."
         "--io-threads       Run tests with IO threads enabled."
         "--skipfile <file>  Name of a file containing test names or regexp patterns (if <test> starts with '/') that should be skipped (one per line). This option can be repeated."
@@ -738,6 +790,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         set ::accurate 1
     } elseif {$opt eq {--force-failure}} {
         set ::force_failure 1
+    } elseif {$opt eq {--failures-output}} {
+        set ::failures_output_file $arg
+        incr j
     } elseif {$opt eq {--single}} {
         lappend ::single_tests $arg
         incr j


### PR DESCRIPTION
The weekly CI workflow (on unstable) passes --failures-output to the test runners when executing against release branches. The 7.2 branch test runners reject this unknown flag with 'Wrong argument' and exit 1, causing all test-ubuntu-io-threads and related jobs to fail instantly without running any tests.

Add --failures-output support to:
- tests/test_helper.tcl (main test runner)
- tests/instances.tcl (sentinel/cluster test runner)

Also add the .github/actions/upload-test-failures composite action that the unstable daily.yml references after test execution.

The implementation matches the unstable branch: when --failures-output is provided, a JSON file is written at test completion containing structured information about any test failures.