### PR TITLE
Fix timing issue in cluster manual-takeover test

### DIFF
--- a/tests/unit/cluster/manual-takeover.tcl
+++ b/tests/unit/cluster/manual-takeover.tcl
@@ -27,10 +27,6 @@ test "Killing majority of master nodes" {
     pause_process $paused_pid2
 }
 
-foreach id $replica_ids {
-    R $id config set cluster-replica-no-failover no
-}
-
 test "Cluster should eventually be down" {
     for {set j 0} {$j < [llength $::servers]} {incr j} {
         if {[process_is_paused [srv -$j pid]]} continue


### PR DESCRIPTION
Tests sometimes fail here. If we add `after 1000` inside the foreach
loop, it becomes very easy to reproduce.
```
test "Use takeover to bring slaves back" {
    foreach id $replica_ids {
        R $id cluster failover takeover
    }
}

[exception]: Executing test client: ERR You should send CLUSTER FAILOVER to a replica.
```

The reason is that the transition from the PFAIL state to the FAIL
state which requires a quorum, may take a little extra time. From a
node's own perspective, it detects PFAIL and consequently views the
cluster as being in a FAIL state; and then, once the replica-no-failover
setting is disabled, auto failover may kick in, thereby causing the
test to fail.

Since we are verifying manual failover takeover, it is best to keep
`cluster-replica-no-failover` disabled at all times.