### PR TITLE
hashtable: scan no-duplicate guarantee and add HasPassedKey API

### DIFF
--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2012,7 +2012,7 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  * - An entry that is inserted or deleted during a full scan may or may not be
  *   returned during the scan.
  *
- * Additional guarantees when rehashing is paused (or not active):
+ * Additional guarantees when rehashing is paused:
  *
  * - An entry will never be returned more than once.
  *

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2012,7 +2012,9 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  * - An entry that is inserted or deleted during a full scan may or may not be
  *   returned during the scan.
  *
- * Additional guarantees when rehashing is paused for the duration of the scan:
+ * Additional guarantees when shrinking is blocked for the duration of the scan
+ * (e.g. by calling hashtablePauseAutoShrink before starting and
+ * hashtableResumeAutoShrink after finishing):
  *
  * - An entry will never be returned more than once.
  *
@@ -2021,6 +2023,10 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  *
  * - An entry that is created, destroyed, or re-created during the scan may or
  *   may not be returned, but will never be returned more than once.
+ *
+ * Expansion and rehashing may occur freely without breaking these guarantees.
+ * Only a shrink is problematic: it introduces a smaller table whose bucket
+ * boundaries don't align with the existing cursor position.
  *
  * Scan callback rules:
  *
@@ -2042,6 +2048,9 @@ size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, voi
  *
  * When rehashing is not active, this is an exact answer. When rehashing is
  * active, the result is best-effort and not guaranteed to be correct.
+ *
+ * When shrinking is blocked (see scan guarantees above), the result is exact
+ * regardless of whether rehashing is active.
  *
  * A cursor of 0 means the scan has not started, so no keys have been passed. */
 bool hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2012,6 +2012,16 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  * - An entry that is inserted or deleted during a full scan may or may not be
  *   returned during the scan.
  *
+ * Additional guarantees when rehashing is paused (or not active):
+ *
+ * - An entry will never be returned more than once.
+ *
+ * - An entry that exists throughout the entire scan is guaranteed to be
+ *   returned.
+ *
+ * - An entry that is created, destroyed, or re-created during the scan may or
+ *   may not be returned, but will never be returned more than once.
+ *
  * Scan callback rules:
  *
  * - The scan callback may delete the entry that was passed to it.
@@ -2023,6 +2033,25 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata) {
     return hashtableScanDefrag(ht, cursor, fn, privdata, NULL, 0);
+}
+
+/* Given a scan cursor, determines whether the bucket containing 'key' has
+ * already been visited by the scan. Returns 1 if the key's bucket has been
+ * passed (i.e. the key would have been emitted already), 0 if not yet visited.
+ *
+ * When rehashing is not active, this is an exact answer. When rehashing is
+ * active, the result is best-effort and not guaranteed to be correct.
+ *
+ * A cursor of 0 means the scan is complete, so all keys have been passed. */
+int hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {
+    if (cursor == 0) return 1;
+    size_t mask = expToMask(ht->bucket_exp[0]);
+    uint64_t hash = hashKey(ht, key);
+    size_t bucket_idx = hash & mask;
+    size_t cursor_idx = cursor & mask;
+    /* In reverse-bit-increment order, a bucket has been visited if its
+     * reversed index is less than the reversed cursor index. */
+    return rev(bucket_idx) < rev(cursor_idx);
 }
 
 /* Like hashtableScan, but additionally reallocates the memory used by the dict

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2046,11 +2046,9 @@ size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, voi
  * passed (i.e. the key would have been emitted already), false if not yet
  * visited.
  *
- * When rehashing is not active, this is an exact answer. When rehashing is
- * active, the result is best-effort and not guaranteed to be correct.
- *
- * When shrinking is blocked (see scan guarantees above), the result is exact
- * regardless of whether rehashing is active.
+ * The result is exact when shrinking is blocked (see scan guarantees above).
+ * If a shrink has been initiated since the cursor was obtained, the result is
+ * best-effort and not guaranteed to be correct.
  *
  * A cursor of 0 means the scan has not started, so no keys have been passed. */
 bool hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2043,9 +2043,9 @@ size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, voi
  * When rehashing is not active, this is an exact answer. When rehashing is
  * active, the result is best-effort and not guaranteed to be correct.
  *
- * A cursor of 0 means the scan is complete, so all keys have been passed. */
+ * A cursor of 0 means the scan has not started, so no keys have been passed. */
 bool hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {
-    if (cursor == 0) return 1;
+    if (cursor == 0) return false;
     size_t mask = expToMask(ht->bucket_exp[0]);
     uint64_t hash = hashKey(ht, key);
     size_t bucket_idx = hash & mask;

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2035,9 +2035,10 @@ size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, voi
     return hashtableScanDefrag(ht, cursor, fn, privdata, NULL, 0);
 }
 
-/* Given a scan cursor, determines whether the bucket containing 'key' has
- * already been visited by the scan. Returns 1 if the key's bucket has been
- * passed (i.e. the key would have been emitted already), 0 if not yet visited.
+/* Given a scan cursor, determines whether a key's hashtable position has
+ * already been visited by the scan. Returns true if the position has been
+ * passed (i.e. the key would have been emitted already), false if not yet
+ * visited.
  *
  * When rehashing is not active, this is an exact answer. When rehashing is
  * active, the result is best-effort and not guaranteed to be correct.

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2043,7 +2043,7 @@ size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, voi
  * active, the result is best-effort and not guaranteed to be correct.
  *
  * A cursor of 0 means the scan is complete, so all keys have been passed. */
-int hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {
+bool hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor) {
     if (cursor == 0) return 1;
     size_t mask = expToMask(ht->bucket_exp[0]);
     uint64_t hash = hashKey(ht, key);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -2012,7 +2012,7 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
  * - An entry that is inserted or deleted during a full scan may or may not be
  *   returned during the scan.
  *
- * Additional guarantees when rehashing is paused:
+ * Additional guarantees when rehashing is paused for the duration of the scan:
  *
  * - An entry will never be returned more than once.
  *

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -161,6 +161,7 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);
 size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata, void *(*defragfn)(void *), int flags);
+int hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor);
 void hashtableInitIterator(hashtableIterator *iter, hashtable *ht, uint8_t flags);
 void hashtableRetargetIterator(hashtableIterator *iterator, hashtable *ht);
 void hashtableCleanupIterator(hashtableIterator *iter);

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -161,7 +161,7 @@ bool hashtableIncrementalFindGetResult(hashtableIncrementalFindState *state, voi
 /* Iteration & scan */
 size_t hashtableScan(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata);
 size_t hashtableScanDefrag(hashtable *ht, size_t cursor, hashtableScanFunction fn, void *privdata, void *(*defragfn)(void *), int flags);
-int hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor);
+bool hashtableScanHasPassedKey(hashtable *ht, const void *key, size_t cursor);
 void hashtableInitIterator(hashtableIterator *iter, hashtable *ht, uint8_t flags);
 void hashtableRetargetIterator(hashtableIterator *iterator, hashtable *ht);
 void hashtableCleanupIterator(hashtableIterator *iter);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1639,3 +1639,40 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
         hashtableRelease(ht);
     }
 }
