### PR TITLE
Document database-level ACL rules in valkey.conf and acl.c

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1136,8 +1136,8 @@ static aclSelector *aclCreateSelectorFromOpSet(const char *opset, size_t opsetle
  *              It is possible to specify multiple patterns.
  * allchannels              Alias for &*
  * resetchannels            Flush the list of allowed channel patterns.
- * db=<dbid>    Add database ID(s) to the set of allowed database IDs. May be used
- *              with `,` for adding multiple IDs (e.g "db=1,2,3").
+ * db=<dbid>    Sets the specified database id(s) as the databases the selector is allowed to access.
+ *              May be used with `,` for adding multiple IDs (e.g "db=1,2,3").
  * alldbs       Allow access to all databases.
  * resetdbs     Flush the set of allowed database IDs.
  */

--- a/src/acl.c
+++ b/src/acl.c
@@ -1359,7 +1359,8 @@ static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen) {
  *              passwords and there is no way to authenticate without adding
  *              some password (or setting it as "nopass" later).
  * reset        Performs the following actions: resetpass, resetkeys, resetchannels,
- *              allchannels (if acl-pubsub-default is set), off, clearselectors, -@all.
+ *              allchannels (if acl-pubsub-default is set), alldbs (for backwards compatibility),
+ *              off, sanitize-payload, clearselectors, -@all.
  *              The user returns to the same state it has immediately after its creation.
  * (<options>)  Create a new selector with the options specified within the
  *              parentheses and attach it to the user. Each option should be
@@ -1396,6 +1397,7 @@ static int ACLSetSelector(aclSelector *selector, const char *op, size_t oplen) {
  * ENODEV: The password you are trying to remove from the user does not exist.
  * EBADMSG: The hash you are trying to add is not a valid hash.
  * ECHILD: Attempt to allow a specific first argument of a subcommand
+ * ERANGE: A database ID provided with the db= rule is out of the supported range.
  */
 int ACLSetUser(user *u, const char *op, ssize_t oplen) {
     /* as we are changing the ACL, the old generated string is now invalid */

--- a/valkey.conf
+++ b/valkey.conf
@@ -1130,8 +1130,8 @@ replica-priority 100
 #               patterns.
 #  allchannels  Alias for &*
 #  resetchannels            Flush the list of allowed channel patterns.
-#  db=<dbid>    Add database ID(s) to the set of allowed database IDs. May be used
-#               with `,` for adding multiple IDs (e.g "db=1,2,3").
+#  db=<dbid>    Sets the specified database id(s) as the databases the selector is allowed to access.
+#               May be used with `,` for adding multiple IDs (e.g "db=1,2,3").
 #  alldbs       Allow access to all databases.
 #  resetdbs     Flush the set of allowed database IDs.
 #  ><password>  Add this password to the list of valid password for the user.

--- a/valkey.conf
+++ b/valkey.conf
@@ -1130,6 +1130,10 @@ replica-priority 100
 #               patterns.
 #  allchannels  Alias for &*
 #  resetchannels            Flush the list of allowed channel patterns.
+#  db=<dbid>    Add database ID(s) to the set of allowed database IDs. May be used
+#               with `,` for adding multiple IDs (e.g "db=1,2,3").
+#  alldbs       Allow access to all databases.
+#  resetdbs     Flush the set of allowed database IDs.
 #  ><password>  Add this password to the list of valid password for the user.
 #               For example >mypass will add "mypass" to the list.
 #               This directive clears the "nopass" flag (see later).
@@ -1146,7 +1150,8 @@ replica-priority 100
 #               passwords and there is no way to authenticate without adding
 #               some password (or setting it as "nopass" later).
 #  reset        Performs the following actions: resetpass, resetkeys, resetchannels,
-#               allchannels (if acl-pubsub-default is set), off, clearselectors, -@all.
+#               allchannels (if acl-pubsub-default is set), alldbs (for backwards compatibility),
+#               off, sanitize-payload, clearselectors, -@all.
 #               The user returns to the same state it has immediately after its creation.
 # (<options>)   Create a new selector with the options specified within the
 #               parentheses and attach it to the user. Each option should be


### PR DESCRIPTION
The db=, alldbs and resetdbs rules introduced in #2309 were
missing from the ACL self-documenting block in valkey.conf.
Also update the `reset` description to include alldbs and
sanitize-payload, and add ERANGE to the documented errno values.