### PR TITLE
Remove MIGRATE command dead code in ACLSelectorCheckCmd

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1874,8 +1874,6 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
                             *keyidxptr = 2;
                         else if (cmd->proc == swapdbCommand)
                             *keyidxptr = (i == 0) ? 1 : 2;
-                        else if (cmd->proc == migrateCommand)
-                            *keyidxptr = 4;
                         else
                             *keyidxptr = 0;
                     }


### PR DESCRIPTION
In #2309, we ultimately decided not to set `get_dbid_args` for
MIGRATE command and removed the relevant code. But, we missed this
one, just cleanup the dead code.