### PR TITLE
Define test executable path globals for 8.1

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -8,6 +8,7 @@
 # more information.
 
 set tcl_precision 17
+source ../support/set_executable_path.tcl
 source ../support/valkey.tcl
 source ../support/util.tcl
 source ../support/aofmanifest.tcl

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -1,0 +1,45 @@
+# Executable path globals used by tests backported from newer branches.
+#
+# Older release branches still run binaries from src/. Define the same globals
+# newer tests expect without backporting the broader CMake test refactor.
+set __valkey_support_dir [file dirname [file normalize [info script]]]
+set __valkey_root_dir [file dirname [file dirname $__valkey_support_dir]]
+
+if {![info exists ::VALKEY_PROG_SUFFIX]} {
+    if {[info exists ::env(VALKEY_PROG_SUFFIX)]} {
+        set ::VALKEY_PROG_SUFFIX $::env(VALKEY_PROG_SUFFIX)
+    } else {
+        set ::VALKEY_PROG_SUFFIX ""
+    }
+}
+
+if {![info exists ::VALKEY_BIN_DIR]} {
+    if {[info exists ::env(VALKEY_BIN_DIR)]} {
+        set ::VALKEY_BIN_DIR [file normalize $::env(VALKEY_BIN_DIR)]
+    } else {
+        set ::VALKEY_BIN_DIR [file join $__valkey_root_dir src]
+    }
+}
+
+foreach {var name} {
+    ::VALKEY_SERVER_BIN    valkey-server
+    ::VALKEY_CLI_BIN       valkey-cli
+    ::VALKEY_BENCHMARK_BIN valkey-benchmark
+    ::VALKEY_CHECK_AOF_BIN valkey-check-aof
+    ::VALKEY_CHECK_RDB_BIN valkey-check-rdb
+    ::VALKEY_SENTINEL_BIN  valkey-sentinel
+} {
+    if {![info exists $var]} {
+        set $var [file join $::VALKEY_BIN_DIR "${name}${::VALKEY_PROG_SUFFIX}"]
+    }
+}
+
+if {![info exists ::VALKEY_TLS_MODULE]} {
+    if {[info exists ::env(VALKEY_BIN_DIR)]} {
+        set ::VALKEY_TLS_MODULE [file join [file dirname $::VALKEY_BIN_DIR] lib "valkey-tls${::VALKEY_PROG_SUFFIX}.so"]
+    } else {
+        set ::VALKEY_TLS_MODULE [file join $__valkey_root_dir src "valkey-tls${::VALKEY_PROG_SUFFIX}.so"]
+    }
+}
+
+unset __valkey_support_dir __valkey_root_dir

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -3,6 +3,7 @@
 # more information.
 
 set tcl_precision 17
+source tests/support/set_executable_path.tcl
 source tests/support/valkey.tcl
 source tests/support/aofmanifest.tcl
 source tests/support/server.tcl


### PR DESCRIPTION
## Summary

Define the test executable path globals used by tests backported from newer branches, including `::VALKEY_CLI_BIN`, without backporting the broader CMake test refactor.

This keeps the 8.1 test harness compatible with newer test snippets that invoke Valkey binaries through these globals while preserving the old branch binary layout under `src/`.

## Test Plan

- `./runtest --help`
- `./runtest-cluster --help`
- `./runtest-sentinel --help`
- sourced `tests/support/set_executable_path.tcl` from the repo root and from `tests/cluster` to verify `::VALKEY_CLI_BIN` resolves correctly
- verified `VALKEY_BIN_DIR` and `VALKEY_PROG_SUFFIX` override handling