### PR TITLE
hashtable: disallow insert during safe iteration (fixes #2302)

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1090,6 +1090,7 @@ static bucket *findBucketForInsert(hashtable *ht, uint64_t hash, int *pos_in_buc
 /* Helper to insert an entry. Doesn't check if an entry with a matching key
  * already exists. This must be ensured by the caller. */
 static void insert(hashtable *ht, uint64_t hash, void *entry) {
+    assert(!ht->safe_iterators && "Inserting during safe iteration is not supported.");
     hashtableExpandIfNeeded(ht);
     rehashStepOnWriteIfNeeded(ht);
     int pos_in_bucket;
@@ -2184,13 +2185,14 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
  * is returned exactly once.
  *
  * For a safe iterator (when HASHTABLE_ITER_SAFE is set):
- * It is allowed to modify the hash table while iterating. It pauses incremental
- * rehashing to prevent entries from moving around. It's allowed to insert and
- * replace entries. Deleting entries is only allowed for the entry that was just
- * returned by hashtableNext. Deleting other entries is possible, but doing so
- * can cause internal fragmentation, so don't. The hash table itself can be
- * safely deleted while safe iterators exist - they will be invalidated and
- * subsequent calls to hashtableNext will return false.
+ * It is allowed to delete and replace entries while iterating. It pauses
+ * incremental rehashing to prevent entries from moving around. Inserting new
+ * entries during safe iteration is NOT supported.
+ * Deleting entries is only allowed for the entry that was just returned by
+ * hashtableNext. Deleting other entries is possible, but doing so can cause
+ * internal fragmentation, so don't. The hash table itself can be safely deleted
+ * while safe iterators exist - they will be invalidated and subsequent calls to
+ * hashtableNext will return false.
  *
  * Guarantees for safe iterators:
  *
@@ -2202,9 +2204,6 @@ size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction f
  *
  * - Entries that are replaced before they've been returned by the iterator will
  *   be returned.
- *
- * - Entries that are inserted during the iteration may or may not be returned
- *   by the iterator.
  *
  * Call hashtableNext to fetch each entry. You must call hashtableCleanupIterator
  * when you are done with the iterator.

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -1090,7 +1090,7 @@ static bucket *findBucketForInsert(hashtable *ht, uint64_t hash, int *pos_in_buc
 /* Helper to insert an entry. Doesn't check if an entry with a matching key
  * already exists. This must be ensured by the caller. */
 static void insert(hashtable *ht, uint64_t hash, void *entry) {
-    assert(!ht->safe_iterators && "Inserting during safe iteration is not supported.");
+    assert(ht->safe_iterators == NULL);
     hashtableExpandIfNeeded(ht);
     rehashStepOnWriteIfNeeded(ht);
     int pos_in_bucket;

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -680,8 +680,8 @@ TEST_F(HashtableTest, iterator) {
 
 TEST_F(HashtableTest, safe_iterator) {
     size_t count = 1000;
-    uint8_t *entry_counts = (uint8_t *)malloc(count * 2);
-    memset(entry_counts, 0, count * 2);
+    uint8_t *entry_counts = (uint8_t *)malloc(count);
+    memset(entry_counts, 0, count);
 
     /* A set of pointers into the uint8_t array. */
     hashtableType type = {};
@@ -692,7 +692,7 @@ TEST_F(HashtableTest, safe_iterator) {
         ASSERT_TRUE(hashtableAdd(ht, entry_counts + j));
     }
 
-    /* Iterate */
+    /* Iterate with deletes (the supported safe iterator contract) */
     size_t num_returned = 0;
     hashtableIterator iter;
     void *next;
@@ -702,33 +702,24 @@ TEST_F(HashtableTest, safe_iterator) {
         size_t index = entry - entry_counts;
         num_returned++;
         ASSERT_GE(entry, entry_counts);
-        ASSERT_LT(entry, entry_counts + count * 2);
+        ASSERT_LT(entry, entry_counts + count);
         /* increment entry at this position as a counter */
         (*entry)++;
+        /* Delete every 4th entry after returning it */
         if (index % 4 == 0) {
             ASSERT_TRUE(hashtableDelete(ht, entry));
-        }
-        /* Add new item each time we see one of the original items */
-        if (index < count) {
-            ASSERT_TRUE(hashtableAdd(ht, entry + count));
         }
     }
     hashtableCleanupIterator(&iter);
 
-    /* Check that all entries present during the whole iteration were returned
-     * exactly once. (Some are deleted after being returned.) */
-    ASSERT_GE(num_returned, count);
+    /* All entries must be returned exactly once */
+    ASSERT_EQ(num_returned, count);
     for (size_t j = 0; j < count; j++) {
         ASSERT_EQ(entry_counts[j], 1u) << "Entry " << j << " returned " << (int)entry_counts[j] << " times";
     }
-    /* Check that entries inserted during the iteration were returned at most
-     * once. */
-    unsigned long num_optional_returned = 0;
-    for (size_t j = count; j < count * 2; j++) {
-        ASSERT_LE(entry_counts[j], 1u);
-        num_optional_returned += entry_counts[j];
-    }
-    printf("Safe iterator returned %lu of the %zu entries inserted while iterating.\n", num_optional_returned, count);
+
+    /* Verify correct number of entries remain */
+    ASSERT_EQ(hashtableSize(ht), count - count / 4);
 
     hashtableRelease(ht);
     free(entry_counts);


### PR DESCRIPTION
The safe iterator contract claimed that inserting entries during iteration was supported. However, inserting into a full bucket triggers bucketConvertToChained which moves an entry the iterator may have already returned, causing it to be visited twice. (Closes #2302, and will resolve a flaky UT failure)

No production code inserts during safe iteration — all safe iterator usages only read, delete, or gather stats.

Changes:
- Add assert in insert() to catch inserts during safe iteration.
- Update the safe iterator contract comment to document that insert is not supported.
- Rewrite the safe_iterator test to only test delete-during-iteration (the supported contract).