+
+/* Callback that deletes many entries, attempting to trigger shrink. */
+static void scanDeleteManyCb(void *privdata, void *entry) {
+    hashtable *ht = (hashtable *)privdata;
+    (void)entry;
+    /* Delete most entries to drop well below shrink threshold (13%). */
+    for (long j = 50; j <= 5000; j++) {
+        hashtableDelete(ht, (void *)j);
+    }
+}
+
+TEST_F(HashtableTest, scan_no_shrink_during_callback) {
+    /* Verify that shrink doesn't start during a scan callback even when the
+     * fill factor drops below the threshold. This is guaranteed by
+     * hashtablePauseRehashing (called by scan) which also pauses auto-shrink. */
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    populateSequential(ht, 5000);
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+
+    /* Record table size before scan. */
+    size_t size_before = hashtableSize(ht);
+
+    /* Scan one step -- the callback deletes most entries. */
+    size_t cursor = hashtableScan(ht, 0, scanDeleteManyCb, ht);
+    (void)cursor;
+
+    /* Shrink was deferred until after scan resumed auto-shrink. Verify that
+     * entries were actually deleted (shrink threshold was crossed). */
+    ASSERT_LT(hashtableSize(ht), size_before / 2);
+
+    /* Rehashing (shrink) started on resume -- this is correct. */
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+
+    hashtableRelease(ht);
+}

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1416,9 +1416,10 @@ static void populateSequential(hashtable *ht, long count) {
 
 TEST_F(HashtableTest, scan_no_duplicates_static) {
     /* Full scan of a static table: every entry emitted exactly once. */
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     long count = 5000;
     populateSequential(ht, count);
@@ -1437,9 +1438,10 @@ TEST_F(HashtableTest, scan_no_duplicates_static) {
 
 TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
     /* Scan with deletions mid-scan: no duplicates, some entries may be missed. */
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     long count = 5000;
     populateSequential(ht, count);
@@ -1461,9 +1463,10 @@ TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
 
 TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
     /* Scan with insertions mid-scan: no duplicates. */
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     long count = 2000;
     populateSequential(ht, count);
@@ -1488,13 +1491,12 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
     unsigned int fuzz_seed = (unsigned int)time(NULL);
     printf("scan_no_duplicates_fuzz seed: %u\n", fuzz_seed);
     srand(fuzz_seed);
-
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
     int iterations = 50;
 
     for (int iter = 0; iter < iterations; iter++) {
         hashtableType type = {};
         hashtable *ht = hashtableCreate(&type);
+        hashtablePauseAutoShrink(ht);
 
         long count = 64 + (rand() % 4033);
         populateSequential(ht, count);
@@ -1527,9 +1529,10 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
 TEST_F(HashtableTest, scan_has_passed_key_correctness) {
     /* After each scan step, HasPassedKey should return true for all emitted
      * entries and false for entries not yet emitted (on a static table). */
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     long count = 1000;
     populateSequential(ht, count);
@@ -1567,6 +1570,7 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
     /* Cursor 0 means scan has not started -- no keys have been passed. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     populateSequential(ht, 100);
 
@@ -1581,10 +1585,9 @@ TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
     /* HasPassedKey works for keys not in the table. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     populateSequential(ht, 5000);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
-
     /* Do a partial scan (just one step). */
     size_t cursor = 0;
     cursor = hashtableScan(ht, cursor, NULL, NULL);
@@ -1601,13 +1604,12 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
     unsigned int fuzz_seed = (unsigned int)time(NULL);
     printf("scan_has_passed_key_fuzz seed: %u\n", fuzz_seed);
     srand(fuzz_seed);
-
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
     int iterations = 50;
 
     for (int iter = 0; iter < iterations; iter++) {
         hashtableType type = {};
         hashtable *ht = hashtableCreate(&type);
+        hashtablePauseAutoShrink(ht);
 
         long count = 100 + (rand() % 2000);
         populateSequential(ht, count);
@@ -1656,6 +1658,7 @@ TEST_F(HashtableTest, scan_no_shrink_during_callback) {
      * hashtablePauseRehashing (called by scan) which also pauses auto-shrink. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+    hashtablePauseAutoShrink(ht);
 
     populateSequential(ht, 5000);
     ASSERT_FALSE(hashtableIsRehashing(ht));
@@ -1671,7 +1674,11 @@ TEST_F(HashtableTest, scan_no_shrink_during_callback) {
      * entries were actually deleted (shrink threshold was crossed). */
     ASSERT_LT(hashtableSize(ht), size_before / 2);
 
-    /* Rehashing (shrink) started on resume -- this is correct. */
+    /* Shrink is still blocked by our external PauseAutoShrink. */
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+
+    /* Resume auto-shrink -- shrink should trigger immediately. */
+    hashtableResumeAutoShrink(ht);
     ASSERT_TRUE(hashtableIsRehashing(ht));
 
     hashtableRelease(ht);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1410,7 +1410,7 @@ static void scanContractFn(void *privdata, void *entry) {
 
 static void populateSequential(hashtable *ht, long count) {
     for (long j = 1; j <= count; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+        EXPECT_TRUE(hashtableAdd(ht, (void *)j));
     }
 }
 

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1740,16 +1740,20 @@ TEST_F(HashtableTest, scan_no_duplicates_during_expand_rehash) {
     }
 
     /* Continue scanning while driving rehash to completion with lookups. */
+    bool rehash_completed_during_scan = false;
     while (cursor != 0) {
         cursor = hashtableScan(ht, cursor, scanContractFn, &data);
         for (int i = 0; i < 200; i++) {
             void *found;
             hashtableFind(ht, (void *)(long)(1 + rand() % (next - 1)), &found);
         }
+        if (!hashtableIsRehashing(ht)) {
+            rehash_completed_during_scan = true;
+        }
     }
 
-    /* Rehash should have completed during the scan. */
-    ASSERT_FALSE(hashtableIsRehashing(ht));
+    /* Rehash must have completed while the scan was still in progress. */
+    ASSERT_TRUE(rehash_completed_during_scan);
     ASSERT_EQ(data.duplicates, 0);
 
     hashtableResumeAutoShrink(ht);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1391,7 +1391,7 @@ TEST_F(HashtableTest, safe_iterator_release_before_cleanup) {
     hashtableCleanupIterator(&iter);
 }
 
-/* --- Scan contract tests: no duplicates when rehashing is not active --- */
+/* Scan contract tests: no duplicates when rehashing is not active */
 
 /* Scan callback that records entries in a set for duplicate detection. */
 struct ScanContractData {
@@ -1547,7 +1547,7 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
     hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
-/* --- hashtableScanHasPassedKey tests --- */
+/* hashtableScanHasPassedKey tests */
 
 TEST_F(HashtableTest, scan_has_passed_key_correctness) {
     /* After each scan step, HasPassedKey should return true for all emitted

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1391,7 +1391,7 @@ TEST_F(HashtableTest, safe_iterator_release_before_cleanup) {
     hashtableCleanupIterator(&iter);
 }
 
-/* Scan contract tests: no duplicates when rehashing is not active */
+/* Scan contract tests: no duplicates when shrinking is blocked */
 
 /* Scan callback that records entries in a set for duplicate detection. */
 struct ScanContractData {
@@ -1414,65 +1414,71 @@ static void populateSequential(hashtable *ht, long count) {
     }
 }
 
+/* Finish any in-progress rehashing via lookups. */
+static void completeRehashing(hashtable *ht) {
+    while (hashtableIsRehashing(ht)) {
+        hashtableRehashMicroseconds(ht, 1000);
+    }
+}
+
 TEST_F(HashtableTest, scan_no_duplicates_static) {
     /* Full scan of a static table: every entry emitted exactly once. */
-
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     long count = 5000;
     populateSequential(ht, count);
+    completeRehashing(ht);
 
+    hashtablePauseAutoShrink(ht);
     ScanContractData data = {};
     size_t cursor = 0;
     do {
         cursor = hashtableScan(ht, cursor, scanContractFn, &data);
     } while (cursor != 0);
+    hashtableResumeAutoShrink(ht);
 
     ASSERT_EQ(data.duplicates, 0);
     ASSERT_EQ((long)data.seen.size(), count);
 
-    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
 TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
     /* Scan with deletions mid-scan: no duplicates, some entries may be missed. */
-
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     long count = 5000;
     populateSequential(ht, count);
+    completeRehashing(ht);
 
+    hashtablePauseAutoShrink(ht);
     ScanContractData data = {};
     size_t cursor = 0;
     do {
         cursor = hashtableScan(ht, cursor, scanContractFn, &data);
-        /* Randomly delete an entry. */
         if (rand() % 3 == 0) {
             hashtableDelete(ht, (void *)(long)(1 + rand() % count));
         }
     } while (cursor != 0);
+    hashtableResumeAutoShrink(ht);
 
     ASSERT_EQ(data.duplicates, 0);
 
-    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
 TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
     /* Scan with insertions mid-scan: no duplicates. */
-
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     long count = 2000;
     populateSequential(ht, count);
+    completeRehashing(ht);
 
+    hashtablePauseAutoShrink(ht);
     ScanContractData data = {};
     size_t cursor = 0;
     long next_insert = count + 1;
@@ -1482,10 +1488,10 @@ TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
             hashtableAdd(ht, (void *)next_insert++);
         }
     } while (cursor != 0);
+    hashtableResumeAutoShrink(ht);
 
     ASSERT_EQ(data.duplicates, 0);
 
-    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1499,11 +1505,12 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
     for (int iter = 0; iter < iterations; iter++) {
         hashtableType type = {};
         hashtable *ht = hashtableCreate(&type);
-        hashtablePauseAutoShrink(ht);
 
         long count = 64 + (rand() % 4033);
         populateSequential(ht, count);
+        completeRehashing(ht);
 
+        hashtablePauseAutoShrink(ht);
         ScanContractData data = {};
         size_t cursor = 0;
         long next_val = count + 1;
@@ -1511,19 +1518,18 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
             cursor = hashtableScan(ht, cursor, scanContractFn, &data);
             int op = rand() % 10;
             if (op < 3) {
-                /* Delete a random entry (may be original or newly added). */
                 hashtableDelete(ht, (void *)(long)(1 + rand() % (next_val - 1)));
             } else if (op < 6) {
                 hashtableAdd(ht, (void *)next_val++);
             }
         } while (cursor != 0);
+        hashtableResumeAutoShrink(ht);
 
         if (data.duplicates > 0) {
             printf("FAIL at iteration %d (seed %u, count %ld)\n", iter, fuzz_seed, count);
         }
         ASSERT_EQ(data.duplicates, 0);
 
-        hashtableResumeAutoShrink(ht);
         hashtableRelease(ht);
     }
 }
@@ -1533,14 +1539,14 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
 TEST_F(HashtableTest, scan_has_passed_key_correctness) {
     /* After each scan step, HasPassedKey should return true for all emitted
      * entries and false for entries not yet emitted (on a static table). */
-
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     long count = 1000;
     populateSequential(ht, count);
+    completeRehashing(ht);
 
+    hashtablePauseAutoShrink(ht);
     std::set<unsigned long> emitted;
     size_t cursor = 0;
     do {
@@ -1564,10 +1570,10 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
             }
         }
     } while (cursor != 0);
+    hashtableResumeAutoShrink(ht);
 
     ASSERT_EQ((long)emitted.size(), count);
 
-    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1575,7 +1581,6 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
     /* Cursor 0 means scan has not started -- no keys have been passed. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     populateSequential(ht, 100);
 
@@ -1583,24 +1588,50 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
         ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, 0));
     }
 
-    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
-TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
-    /* HasPassedKey works for keys not in the table. */
+TEST_F(HashtableTest, scan_has_passed_key_deleted) {
+    /* HasPassedKey works correctly for keys that have been deleted. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
+
+    long count = 5000;
+    populateSequential(ht, count);
+    completeRehashing(ht);
+
+    /* Scan partway. */
     hashtablePauseAutoShrink(ht);
-
-    populateSequential(ht, 5000);
-    /* Do a partial scan (just one step). */
+    std::set<unsigned long> emitted;
     size_t cursor = 0;
-    cursor = hashtableScan(ht, cursor, NULL, NULL);
+    for (int i = 0; i < 10; i++) {
+        ScanContractData step_data = {};
+        cursor = hashtableScan(ht, cursor, scanContractFn, &step_data);
+        for (unsigned long val : step_data.seen) {
+            emitted.insert(val);
+        }
+    }
     ASSERT_NE(cursor, (size_t)0);
+    ASSERT_GT(emitted.size(), 0u);
 
-    /* Check a key that doesn't exist in the table -- should not crash. */
-    (void)hashtableScanHasPassedKey(ht, (void *)99999L, cursor);
+    /* Pick one emitted key and one non-emitted key. */
+    unsigned long emitted_key = *emitted.begin();
+    unsigned long nonemitted_key = 0;
+    for (long j = 1; j <= count; j++) {
+        if (!emitted.count(j)) {
+            nonemitted_key = j;
+            break;
+        }
+    }
+    ASSERT_NE(nonemitted_key, 0u);
+
+    /* Delete both. */
+    hashtableDelete(ht, (void *)emitted_key);
+    hashtableDelete(ht, (void *)nonemitted_key);
+
+    /* HasPassedKey should still reflect their original positions. */
+    ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)emitted_key, cursor));
+    ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)nonemitted_key, cursor));
 
     hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
@@ -1616,11 +1647,12 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
     for (int iter = 0; iter < iterations; iter++) {
         hashtableType type = {};
         hashtable *ht = hashtableCreate(&type);
-        hashtablePauseAutoShrink(ht);
 
         long count = 100 + (rand() % 2000);
         populateSequential(ht, count);
+        completeRehashing(ht);
 
+        hashtablePauseAutoShrink(ht);
         std::set<unsigned long> emitted;
         size_t cursor = 0;
         do {
@@ -1644,8 +1676,8 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
                 }
             }
         } while (cursor != 0);
-
         hashtableResumeAutoShrink(ht);
+
         hashtableRelease(ht);
     }
 }
