### PR TITLE
Report exact dbid for COPY in ACL LOG when db= access is denied

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -1856,18 +1856,19 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
     /* Check database level permissions based on cmd->get_dbid_args implementation. */
     if (cmd->get_dbid_args) {
         int count = 0;
-        int *positions = NULL;
-        int *dbids = cmd->get_dbid_args(argv, argc, &count, &positions);
-        if (dbids) {
+        int *positions = cmd->get_dbid_args(argv, argc, &count);
+        if (positions) {
             for (int i = 0; i < count; i++) {
-                if (!ACLSelectorCanAccessDb(selector, dbids[i])) {
+                long long dbid;
+                /* The helper has already validated argv[positions[i]] as a
+                 * valid in-range dbid, so this should never fail. */
+                serverAssert(getLongLongFromObject(argv[positions[i]], &dbid) == C_OK);
+                if (!ACLSelectorCanAccessDb(selector, (int)dbid)) {
                     if (keyidxptr) *keyidxptr = positions[i];
-                    zfree(dbids);
                     zfree(positions);
                     return ACL_DENIED_DB;
                 }
             }
-            zfree(dbids);
             zfree(positions);
         }
     } else if ((cmd->flags & CMD_ALL_DBS) && !(selector->flags & SELECTOR_FLAG_ALLDBS)) {

--- a/src/acl.c
+++ b/src/acl.c
@@ -1856,25 +1856,19 @@ static int ACLSelectorCheckCmd(aclSelector *selector,
     /* Check database level permissions based on cmd->get_dbid_args implementation. */
     if (cmd->get_dbid_args) {
         int count = 0;
-        int *dbids = cmd->get_dbid_args(argv, argc, &count);
+        int *positions = NULL;
+        int *dbids = cmd->get_dbid_args(argv, argc, &count, &positions);
         if (dbids) {
             for (int i = 0; i < count; i++) {
                 if (!ACLSelectorCanAccessDb(selector, dbids[i])) {
-                    if (keyidxptr) {
-                        if (cmd->proc == selectCommand)
-                            *keyidxptr = 1;
-                        else if (cmd->proc == moveCommand)
-                            *keyidxptr = 2;
-                        else if (cmd->proc == swapdbCommand)
-                            *keyidxptr = (i == 0) ? 1 : 2;
-                        else
-                            *keyidxptr = 0;
-                    }
+                    if (keyidxptr) *keyidxptr = positions[i];
                     zfree(dbids);
+                    zfree(positions);
                     return ACL_DENIED_DB;
                 }
             }
             zfree(dbids);
+            zfree(positions);
         }
     } else if ((cmd->flags & CMD_ALL_DBS) && !(selector->flags & SELECTOR_FLAG_ALLDBS)) {
         for (int i = 0; i < server.dbnum; i++) {

--- a/src/db.c
+++ b/src/db.c
@@ -3029,24 +3029,24 @@ int bitfieldGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysRes
     return 1;
 }
 
-int *selectDbIdArgs(robj **argv, int argc, int *count, int **positions) {
+/* See commandDbIdArgs in server.h. Returns argv[1] (the dbid).
+ * Caller should free the returned array. */
+int *selectDbIdArgs(robj **argv, int argc, int *count) {
     if (argc < 2) return NULL;
 
     long long dbid;
     if (getLongLongFromObject(argv[1], &dbid) != C_OK) return NULL;
     if (dbid < 0 || dbid >= server.dbnum) return NULL;
 
-    int *result = zmalloc(sizeof(int));
-    result[0] = (int)dbid;
+    int *positions = zmalloc(sizeof(int));
+    positions[0] = 1;
     *count = 1;
-    if (positions) {
-        *positions = zmalloc(sizeof(int));
-        (*positions)[0] = 1;
-    }
-    return result;
+    return positions;
 }
 
-int *swapdbDbIdArgs(robj **argv, int argc, int *count, int **positions) {
+/* See commandDbIdArgs in server.h. Returns argv[1] and argv[2] (the two dbids).
+ * Caller should free the returned array. */
+int *swapdbDbIdArgs(robj **argv, int argc, int *count) {
     if (argc < 3) return NULL;
 
     long long db1, db2;
@@ -3054,33 +3054,26 @@ int *swapdbDbIdArgs(robj **argv, int argc, int *count, int **positions) {
         getLongLongFromObject(argv[2], &db2) != C_OK) return NULL;
     if (db1 < 0 || db1 >= server.dbnum || db2 < 0 || db2 >= server.dbnum) return NULL;
 
-    int *result = zmalloc(2 * sizeof(int));
-    result[0] = (int)db1;
-    result[1] = (int)db2;
+    int *positions = zmalloc(2 * sizeof(int));
+    positions[0] = 1;
+    positions[1] = 2;
     *count = 2;
-    if (positions) {
-        *positions = zmalloc(2 * sizeof(int));
-        (*positions)[0] = 1;
-        (*positions)[1] = 2;
-    }
-    return result;
+    return positions;
 }
 
-int *moveDbIdArgs(robj **argv, int argc, int *count, int **positions) {
+/* See commandDbIdArgs in server.h. Returns argv[2] (the destination dbid).
+ * Caller should free the returned array. */
+int *moveDbIdArgs(robj **argv, int argc, int *count) {
     if (argc < 3) return NULL;
 
     long long dbid;
     if (getLongLongFromObject(argv[2], &dbid) != C_OK) return NULL;
     if (dbid < 0 || dbid >= server.dbnum) return NULL;
 
-    int *result = zmalloc(sizeof(int));
-    result[0] = (int)dbid;
+    int *positions = zmalloc(sizeof(int));
+    positions[0] = 2;
     *count = 1;
-    if (positions) {
-        *positions = zmalloc(sizeof(int));
-        (*positions)[0] = 2;
-    }
-    return result;
+    return positions;
 }
 
 /* COPY source destination [ DB destination-db ] [ REPLACE ]
@@ -3089,8 +3082,12 @@ int *moveDbIdArgs(robj **argv, int argc, int *count, int **positions) {
  * Also if the DB token appears more than once, copyCommand keeps overwriting
  * the destination DB, so ACL must validate every occurrence: a permission
  * check against only the first or only the last value would let a user craft
- * 'COPY src dst DB <allowed> DB <denied>' (or vice versa) to bypass the ACL. */
-int *copyDbIdArgs(robj **argv, int argc, int *count, int **positions) {
+ * 'COPY src dst DB <allowed> DB <denied>' (or vice versa) to bypass the ACL.
+ *
+ * See commandDbIdArgs in server.h. Returns the argv index of every DB clause's
+ * dbid in argv order, or NULL if no DB clause is present.
+ * Caller should free the returned array. */
+int *copyDbIdArgs(robj **argv, int argc, int *count) {
     if (argc < 5) return NULL;
 
     /* First pass: validate syntax and count DB clauses. */
@@ -3111,19 +3108,14 @@ int *copyDbIdArgs(robj **argv, int argc, int *count, int **positions) {
     }
     if (n == 0) return NULL;
 
-    /* Second pass: collect the dbids and their argv positions. */
-    int *result = zmalloc(n * sizeof(int));
-    if (positions) *positions = zmalloc(n * sizeof(int));
+    /* Second pass: collect the argv positions of each DB clause's dbid. */
+    int *positions = zmalloc(n * sizeof(int));
     *count = 0;
     for (int j = 3; j < argc; j++) {
         if (!strcasecmp(objectGetVal(argv[j]), "db")) {
-            long long dbid;
-            getLongLongFromObject(argv[j + 1], &dbid);
-            result[*count] = (int)dbid;
-            if (positions) (*positions)[*count] = j + 1;
-            (*count)++;
+            positions[(*count)++] = j + 1;
             j++;
         }
     }
-    return result;
+    return positions;
 }

--- a/src/db.c
+++ b/src/db.c
@@ -3029,7 +3029,7 @@ int bitfieldGetKeys(struct serverCommand *cmd, robj **argv, int argc, getKeysRes
     return 1;
 }
 
-int *selectDbIdArgs(robj **argv, int argc, int *count) {
+int *selectDbIdArgs(robj **argv, int argc, int *count, int **positions) {
     if (argc < 2) return NULL;
 
     long long dbid;
@@ -3039,10 +3039,14 @@ int *selectDbIdArgs(robj **argv, int argc, int *count) {
     int *result = zmalloc(sizeof(int));
     result[0] = (int)dbid;
     *count = 1;
+    if (positions) {
+        *positions = zmalloc(sizeof(int));
+        (*positions)[0] = 1;
+    }
     return result;
 }
 
-int *swapdbDbIdArgs(robj **argv, int argc, int *count) {
+int *swapdbDbIdArgs(robj **argv, int argc, int *count, int **positions) {
     if (argc < 3) return NULL;
 
     long long db1, db2;
@@ -3054,10 +3058,15 @@ int *swapdbDbIdArgs(robj **argv, int argc, int *count) {
     result[0] = (int)db1;
     result[1] = (int)db2;
     *count = 2;
+    if (positions) {
+        *positions = zmalloc(2 * sizeof(int));
+        (*positions)[0] = 1;
+        (*positions)[1] = 2;
+    }
     return result;
 }
 
-int *moveDbIdArgs(robj **argv, int argc, int *count) {
+int *moveDbIdArgs(robj **argv, int argc, int *count, int **positions) {
     if (argc < 3) return NULL;
 
     long long dbid;
@@ -3067,6 +3076,10 @@ int *moveDbIdArgs(robj **argv, int argc, int *count) {
     int *result = zmalloc(sizeof(int));
     result[0] = (int)dbid;
     *count = 1;
+    if (positions) {
+        *positions = zmalloc(sizeof(int));
+        (*positions)[0] = 2;
+    }
     return result;
 }
 
@@ -3077,7 +3090,7 @@ int *moveDbIdArgs(robj **argv, int argc, int *count) {
  * the destination DB, so ACL must validate every occurrence: a permission
  * check against only the first or only the last value would let a user craft
  * 'COPY src dst DB <allowed> DB <denied>' (or vice versa) to bypass the ACL. */
-int *copyDbIdArgs(robj **argv, int argc, int *count) {
+int *copyDbIdArgs(robj **argv, int argc, int *count, int **positions) {
     if (argc < 5) return NULL;
 
     /* First pass: validate syntax and count DB clauses. */
@@ -3098,14 +3111,17 @@ int *copyDbIdArgs(robj **argv, int argc, int *count) {
     }
     if (n == 0) return NULL;
 
-    /* Second pass: collect the dbids now that we know the exact size. */
+    /* Second pass: collect the dbids and their argv positions. */
     int *result = zmalloc(n * sizeof(int));
+    if (positions) *positions = zmalloc(n * sizeof(int));
     *count = 0;
     for (int j = 3; j < argc; j++) {
         if (!strcasecmp(objectGetVal(argv[j]), "db")) {
             long long dbid;
             getLongLongFromObject(argv[j + 1], &dbid);
-            result[(*count)++] = (int)dbid;
+            result[*count] = (int)dbid;
+            if (positions) (*positions)[*count] = j + 1;
+            (*count)++;
             j++;
         }
     }

--- a/src/multi.c
+++ b/src/multi.c
@@ -116,9 +116,9 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
 
     if (mc->cmd->get_dbid_args && mc->cmd->proc == selectCommand) {
         int count;
-        int *dbids = mc->cmd->get_dbid_args(mc->argv, mc->argc, &count);
-        if (dbids && count > 0) {
-            c->mstate->transaction_db_id = dbids[0];
+        int *dbids = mc->cmd->get_dbid_args(mc->argv, mc->argc, &count, NULL);
+        if (dbids) {
+            if (count > 0) c->mstate->transaction_db_id = dbids[0];
             zfree(dbids);
         }
     }

--- a/src/multi.c
+++ b/src/multi.c
@@ -115,11 +115,17 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
     mc->slot = c->slot;
 
     if (mc->cmd->get_dbid_args && mc->cmd->proc == selectCommand) {
-        int count;
-        int *dbids = mc->cmd->get_dbid_args(mc->argv, mc->argc, &count, NULL);
-        if (dbids) {
-            if (count > 0) c->mstate->transaction_db_id = dbids[0];
-            zfree(dbids);
+        int count = 0;
+        int *positions = mc->cmd->get_dbid_args(mc->argv, mc->argc, &count);
+        if (positions) {
+            if (count > 0) {
+                long long dbid;
+                /* The helper has already validated argv[positions[i]] as a
+                 * valid in-range dbid, so this should never fail. */
+                serverAssert (getLongLongFromObject(mc->argv[positions[0]], &dbid) == C_OK);
+                c->mstate->transaction_db_id = (int)dbid;
+            }
+            zfree(positions);
         }
     }
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -122,7 +122,7 @@ void queueMultiCommand(client *c, uint64_t cmd_flags) {
                 long long dbid;
                 /* The helper has already validated argv[positions[i]] as a
                  * valid in-range dbid, so this should never fail. */
-                serverAssert (getLongLongFromObject(mc->argv[positions[0]], &dbid) == C_OK);
+                serverAssert(getLongLongFromObject(mc->argv[positions[0]], &dbid) == C_OK);
                 c->mstate->transaction_db_id = (int)dbid;
             }
             zfree(positions);

--- a/src/server.h
+++ b/src/server.h
@@ -2551,7 +2551,17 @@ typedef enum {
 
 typedef void serverCommandProc(client *c);
 typedef int serverGetKeysProc(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *result);
-typedef int *commandDbIdArgs(robj **argv, int argc, int *count, int **positions);
+
+/* Returns a heap-allocated array of argv indices that hold a database id
+ * argument to be validated by db-level ACL. The caller dereferences each
+ * argv[positions[i]] (via getLongLongFromObject) to obtain the dbid value.
+ * On success, *count is set to the array length.
+ *
+ * Returns NULL on syntax error or if the command has no dbid arguments;
+ * *count is unspecified in that case.
+ *
+ * Caller should free the returned array. */
+typedef int *commandDbIdArgs(robj **argv, int argc, int *count);
 
 /* Command structure.
  *
@@ -4222,10 +4232,10 @@ void resetCommand(client *c);
 void failoverCommand(client *c);
 
 /* Helper functions for getting database id args from argv, argc */
-int *selectDbIdArgs(robj **argv, int argc, int *count, int **positions);
-int *swapdbDbIdArgs(robj **argv, int argc, int *count, int **positions);
-int *moveDbIdArgs(robj **argv, int argc, int *count, int **positions);
-int *copyDbIdArgs(robj **argv, int argc, int *count, int **positions);
+int *selectDbIdArgs(robj **argv, int argc, int *count);
+int *swapdbDbIdArgs(robj **argv, int argc, int *count);
+int *moveDbIdArgs(robj **argv, int argc, int *count);
+int *copyDbIdArgs(robj **argv, int argc, int *count);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__((deprecated));

--- a/src/server.h
+++ b/src/server.h
@@ -2551,7 +2551,7 @@ typedef enum {
 
 typedef void serverCommandProc(client *c);
 typedef int serverGetKeysProc(struct serverCommand *cmd, robj **argv, int argc, getKeysResult *result);
-typedef int *commandDbIdArgs(robj **argv, int argc, int *count);
+typedef int *commandDbIdArgs(robj **argv, int argc, int *count, int **positions);
 
 /* Command structure.
  *
@@ -4222,10 +4222,10 @@ void resetCommand(client *c);
 void failoverCommand(client *c);
 
 /* Helper functions for getting database id args from argv, argc */
-int *selectDbIdArgs(robj **argv, int argc, int *count);
-int *swapdbDbIdArgs(robj **argv, int argc, int *count);
-int *moveDbIdArgs(robj **argv, int argc, int *count);
-int *copyDbIdArgs(robj **argv, int argc, int *count);
+int *selectDbIdArgs(robj **argv, int argc, int *count, int **positions);
+int *swapdbDbIdArgs(robj **argv, int argc, int *count, int **positions);
+int *moveDbIdArgs(robj **argv, int argc, int *count, int **positions);
+int *copyDbIdArgs(robj **argv, int argc, int *count, int **positions);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__((deprecated));

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -953,18 +953,24 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "OK" [r ACL DRYRUN db-dryrun SELECT 0]
         assert_equal "OK" [r ACL DRYRUN db-dryrun SELECT 1]
         
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun SELECT 2]
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun MOVE key 2]
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun SWAPDB 0 2]
+        # The denied error message should point at the specific dbid.
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun SELECT 2]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun MOVE key 2]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun SWAPDB 0 2]
 
         assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 1]
         assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 1 REPLACE]
         assert_equal "OK" [r ACL DRYRUN db-dryrun COPY key1 key2 REPLACE DB 1]
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2]
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2 REPLACE]
-        assert_match "*has no permissions to access database*" [r ACL DRYRUN db-dryrun COPY key1 key2 REPLACE DB 2]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2 REPLACE]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun COPY key1 key2 REPLACE DB 2]
+
+        # When DB appears more than once in COPY, the error should
+        # name the first denied dbid (here DB 2 is the offending one).
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 2 DB 1]
+        assert_match "*has no permissions to access database 2*" [r ACL DRYRUN db-dryrun COPY key1 key2 DB 1 DB 2]
     }
-    
+
     test {Test db= with maximum database ID} {
         set max_db [expr {[lindex [r config get databases] 1] - 1}]
         r ACL SETUSER db-max on nopass +@all ~* db=$max_db
@@ -1485,7 +1491,41 @@ start_server {tags {"acl external:skip"}} {
         assert {[s acl_access_denied_db] eq [expr $current_invalid_db_accesses + 3]}
         
         # Cleanup
+        $r2 reset
         r ACL deluser invaliddbuser
+    }
+
+    test {ACL LOG records the offending dbid for db=denied commands} {
+        r ACL SETUSER db-log-user on nopass +@all ~* db=0,1
+        $r2 auth db-log-user password
+        $r2 select 0
+        $r2 set src hello
+
+        # Each command exercises a different argv position for the dbid.
+        foreach {cmd expected} {
+            {SELECT 2}                        "2"
+            {MOVE k 2}                        "2"
+            {SWAPDB 2 0}                      "2"
+            {SWAPDB 0 2}                      "2"
+            {COPY src dst DB 2}               "2"
+            {COPY src dst REPLACE DB 2}       "2"
+            {COPY src dst DB 2 REPLACE}       "2"
+            {COPY src dst DB 1 DB 2}          "2"
+            {COPY src dst REPLACE DB 1 DB 2}  "2"
+            {COPY src dst DB 1 REPLACE DB 2}  "2"
+            {COPY src dst DB 1 DB 2 REPLACE}  "2"
+            {COPY src dst DB 2 DB 1}          "2"
+            {COPY src dst REPLACE DB 2 DB 1}  "2"
+            {COPY src dst DB 2 REPLACE DB 1}  "2"
+            {COPY src dst DB 2 DB 1 REPLACE}  "2"
+            {FLUSHALL}                        "flushall"
+        } {
+            r ACL LOG RESET
+            assert_error {NOPERM *} {$r2 {*}$cmd}
+            set entry [lindex [r ACL LOG] 0]
+            assert_equal "database" [dict get $entry reason]
+            assert_equal $expected [dict get $entry object]
+        }
     }
 
     $r2 close


### PR DESCRIPTION
Rework commandDbIdArgs so each helper returns the argv index of every dbid
argument it owns. ACLSelectorCheckCmd uses those positions to set keyidxptr
directly, replacing the cmd->proc-based offset table. The caller now reads
the dbid value via getLongLongFromObject(argv[positions[i]], ...). New
db=-checked commands only need to implement their own *DbIdArgs helper.

The fix is for COPY: the old chain fell through to 0, so the "object"
field in ACL LOG was always showed "copy", it now reports the first
denied dbid.

Based on #3801, also see it for more details, DB ACL was added in #2309.