### PR TITLE
Deflake temp-rdb checks in shutdown test

### DIFF
--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -16,7 +16,7 @@ start_server {tags {"shutdown external:skip"}} {
         set child_pid [get_child_pid 0]
         set temp_rdb [file join [lindex [r config get dir] 1] temp-${child_pid}.rdb]
         # Temp rdb must exist; the child creates it shortly after fork, so poll
-        wait_for_condition 50 10 {
+        wait_for_condition 50 100 {
             [file exists $temp_rdb]
         } else {
             fail "temp rdb file was not created"
@@ -28,7 +28,7 @@ start_server {tags {"shutdown external:skip"}} {
         assert_match {*connection refused*} $e
 
         # Temp rdb file must be deleted (bg_unlink runs in a bio thread, so poll)
-        wait_for_condition 50 10 {
+        wait_for_condition 50 100 {
             ![file exists $temp_rdb]
         } else {
             fail "temp rdb file was not deleted on shutdown"

--- a/tests/unit/shutdown.tcl
+++ b/tests/unit/shutdown.tcl
@@ -12,21 +12,27 @@ start_server {tags {"shutdown external:skip"}} {
         } else {
             fail "bgsave did not start in time"
         }
-        after 100 ;# give the child a bit of time for the file to be created
-
         set dir [lindex [r config get dir] 1]
         set child_pid [get_child_pid 0]
         set temp_rdb [file join [lindex [r config get dir] 1] temp-${child_pid}.rdb]
-        # Temp rdb must be existed
-        assert {[file exists $temp_rdb]}
+        # Temp rdb must exist; the child creates it shortly after fork, so poll
+        wait_for_condition 50 10 {
+            [file exists $temp_rdb]
+        } else {
+            fail "temp rdb file was not created"
+        }
 
         catch {r shutdown nosave}
         # Make sure the server was killed
         catch {set rd [valkey_deferring_client]} e
         assert_match {*connection refused*} $e
 
-        # Temp rdb file must be deleted
-        assert {![file exists $temp_rdb]}
+        # Temp rdb file must be deleted (bg_unlink runs in a bio thread, so poll)
+        wait_for_condition 50 10 {
+            ![file exists $temp_rdb]
+        } else {
+            fail "temp rdb file was not deleted on shutdown"
+        }
     }
 }
 


### PR DESCRIPTION
The first test in shutdown.tcl waited a fixed 100ms after rdb_bgsave_in_progress flipped to 1 before asserting the child's temp rdb exists. That flag is set by the parent at fork() time, while temp-<childpid>.rdb is created slightly later by the child, so on slow/loaded machines the file may not exist yet, making the test flaky.

Replace the fixed sleep + single existence assert with a wait_for_condition poll. Also harden the post-shutdown deletion check the same way, since bg_unlink removes the file from a background bio thread and may not complete immediately.