@@ -1654,7 +1686,6 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
 static void scanDeleteManyCb(void *privdata, void *entry) {
     hashtable *ht = (hashtable *)privdata;
     (void)entry;
-    /* Delete most entries to drop well below shrink threshold (13%). */
     for (long j = 50; j <= 5000; j++) {
         hashtableDelete(ht, (void *)j);
     }
@@ -1662,32 +1693,65 @@ static void scanDeleteManyCb(void *privdata, void *entry) {
 
 TEST_F(HashtableTest, scan_no_shrink_during_callback) {
     /* Verify that shrink doesn't start during a scan callback even when the
-     * fill factor drops below the threshold. This is guaranteed by
-     * hashtablePauseRehashing (called by scan) which also pauses auto-shrink. */
+     * fill factor drops below the threshold. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
-    hashtablePauseAutoShrink(ht);
 
     populateSequential(ht, 5000);
+    completeRehashing(ht);
     ASSERT_FALSE(hashtableIsRehashing(ht));
 
-    /* Record table size before scan. */
+    hashtablePauseAutoShrink(ht);
     size_t size_before = hashtableSize(ht);
-
-    /* Scan one step -- the callback deletes most entries. */
     size_t cursor = hashtableScan(ht, 0, scanDeleteManyCb, ht);
     (void)cursor;
 
-    /* Shrink was deferred until after scan resumed auto-shrink. Verify that
-     * entries were actually deleted (shrink threshold was crossed). */
+    /* Shrink is still blocked by PauseAutoShrink. */
     ASSERT_LT(hashtableSize(ht), size_before / 2);
-
-    /* Shrink is still blocked by our external PauseAutoShrink. */
     ASSERT_FALSE(hashtableIsRehashing(ht));
 
-    /* Resume auto-shrink -- shrink should trigger immediately. */
+    /* Resume -- shrink triggers immediately. */
     hashtableResumeAutoShrink(ht);
     ASSERT_TRUE(hashtableIsRehashing(ht));
 
+    hashtableRelease(ht);
+}
+
+TEST_F(HashtableTest, scan_no_duplicates_during_expand_rehash) {
+    /* Verify no duplicates when expansion starts and rehashing completes
+     * during an ongoing scan. Lookups between scan calls drive rehash steps. */
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    long count = 5000;
+    populateSequential(ht, count);
+    completeRehashing(ht);
+
+    /* Start scanning. */
+    hashtablePauseAutoShrink(ht);
+    ScanContractData data = {};
+    size_t cursor = hashtableScan(ht, 0, scanContractFn, &data);
+    ASSERT_NE(cursor, (size_t)0);
+
+    /* Trigger expansion by adding entries until rehashing starts. */
+    long next = count + 1;
+    while (!hashtableIsRehashing(ht)) {
+        hashtableAdd(ht, (void *)next++);
+    }
+
+    /* Continue scanning while driving rehash to completion with lookups. */
+    while (cursor != 0) {
+        cursor = hashtableScan(ht, cursor, scanContractFn, &data);
+        for (int i = 0; i < 200; i++) {
+            void *found;
+            hashtableFind(ht, (void *)(long)(1 + rand() % (next - 1)), &found);
+        }
+    }
+
+    /* Rehash should have completed during the scan. */
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+    ASSERT_EQ(data.duplicates, 0);
+
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1627,9 +1627,8 @@ TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
 
     /* Check a key that doesn't exist in the table. */
     long nonexistent = 99999;
-    int result = hashtableScanHasPassedKey(ht, (void *)nonexistent, cursor);
-    /* We just verify it doesn't crash and returns 0 or 1. */
-    ASSERT_TRUE(result == 0 || result == 1);
+    /* We just verify it doesn't crash and returns a valid result. */
+    (void)hashtableScanHasPassedKey(ht, (void *)nonexistent, cursor);
 
     hashtableRelease(ht);
     hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
@@ -1708,8 +1707,7 @@ TEST_F(HashtableTest, scan_has_passed_key_during_rehash) {
 
     /* Just verify it doesn't crash. */
     for (long j = 1; j <= 100; j++) {
-        int result = hashtableScanHasPassedKey(ht, (void *)j, cursor);
-        ASSERT_TRUE(result == 0 || result == 1);
+        (void)hashtableScanHasPassedKey(ht, (void *)j, cursor);
     }
 
     hashtableRelease(ht);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1433,6 +1433,7 @@ TEST_F(HashtableTest, scan_no_duplicates_static) {
     ASSERT_EQ(data.duplicates, 0);
     ASSERT_EQ((long)data.seen.size(), count);
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1458,6 +1459,7 @@ TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
 
     ASSERT_EQ(data.duplicates, 0);
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1483,6 +1485,7 @@ TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
 
     ASSERT_EQ(data.duplicates, 0);
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1520,6 +1523,7 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
         }
         ASSERT_EQ(data.duplicates, 0);
 
+        hashtableResumeAutoShrink(ht);
         hashtableRelease(ht);
     }
 }
@@ -1563,6 +1567,7 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
 
     ASSERT_EQ((long)emitted.size(), count);
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1578,6 +1583,7 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
         ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, 0));
     }
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1596,6 +1602,7 @@ TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
     /* Check a key that doesn't exist in the table -- should not crash. */
     (void)hashtableScanHasPassedKey(ht, (void *)99999L, cursor);
 
