### PR TITLE
Add full sync function test case for CVE-2026-23631

### DIFF
--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -1274,44 +1274,42 @@ start_server {tags {"scripting"}} {
 
 }
 
-start_server {tags {"repl scripting external:skip"}} {
-    start_server {} {
-        test "Full sync events are not processed during the replica slow script" {
-            set primary [srv -1 client]
-            set primary_host [srv -1 host]
-            set primary_port [srv -1 port]
+start_multiple_servers 2 {tags {"repl scripting external:skip"}} {
+    test "Full sync events are not processed during the replica slow script" {
+        set primary [srv -1 client]
+        set primary_host [srv -1 host]
+        set primary_port [srv -1 port]
 
-            set replica [srv 0 client]
-            $replica config set busy-reply-threshold 1
-            $replica config set loading-process-events-interval-bytes 1024
-            $replica config set repl-diskless-load flush-before-load
+        set replica [srv 0 client]
+        $replica config set busy-reply-threshold 1
+        $replica config set loading-process-events-interval-bytes 1024
+        $replica config set repl-diskless-load flush-before-load
 
-            # Load a `while true` function.
-            $primary function load [get_no_writes_function_code lua test test {while true do end}]
+        # Load a `while true` function.
+        $primary function load [get_no_writes_function_code lua test test {while true do end}]
 
-            # Setup the replication
-            $replica replicaof $primary_host $primary_port
-            wait_for_sync $replica
+        # Setup the replication
+        $replica replicaof $primary_host $primary_port
+        wait_for_sync $replica
 
-            # Replica executes the function and make sure it enters the BUSY state.
-            set rd [valkey_deferring_client]
-            $rd fcall_ro test 0
-            set loglines [wait_for_log_messages 0 {"*Slow script detected*"} 0 1000 10]
-            assert_error {BUSY*} {$replica ping}
+        # Replica executes the function and make sure it enters the BUSY state.
+        set rd [valkey_deferring_client]
+        $rd fcall_ro test 0
+        set loglines [wait_for_log_messages 0 {"*Slow script detected*"} 0 1000 10]
+        assert_error {BUSY*} {$replica ping}
 
-            # Trigger a full sync.
-            $primary debug change-repl-id
-            $primary client kill type replica
-            wait_replica_online $primary
+        # Trigger a full sync.
+        $primary debug change-repl-id
+        $primary client kill type replica
+        wait_replica_online $primary
 
-            # Replica is still running the function and it is OK
-            assert_error {BUSY*} {$replica ping}
-            $replica function kill
-            after 200 ; # Give some time to Lua to call the hook again...
-            wait_for_sync $replica
-            $replica ping
+        # Replica is still running the function and it is OK
+        assert_error {BUSY*} {$replica ping}
+        $replica function kill
+        after 200 ; # Give some time to Lua to call the hook again...
+        wait_for_sync $replica
+        $replica ping
 
-            $rd close
-        }
+        $rd close
     }
 }

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -1307,6 +1307,7 @@ start_server {tags {"repl scripting external:skip"}} {
             # Replica is still running the function and it is OK
             assert_error {BUSY*} {$replica ping}
             $replica function kill
+            after 200 ; # Give some time to Lua to call the hook again...
             wait_for_sync $replica
             $replica ping
 

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -1274,7 +1274,7 @@ start_server {tags {"scripting"}} {
 
 }
 
-start_multiple_servers 2 {tags {"repl scripting external:skip"}} {
+start_multiple_servers 2 {tags {"repl scripting external:skip needs:debug"}} {
     test "Full sync events are not processed during the replica slow script" {
         set primary [srv -1 client]
         set primary_host [srv -1 host]

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -1273,3 +1273,44 @@ start_server {tags {"scripting"}} {
     } {*Script attempted to access nonexistent global variable 'getmetatable'*}
 
 }
+
+start_server {tags {"repl scripting external:skip"}} {
+    start_server {} {
+        test "Full sync events are not processed during the replica slow script" {
+            set primary [srv -1 client]
+            set primary_host [srv -1 host]
+            set primary_port [srv -1 port]
+
+            set replica [srv 0 client]
+            $replica config set busy-reply-threshold 1
+            $replica config set loading-process-events-interval-bytes 1024
+            $replica config set repl-diskless-load flush-before-load
+
+            # Load a `while true` function.
+            $primary function load [get_no_writes_function_code lua test test {while true do end}]
+
+            # Setup the replication
+            $replica replicaof $primary_host $primary_port
+            wait_for_sync $replica
+
+            # Replica executes the function and make sure it enters the BUSY state.
+            set rd [valkey_deferring_client]
+            $rd fcall_ro test 0
+            set loglines [wait_for_log_messages 0 {"*Slow script detected*"} 0 1000 10]
+            assert_error {BUSY*} {$replica ping}
+
+            # Trigger a full sync.
+            $primary debug change-repl-id
+            $primary client kill type replica
+            wait_replica_online $primary
+
+            # Replica is still running the function and it is OK
+            assert_error {BUSY*} {$replica ping}
+            $replica function kill
+            wait_for_sync $replica
+            $replica ping
+
+            $rd close
+        }
+    }
+}


### PR DESCRIPTION
On the current unstable branch, this issue does not occur when
`repl-diskless-load` is set to `disabled`, because we now use
a bio thread to save the RDB file, the main thread only triggers
the RDB loading process in `replicationCron`.

This test case is reproducible when `repl-diskless-load` is set
to `flush-before-load`, the replica resets the function context,
leading to a "use-after-free" error within a slow function.

Add test case for #3625 (CVE-2026-23631).