### PR TITLE
Validate every DB clause in COPY against ACL db= permissions

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3070,17 +3070,44 @@ int *moveDbIdArgs(robj **argv, int argc, int *count) {
     return result;
 }
 
+/* COPY source destination [ DB destination-db ] [ REPLACE ]
+ *
+ * Note that the DB and REPLACE tokens are optional and order-independent.
+ * Also if the DB token appears more than once, copyCommand keeps overwriting
+ * the destination DB, so ACL must validate every occurrence: a permission
+ * check against only the first or only the last value would let a user craft
+ * 'COPY src dst DB <allowed> DB <denied>' (or vice versa) to bypass the ACL. */
 int *copyDbIdArgs(robj **argv, int argc, int *count) {
     if (argc < 5) return NULL;
 
-    if (strcasecmp(objectGetVal(argv[3]), "db") != 0) return NULL;
+    /* First pass: validate syntax and count DB clauses. */
+    int n = 0;
+    for (int j = 3; j < argc; j++) {
+        int additional = argc - j - 1;
+        if (!strcasecmp(objectGetVal(argv[j]), "replace")) {
+            continue;
+        } else if (!strcasecmp(objectGetVal(argv[j]), "db") && additional >= 1) {
+            long long dbid;
+            if (getLongLongFromObject(argv[j + 1], &dbid) != C_OK) return NULL;
+            if (dbid < 0 || dbid >= server.dbnum) return NULL;
+            n++;
+            j++;
+        } else {
+            return NULL;
+        }
+    }
+    if (n == 0) return NULL;
 
-    long long dbid;
-    if (getLongLongFromObject(argv[4], &dbid) != C_OK) return NULL;
-    if (dbid < 0 || dbid >= server.dbnum) return NULL;
-
-    int *result = zmalloc(sizeof(int));
-    result[0] = (int)dbid;
-    *count = 1;
+    /* Second pass: collect the dbids now that we know the exact size. */
+    int *result = zmalloc(n * sizeof(int));
+    *count = 0;
+    for (int j = 3; j < argc; j++) {
+        if (!strcasecmp(objectGetVal(argv[j]), "db")) {
+            long long dbid;
+            getLongLongFromObject(argv[j + 1], &dbid);
+            result[(*count)++] = (int)dbid;
+            j++;
+        }
+    }
     return result;
 }

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -817,24 +817,41 @@ start_server {tags {"acl external:skip"}} {
     }
 
     test {Test COPY with database permissions} {
-        r ACL SETUSER copy-user on nopass +copy +set +get +select ~* db=0,1
+        r ACL SETUSER copy-user on nopass +copy +set +get +del +select ~* db=0,1
         $r2 auth copy-user password
-        
+
         $r2 select 0
         $r2 set copy-key value
-        
+        $r2 set copy-key2 value
         assert_equal "1" [$r2 copy copy-key copy-key-dest DB 1]
-        
+        assert_equal "1" [$r2 copy copy-key copy-key-dest DB 1 REPLACE]
+        assert_equal "1" [$r2 copy copy-key copy-key-dest REPLACE DB 1]
+        assert_equal "1" [$r2 copy copy-key2 copy-key-dest2 DB 1 DB 1]
+        assert_equal "1" [$r2 copy copy-key2 copy-key-dest2 DB 1 DB 1 REPLACE]
+        assert_equal "1" [$r2 copy copy-key2 copy-key-dest2 REPLACE DB 1 DB 1]
+
         $r2 select 1
         assert_equal "value" [$r2 get copy-key-dest]
-        
+        assert_equal "value" [$r2 get copy-key-dest2]
+        $r2 del copy-key-dest copy-key-dest2
+
         $r2 select 0
-        catch {$r2 copy copy-key copy-key-dest2 DB 2} e
-        assert_match "*NOPERM*database*" $e
-        
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 2}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 2 REPLACE}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 REPLACE DB 2}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 1 DB 2}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 1 DB 2 REPLACE}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 1 REPLACE DB 2}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 REPLACE DB 1 DB 2}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 2 DB 1}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 2 DB 1 REPLACE}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 DB 2 REPLACE DB 1}
+        assert_error "*NOPERM*database*" {$r2 copy copy-key copy-key-dest2 REPLACE DB 2 DB 1}
+
+
         r select 2
         assert_equal {} [r get copy-key-dest2]
-        
+
         # cleanup
         r select 0
     }
@@ -939,8 +956,13 @@ start_server {tags {"acl external:skip"}} {
         assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun SELECT 2]
         assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun MOVE key 2]
         assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun SWAPDB 0 2]
+
         assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 1]
+        assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 1 REPLACE]
+        assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 REPLACE DB 1]
         assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2]
+        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2 REPLACE]
+        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 REPLACE DB 2]
     }
     
     test {Test db= with maximum database ID} {


### PR DESCRIPTION
copyDbIdArgs assumed the DB token was always at argv[3], so
'COPY src dst REPLACE DB n' or 'COPY src dst DB a DB b' could
bypass db= restrictions. Mirror copyCommand's parser to walk
all argv tokens, collect every DB destination, and let the ACL
checker validate each one.

DB ACL was added in #2309.

Please also pick #3888 if you pick this one.