### PR TITLE
Fix "time_t' different  typedef  on 32-bit /64-bit systems

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2038,7 +2038,7 @@ jobs:
             -e SKIPTESTS \
             -e TEST_ARGS \
             -e CLUSTER_TEST_ARGS \
-            i386/alpine:3.23 \
+            i386/alpine:latest \
             sh -euxc '
               apk add --no-cache bash build-base git gtest-dev linux-headers procps python3 tcl tclx
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1996,6 +1996,87 @@ jobs:
         uses: ./.github/actions/upload-test-failures
         with:
           job-name: ${{ github.job }}
+  test-alpine-32bit:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'valkey-io/valkey') ||
+        (github.event_name == 'pull_request' &&
+          (github.event.pull_request.base.ref != 'unstable' ||
+            contains(github.event.pull_request.labels.*.name, 'run-extra-tests')) &&
+          (github.event.action != 'labeled' ||
+            (github.event.pull_request.base.ref == 'unstable' && github.event.label.name == 'run-extra-tests'))
+        )) &&
+      !contains(github.event.inputs.skipjobs, 'alpine') &&
+      !contains(github.event.inputs.skipjobs, '32bit')
+    steps:
+      - name: prep
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        run: |
+          echo "GITHUB_REPOSITORY=${{inputs.use_repo || github.event.inputs.use_repo}}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{inputs.use_git_ref || github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+          echo "skipjobs: ${{github.event.inputs.skipjobs}}"
+          echo "skiptests: ${{github.event.inputs.skiptests}}"
+          echo "test_args: ${{github.event.inputs.test_args}}"
+          echo "cluster_test_args: ${{github.event.inputs.cluster_test_args}}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.use_repo || github.event.inputs.use_repo || github.repository }}
+          ref: ${{ inputs.use_git_ref || github.event.inputs.use_git_ref || github.ref }}
+      - name: Run 32-bit Alpine tests
+        env:
+          RUN_ACCURATE: ${{ github.event_name != 'pull_request' && '--accurate' || '' }}
+          SKIPTESTS: ${{ github.event.inputs.skiptests }}
+          TEST_ARGS: ${{ github.event.inputs.test_args }}
+          CLUSTER_TEST_ARGS: ${{ github.event.inputs.cluster_test_args }}
+        run: |
+          docker run --rm \
+            --platform linux/386 \
+            -v "$PWD:/src" \
+            -w /src \
+            -e RUN_ACCURATE \
+            -e SKIPTESTS \
+            -e TEST_ARGS \
+            -e CLUSTER_TEST_ARGS \
+            i386/alpine:3.23 \
+            sh -euxc '
+              apk add --no-cache bash build-base git gtest-dev linux-headers procps python3 tcl tclx
+
+              rm -rf libbacktrace
+              git clone https://github.com/ianlancetaylor/libbacktrace.git libbacktrace
+              cd libbacktrace
+              git checkout b9e40069c0b47a722286b94eb5231f7f05c08713
+              ./configure
+              make -j$(nproc)
+              make install
+              cd /src
+
+              make SERVER_CFLAGS="-Werror" USE_LIBBACKTRACE=yes 32bit
+
+              case "${SKIPTESTS:-}" in
+                *valkey*) ;;
+                *) ./runtest ${RUN_ACCURATE:-} --failures-output test-failures/valkey.json --verbose --dump-logs ${TEST_ARGS:-} ;;
+              esac
+
+              case "${SKIPTESTS:-}" in
+                *modules*) ;;
+                *)
+                  make -C tests/modules 32bit
+                  CFLAGS="-Werror" ./runtest-moduleapi --failures-output test-failures/moduleapi.json --verbose --dump-logs ${TEST_ARGS:-}
+                  ;;
+              esac
+
+              case "${SKIPTESTS:-}" in
+                *sentinel*) ;;
+                *) ./runtest-sentinel --failures-output test-failures/sentinel.json ${CLUSTER_TEST_ARGS:-} ;;
+              esac
+            '
+      - name: Upload test failures
+        if: always()
+        uses: ./.github/actions/upload-test-failures
+        with:
+          job-name: ${{ github.job }}
+
   reply-schemas-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 1440
