### PR TITLE
Add repl-disable-full-resync-until to gate primary full resync

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3475,6 +3475,7 @@ standardConfig static_configs[] = {
 
     /* Other configs */
     createTimeTConfig("repl-backlog-ttl", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_backlog_time_limit, 60 * 60, INTEGER_CONFIG, NULL, NULL), /* Default: 1 hour */
+    createTimeTConfig("repl-disable-full-resync-until", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, server.repl_disable_full_resync_until, 0, INTEGER_CONFIG, NULL, NULL),
     createOffTConfig("auto-aof-rewrite-min-size", NULL, MODIFIABLE_CONFIG, 0, LLONG_MAX, server.aof_rewrite_min_size, 64 * 1024 * 1024, MEMORY_CONFIG, NULL, NULL),
     createOffTConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG | HIDDEN_CONFIG, 1024, INT_MAX, server.loading_process_events_interval_bytes, 1024 * 1024 * 2, INTEGER_CONFIG, NULL, NULL),
 

--- a/src/replication.c
+++ b/src/replication.c
@@ -1187,6 +1187,23 @@ void syncCommand(client *c) {
         c->flag.pre_psync = 1;
     }
 
+    /* Full resynchronization is gated by repl-disable-full-resync-until.
+     * If configured, refuse full resync requests while wall-clock time is
+     * earlier than the configured unix timestamp. Partial resynchronization
+     * (handled above) is intentionally not affected. */
+    if (server.repl_disable_full_resync_until &&
+        server.unixtime < server.repl_disable_full_resync_until) {
+        server.stat_sync_full_denied++;
+        serverLog(LL_NOTICE,
+                  "Full resync from replica %s denied: "
+                  "repl-disable-full-resync-until=%lld, now=%lld",
+                  replicationGetReplicaName(c),
+                  (long long)server.repl_disable_full_resync_until,
+                  (long long)server.unixtime);
+        addReplyError(c, "-NOMASTERLINK Full resynchronization is temporarily disabled on this primary");
+        return;
+    }
+
     /* Full resynchronization. */
     server.stat_sync_full++;
 

--- a/src/server.c
+++ b/src/server.c
@@ -2822,6 +2822,7 @@ void resetServerStats(void) {
     server.stat_sync_full = 0;
     server.stat_sync_partial_ok = 0;
     server.stat_sync_partial_err = 0;
+    server.stat_sync_full_denied = 0;
     server.stat_io_reads_processed = 0;
     server.stat_total_reads_processed = 0;
     server.stat_io_writes_processed = 0;
@@ -6500,6 +6501,7 @@ sds genValkeyInfoString(dict *section_dict, int all_sections, int everything) {
                 "sync_full:%lld\r\n", server.stat_sync_full,
                 "sync_partial_ok:%lld\r\n", server.stat_sync_partial_ok,
                 "sync_partial_err:%lld\r\n", server.stat_sync_partial_err,
+                "sync_full_denied:%lld\r\n", server.stat_sync_full_denied,
                 "expired_keys:%lld\r\n", server.stat_expiredkeys,
                 "expired_fields:%lld\r\n", server.stat_expiredfields,
                 "expired_stale_perc:%.2f\r\n", server.stat_expired_keys_stale_perc * 100,

--- a/src/server.h
+++ b/src/server.h
@@ -1903,6 +1903,8 @@ struct valkeyServer {
     long long stat_sync_full;                      /* Number of full resyncs with replicas. */
     long long stat_sync_partial_ok;                /* Number of accepted PSYNC requests. */
     long long stat_sync_partial_err;               /* Number of unaccepted PSYNC requests. */
+    long long stat_sync_full_denied;               /* Number of full resyncs refused due to
+                                                      repl-disable-full-resync-until. */
     commandlog commandlog[COMMANDLOG_TYPE_NUM];    /* Logs of commands. */
     struct malloc_stats cron_malloc_stats;         /* sampled in serverCron(). */
     long long stat_net_input_bytes;                /* Bytes read from network. */
@@ -2122,6 +2124,9 @@ struct valkeyServer {
     replDataBuf pending_repl_data;              /* Replication data buffer for dual-channel-replication */
     time_t repl_backlog_time_limit;             /* Time without replicas after the backlog
                                                    gets released. */
+    time_t repl_disable_full_resync_until;      /* If non-zero, refuse full resync as a
+                                                   primary while server.unixtime is less
+                                                   than this unix timestamp. */
     time_t repl_no_replicas_since;              /* We have no replicas since that time.
                                                  Only valid if server.replicas len is 0. */
     int repl_min_replicas_to_write;             /* Min number of replicas to write. */

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -1647,3 +1647,61 @@ start_server {tags {"repl external:skip"}} {
         }
     }
 }
+
+# Tests for repl-disable-full-resync-until: a primary-side gate that refuses
+# full resynchronization while wall-clock time is earlier than the configured
+# unix timestamp, accounted via INFO Stats sync_full_denied.
+start_server {tags {"repl external:skip"} overrides {save {}}} {
+    set primary [srv 0 client]
+    set primary_host [srv 0 host]
+    set primary_port [srv 0 port]
+    $primary set primary_key primary_value
+
+    start_server {overrides {save {}}} {
+        set replica [srv 0 client]
+
+        test {repl-disable-full-resync-until refuses full resync before deadline} {
+            # Set the deadline far enough in the future to cover the whole test.
+            set future_ts [expr {[clock seconds] + 3600}]
+            $primary config set repl-disable-full-resync-until $future_ts
+
+            set baseline_full [s -1 sync_full]
+            set baseline_denied [s -1 sync_full_denied]
+
+            $replica replicaof $primary_host $primary_port
+
+            # Wait until at least one full resync attempt is denied and
+            # logged on the primary.
+            wait_for_condition 100 100 {
+                [s -1 sync_full_denied] > $baseline_denied
+            } else {
+                fail "Primary did not deny full resync before the configured deadline"
+            }
+
+            # The replica must NOT have completed full sync, so its data
+            # remains untouched (no primary_key replicated).
+            assert_equal {} [$replica get primary_key]
+
+            # The successful full-sync counter must stay unchanged.
+            assert_equal $baseline_full [s -1 sync_full]
+
+            # Replica must keep retrying (-NOMASTERLINK is treated as
+            # transient), so it stays in a non-connected replication state.
+            assert_equal {down} [s 0 master_link_status]
+        }
+
+        test {repl-disable-full-resync-until allows full resync once disabled} {
+            # Disable the gate; the replica should now finish full sync.
+            $primary config set repl-disable-full-resync-until 0
+
+            wait_for_condition 100 100 {
+                [s 0 master_link_status] eq {up} &&
+                [$replica get primary_key] eq {primary_value}
+            } else {
+                fail "Replica failed to perform full resync after gate was disabled"
+            }
+
+            assert {[s -1 sync_full] >= 1}
+        }
+    }
+}


### PR DESCRIPTION
Introduce a primary-side configuration that refuses full resynchronization requests while the wall-clock time is earlier than the configured unix timestamp. Partial resynchronization is left untouched so existing replicas with valid replids/offsets keep working.

The gate is enforced at the single full-resync entry point in syncCommand (after the partial-resync attempt). Refused requests reply with -NOMASTERLINK so replicas fall into the existing transient-error retry path until the deadline passes. A dedicated counter stat_sync_full_denied is incremented and exposed in INFO Stats as sync_full_denied to make the rejections observable.

Default value 0 keeps the feature disabled and preserves current behavior. Integration coverage in tests/integration/replication.tcl exercises both the deny and the auto-recover paths.