### PR TITLE
Raft Cluster: fix CLUSTER SHARDS visibility and replica health reporting

### DIFF
--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -273,7 +273,6 @@ static clusterMsgSendBlock *clusterRaftBuildAllOffsetsMsg(void) {
         if (n->flags & CLUSTER_NODE_MEET) continue;
         long long off = (n == myself) ? getNodeReplicationOffset(myself)
                                       : n->repl_offset;
-        if (off == 0) continue;
         msg = sdscatlen(msg, " ", 1);
         msg = sdscatlen(msg, n->name, CLUSTER_NAMELEN);
         msg = sdscatfmt(msg, " %I", off);
@@ -1311,8 +1310,10 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
     node->repl_offset = follower_repl_offset;
 
     /* Broadcast this node's offset to all peers when it transitions
-     * from 0 to non-zero (e.g. replica finishes initial sync). */
-    if (prev_offset == 0 && follower_repl_offset > 0 && !(node->flags & CLUSTER_NODE_MEET)) {
+     * between 0 and non-zero (replica finishes sync or starts resync). */
+    if (prev_offset != follower_repl_offset &&
+        (prev_offset == 0 || follower_repl_offset == 0) &&
+        !(node->flags & CLUSTER_NODE_MEET)) {
         clusterRaftBroadcastNodeOffset(node, follower_repl_offset);
     }
 
@@ -1520,6 +1521,7 @@ static void clusterRaftInit(void) {
     rs->deferred_meets = listCreate();
     rs->my_last_committed_info = sdsempty();
     rs->last_node_info_check = monotonicMs();
+    rs->last_repl_offsets_broadcast = monotonicMs();
     server.cluster->size = 0; /* Incremented by NODE_JOIN apply */
 }
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -928,13 +928,15 @@ static void raftLogApply(raftLogEntry *e) {
                 /* Update address for existing node. */
                 clusterNodeParseAddressString(existing, argv[1]);
             }
-            /* Only count the first NODE_JOIN for each node. New nodes
-             * don't have HANDSHAKE. Existing nodes from handshake do. */
+            /* Increment size on first official join. Nodes created from MEET
+             * handshake have CLUSTER_NODE_MEET set; clear it now. Nodes created
+             * fresh (on followers) don't exist yet. Either way, count once. */
             clusterNode *joined = existing ? existing : clusterLookupNode(argv[0], CLUSTER_NAMELEN);
             if (joined) {
                 if (!existing || (joined->flags & CLUSTER_NODE_MEET)) {
                     joined->flags &= ~CLUSTER_NODE_MEET;
                     server.cluster->size++;
+                    clusterAddNodeToShard(joined->shard_id, joined);
 
                     /* Process deferred MEET messages now that we're in a cluster. */
                     if (server.cluster->size > 1 && listLength(rs->deferred_meets) > 0) {


### PR DESCRIPTION
Some fixes for the raft cluster bus:

1. Add nodes to shards dict on NODE_JOIN apply — Nodes joining the cluster were added to the nodes dict but not the shards dict, making them invisible in CLUSTER SHARDS. 
This affected both paths: fresh node creation on followers and MEET-flagged nodes transitioning to full members.

2. Broadcast repl_offset when it drops to zero — The leader broadcasts a follower's replication offset to peers when it changes from 0 to non-zero (replica finishes sync).
Now also broadcasts when it drops from non-zero to 0 (replica starts full resync), so other nodes correctly report the replica's health as "loading" in CLUSTER SHARDS.

3. Include zero offsets in periodic REPL_OFFSETS broadcast — The periodic broadcast skipped nodes with offset 0, so a peer that missed the immediate transition broadcast (e.g. due to a brief disconnection) would never learn the correct value. Also fixes the case where the raft leader is a data replica and its offset drops to 0.

4. Defer first REPL_OFFSETS broadcast — Initialize the broadcast timer to startup time so the first periodic broadcast is deferred by 10 seconds, avoiding unnecessary 
traffic during cluster formation.

I discovered these when working on #3887, running the `cluster-shards.tcl` test suite, involving node restarts. These two fixes are not depending on persistence though.