@@ -2092,6 +2173,7 @@ jobs:
       - test-freebsd
       - test-alpine-jemalloc
       - test-alpine-libc-malloc
+      - test-alpine-32bit
       - reply-schemas-validator
     steps:
       - name: Download all failures
@@ -2195,6 +2277,7 @@ jobs:
       - test-freebsd
       - test-alpine-jemalloc
       - test-alpine-libc-malloc
+      - test-alpine-32bit
       - reply-schemas-validator
     steps:
       - name: Collect job status

--- a/src/fuzzer_command_generator.c
+++ b/src/fuzzer_command_generator.c
@@ -17,6 +17,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <sys/time.h>
 #include <pthread.h>
@@ -1658,7 +1659,7 @@ static void addArgumentToCommand(FuzzerCommand *cmd, CommandArgument *arg) {
             time_t currentTime = time(NULL);
             /* add a random number of seconds to the current time */
             currentTime += rand() % RANDOM_TIME_VARIANCE;
-            appendArg(cmd, sdscatprintf(sdsempty(), "%ld", currentTime));
+            appendArg(cmd, sdscatprintf(sdsempty(), "%jd", (intmax_t)currentTime));
         } else if (arg->type == ARG_TYPE_PATTERN) {
             appendArg(cmd, sdsnew("*"));
         } else if (arg->type == ARG_TYPE_KEY) {

--- a/src/server.c
+++ b/src/server.c
@@ -6191,7 +6191,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "hz:%i\r\n", server.hz,
                 "configured_hz:%i\r\n", server.hz,
                 "clients_hz:%i\r\n", server.clients_hz,
-                "lru_clock:%u\r\n", server.unixtime & ((1 << LRULFU_BITS) - 1),
+                "lru_clock:%u\r\n", (unsigned int)(server.unixtime & ((1 << LRULFU_BITS) - 1)),
                 "executable:%s\r\n", server.executable ? server.executable : "",
                 "config_file:%s\r\n", server.configfile ? server.configfile : "",
                 "io_threads_active:%i\r\n", server.active_io_threads_num > 1,

--- a/src/valkey-check-aof.c
+++ b/src/valkey-check-aof.c
@@ -34,7 +34,7 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <libgen.h>
-
+#include <stdint.h>
 #define AOF_CHECK_OK 0
 #define AOF_CHECK_EMPTY 1
 #define AOF_CHECK_TRUNCATED 2
@@ -193,14 +193,14 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         }
         if (ts <= to_timestamp) return 1;
         if (epos == 0) {
-            printf("AOF %s has nothing before timestamp %ld, "
+            printf("AOF %s has nothing before timestamp %jd, "
                    "aborting...\n",
-                   filename, to_timestamp);
+                   filename, (intmax_t)to_timestamp);
             exit(1);
         }
         if (!last_file) {
-            printf("Failed to truncate AOF %s to timestamp %ld to offset %ld because it is not the last file.\n",
-                   filename, to_timestamp, (long int)epos);
+            printf("Failed to truncate AOF %s to timestamp %jd to offset %lld because it is not the last file.\n",
+                   filename, (intmax_t)to_timestamp, (long long)epos);
             printf(
                 "If you insist, please delete all files after this file according to the manifest "
                 "file and delete the corresponding records in manifest file manually. Then re-run valkey-check-aof.\n");
@@ -208,7 +208,7 @@ int processAnnotations(FILE *fp, char *filename, int last_file) {
         }
         /* Truncate remaining AOF if exceeding 'to_timestamp' */
         if (ftruncate(fileno(fp), epos) == -1) {
-            printf("Failed to truncate AOF %s to timestamp %ld\n", filename, to_timestamp);
+            printf("Failed to truncate AOF %s to timestamp %jd\n", filename, (intmax_t)to_timestamp);
             exit(1);
         } else {
             return 0;
@@ -296,7 +296,7 @@ int checkSingleAof(char *aof_filename, char *aof_filepath, int last_file, int fi
 
     /* In truncate-to-timestamp mode, just exit if there is nothing to truncate. */
     if (diff == 0 && to_timestamp) {
-        printf("Truncate nothing in AOF %s to timestamp %ld\n", aof_filename, to_timestamp);
+        printf("Truncate nothing in AOF %s to timestamp %jd\n", aof_filename, (intmax_t)to_timestamp);
         fclose(fp);
         return AOF_CHECK_OK;
     }
@@ -446,7 +446,7 @@ void printAofStyle(int ret, char *aofFileName, char *aofType) {
     } else if (ret == AOF_CHECK_EMPTY) {
         printf("%s %s is empty\n", aofType, aofFileName);
     } else if (ret == AOF_CHECK_TIMESTAMP_TRUNCATED) {
-        printf("Successfully truncated AOF %s to timestamp %ld\n", aofFileName, to_timestamp);
+        printf("Successfully truncated AOF %s to timestamp %jd\n", aofFileName, (intmax_t)to_timestamp);
     } else if (ret == AOF_CHECK_TRUNCATED) {
         printf("Successfully truncated AOF %s\n", aofFileName);
     }


### PR DESCRIPTION
Fix #3781 

## Description
This PR fixes a crash on 32-bit Alpine 3.23 / time64 environments when starting `valkey-server` and generating the `INFO server` output.

On 32-bit Alpine 3.23, `time_t` is 64-bit. In `genValkeyInfoString()`, the `lru_clock` field is formatted with `%u`, but the expression passed to `sdscatfmt()` was derived from `server.unixtime`, whose type is `time_t`. This can pass a 64-bit varargs argument to a formatter expecting an unsigned int-sized value. As a result, later varargs arguments may be read at the wrong offset, which can lead to a segmentation fault during startup.

The fix explicitly casts the computed `lru_clock` value to `unsigned int` before passing it to `sdscatfmt()`, matching the `%u` format specifier and preserving the intended 24-bit LRU clo

The Alpine 32-bit build fails with `-Werror=format` because a few `time_t` values are printed with `%ld`. This assumes that `time_t` is always compatible with `long`, which is not portable across all 32-bit and 64-bit targets. In particular, 32-bit Linux environments may use a `time_t` representation that does not match `long`, causing format checking failures when warnings are treated as errors.

## Root Cause

The crash is caused by a varargs width mismatch on 32-bit time64 systems:

```c
"lru_clock:%u\r\n",
(server.unixtime / LRU_CLOCK_RESOLUTION) & LRU_CLOCK_MAX,
```

On 32-bit Alpine 3.23, server.unixtime is backed by 64-bit time_t, so the expression may be passed as a 64-bit value. Since %u expects an unsigned int, sdscatfmt() consumes only part of the argument and subsequent arguments can become misaligned.

# Fix
Cast the value passed for %u to unsigned int:
server.c
```c
(unsigned int)((server.unixtime / LRU_CLOCK_RESOLUTION) & LRU_CLOCK_MAX)
```

updates the affected `time_t` formatting sites to use `%jd` together with an explicit `(intmax_t)` cast. This keeps the output portable across architectures without changing the `time_t` ABI or making assumptions about its underlying typedef.

| File | Change |
|---|---|
| `src/valkey-check-aof.c` | Print `to_timestamp` with `%jd` and `(intmax_t)to_timestamp` in all AOF truncate-to-timestamp messages. |
| `src/fuzzer_command_generator.c` | Print generated `ARG_TYPE_UNIX_TIME` values with `%jd` and `(intmax_t)currentTime`. |


# Test 

This PR also added a new daily CI "test-alpine-32bit"