+    hashtableResumeAutoShrink(ht);
     hashtableRelease(ht);
 }
 
@@ -1638,6 +1645,7 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
             }
         } while (cursor != 0);
 
+        hashtableResumeAutoShrink(ht);
         hashtableRelease(ht);
     }
 }

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1686,29 +1686,3 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
     hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
-TEST_F(HashtableTest, scan_has_passed_key_during_rehash) {
-    /* When rehashing is active, HasPassedKey should not crash (best-effort). */
-    hashtableType type = {};
-    hashtable *ht = hashtableCreate(&type);
-
-    for (long j = 1; j <= 1000; j++) {
-        hashtableAdd(ht, (void *)j);
-    }
-
-    /* Force rehashing by expanding. */
-    hashtableExpand(ht, 8192);
-    ASSERT_TRUE(hashtableIsRehashing(ht));
-
-    /* Do a partial scan. */
-    size_t cursor = 0;
-    for (int i = 0; i < 5; i++) {
-        cursor = hashtableScan(ht, cursor, NULL, NULL);
-    }
-
-    /* Just verify it doesn't crash. */
-    for (long j = 1; j <= 100; j++) {
-        (void)hashtableScanHasPassedKey(ht, (void *)j, cursor);
-    }
-
-    hashtableRelease(ht);
-}

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -10,6 +10,8 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
+#include <set>
 
 extern "C" {
 #include "fmacros.h"
@@ -1387,4 +1389,328 @@ TEST_F(HashtableTest, safe_iterator_release_before_cleanup) {
 
     /* Cleanup should be a no-op (hashtable == NULL). */
     hashtableCleanupIterator(&iter);
+}
+
+/* --- Scan contract tests: no duplicates when rehashing is not active --- */
+
+/* Scan callback that records entries in a set for duplicate detection. */
+struct ScanContractData {
+    std::set<unsigned long> seen;
+    int duplicates;
+};
+
+static void scanContractFn(void *privdata, void *entry) {
+    ScanContractData *data = (ScanContractData *)privdata;
+    unsigned long val = (unsigned long)entry;
+    if (data->seen.count(val)) {
+        data->duplicates++;
+    }
+    data->seen.insert(val);
+}
+
+TEST_F(HashtableTest, scan_no_duplicates_static) {
+    /* Full scan of a static table: every entry emitted exactly once. */
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    long count = 5000;
+    for (long j = 1; j <= count; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+
+    ScanContractData data = {};
+    size_t cursor = 0;
+    do {
+        cursor = hashtableScan(ht, cursor, scanContractFn, &data);
+    } while (cursor != 0);
+
+    ASSERT_EQ(data.duplicates, 0);
+    ASSERT_EQ((long)data.seen.size(), count);
+
+    hashtableRelease(ht);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
+    /* Scan with deletions mid-scan: no duplicates, some entries may be missed. */
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    long count = 5000;
+    for (long j = 1; j <= count; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+
+    ScanContractData data = {};
+    size_t cursor = 0;
+    int step = 0;
+    do {
+        cursor = hashtableScan(ht, cursor, scanContractFn, &data);
+        /* Delete some entries every few steps. */
+        if (++step % 10 == 0) {
+            for (long d = step; d < step + 5 && d <= count; d++) {
+                hashtableDelete(ht, (void *)d);
+            }
+        }
+    } while (cursor != 0);
+
+    ASSERT_EQ(data.duplicates, 0);
+
+    hashtableRelease(ht);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
+    /* Scan with insertions mid-scan: no duplicates. */
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    /* Pre-expand to avoid triggering resize. */
+    hashtableExpand(ht, 16384);
+    long count = 2000;
+    for (long j = 1; j <= count; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+
+    ScanContractData data = {};
+    size_t cursor = 0;
+    long next_insert = count + 1;
+    int step = 0;
+    do {
+        cursor = hashtableScan(ht, cursor, scanContractFn, &data);
+        /* Insert new entries every few steps. */
+        if (++step % 10 == 0) {
+            for (int i = 0; i < 5; i++) {
+                hashtableAdd(ht, (void *)next_insert++);
+            }
+        }
+    } while (cursor != 0);
+
+    ASSERT_EQ(data.duplicates, 0);
+
+    hashtableRelease(ht);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
+    /* Fuzz test: random seed, random ops during scan, assert no duplicates. */
+    unsigned int fuzz_seed = (unsigned int)time(NULL);
+    printf("scan_no_duplicates_fuzz seed: %u\n", fuzz_seed);
+    srand(fuzz_seed);
+
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    int iterations = 50;
+
+    for (int iter = 0; iter < iterations; iter++) {
+        hashtableType type = {};
+        hashtable *ht = hashtableCreate(&type);
+
+        /* Random table size between 64 and 4096. */
+        long table_size = 64 + (rand() % 4033);
+        hashtableExpand(ht, table_size * 2); /* Pre-expand to avoid resize. */
+
+        /* Fill to random factor between 25% and 90%. */
+        long count = table_size;
+        for (long j = 1; j <= count; j++) {
+            hashtableAdd(ht, (void *)j);
+        }
+        ASSERT_FALSE(hashtableIsRehashing(ht));
+
+        ScanContractData data = {};
+        size_t cursor = 0;
+        long next_val = count + 1;
+        do {
+            cursor = hashtableScan(ht, cursor, scanContractFn, &data);
+            /* Random operation: 40% nothing, 30% delete, 30% insert. */
+            int op = rand() % 10;
+            if (op < 3 && count > 10) {
+                /* Delete a random existing entry. */
+                long target = 1 + (rand() % count);
+                hashtableDelete(ht, (void *)target);
+            } else if (op < 6) {
+                /* Insert a new entry. */
+                hashtableAdd(ht, (void *)next_val++);
+            }
+        } while (cursor != 0);
+
+        if (data.duplicates > 0) {
+            printf("FAIL at iteration %d (seed %u, table_size %ld)\n", iter, fuzz_seed, table_size);
+        }
+        ASSERT_EQ(data.duplicates, 0);
+
+        hashtableRelease(ht);
+    }
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+/* --- hashtableScanHasPassedKey tests --- */
+
+TEST_F(HashtableTest, scan_has_passed_key_correctness) {
+    /* After each scan step, HasPassedKey should return true for all emitted
+     * entries and false for entries not yet emitted (on a static table). */
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    long count = 1000;
+    for (long j = 1; j <= count; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+    ASSERT_FALSE(hashtableIsRehashing(ht));
+
+    std::set<unsigned long> emitted;
+    size_t cursor = 0;
+    do {
+        ScanContractData step_data = {};
+        cursor = hashtableScan(ht, cursor, scanContractFn, &step_data);
+        for (unsigned long val : step_data.seen) {
+            emitted.insert(val);
+        }
+        /* Check: all emitted entries should be "passed". */
+        for (unsigned long val : emitted) {
+            ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)val, cursor))
+                << "Entry " << val << " was emitted but HasPassedKey returned false at cursor " << cursor;
+        }
+        /* Check: sample some non-emitted entries -- they should NOT be passed. */
+        int checked = 0;
+        for (long j = 1; j <= count && checked < 20; j++) {
+            if (!emitted.count(j)) {
+                ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, cursor))
+                    << "Entry " << j << " was NOT emitted but HasPassedKey returned true at cursor " << cursor;
+                checked++;
+            }
+        }
+    } while (cursor != 0);
+
+    ASSERT_EQ((long)emitted.size(), count);
+
+    hashtableRelease(ht);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
+    /* Cursor 0 means scan is complete -- all keys have been passed. */
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    for (long j = 1; j <= 100; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+
+    /* Every key should be "passed" when cursor is 0. */
+    for (long j = 1; j <= 100; j++) {
+        ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)j, 0));
+    }
+
+    hashtableRelease(ht);
+}
+
+TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
+    /* HasPassedKey works for keys not in the table (hashes to a bucket position). */
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    hashtableExpand(ht, 16384);
+    for (long j = 1; j <= 5000; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+
+    /* Do a partial scan (just one step). */
+    size_t cursor = 0;
+    cursor = hashtableScan(ht, cursor, NULL, NULL);
+    ASSERT_NE(cursor, (size_t)0);
+
+    /* Check a key that doesn't exist in the table. */
+    long nonexistent = 99999;
+    int result = hashtableScanHasPassedKey(ht, (void *)nonexistent, cursor);
+    /* We just verify it doesn't crash and returns 0 or 1. */
+    ASSERT_TRUE(result == 0 || result == 1);
+
+    hashtableRelease(ht);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
+    /* Fuzz: verify HasPassedKey agrees with actual scan emission. */
+    unsigned int fuzz_seed = (unsigned int)time(NULL);
+    printf("scan_has_passed_key_fuzz seed: %u\n", fuzz_seed);
+    srand(fuzz_seed);
+
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    int iterations = 50;
+
+    for (int iter = 0; iter < iterations; iter++) {
+        hashtableType type = {};
+        hashtable *ht = hashtableCreate(&type);
+
+        long count = 100 + (rand() % 2000);
+        hashtableExpand(ht, count * 2);
+        for (long j = 1; j <= count; j++) {
+            hashtableAdd(ht, (void *)j);
+        }
+        ASSERT_FALSE(hashtableIsRehashing(ht));
+
+        std::set<unsigned long> emitted;
+        size_t cursor = 0;
+        do {
+            ScanContractData step_data = {};
+            cursor = hashtableScan(ht, cursor, scanContractFn, &step_data);
+            for (unsigned long val : step_data.seen) {
+                emitted.insert(val);
+            }
+            /* Verify consistency for a sample of entries. */
+            for (long j = 1; j <= count && j <= 50; j++) {
+                int passed = hashtableScanHasPassedKey(ht, (void *)j, cursor);
+                if (emitted.count(j)) {
+                    if (!passed) {
+                        printf("FAIL iter %d seed %u: entry %ld emitted but HasPassedKey=false, cursor=%zu\n",
+                               iter, fuzz_seed, j, cursor);
+                    }
+                    ASSERT_TRUE(passed);
+                } else {
+                    if (passed) {
+                        printf("FAIL iter %d seed %u: entry %ld NOT emitted but HasPassedKey=true, cursor=%zu\n",
+                               iter, fuzz_seed, j, cursor);
+                    }
+                    ASSERT_FALSE(passed);
+                }
+            }
+        } while (cursor != 0);
+
+        hashtableRelease(ht);
+    }
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
+}
+
+TEST_F(HashtableTest, scan_has_passed_key_during_rehash) {
+    /* When rehashing is active, HasPassedKey should not crash (best-effort). */
+    hashtableType type = {};
+    hashtable *ht = hashtableCreate(&type);
+
+    for (long j = 1; j <= 1000; j++) {
+        hashtableAdd(ht, (void *)j);
+    }
+
+    /* Force rehashing by expanding. */
+    hashtableExpand(ht, 8192);
+    ASSERT_TRUE(hashtableIsRehashing(ht));
+
+    /* Do a partial scan. */
+    size_t cursor = 0;
+    for (int i = 0; i < 5; i++) {
+        cursor = hashtableScan(ht, cursor, NULL, NULL);
+    }
+
+    /* Just verify it doesn't crash. */
+    for (long j = 1; j <= 100; j++) {
+        int result = hashtableScanHasPassedKey(ht, (void *)j, cursor);
+        ASSERT_TRUE(result == 0 || result == 1);
+    }
+
+    hashtableRelease(ht);
 }

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1685,4 +1685,3 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
     }
     hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
