### PR TITLE
Define test binary path variables on the 8.1 branch

### DIFF
--- a/tests/sentinel/run.tcl
+++ b/tests/sentinel/run.tcl
@@ -2,6 +2,9 @@
 # This software is released under the BSD License. See the COPYING file for
 # more information.
 
+# Set the executable paths at project root
+source tests/support/set_executable_path.tcl
+
 cd tests/sentinel
 source ../instances.tcl
 

--- a/tests/support/set_executable_path.tcl
+++ b/tests/support/set_executable_path.tcl
@@ -1,0 +1,26 @@
+# Set the directory to find Valkey binaries for tests. Historically we've been
+# using make to build binaries under the src/ directory. Since we start supporting
+# CMake as well, we allow changing base dir by passing ENV variable `VALKEY_BIN_DIR`,
+# which could be either absolute or relative path (e.g. cmake-build-debug/bin).
+if {[info exists ::env(VALKEY_BIN_DIR)]} {
+    set ::VALKEY_BIN_DIR [file normalize $::env(VALKEY_BIN_DIR)]
+} else {
+    set ::VALKEY_BIN_DIR "[pwd]/src"
+}
+
+# Helper to build absolute paths
+proc valkey_bin_absolute_path {name} {
+    set p [file join $::VALKEY_BIN_DIR $name]
+    return $p
+}
+
+set ::VALKEY_SERVER_BIN    [valkey_bin_absolute_path "valkey-server"]
+set ::VALKEY_CLI_BIN       [valkey_bin_absolute_path "valkey-cli"]
+set ::VALKEY_BENCHMARK_BIN [valkey_bin_absolute_path "valkey-benchmark"]
+set ::VALKEY_CHECK_AOF_BIN [valkey_bin_absolute_path "valkey-check-aof"]
+set ::VALKEY_CHECK_RDB_BIN [valkey_bin_absolute_path "valkey-check-rdb"]
+set ::VALKEY_SENTINEL_BIN  [valkey_bin_absolute_path "valkey-sentinel"]
+
+if {![file executable $::VALKEY_SERVER_BIN]} {
+    error "Binary not found or not executable: $::VALKEY_SERVER_BIN"
+}

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -10,6 +10,7 @@ source tests/support/cluster_util.tcl
 source tests/support/tmpfile.tcl
 source tests/support/test.tcl
 source tests/support/util.tcl
+source tests/support/set_executable_path.tcl
 
 set dir [pwd]
 set ::all_tests []


### PR DESCRIPTION
Backports part of https://github.com/valkey-io/valkey/pull/2816

The test suite on newer branches locates binaries through `$::VALKEY_CLI_BIN` and the related `$::VALKEY_*_BIN` variables. That file isn't present on 8.1, so any test backported from a newer branch that relies on these variables fails at startup with:

```
    can't read "::VALKEY_CLI_BIN": no such variable
```

More context: #3898