### PR TITLE
fix: add CLUSTER SAVECONFIG before pause in shard restart tests

### DIFF
--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -285,6 +285,7 @@ test "CLUSTER MYSHARDID reports same shard id after shard restart" {
     set node_ids {}
     for {set i 0} {$i < 8} {incr i 4} {
         dict set node_ids $i [R $i cluster myshardid]
+        R $i cluster saveconfig
         pause_process [srv [expr -1*$i] pid]
     }
     for {set i 0} {$i < 8} {incr i 4} {
@@ -300,6 +301,9 @@ test "CLUSTER MYSHARDID reports same shard id after cluster restart" {
     set node_ids {}
     for {set i 0} {$i < 8} {incr i} {
         dict set node_ids $i [R $i cluster myshardid]
+    }
+    for {set i 0} {$i < 8} {incr i} {
+        R $i cluster saveconfig
     }
     for {set i 0} {$i < 8} {incr i} {
         pause_process [srv [expr -1*$i] pid]


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/3883

## Problem

The shard ID restart tests in `cluster-shards.tcl` fail intermittently under valgrind because `pause_process` (SIGSTOP) can hit before the deferred config save is flushed to `nodes.conf`.

When a replica learns its primary's shard ID via gossip, it updates `myself->shard_id` and sets `CLUSTER_TODO_SAVE_CONFIG` but the actual write only happens in `clusterBeforeSleep()` during the next event loop iteration. Under valgrind's slower execution, the test's SIGSTOP can arrive before that flush, so on restart the node gets a fresh random shard ID instead of the persisted one.

## Fix

Add `CLUSTER SAVECONFIG` before pausing nodes in both restart tests, ensuring `nodes.conf` contains the current shard IDs on disk before SIGSTOP. This follows the same pattern used in `latency-monitor.tcl`.