### PR TITLE
Trigger failover check ASAP when cluster-replica-no-failover is disabled

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -1256,6 +1256,13 @@ void clusterUpdateMyselfFlags(void) {
                      CLUSTER_NODE_MULTI_MEET_SUPPORTED;
     if (myself->flags != oldflags) {
         clusterDoBeforeSleep(CLUSTER_TODO_SAVE_CONFIG | CLUSTER_TODO_UPDATE_STATE);
+
+        /* If NOFAILOVER was just cleared (i.e. cluster-replica-no-failover
+         * was turned off at runtime), trigger a failover check ASAP instead
+         * of waiting for the next clusterCron tick. */
+        if ((oldflags & CLUSTER_NODE_NOFAILOVER) && !nofailover) {
+            clusterDoBeforeSleep(CLUSTER_TODO_HANDLE_FAILOVER);
+        }
     }
 }
 


### PR DESCRIPTION
When a replica has cluster-replica-no-failover enabled and the operator
later disables it via CONFIG SET while the primary is failing, the replica
previously had to wait for the next clusterCron (100ms) tick before it
could start an auto election.

Set CLUSTER_TODO_HANDLE_FAILOVER in clusterUpdateMyselfFlags() when the
NOFAILOVER flag transitions from set to cleared, so the failover handler
runs in the next beforeSleep instead.