### PR TITLE
Fix heap-use-after-free in ACL LOAD when client free is deferred

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -2670,6 +2670,7 @@ static sds ACLLoadFromFile(const char *filename) {
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's
              * list. */
             if (!new_user || (channels && ACLShouldKillPubsubClient(c, channels))) {
+                c->user = NULL;
                 freeClientOrCloseLater(c, 0);
                 continue;
             }

--- a/src/acl.c
+++ b/src/acl.c
@@ -2670,7 +2670,7 @@ static sds ACLLoadFromFile(const char *filename) {
             /* When the new channel list is NULL, it means the new user's channel list is a superset of the old user's
              * list. */
             if (!new_user || (channels && ACLShouldKillPubsubClient(c, channels))) {
-                c->user = NULL;
+                clientSetUser(c, DefaultUser, 0);
                 freeClientOrCloseLater(c, 0);
                 continue;
             }

--- a/src/debug.c
+++ b/src/debug.c
@@ -525,6 +525,10 @@ void debugCommand(client *c) {
             "    When set to 1, slot migrations will be prevented from pausing on the source node.",
             "SLOTMIGRATION PREVENT-FAILOVER <0|1>",
             "    When set to 1, slot migrations will be prevented from performing the slot-level failover on the target node.",
+            "FORCE-FREE-PRIMARY-ASYNC <0|1>",
+            "    Force freeClient on primary to use async path.",
+            "PROTECT-CLIENT <id>",
+            "    Protect a client from being freed, forcing deferred close.",
             NULL};
         addExtendedReplyHelp(c, help, clusterDebugCommandExtendedHelp());
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "segfault")) {
@@ -1070,7 +1074,13 @@ void debugCommand(client *c) {
         server.debug_force_free_primary_async = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "protect-client") && c->argc == 3) {
-        uint64_t id = strtoull(objectGetVal(c->argv[2]), NULL, 10);
+        char *endptr;
+        errno = 0;
+        uint64_t id = strtoull(objectGetVal(c->argv[2]), &endptr, 10);
+        if (errno == ERANGE || endptr == objectGetVal(c->argv[2]) || *endptr != '\0') {
+            addReplyError(c, "Invalid client id");
+            return;
+        }
         client *target = lookupClientByID(id);
         if (target) {
             protectClient(target);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1069,6 +1069,15 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(objectGetVal(c->argv[1]), "force-free-primary-async") && c->argc == 3) {
         server.debug_force_free_primary_async = atoi(objectGetVal(c->argv[2]));
         addReply(c, shared.ok);
+    } else if (!strcasecmp(objectGetVal(c->argv[1]), "protect-client") && c->argc == 3) {
+        uint64_t id = strtoull(objectGetVal(c->argv[2]), NULL, 10);
+        client *target = lookupClientByID(id);
+        if (target) {
+            protectClient(target);
+            addReply(c, shared.ok);
+        } else {
+            addReplyError(c, "No such client");
+        }
     } else if (!handleDebugClusterCommand(c)) {
         addReplySubcommandSyntaxError(c);
         return;

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1103,6 +1103,47 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         $rd2 close
     }
 
+    test {ACL LOAD does not leave dangling user pointer on protected clients} {
+        # Create a user that will be deleted on ACL LOAD
+        r ACL SETUSER tempuser on >temppass ~* &* +@all
+        r ACL SAVE
+
+        # Connect as tempuser
+        set rd [valkey_deferring_client]
+        $rd AUTH tempuser temppass
+        $rd read ;# consume OK
+        $rd CLIENT ID
+        set cid [$rd read]
+
+        # Protect the client so freeClient defers to async
+        r DEBUG PROTECT-CLIENT $cid
+
+        # Remove tempuser from ACL file and reload
+        set aclfile [file join [lindex [r CONFIG GET dir] 1] [lindex [r CONFIG GET aclfile] 1]]
+        set fd [open $aclfile r]
+        set content [read $fd]
+        close $fd
+        # Rewrite without tempuser
+        set fd [open $aclfile w]
+        foreach line [split $content "\n"] {
+            if {![string match "*tempuser*" $line]} {
+                puts $fd $line
+            }
+        }
+        close $fd
+
+        r ACL LOAD
+
+        # The protected client is still in server.clients with a dangling c->user.
+        # CLIENT LIST will dereference c->user->name via catClientInfoString.
+        # Under ASAN this would fire heap-use-after-free without the fix.
+        set cl [r CLIENT LIST]
+        assert {[string length $cl] > 0}
+
+        $rd close
+        set _ {}
+    } {} {needs:debug}
+
     test {ACL load and save} {
         r ACL setuser eve +get allkeys >eve on
         r ACL save

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1138,7 +1138,7 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         # CLIENT LIST will dereference c->user->name via catClientInfoString.
         # Under ASAN this would fire heap-use-after-free without the fix.
         set cl [r CLIENT LIST]
-        assert_match "*id=$cid*" $cl
+        assert_match "*id=$cid *" $cl
 
         $rd close
         set _ {}

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -1138,7 +1138,7 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
         # CLIENT LIST will dereference c->user->name via catClientInfoString.
         # Under ASAN this would fire heap-use-after-free without the fix.
         set cl [r CLIENT LIST]
-        assert {[string length $cl] > 0}
+        assert_match "*id=$cid*" $cl
 
         $rd close
         set _ {}


### PR DESCRIPTION
### Bug

When `ACL LOAD` deletes a user, it calls `freeClientOrCloseLater()` on clients authenticated as that user. If `freeClient()` defers the actual free (because the client has `flag.protected` set or has pending IO), the client remains in `server.clients` with `c->user` still pointing to the old user object.

After `raxFreeWithCallback(old_users, ACLFreeUserVoid)` frees all old user objects, `c->user` becomes a dangling pointer. Any subsequent code that dereferences `c->user` on the deferred client triggers a heap-use-after-free.

### Crash sequence

1. Client A runs `ACL LOAD`
2. Client B is authenticated as a user that was removed from the ACL file
3. Client B has `flag.protected` set (e.g. has pending IO (IO threads)
4. `ACLLoadFromFile` → `freeClientOrCloseLater(B, 0)` → `freeClient(B)` → defers to `freeClientAsync` because B is protected
5. `raxFreeWithCallback(old_users, ...)` frees all old user objects including B's user
6. B is still in `server.clients` with `c->user` pointing to freed memory
7. `CLIENT LIST` or any path that calls `catClientInfoString` dereferences `c->user->name` → **UAF**

### Fix

Set `c->user` to default user before calling `freeClientOrCloseLater()` in `ACLLoadFromFile`. The existing NULL guard in `catClientInfoString` (`client->user ? client->user->name : "(superuser)"`) handles this safely.

### Test

Added `DEBUG PROTECT-CLIENT <client-id>` subcommand that calls `protectClient()` on the target, forcing `freeClient` to defer to async. This enables deterministic reproduction without timing races.

The test:
1. Creates a user, connects a client as that user
2. Protects the client via `DEBUG PROTECT-CLIENT`
3. Removes the user from the ACL file and runs `ACL LOAD`
4. Runs `CLIENT LIST` which dereferences `c->user->name`

Without the fix, this crashes under ASAN with:
```
ERROR: AddressSanitizer: heap-use-after-free in catClientInfoString
READ of size 8
freed by: raxRecursiveFree → raxFreeWithCallback → ACLLoadFromFile
```