### PR TITLE
Fix TLS example argument validation

### DIFF
--- a/deps/libvalkey/examples/async-libevent-tls.c
+++ b/deps/libvalkey/examples/async-libevent-tls.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 #endif
 
     struct event_base *base = event_base_new();
-    if (argc < 5) {
+    if (argc < 6) {
         fprintf(stderr,
                 "Usage: %s <key> <host> <port> <cert> <certKey> [ca]\n", argv[0]);
         exit(1);
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
 
     const char *cert = argv[4];
     const char *certKey = argv[5];
-    const char *caCert = argc > 5 ? argv[6] : NULL;
+    const char *caCert = argc > 6 ? argv[6] : NULL;
 
     valkeyTLSContext *tls;
     valkeyTLSContextError tls_error = VALKEY_TLS_CTX_NONE;

--- a/deps/libvalkey/examples/blocking-tls.c
+++ b/deps/libvalkey/examples/blocking-tls.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     valkeyTLSContextError tls_error = VALKEY_TLS_CTX_NONE;
     valkeyContext *c;
     valkeyReply *reply;
-    if (argc < 4) {
+    if (argc < 5) {
         printf("Usage: %s <host> <port> <cert> <key> [ca]\n", argv[0]);
         exit(1);
     }
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     int port = atoi(argv[2]);
     const char *cert = argv[3];
     const char *key = argv[4];
-    const char *ca = argc > 4 ? argv[5] : NULL;
+    const char *ca = argc > 5 ? argv[5] : NULL;
 
     valkeyInitOpenSSL();
     tls = valkeyCreateTLSContext(ca, NULL, cert, key, NULL, &tls_error);


### PR DESCRIPTION
## Summary
- fix the required argument count in `blocking-tls.c`
- fix the required argument count in `async-libevent-tls.c`
- align the optional CA argument checks with the documented usage

## Why
Both examples validated too few required arguments and could read past the validated `argv` range when the certificate or key arguments were missing.

## Validation
- `make -C deps/libvalkey/examples USE_TLS=1 TLS_LDFLAGS='-L/opt/homebrew/opt/openssl/lib -lssl -lcrypto' example-blocking-tls`
- `make -C deps/libvalkey/examples USE_TLS=1 CFLAGS='-fPIC -g -O2 -Wall -Wextra -Werror -I ../include -I/opt/homebrew/Cellar/libevent/2.1.12_1/include -L/opt/homebrew/Cellar/libevent/2.1.12_1/lib' TLS_LDFLAGS='-L/opt/homebrew/opt/openssl/lib -lssl -lcrypto' example-async-libevent-tls`