-

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1408,6 +1408,12 @@ static void scanContractFn(void *privdata, void *entry) {
     data->seen.insert(val);
 }
 
+static void populateSequential(hashtable *ht, long count) {
+    for (long j = 1; j <= count; j++) {
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
+    }
+}
+
 TEST_F(HashtableTest, scan_no_duplicates_static) {
     /* Full scan of a static table: every entry emitted exactly once. */
     hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
@@ -1415,10 +1421,7 @@ TEST_F(HashtableTest, scan_no_duplicates_static) {
     hashtable *ht = hashtableCreate(&type);
 
     long count = 5000;
-    for (long j = 1; j <= count; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
-    ASSERT_FALSE(hashtableIsRehashing(ht));
+    populateSequential(ht, count);
 
     ScanContractData data = {};
     size_t cursor = 0;
@@ -1430,7 +1433,6 @@ TEST_F(HashtableTest, scan_no_duplicates_static) {
     ASSERT_EQ((long)data.seen.size(), count);
 
     hashtableRelease(ht);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
@@ -1440,27 +1442,21 @@ TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
     hashtable *ht = hashtableCreate(&type);
 
     long count = 5000;
-    for (long j = 1; j <= count; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
+    populateSequential(ht, count);
 
     ScanContractData data = {};
     size_t cursor = 0;
-    int step = 0;
     do {
         cursor = hashtableScan(ht, cursor, scanContractFn, &data);
-        /* Delete some entries every few steps. */
-        if (++step % 10 == 0) {
-            for (long d = step; d < step + 5 && d <= count; d++) {
-                hashtableDelete(ht, (void *)d);
-            }
+        /* Randomly delete an entry. */
+        if (rand() % 3 == 0) {
+            hashtableDelete(ht, (void *)(long)(1 + rand() % count));
         }
     } while (cursor != 0);
 
     ASSERT_EQ(data.duplicates, 0);
 
     hashtableRelease(ht);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
@@ -1469,31 +1465,22 @@ TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
 
-    /* Pre-expand to avoid triggering resize. */
-    hashtableExpand(ht, 16384);
     long count = 2000;
-    for (long j = 1; j <= count; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
+    populateSequential(ht, count);
 
     ScanContractData data = {};
     size_t cursor = 0;
     long next_insert = count + 1;
-    int step = 0;
     do {
         cursor = hashtableScan(ht, cursor, scanContractFn, &data);
-        /* Insert new entries every few steps. */
-        if (++step % 10 == 0) {
-            for (int i = 0; i < 5; i++) {
-                ASSERT_TRUE(hashtableAdd(ht, (void *)next_insert++));
-            }
+        if (rand() % 3 == 0) {
+            hashtableAdd(ht, (void *)next_insert++);
         }
     } while (cursor != 0);
 
     ASSERT_EQ(data.duplicates, 0);
 
     hashtableRelease(ht);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
@@ -1509,42 +1496,30 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
         hashtableType type = {};
         hashtable *ht = hashtableCreate(&type);
 
-        /* Random table size between 64 and 4096. */
-        long table_size = 64 + (rand() % 4033);
-        hashtableExpand(ht, table_size * 2); /* Pre-expand to avoid resize. */
-
-        /* Fill to random factor between 25% and 90%. */
-        long count = table_size;
-        for (long j = 1; j <= count; j++) {
-            ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-        }
-        ASSERT_FALSE(hashtableIsRehashing(ht));
+        long count = 64 + (rand() % 4033);
+        populateSequential(ht, count);
 
         ScanContractData data = {};
         size_t cursor = 0;
         long next_val = count + 1;
         do {
             cursor = hashtableScan(ht, cursor, scanContractFn, &data);
-            /* Random operation: 40% nothing, 30% delete, 30% insert. */
             int op = rand() % 10;
-            if (op < 3 && count > 10) {
-                /* Delete a random existing entry. */
-                long target = 1 + (rand() % count);
-                hashtableDelete(ht, (void *)target);
+            if (op < 3) {
+                /* Delete a random entry (may be original or newly added). */
+                hashtableDelete(ht, (void *)(long)(1 + rand() % (next_val - 1)));
             } else if (op < 6) {
-                /* Insert a new entry. */
-                ASSERT_TRUE(hashtableAdd(ht, (void *)next_val++));
+                hashtableAdd(ht, (void *)next_val++);
             }
         } while (cursor != 0);
 
         if (data.duplicates > 0) {
-            printf("FAIL at iteration %d (seed %u, table_size %ld)\n", iter, fuzz_seed, table_size);
+            printf("FAIL at iteration %d (seed %u, count %ld)\n", iter, fuzz_seed, count);
         }
         ASSERT_EQ(data.duplicates, 0);
 
         hashtableRelease(ht);
     }
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 /* hashtableScanHasPassedKey tests */
@@ -1557,10 +1532,7 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
     hashtable *ht = hashtableCreate(&type);
 
     long count = 1000;
-    for (long j = 1; j <= count; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
-    ASSERT_FALSE(hashtableIsRehashing(ht));
+    populateSequential(ht, count);
 
     std::set<unsigned long> emitted;
     size_t cursor = 0;
@@ -1570,14 +1542,11 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
         for (unsigned long val : step_data.seen) {
             emitted.insert(val);
         }
-        /* Check: all emitted entries should be "passed" (skip when cursor==0,
-         * which means scan complete -- caller handles that state). */
         if (cursor != 0) {
             for (unsigned long val : emitted) {
                 ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)val, cursor))
                     << "Entry " << val << " was emitted but HasPassedKey returned false at cursor " << cursor;
             }
-            /* Check: sample some non-emitted entries -- they should NOT be passed. */
             int checked = 0;
             for (long j = 1; j <= count && checked < 20; j++) {
                 if (!emitted.count(j)) {
@@ -1592,7 +1561,6 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
     ASSERT_EQ((long)emitted.size(), count);
 
     hashtableRelease(ht);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
@@ -1600,11 +1568,8 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
 
-    for (long j = 1; j <= 100; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
+    populateSequential(ht, 100);
 
-    /* No key should be "passed" when cursor is 0. */
     for (long j = 1; j <= 100; j++) {
         ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, 0));
     }
@@ -1613,28 +1578,22 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
 }
 
 TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
-    /* HasPassedKey works for keys not in the table (hashes to a bucket position). */
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
+    /* HasPassedKey works for keys not in the table. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
 
-    hashtableExpand(ht, 16384);
-    for (long j = 1; j <= 5000; j++) {
-        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-    }
+    populateSequential(ht, 5000);
+    hashtableSetResizePolicy(HASHTABLE_RESIZE_FORBID);
 
     /* Do a partial scan (just one step). */
     size_t cursor = 0;
     cursor = hashtableScan(ht, cursor, NULL, NULL);
     ASSERT_NE(cursor, (size_t)0);
 
-    /* Check a key that doesn't exist in the table. */
-    long nonexistent = 99999;
-    /* We just verify it doesn't crash and returns a valid result. */
-    (void)hashtableScanHasPassedKey(ht, (void *)nonexistent, cursor);
+    /* Check a key that doesn't exist in the table -- should not crash. */
+    (void)hashtableScanHasPassedKey(ht, (void *)99999L, cursor);
 
     hashtableRelease(ht);
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }
 
 TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
@@ -1651,11 +1610,7 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
         hashtable *ht = hashtableCreate(&type);
 
         long count = 100 + (rand() % 2000);
-        hashtableExpand(ht, count * 2);
-        for (long j = 1; j <= count; j++) {
-            ASSERT_TRUE(hashtableAdd(ht, (void *)j));
-        }
-        ASSERT_FALSE(hashtableIsRehashing(ht));
+        populateSequential(ht, count);
 
         std::set<unsigned long> emitted;
         size_t cursor = 0;
@@ -1665,22 +1620,17 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
             for (unsigned long val : step_data.seen) {
                 emitted.insert(val);
             }
-            /* Verify consistency for a sample of entries (skip at cursor==0). */
             if (cursor != 0) {
                 for (long j = 1; j <= count && j <= 50; j++) {
                     bool passed = hashtableScanHasPassedKey(ht, (void *)j, cursor);
                     if (emitted.count(j)) {
-                        if (!passed) {
-                            printf("FAIL iter %d seed %u: entry %ld emitted but HasPassedKey=false, cursor=%zu\n",
-                                   iter, fuzz_seed, j, cursor);
-                        }
-                        ASSERT_TRUE(passed);
+                        ASSERT_TRUE(passed)
+                            << "iter " << iter << " seed " << fuzz_seed
+                            << ": entry " << j << " emitted but HasPassedKey=false";
                     } else {
-                        if (passed) {
-                            printf("FAIL iter %d seed %u: entry %ld NOT emitted but HasPassedKey=true, cursor=%zu\n",
-                                   iter, fuzz_seed, j, cursor);
-                        }
-                        ASSERT_FALSE(passed);
+                        ASSERT_FALSE(passed)
+                            << "iter " << iter << " seed " << fuzz_seed
+                            << ": entry " << j << " NOT emitted but HasPassedKey=true";
                     }
                 }
             }
@@ -1688,5 +1638,4 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
 
         hashtableRelease(ht);
     }
-    hashtableSetResizePolicy(HASHTABLE_RESIZE_ALLOW);
 }

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1570,18 +1570,21 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
         for (unsigned long val : step_data.seen) {
             emitted.insert(val);
         }
-        /* Check: all emitted entries should be "passed". */
-        for (unsigned long val : emitted) {
-            ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)val, cursor))
-                << "Entry " << val << " was emitted but HasPassedKey returned false at cursor " << cursor;
-        }
-        /* Check: sample some non-emitted entries -- they should NOT be passed. */
-        int checked = 0;
-        for (long j = 1; j <= count && checked < 20; j++) {
-            if (!emitted.count(j)) {
-                ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, cursor))
-                    << "Entry " << j << " was NOT emitted but HasPassedKey returned true at cursor " << cursor;
-                checked++;
+        /* Check: all emitted entries should be "passed" (skip when cursor==0,
+         * which means scan complete -- caller handles that state). */
+        if (cursor != 0) {
+            for (unsigned long val : emitted) {
+                ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)val, cursor))
+                    << "Entry " << val << " was emitted but HasPassedKey returned false at cursor " << cursor;
+            }
+            /* Check: sample some non-emitted entries -- they should NOT be passed. */
+            int checked = 0;
+            for (long j = 1; j <= count && checked < 20; j++) {
+                if (!emitted.count(j)) {
+                    ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, cursor))
+                        << "Entry " << j << " was NOT emitted but HasPassedKey returned true at cursor " << cursor;
+                    checked++;
+                }
             }
         }
     } while (cursor != 0);
