### PR TITLE
Remove apt-get upgrade in clang-format job

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Set up Clang
         run: |
           sudo apt-get update -y
-          sudo apt-get upgrade -y
           sudo apt-get install software-properties-common -y
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/llvm-toolchain.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/llvm-toolchain.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
Thanks to @zuiderkwast for pointing this out. This changes helps speed up the clang-format job. We don't really need to upgrade every pre-installed package on the runner (firefox and a bunch of other things the job never uses).

Before this change: 2m 47s ([Eg](https://github.com/valkey-io/valkey/actions/runs/26908398204/job/79379498231?pr=3911))
After this change: 31s ([Eg](https://github.com/sarthakaggarwal97/valkey/actions/runs/26910300600/job/79386217458?pr=280))