### PR TITLE
Redacting customer information when hide_user_data_from_log is true in rdb.c, networking.c, debug.c and t_hash 

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -2084,7 +2084,11 @@ void logCurrentClient(client *cc, const char *title) {
         key = getDecodedObject(cc->argv[1]);
         val = dbFind(cc->db, objectGetVal(key));
         if (val) {
-            serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)objectGetVal(key));
+            if (server.hide_user_data_from_log) {
+                serverLog(LL_WARNING, "key '*redacted*' found in DB containing the following object:");
+            } else {
+                serverLog(LL_WARNING, "key '%s' found in DB containing the following object:", (char *)objectGetVal(key));
+            }
             serverLogObjectDebugInfo(val);
         }
         decrRefCount(key);

--- a/src/networking.c
+++ b/src/networking.c
@@ -3080,9 +3080,13 @@ void sendReplyToClient(connection *conn) {
 
 void handleQbLimitReached(client *c) {
     sds ci = catClientInfoString(sdsempty(), c, server.hide_user_data_from_log), bytes = sdsempty();
-    bytes = sdscatrepr(bytes, c->querybuf, 64);
-    serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s (qbuf initial bytes: %s)", ci,
-              bytes);
+    if (server.hide_user_data_from_log) {
+        serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s", ci);
+    } else {
+        bytes = sdscatrepr(bytes, c->querybuf, 64);
+        serverLog(LL_WARNING, "Closing client that reached max query buffer length: %s (qbuf initial bytes: %s)", ci,
+                  bytes);
+    }
     sdsfree(ci);
     sdsfree(bytes);
     freeClientAsync(c);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2733,7 +2733,11 @@ robj *rdbLoadObject(int rdbtype, rio *rdb, sds key, int dbid, int *error, int rd
 
             streamCG *cgroup = streamCreateCG(s, cgname, sdslen(cgname), &cg_id, cg_offset);
             if (cgroup == NULL) {
-                rdbReportCorruptRDB("Duplicated consumer group name %s", cgname);
+                if (server.hide_user_data_from_log) {
+                    rdbReportCorruptRDB("Duplicated consumer group name");
+                } else {
+                    rdbReportCorruptRDB("Duplicated consumer group name %s", cgname);
+                }
                 decrRefCount(o);
                 sdsfree(cgname);
                 return NULL;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1218,8 +1218,12 @@ int rdbSaveKeyValuePair(rio *rdb, robj *key, robj *val, long long expiretime, in
     /* Save type, key, value */
     int rdbtype = rdbGetObjectType(val, rdbver);
     if (rdbtype == -1) {
-        serverLog(LL_WARNING, "Can't store key '%s' (db %d) in RDB version %d",
-                  (char *)objectGetVal(key), dbid, rdbver);
+        if (server.hide_user_data_from_log) {
+            serverLog(LL_WARNING, "Can't store key (db %d) in RDB version %d", dbid, rdbver);
+        } else {
+            serverLog(LL_WARNING, "Can't store key '%s' (db %d) in RDB version %d",
+                      (char *)objectGetVal(key), dbid, rdbver);
+        }
         return -1;
     }
     if (rdbSaveType(rdb, rdbtype) == -1) return -1;
@@ -3458,7 +3462,13 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
              * in an RDB file, instead we will silently discard it and
              * continue loading. */
             if (error == RDB_LOAD_ERR_EMPTY_KEY) {
-                if (empty_keys_skipped++ < 10) serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", key);
+                if (empty_keys_skipped++ < 10) {
+                    if (server.hide_user_data_from_log) {
+                        serverLog(LL_NOTICE, "rdbLoadObject skipping empty key");
+                    } else {
+                        serverLog(LL_NOTICE, "rdbLoadObject skipping empty key: %s", key);
+                    }
+                }
                 sdsfree(key);
             } else if (error == RDB_LOAD_ERR_UNKNOWN_TYPE) {
                 sdsfree(key);
@@ -3503,7 +3513,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
                     added = dbAddRDBLoad(db, key, &val);
                     serverAssert(added);
                 } else {
-                    serverLog(LL_WARNING, "RDB has duplicated key '%s' in DB %d", key, db->id);
+                    if (server.hide_user_data_from_log) {
+                        serverLog(LL_WARNING, "RDB has duplicated key in DB %d", db->id);
+                    } else {
+                        serverLog(LL_WARNING, "RDB has duplicated key '%s' in DB %d", key, db->id);
+                    }
                     serverPanic("Duplicated key found in RDB file");
                 }
             }

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -790,7 +790,10 @@ void hashTypeConvertListpack(robj *o, int enc) {
             if (!hashtableAdd(ht, entry)) {
                 entryFree(entry);
                 hashTypeResetIterator(&hi); /* Needed for gcc ASAN */
-                serverLogHexDump(LL_WARNING, "listpack with dup elements dump", objectGetVal(o), lpBytes(objectGetVal(o)));
+                if (!server.hide_user_data_from_log) {
+                    serverLogHexDump(LL_WARNING, "listpack with dup elements dump", objectGetVal(o),
+                                     lpBytes(objectGetVal(o)));
+                }
                 serverPanic("Listpack corruption detected");
             }
         }


### PR DESCRIPTION
Removing logging key names when hide_user_data_from_log is true in rdb.c file as well as networking.c, t_hash.c and debug.c files

Made simple if else in order to distinguish for read ability