@@ -1593,7 +1596,7 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
 }
 
 TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
-    /* Cursor 0 means scan is complete -- all keys have been passed. */
+    /* Cursor 0 means scan has not started -- no keys have been passed. */
     hashtableType type = {};
     hashtable *ht = hashtableCreate(&type);
 
@@ -1601,9 +1604,9 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
         ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
 
-    /* Every key should be "passed" when cursor is 0. */
+    /* No key should be "passed" when cursor is 0. */
     for (long j = 1; j <= 100; j++) {
-        ASSERT_TRUE(hashtableScanHasPassedKey(ht, (void *)j, 0));
+        ASSERT_FALSE(hashtableScanHasPassedKey(ht, (void *)j, 0));
     }
 
     hashtableRelease(ht);
@@ -1662,21 +1665,23 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
             for (unsigned long val : step_data.seen) {
                 emitted.insert(val);
             }
-            /* Verify consistency for a sample of entries. */
-            for (long j = 1; j <= count && j <= 50; j++) {
-                int passed = hashtableScanHasPassedKey(ht, (void *)j, cursor);
-                if (emitted.count(j)) {
-                    if (!passed) {
-                        printf("FAIL iter %d seed %u: entry %ld emitted but HasPassedKey=false, cursor=%zu\n",
-                               iter, fuzz_seed, j, cursor);
+            /* Verify consistency for a sample of entries (skip at cursor==0). */
+            if (cursor != 0) {
+                for (long j = 1; j <= count && j <= 50; j++) {
+                    bool passed = hashtableScanHasPassedKey(ht, (void *)j, cursor);
+                    if (emitted.count(j)) {
+                        if (!passed) {
+                            printf("FAIL iter %d seed %u: entry %ld emitted but HasPassedKey=false, cursor=%zu\n",
+                                   iter, fuzz_seed, j, cursor);
+                        }
+                        ASSERT_TRUE(passed);
+                    } else {
+                        if (passed) {
+                            printf("FAIL iter %d seed %u: entry %ld NOT emitted but HasPassedKey=true, cursor=%zu\n",
+                                   iter, fuzz_seed, j, cursor);
+                        }
+                        ASSERT_FALSE(passed);
                     }
-                    ASSERT_TRUE(passed);
-                } else {
-                    if (passed) {
-                        printf("FAIL iter %d seed %u: entry %ld NOT emitted but HasPassedKey=true, cursor=%zu\n",
-                               iter, fuzz_seed, j, cursor);
-                    }
-                    ASSERT_FALSE(passed);
                 }
             }
         } while (cursor != 0);

--- a/src/unit/test_hashtable.cpp
+++ b/src/unit/test_hashtable.cpp
@@ -1416,7 +1416,7 @@ TEST_F(HashtableTest, scan_no_duplicates_static) {
 
     long count = 5000;
     for (long j = 1; j <= count; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
     ASSERT_FALSE(hashtableIsRehashing(ht));
 
@@ -1441,7 +1441,7 @@ TEST_F(HashtableTest, scan_no_duplicates_with_deletions) {
 
     long count = 5000;
     for (long j = 1; j <= count; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
 
     ScanContractData data = {};
@@ -1473,7 +1473,7 @@ TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
     hashtableExpand(ht, 16384);
     long count = 2000;
     for (long j = 1; j <= count; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
 
     ScanContractData data = {};
@@ -1485,7 +1485,7 @@ TEST_F(HashtableTest, scan_no_duplicates_with_insertions) {
         /* Insert new entries every few steps. */
         if (++step % 10 == 0) {
             for (int i = 0; i < 5; i++) {
-                hashtableAdd(ht, (void *)next_insert++);
+                ASSERT_TRUE(hashtableAdd(ht, (void *)next_insert++));
             }
         }
     } while (cursor != 0);
@@ -1516,7 +1516,7 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
         /* Fill to random factor between 25% and 90%. */
         long count = table_size;
         for (long j = 1; j <= count; j++) {
-            hashtableAdd(ht, (void *)j);
+            ASSERT_TRUE(hashtableAdd(ht, (void *)j));
         }
         ASSERT_FALSE(hashtableIsRehashing(ht));
 
@@ -1533,7 +1533,7 @@ TEST_F(HashtableTest, scan_no_duplicates_fuzz) {
                 hashtableDelete(ht, (void *)target);
             } else if (op < 6) {
                 /* Insert a new entry. */
-                hashtableAdd(ht, (void *)next_val++);
+                ASSERT_TRUE(hashtableAdd(ht, (void *)next_val++));
             }
         } while (cursor != 0);
 
@@ -1558,7 +1558,7 @@ TEST_F(HashtableTest, scan_has_passed_key_correctness) {
 
     long count = 1000;
     for (long j = 1; j <= count; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
     ASSERT_FALSE(hashtableIsRehashing(ht));
 
@@ -1598,7 +1598,7 @@ TEST_F(HashtableTest, scan_has_passed_key_cursor_zero) {
     hashtable *ht = hashtableCreate(&type);
 
     for (long j = 1; j <= 100; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
 
     /* Every key should be "passed" when cursor is 0. */
@@ -1617,7 +1617,7 @@ TEST_F(HashtableTest, scan_has_passed_key_nonexistent) {
 
     hashtableExpand(ht, 16384);
     for (long j = 1; j <= 5000; j++) {
-        hashtableAdd(ht, (void *)j);
+        ASSERT_TRUE(hashtableAdd(ht, (void *)j));
     }
 
     /* Do a partial scan (just one step). */
@@ -1650,7 +1650,7 @@ TEST_F(HashtableTest, scan_has_passed_key_fuzz) {
         long count = 100 + (rand() % 2000);
         hashtableExpand(ht, count * 2);
         for (long j = 1; j <= count; j++) {
-            hashtableAdd(ht, (void *)j);
+            ASSERT_TRUE(hashtableAdd(ht, (void *)j));
         }
         ASSERT_FALSE(hashtableIsRehashing(ht));
 


### PR DESCRIPTION
Description:

When shrinking is blocked for the duration of a scan (via hashtablePauseAutoShrink), the hashtable scan guarantees no entry is emitted more than once. Expansion and rehashing may occur freely — only a shrink is problematic because it introduces a smaller table whose bucket boundaries might not align with the existing cursor position. This was already true but undocumented.

New API: `hashtableScanHasPassedKey(ht, key, cursor)`

Given a scan cursor, determines whether a key's hashtable position has already been visited. This enables callers to definitively answer: "would this key have been returned already?" — useful for background iteration that needs to track which keys have been seen without maintaining a separate visited-set. The key does not need to exist in the table (position is computed from its hash). The result is exact when shrinking is blocked; best-effort otherwise.

Motivated by https://github.com/valkey-io/valkey/issues/2878 (forkless save, to be used by bgiterator).

Tests: 10 unit tests including fuzz tests with random seeds, a test proving expansion + full rehash completion mid-scan produces no duplicates, and a test verifying shrink is correctly deferred during scan callbacks.
