### PR TITLE
implement `VM_ClusterIsSlotImporting`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -9845,6 +9845,14 @@ const char *VM_ClusterCanonicalKeyNameInSlot(unsigned int slot) {
     return (slot < CLUSTER_SLOTS) ? crc16_slot_table[slot] : NULL;
 }
 
+/* Returns 1 if the specified cluster slot is currently being imported by an
+ * atomic slot migration, and 0 otherwise. Returns 0 if cluster mode is disabled
+ * or if the slot is not valid. */
+int VM_ClusterIsSlotImporting(unsigned int slot) {
+    if (!server.cluster_enabled || slot >= CLUSTER_SLOTS) return 0;
+    return clusterIsSlotImporting(slot);
+}
+
 /* --------------------------------------------------------------------------
  * ## Modules Timers API
  *
@@ -15328,6 +15336,7 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(ClusterKeySlotC);
     REGISTER_API(ClusterKeySlot);
     REGISTER_API(ClusterCanonicalKeyNameInSlot);
+    REGISTER_API(ClusterIsSlotImporting);
     REGISTER_API(CreateDict);
     REGISTER_API(FreeDict);
     REGISTER_API(DictSize);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -2126,6 +2126,7 @@ VALKEYMODULE_API void (*ValkeyModule_SetClusterFlags)(ValkeyModuleCtx *ctx, uint
 VALKEYMODULE_API unsigned int (*ValkeyModule_ClusterKeySlotC)(const char *key, size_t keylen) VALKEYMODULE_ATTR;
 VALKEYMODULE_API unsigned int (*ValkeyModule_ClusterKeySlot)(ValkeyModuleString *key) VALKEYMODULE_ATTR;
 VALKEYMODULE_API const char *(*ValkeyModule_ClusterCanonicalKeyNameInSlot)(unsigned int slot)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ClusterIsSlotImporting)(unsigned int slot) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_ExportSharedAPI)(ValkeyModuleCtx *ctx,
                                                      const char *apiname,
                                                      void *func) VALKEYMODULE_ATTR;
@@ -2630,6 +2631,7 @@ static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver, in
     VALKEYMODULE_GET_API(ClusterKeySlotC);
     VALKEYMODULE_GET_API(ClusterKeySlot);
     VALKEYMODULE_GET_API(ClusterCanonicalKeyNameInSlot);
+    VALKEYMODULE_GET_API(ClusterIsSlotImporting);
     VALKEYMODULE_GET_API(ExportSharedAPI);
     VALKEYMODULE_GET_API(GetSharedAPI);
     VALKEYMODULE_GET_API(RegisterCommandFilter);

--- a/tests/modules/hooks.c
+++ b/tests/modules/hooks.c
@@ -31,6 +31,7 @@
  */
 
 #include "valkeymodule.h"
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
@@ -474,6 +475,22 @@ static int cmdKeyExpiry(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     return VALKEYMODULE_OK;
 }
 
+/* Test command for exercising the slot importing module API with raw slot input. */
+static int cmdClusterIsSlotImporting(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (argc != 2) {
+        return ValkeyModule_WrongArity(ctx);
+    }
+
+    long long slot;
+    if (ValkeyModule_StringToLongLong(argv[1], &slot) == VALKEYMODULE_ERR || slot < 0 || slot > UINT_MAX) {
+        ValkeyModule_ReplyWithError(ctx, "ERR invalid slot");
+        return VALKEYMODULE_OK;
+    }
+
+    ValkeyModule_ReplyWithLongLong(ctx, ValkeyModule_ClusterIsSlotImporting((unsigned int)slot));
+    return VALKEYMODULE_OK;
+}
+
 /* This function must be present on each module. It is used in order to
  * register the commands into the server. */
 int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
@@ -548,6 +565,8 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
         return VALKEYMODULE_ERR;
     if (ValkeyModule_CreateCommand(ctx,"hooks.pexpireat", cmdKeyExpiry,"",0,0,0) == VALKEYMODULE_ERR)
         return VALKEYMODULE_ERR;
+    if (ValkeyModule_CreateCommand(ctx,"hooks.cluster_is_slot_importing", cmdClusterIsSlotImporting,"",0,0,0) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
 
     if (argc == 1) {
         const char *ptr = ValkeyModule_StringPtrLen(argv[0], NULL);
@@ -595,4 +614,3 @@ int ValkeyModule_OnUnload(ValkeyModuleCtx *ctx) {
 
     return VALKEYMODULE_OK;
 }
-

--- a/tests/unit/moduleapi/hooks.tcl
+++ b/tests/unit/moduleapi/hooks.tcl
@@ -7,6 +7,11 @@ tags "modules" {
             assert {[r hooks.event_count persistence-syncaof-start] == 1}
         }
 
+        test {Test slot importing API without cluster} {
+            assert_equal [r hooks.cluster_is_slot_importing 0] 0
+            assert_error "ERR invalid slot" {r hooks.cluster_is_slot_importing 4294967296}
+        }
+
         test {Test clients connection / disconnection hooks} {
             for {set j 0} {$j < 2} {incr j} {
                 set rd1 [valkey_deferring_client]
@@ -390,6 +395,8 @@ tags "modules" {
             assert_match "OK" [R 2 DEBUG SLOTMIGRATION PREVENT-PAUSE 1]
             set node0_id [R 0 CLUSTER MYID]
             set node2_id [R 2 CLUSTER MYID]
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16383] 0
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16384] 0
 
             # Start a migration
             assert_match "OK" [R 2 CLUSTER MIGRATESLOTS SLOTSRANGE 16383 16383 NODE $node0_id]
@@ -409,6 +416,10 @@ tags "modules" {
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-slotranges] "16383-16383"
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-numslotranges] "1"
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-start-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16383] 1
+            assert_equal [R 3 hooks.cluster_is_slot_importing 16383] 1
+            assert_equal [R 2 hooks.cluster_is_slot_importing 16383] 0
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16382] 0
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-start-slotranges] "16383-16383"
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-start-jobname] $job_name
@@ -434,6 +445,8 @@ tags "modules" {
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-slotranges] "16383-16383"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16383] 0
+            assert_equal [R 3 hooks.cluster_is_slot_importing 16383] 0
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-abort-jobname] $job_name
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-abort-jobname] $job_name
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-abort-jobname] $job_name
@@ -461,6 +474,8 @@ tags "modules" {
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-slotranges] "16383-16383"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-numslotranges] "1"
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-slotranges] "16383-16383"
+            assert_equal [R 0 hooks.cluster_is_slot_importing 16383] 0
+            assert_equal [R 3 hooks.cluster_is_slot_importing 16383] 0
             assert_equal [R 0 hooks.event_last atomic-slot-migration-import-complete-jobname] $job_name
             assert_equal [R 3 hooks.event_last atomic-slot-migration-import-complete-jobname] $job_name
             assert_equal [R 2 hooks.event_last atomic-slot-migration-export-complete-jobname] $job_name


### PR DESCRIPTION
Expose `clusterIsSlotImporting` through the module API.
`ValkeyModule_ClusterIsSlotImporting(slot)` so modules can check whether a slot is currently being imported.

issue : #3715