### PR TITLE
Raft Cluster: Implement stale leader step-down after quorum loss

### DIFF
--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1595,46 +1595,16 @@ static void clusterRaftInitLast(void) {
 }
 
 /* Leader: detect node failures and propose NODE_FAIL.
- * If a majority of peers are overdue, the problem is likely on our side
- * (paused or partitioned) — reset ack times to avoid false positives. */
+ * Skip failure detection while quorum loss is in progress so a stale leader
+ * does not keep originating NODE_FAIL proposals in a minority partition. */
 static void clusterRaftDetectFailures(mstime_t now) {
     mstime_t node_timeout = server.cluster_node_timeout;
-
-    /* Check if a majority of peers are overdue. */
-    int overdue = 0, total = 0;
-    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
-    dictEntry *de;
-    while ((de = dictNext(di)) != NULL) {
-        clusterNode *n = dictGetVal(de);
-        if (n == myself) continue;
-        total++;
-        clusterNodeRaftData *rd = RAFT_NODE(n);
-        if (rd->last_ack_time > 0 &&
-            now - rd->last_ack_time > node_timeout) {
-            overdue++;
-        }
-    }
-    dictReleaseIterator(di);
-
-    if (overdue > total / 2) {
-        if (RAFT_STATE()->lost_quorum_since) {
-            /* Let quorum-loss step-down proceed without refreshing ack state. */
-            return;
-        }
-        /* Majority overdue — reset all ack times. */
-        di = dictGetSafeIterator(server.cluster->nodes);
-        while ((de = dictNext(di)) != NULL) {
-            clusterNode *n = dictGetVal(de);
-            if (n == myself) continue;
-            RAFT_NODE(n)->last_ack_time = now;
-        }
-        dictReleaseIterator(di);
-        return;
-    }
+    if (RAFT_STATE()->lost_quorum_since) return;
 
     /* Check individual nodes. */
-    di = dictGetSafeIterator(server.cluster->nodes);
-    while ((de = dictNext(di)) != NULL) {
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+     while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (node == myself) continue;
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1604,7 +1604,7 @@ static void clusterRaftDetectFailures(mstime_t now) {
     /* Check individual nodes. */
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
     dictEntry *de;
-     while ((de = dictNext(di)) != NULL) {
+    while ((de = dictNext(di)) != NULL) {
         clusterNode *node = dictGetVal(de);
         if (node == myself) continue;
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1748,8 +1748,9 @@ static void clusterRaftCron(void) {
                 if (rs->lost_quorum_since == 0) {
                     rs->lost_quorum_since = now;
                     serverLog(LL_NOTICE, "Leader lost quorum freshness, waiting before step-down.");
-                } else if (rs->last_fresh_quorum_time > 0 &&
-                           now - rs->last_fresh_quorum_time > server.cluster_node_timeout) {
+                }
+                if (rs->last_fresh_quorum_time > 0 &&
+                    now - rs->last_fresh_quorum_time > server.cluster_node_timeout) {
                     clusterRaftStepDown(now, "lost quorum freshness");
                 }
             }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1017,7 +1017,6 @@ static void raftLogApply(raftLogEntry *e) {
             if (memcmp(argv[0], myself->name, CLUSTER_NAMELEN) == 0) {
                 if (rs->role == RAFT_ROLE_JOINER) {
                     rs->role = RAFT_ROLE_FOLLOWER;
-                    rs->lost_quorum_since = 0;
                     serverLog(LL_NOTICE, "Promoted from joiner to follower.");
 
                     /* Propose SLOT_CHANGE for slots assigned before joining
@@ -1276,8 +1275,6 @@ static int clusterRaftProcessAppendEntries(clusterLink *link, int argc, sds *arg
 
     /* Accept heartbeat. */
     if (rs->role != RAFT_ROLE_JOINER) rs->role = RAFT_ROLE_FOLLOWER;
-    rs->lost_quorum_since = 0;
-    rs->last_fresh_quorum_time = 0;
     rs->last_heartbeat = monotonicMs();
     memcpy(rs->leader, argv[1], CLUSTER_NAMELEN);
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -143,6 +143,8 @@ typedef struct {
     mstime_t election_timeout;            /* Randomized timeout */
     mstime_t last_heartbeat;              /* Last time we heard from leader */
     mstime_t last_repl_offsets_broadcast; /* Last REPL_OFFSETS broadcast */
+    mstime_t lost_quorum_since;           /* When leader quorum freshness was lost */
+    mstime_t last_fresh_quorum_time;      /* Last AE_ACK-confirmed fresh quorum time */
     mstime_t joiner_since;                /* When we became a joiner (for timeout) */
 
     /* Leader identity */
@@ -319,12 +321,53 @@ static void clusterRaftRandomizeElectionTimeout(void) {
     RAFT_STATE()->election_timeout = base + (rand() % base);
 }
 
+static int clusterRaftQuorum(void) {
+    return server.cluster->size / 2 + 1;
+}
+
+static void clusterRaftStepDown(clusterRaftState *rs, mstime_t now, const char *reason) {
+    clusterRaftDeferPendingProposals();
+    rs->role = RAFT_ROLE_FOLLOWER;
+    rs->votes_received = 0;
+    rs->lost_quorum_since = 0;
+    rs->last_fresh_quorum_time = 0;
+    memset(rs->voted_for, 0, CLUSTER_NAMELEN);
+    memset(rs->leader, 0, CLUSTER_NAMELEN);
+    clusterRaftRandomizeElectionTimeout();
+    rs->last_heartbeat = now;
+    serverLog(LL_NOTICE, "Stepping down to follower: %s.", reason);
+}
+
+static int clusterRaftLeaderHasFreshQuorum(clusterRaftState *rs, mstime_t now) {
+    if (rs->role != RAFT_ROLE_LEADER || server.cluster->size <= 1) return 1;
+
+    int fresh = 1; /* Self */
+    int quorum = clusterRaftQuorum();
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (node == myself) continue;
+        if (node->flags & CLUSTER_NODE_MEET) continue;
+        clusterNodeRaftData *rd = RAFT_NODE(node);
+        if (rd->last_ack_time > 0 &&
+            now - rd->last_ack_time <= server.cluster_node_timeout) {
+            fresh++;
+            if (fresh >= quorum) break;
+        }
+    }
+    dictReleaseIterator(di);
+    return fresh >= quorum;
+}
+
 /* Singleton leader steps down to joiner when joining another cluster. */
 static void clusterRaftSingletonStepDown(void) {
     clusterRaftState *rs = RAFT_STATE();
     clusterRaftDeferPendingProposals();
     rs->role = RAFT_ROLE_JOINER;
     rs->joiner_since = monotonicMs();
+    rs->lost_quorum_since = 0;
+    rs->last_fresh_quorum_time = 0;
     memset(rs->leader, 0, CLUSTER_NAMELEN);
     memset(rs->voted_for, 0, CLUSTER_NAMELEN);
     clusterRaftRandomizeElectionTimeout();
@@ -826,13 +869,8 @@ static void clusterRaftDeferPendingProposals(void) {
 /* Step down to follower if we see a higher term. Returns 1 if stepped down. */
 static int clusterRaftMaybeStepDown(clusterRaftState *rs, uint64_t term) {
     if (term > rs->current_term) {
-        clusterRaftDeferPendingProposals();
         rs->current_term = term;
-        rs->role = RAFT_ROLE_FOLLOWER;
-        memset(rs->voted_for, 0, CLUSTER_NAMELEN);
-        memset(rs->leader, 0, CLUSTER_NAMELEN);
-        clusterRaftRandomizeElectionTimeout();
-        rs->last_heartbeat = monotonicMs();
+        clusterRaftStepDown(rs, monotonicMs(), "observed higher term");
         return 1;
     }
     return 0;
@@ -972,6 +1010,7 @@ static void raftLogApply(raftLogEntry *e) {
             if (memcmp(argv[0], myself->name, CLUSTER_NAMELEN) == 0) {
                 if (rs->role == RAFT_ROLE_JOINER) {
                     rs->role = RAFT_ROLE_FOLLOWER;
+                    rs->lost_quorum_since = 0;
                     serverLog(LL_NOTICE, "Promoted from joiner to follower.");
 
                     /* Propose SLOT_CHANGE for slots assigned before joining
@@ -1230,6 +1269,8 @@ static int clusterRaftProcessAppendEntries(clusterLink *link, int argc, sds *arg
 
     /* Accept heartbeat. */
     if (rs->role != RAFT_ROLE_JOINER) rs->role = RAFT_ROLE_FOLLOWER;
+    rs->lost_quorum_since = 0;
+    rs->last_fresh_quorum_time = 0;
     rs->last_heartbeat = monotonicMs();
     memcpy(rs->leader, argv[1], CLUSTER_NAMELEN);
 
@@ -1305,6 +1346,10 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
     if (!node) return 1;
     clusterNodeRaftData *rd = RAFT_NODE(node);
     rd->last_ack_time = monotonicMs();
+    if (clusterRaftLeaderHasFreshQuorum(rs, rd->last_ack_time)) {
+        rs->lost_quorum_since = 0;
+        rs->last_fresh_quorum_time = rd->last_ack_time;
+    }
     /* Keep node->repl_offset in sync for CLUSTER SLOTS/SHARDS on the leader. */
     long long prev_offset = node->repl_offset;
     node->repl_offset = follower_repl_offset;
@@ -1445,6 +1490,8 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
             char old_leader[CLUSTER_NAMELEN];
             memcpy(old_leader, rs->leader, CLUSTER_NAMELEN);
             rs->role = RAFT_ROLE_LEADER;
+            rs->lost_quorum_since = 0;
+            rs->last_fresh_quorum_time = monotonicMs();
             memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
             serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                       (unsigned long long)rs->current_term, rs->votes_received);
@@ -1500,6 +1547,8 @@ static void clusterRaftStartElection(void) {
     int quorum = server.cluster->size / 2 + 1;
     if (rs->votes_received >= quorum) {
         rs->role = RAFT_ROLE_LEADER;
+        rs->lost_quorum_since = 0;
+        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                   (unsigned long long)rs->current_term, rs->votes_received);
@@ -1537,6 +1586,8 @@ static void clusterRaftInitLast(void) {
     if (dictSize(server.cluster->nodes) == 1) {
         rs->role = RAFT_ROLE_LEADER;
         rs->current_term = 1;
+        rs->lost_quorum_since = 0;
+        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Single-node cluster: becoming Raft leader (term %llu).",
                   (unsigned long long)rs->current_term);
@@ -1566,6 +1617,10 @@ static void clusterRaftDetectFailures(mstime_t now) {
     dictReleaseIterator(di);
 
     if (overdue > total / 2) {
+        if (RAFT_STATE()->lost_quorum_since) {
+            /* Let quorum-loss step-down proceed without refreshing ack state. */
+            return;
+        }
         /* Majority overdue — reset all ack times. */
         di = dictGetSafeIterator(server.cluster->nodes);
         while ((de = dictNext(di)) != NULL) {
@@ -1703,6 +1758,8 @@ static void clusterRaftCron(void) {
         serverLog(LL_NOTICE, "Joiner timed out waiting to be added, reverting to singleton leader.");
         rs->role = RAFT_ROLE_LEADER;
         rs->current_term++;
+        rs->lost_quorum_since = 0;
+        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->voted_for, myself->name, CLUSTER_NAMELEN);
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
     }
@@ -1712,6 +1769,18 @@ static void clusterRaftCron(void) {
         if ((rs->role == RAFT_ROLE_FOLLOWER || rs->role == RAFT_ROLE_CANDIDATE) &&
             now - rs->last_heartbeat > rs->election_timeout) {
             clusterRaftStartElection();
+        }
+
+        if (rs->role == RAFT_ROLE_LEADER) {
+            if (!clusterRaftLeaderHasFreshQuorum(rs, now)) {
+                if (rs->lost_quorum_since == 0) {
+                    rs->lost_quorum_since = now;
+                    serverLog(LL_NOTICE, "Leader lost quorum freshness, waiting before step-down.");
+                } else if (rs->last_fresh_quorum_time > 0 &&
+                           now - rs->last_fresh_quorum_time > server.cluster_node_timeout) {
+                    clusterRaftStepDown(rs, now, "lost quorum freshness");
+                }
+            }
         }
 
         /* Expire stale pending proposals to prevent unbounded buildup

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1393,7 +1393,7 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
             }
             dictReleaseIterator(di);
 
-            int quorum = server.cluster->size / 2 + 1;
+            int quorum = clusterRaftQuorum();
             if (matches >= quorum) {
                 rs->commit_index = idx;
                 break;
@@ -1485,7 +1485,7 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
 
     if (granted) {
         rs->votes_received++;
-        int quorum = server.cluster->size / 2 + 1;
+        int quorum = clusterRaftQuorum();
         if (rs->votes_received >= quorum) {
             char old_leader[CLUSTER_NAMELEN];
             memcpy(old_leader, rs->leader, CLUSTER_NAMELEN);
@@ -1544,7 +1544,7 @@ static void clusterRaftStartElection(void) {
     dictReleaseIterator(di);
 
     /* Single-node: already have quorum. */
-    int quorum = server.cluster->size / 2 + 1;
+    int quorum = clusterRaftQuorum();
     if (rs->votes_received >= quorum) {
         rs->role = RAFT_ROLE_LEADER;
         rs->lost_quorum_since = 0;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -325,6 +325,8 @@ static int clusterRaftQuorum(void) {
     return server.cluster->size / 2 + 1;
 }
 
+/* Leader step-down to follower. Unlike clusterRaftSingletonStepDown(),
+ * this is used when a non-singleton leader loses leadership. */
 static void clusterRaftStepDown(mstime_t now, const char *reason) {
     clusterRaftState *rs = RAFT_STATE();
     clusterRaftDeferPendingProposals();
@@ -339,6 +341,8 @@ static void clusterRaftStepDown(mstime_t now, const char *reason) {
     serverLog(LL_NOTICE, "Stepping down to follower: %s.", reason);
 }
 
+/* Return non-zero if the leader still has a recently responsive voting
+ * quorum based on follower AE_ACK timing. */
 static int clusterRaftLeaderHasFreshQuorum(mstime_t now) {
     clusterRaftState *rs = RAFT_STATE();
     if (rs->role != RAFT_ROLE_LEADER || server.cluster->size <= 1) return 1;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1353,10 +1353,6 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
     if (!node) return 1;
     clusterNodeRaftData *rd = RAFT_NODE(node);
     rd->last_ack_time = monotonicMs();
-    if (clusterRaftLeaderHasFreshQuorum(rd->last_ack_time)) {
-        rs->lost_quorum_since = 0;
-        rs->last_fresh_quorum_time = rd->last_ack_time;
-    }
     /* Keep node->repl_offset in sync for CLUSTER SLOTS/SHARDS on the leader. */
     long long prev_offset = node->repl_offset;
     node->repl_offset = follower_repl_offset;
@@ -1779,7 +1775,10 @@ static void clusterRaftCron(void) {
         }
 
         if (rs->role == RAFT_ROLE_LEADER) {
-            if (!clusterRaftLeaderHasFreshQuorum(now)) {
+            if (clusterRaftLeaderHasFreshQuorum(now)) {
+                rs->lost_quorum_since = 0;
+                rs->last_fresh_quorum_time = now;
+            } else {
                 if (rs->lost_quorum_since == 0) {
                     rs->lost_quorum_since = now;
                     serverLog(LL_NOTICE, "Leader lost quorum freshness, waiting before step-down.");

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -325,7 +325,8 @@ static int clusterRaftQuorum(void) {
     return server.cluster->size / 2 + 1;
 }
 
-static void clusterRaftStepDown(clusterRaftState *rs, mstime_t now, const char *reason) {
+static void clusterRaftStepDown(mstime_t now, const char *reason) {
+    clusterRaftState *rs = RAFT_STATE();
     clusterRaftDeferPendingProposals();
     rs->role = RAFT_ROLE_FOLLOWER;
     rs->votes_received = 0;
@@ -338,7 +339,8 @@ static void clusterRaftStepDown(clusterRaftState *rs, mstime_t now, const char *
     serverLog(LL_NOTICE, "Stepping down to follower: %s.", reason);
 }
 
-static int clusterRaftLeaderHasFreshQuorum(clusterRaftState *rs, mstime_t now) {
+static int clusterRaftLeaderHasFreshQuorum(mstime_t now) {
+    clusterRaftState *rs = RAFT_STATE();
     if (rs->role != RAFT_ROLE_LEADER || server.cluster->size <= 1) return 1;
 
     int fresh = 1; /* Self */
@@ -867,10 +869,11 @@ static void clusterRaftDeferPendingProposals(void) {
 }
 
 /* Step down to follower if we see a higher term. Returns 1 if stepped down. */
-static int clusterRaftMaybeStepDown(clusterRaftState *rs, uint64_t term) {
+static int clusterRaftMaybeStepDown(uint64_t term) {
+    clusterRaftState *rs = RAFT_STATE();
     if (term > rs->current_term) {
         rs->current_term = term;
-        clusterRaftStepDown(rs, monotonicMs(), "observed higher term");
+        clusterRaftStepDown(monotonicMs(), "observed higher term");
         return 1;
     }
     return 0;
@@ -1265,7 +1268,7 @@ static int clusterRaftProcessAppendEntries(clusterLink *link, int argc, sds *arg
         return 1;
     }
 
-    clusterRaftMaybeStepDown(rs, msg_term);
+    clusterRaftMaybeStepDown(msg_term);
 
     /* Accept heartbeat. */
     if (rs->role != RAFT_ROLE_JOINER) rs->role = RAFT_ROLE_FOLLOWER;
@@ -1339,14 +1342,14 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
     uint64_t follower_last_index = strtoull(argv[3], NULL, 10);
     long long follower_repl_offset = (argc >= 5) ? strtoll(argv[4], NULL, 10) : 0;
 
-    clusterRaftMaybeStepDown(rs, msg_term);
+    clusterRaftMaybeStepDown(msg_term);
     if (rs->role != RAFT_ROLE_LEADER) return 1;
 
     clusterNode *node = link->node;
     if (!node) return 1;
     clusterNodeRaftData *rd = RAFT_NODE(node);
     rd->last_ack_time = monotonicMs();
-    if (clusterRaftLeaderHasFreshQuorum(rs, rd->last_ack_time)) {
+    if (clusterRaftLeaderHasFreshQuorum(rd->last_ack_time)) {
         rs->lost_quorum_since = 0;
         rs->last_fresh_quorum_time = rd->last_ack_time;
     }
@@ -1453,7 +1456,7 @@ static int clusterRaftProcessRequestVote(clusterLink *link, int argc, sds *argv)
     uint64_t msg_term = strtoull(argv[2], NULL, 10);
     int granted = 0;
 
-    clusterRaftMaybeStepDown(rs, msg_term);
+    clusterRaftMaybeStepDown(msg_term);
 
     if (msg_term < rs->current_term) {
         /* Stale term. */
@@ -1478,7 +1481,7 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
     uint64_t msg_term = strtoull(argv[1], NULL, 10);
     int granted = atoi(argv[2]);
 
-    clusterRaftMaybeStepDown(rs, msg_term);
+    clusterRaftMaybeStepDown(msg_term);
 
     if (rs->role != RAFT_ROLE_CANDIDATE) return 1;
     if (msg_term != rs->current_term) return 1;
@@ -1772,13 +1775,13 @@ static void clusterRaftCron(void) {
         }
 
         if (rs->role == RAFT_ROLE_LEADER) {
-            if (!clusterRaftLeaderHasFreshQuorum(rs, now)) {
+            if (!clusterRaftLeaderHasFreshQuorum(now)) {
                 if (rs->lost_quorum_since == 0) {
                     rs->lost_quorum_since = now;
                     serverLog(LL_NOTICE, "Leader lost quorum freshness, waiting before step-down.");
                 } else if (rs->last_fresh_quorum_time > 0 &&
                            now - rs->last_fresh_quorum_time > server.cluster_node_timeout) {
-                    clusterRaftStepDown(rs, now, "lost quorum freshness");
+                    clusterRaftStepDown(now, "lost quorum freshness");
                 }
             }
         }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -143,8 +143,6 @@ typedef struct {
     mstime_t election_timeout;            /* Randomized timeout */
     mstime_t last_heartbeat;              /* Last time we heard from leader */
     mstime_t last_repl_offsets_broadcast; /* Last REPL_OFFSETS broadcast */
-    mstime_t lost_quorum_since;           /* When leader quorum freshness was lost */
-    mstime_t last_fresh_quorum_time;      /* Last AE_ACK-confirmed fresh quorum time */
     mstime_t joiner_since;                /* When we became a joiner (for timeout) */
 
     /* Leader identity */
@@ -331,8 +329,6 @@ static void clusterRaftStepDown(mstime_t now, const char *reason) {
     clusterRaftDeferPendingProposals();
     rs->role = RAFT_ROLE_FOLLOWER;
     rs->votes_received = 0;
-    rs->lost_quorum_since = 0;
-    rs->last_fresh_quorum_time = 0;
     memset(rs->voted_for, 0, CLUSTER_NAMELEN);
     memset(rs->leader, 0, CLUSTER_NAMELEN);
     clusterRaftRandomizeElectionTimeout();
@@ -371,8 +367,6 @@ static void clusterRaftSingletonStepDown(void) {
     clusterRaftDeferPendingProposals();
     rs->role = RAFT_ROLE_JOINER;
     rs->joiner_since = monotonicMs();
-    rs->lost_quorum_since = 0;
-    rs->last_fresh_quorum_time = 0;
     memset(rs->leader, 0, CLUSTER_NAMELEN);
     memset(rs->voted_for, 0, CLUSTER_NAMELEN);
     clusterRaftRandomizeElectionTimeout();
@@ -1489,8 +1483,6 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
             char old_leader[CLUSTER_NAMELEN];
             memcpy(old_leader, rs->leader, CLUSTER_NAMELEN);
             rs->role = RAFT_ROLE_LEADER;
-            rs->lost_quorum_since = 0;
-            rs->last_fresh_quorum_time = monotonicMs();
             memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
             serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                       (unsigned long long)rs->current_term, rs->votes_received);
@@ -1546,8 +1538,6 @@ static void clusterRaftStartElection(void) {
     int quorum = clusterRaftQuorum();
     if (rs->votes_received >= quorum) {
         rs->role = RAFT_ROLE_LEADER;
-        rs->lost_quorum_since = 0;
-        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Elected as Raft leader (term %llu, %d votes).",
                   (unsigned long long)rs->current_term, rs->votes_received);
@@ -1585,20 +1575,15 @@ static void clusterRaftInitLast(void) {
     if (dictSize(server.cluster->nodes) == 1) {
         rs->role = RAFT_ROLE_LEADER;
         rs->current_term = 1;
-        rs->lost_quorum_since = 0;
-        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
         serverLog(LL_NOTICE, "Single-node cluster: becoming Raft leader (term %llu).",
                   (unsigned long long)rs->current_term);
     }
 }
 
-/* Leader: detect node failures and propose NODE_FAIL.
- * Skip failure detection while quorum loss is in progress so a stale leader
- * does not keep originating NODE_FAIL proposals in a minority partition. */
+/* Leader: detect node failures and propose NODE_FAIL. */
 static void clusterRaftDetectFailures(mstime_t now) {
     mstime_t node_timeout = server.cluster_node_timeout;
-    if (RAFT_STATE()->lost_quorum_since) return;
 
     /* Check individual nodes. */
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
@@ -1727,8 +1712,6 @@ static void clusterRaftCron(void) {
         serverLog(LL_NOTICE, "Joiner timed out waiting to be added, reverting to singleton leader.");
         rs->role = RAFT_ROLE_LEADER;
         rs->current_term++;
-        rs->lost_quorum_since = 0;
-        rs->last_fresh_quorum_time = monotonicMs();
         memcpy(rs->voted_for, myself->name, CLUSTER_NAMELEN);
         memcpy(rs->leader, myself->name, CLUSTER_NAMELEN);
     }
@@ -1740,20 +1723,9 @@ static void clusterRaftCron(void) {
             clusterRaftStartElection();
         }
 
-        if (rs->role == RAFT_ROLE_LEADER) {
-            if (clusterRaftLeaderHasFreshQuorum(now)) {
-                rs->lost_quorum_since = 0;
-                rs->last_fresh_quorum_time = now;
-            } else {
-                if (rs->lost_quorum_since == 0) {
-                    rs->lost_quorum_since = now;
-                    serverLog(LL_NOTICE, "Leader lost quorum freshness, waiting before step-down.");
-                }
-                if (rs->last_fresh_quorum_time > 0 &&
-                    now - rs->last_fresh_quorum_time > server.cluster_node_timeout) {
-                    clusterRaftStepDown(now, "lost quorum freshness");
-                }
-            }
+        if (rs->role == RAFT_ROLE_LEADER &&
+            !clusterRaftLeaderHasFreshQuorum(now)) {
+            clusterRaftStepDown(now, "lost quorum freshness");
         }
 
         /* Expire stale pending proposals to prevent unbounded buildup

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -325,8 +325,7 @@ static int clusterRaftQuorum(void) {
     return server.cluster->size / 2 + 1;
 }
 
-/* Leader step-down to follower. Unlike clusterRaftSingletonStepDown(),
- * this is used when a non-singleton leader loses leadership. */
+/* Leader step-down to follower. */
 static void clusterRaftStepDown(mstime_t now, const char *reason) {
     clusterRaftState *rs = RAFT_STATE();
     clusterRaftDeferPendingProposals();

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -57,6 +57,17 @@ proc raft_recv {fd {timeout 5000}} {
     return $payload
 }
 
+proc get_cluster_info_field {client field} {
+    set info [$client CLUSTER INFO]
+    foreach line [split $info "\n"] {
+        set line [string trim $line "\r"]
+        if {[string match "${field}:*" $line]} {
+            return [lindex [split $line ":"] 1]
+        }
+    }
+    return ""
+}
+
 tags {tls:skip external:skip cluster singledb} {
 
 # Listen on a random port, accept one connection, close the listener.
@@ -334,6 +345,57 @@ test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
         assert_equal 1 $found "leader should send REPL_OFFSETS with offset 5000"
 
         close $fd
+    }
+}
+
+test "Raft proto: leader steps down after losing quorum freshness" {
+    start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set r0 [srv 0 client]
+        set r1 [srv -1 client]
+        set r2 [srv -2 client]
+
+        $r0 CLUSTER MEET [srv -1 host] [srv -1 port]
+        $r0 CLUSTER MEET [srv -2 host] [srv -2 port]
+
+        wait_for_condition 50 100 {
+            [get_cluster_info_field $r0 cluster_size] == 3 &&
+            [get_cluster_info_field $r1 cluster_size] == 3 &&
+            [get_cluster_info_field $r2 cluster_size] == 3
+        } else {
+            fail "Cluster did not form: sizes=[get_cluster_info_field $r0 cluster_size],[get_cluster_info_field $r1 cluster_size],[get_cluster_info_field $r2 cluster_size]"
+        }
+
+        set leader_idx -999
+        set leader_client ""
+        foreach {idx client} [list 0 $r0 -1 $r1 -2 $r2] {
+            if {[get_cluster_info_field $client cluster_raft_role] eq "leader"} {
+                set leader_idx $idx
+                set leader_client $client
+                break
+            }
+        }
+        assert {$leader_idx != -999}
+
+        set paused [list]
+        foreach idx {0 -1 -2} {
+            if {$idx == $leader_idx} continue
+            pause_process [srv $idx pid]
+            lappend paused $idx
+        }
+
+        wait_for_condition 100 50 {
+            [get_cluster_info_field $leader_client cluster_raft_role] eq "follower" &&
+            [get_cluster_info_field $leader_client cluster_raft_leader] eq ""
+        } else {
+            foreach idx $paused {
+                resume_process [srv $idx pid]
+            }
+            fail "Leader did not step down after losing quorum freshness: role=[get_cluster_info_field $leader_client cluster_raft_role] leader=[get_cluster_info_field $leader_client cluster_raft_leader]"
+        }
+
+        foreach idx $paused {
+            resume_process [srv $idx pid]
+        }
     }
 }
 

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -57,17 +57,6 @@ proc raft_recv {fd {timeout 5000}} {
     return $payload
 }
 
-proc get_cluster_info_field {client field} {
-    set info [$client CLUSTER INFO]
-    foreach line [split $info "\n"] {
-        set line [string trim $line "\r"]
-        if {[string match "${field}:*" $line]} {
-            return [lindex [split $line ":"] 1]
-        }
-    }
-    return ""
-}
-
 tags {tls:skip external:skip cluster singledb} {
 
 # Listen on a random port, accept one connection, close the listener.
@@ -345,57 +334,6 @@ test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
         assert_equal 1 $found "leader should send REPL_OFFSETS with offset 5000"
 
         close $fd
-    }
-}
-
-test "Raft proto: leader steps down after losing quorum freshness" {
-    start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
-        set r0 [srv 0 client]
-        set r1 [srv -1 client]
-        set r2 [srv -2 client]
-
-        $r0 CLUSTER MEET [srv -1 host] [srv -1 port]
-        $r0 CLUSTER MEET [srv -2 host] [srv -2 port]
-
-        wait_for_condition 50 100 {
-            [get_cluster_info_field $r0 cluster_size] == 3 &&
-            [get_cluster_info_field $r1 cluster_size] == 3 &&
-            [get_cluster_info_field $r2 cluster_size] == 3
-        } else {
-            fail "Cluster did not form: sizes=[get_cluster_info_field $r0 cluster_size],[get_cluster_info_field $r1 cluster_size],[get_cluster_info_field $r2 cluster_size]"
-        }
-
-        set leader_idx -999
-        set leader_client ""
-        foreach {idx client} [list 0 $r0 -1 $r1 -2 $r2] {
-            if {[get_cluster_info_field $client cluster_raft_role] eq "leader"} {
-                set leader_idx $idx
-                set leader_client $client
-                break
-            }
-        }
-        assert {$leader_idx != -999}
-
-        set paused [list]
-        foreach idx {0 -1 -2} {
-            if {$idx == $leader_idx} continue
-            pause_process [srv $idx pid]
-            lappend paused $idx
-        }
-
-        wait_for_condition 100 50 {
-            [get_cluster_info_field $leader_client cluster_raft_role] eq "follower" &&
-            [get_cluster_info_field $leader_client cluster_raft_leader] eq ""
-        } else {
-            foreach idx $paused {
-                resume_process [srv $idx pid]
-            }
-            fail "Leader did not step down after losing quorum freshness: role=[get_cluster_info_field $leader_client cluster_raft_role] leader=[get_cluster_info_field $leader_client cluster_raft_leader]"
-        }
-
-        foreach idx $paused {
-            resume_process [srv $idx pid]
-        }
     }
 }
 

--- a/tests/unit/cluster/cluster-raft.tcl
+++ b/tests/unit/cluster/cluster-raft.tcl
@@ -1,0 +1,51 @@
+# Test higher-level Raft cluster behavior that does not require direct
+# wire-protocol interaction from Tcl.
+
+tags {external:skip cluster singledb} {
+
+test "Raft: leader steps down after losing quorum freshness" {
+    start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        [srv 0 client] CLUSTER MEET [srv -1 host] [srv -1 port]
+        [srv 0 client] CLUSTER MEET [srv -2 host] [srv -2 port]
+
+        wait_for_condition 50 100 {
+            [CI 0 cluster_size] == 3 &&
+            [CI 1 cluster_size] == 3 &&
+            [CI 2 cluster_size] == 3
+        } else {
+            fail "Cluster did not form: sizes=[CI 0 cluster_size],[CI 1 cluster_size],[CI 2 cluster_size]"
+        }
+
+        set leader_idx -999
+        foreach idx {0 1 2} {
+            if {[CI $idx cluster_raft_role] eq "leader"} {
+                set leader_idx $idx
+                break
+            }
+        }
+        assert {$leader_idx != -999}
+
+        set paused [list]
+        foreach idx {0 1 2} {
+            if {$idx == $leader_idx} continue
+            pause_process [srv [expr {-$idx}] pid]
+            lappend paused $idx
+        }
+
+        wait_for_condition 100 50 {
+            [CI $leader_idx cluster_raft_role] eq "follower" &&
+            [CI $leader_idx cluster_raft_leader] eq ""
+        } else {
+            foreach idx $paused {
+                resume_process [srv [expr {-$idx}] pid]
+            }
+            fail "Leader did not step down after losing quorum freshness: role=[CI $leader_idx cluster_raft_role] leader=[CI $leader_idx cluster_raft_leader]"
+        }
+
+        foreach idx $paused {
+            resume_process [srv [expr {-$idx}] pid]
+        }
+    }
+}
+
+} ;# tags

--- a/tests/unit/cluster/cluster-raft.tcl
+++ b/tests/unit/cluster/cluster-raft.tcl
@@ -32,14 +32,21 @@ test "Raft: leader steps down after losing quorum freshness" {
             lappend paused $idx
         }
 
-        wait_for_condition 100 50 {
-            [CI $leader_idx cluster_raft_role] eq "follower" &&
-            [CI $leader_idx cluster_raft_leader] eq ""
-        } else {
+        set stepped_down 0
+        set leader_role ""
+        for {set i 0} {$i < 150} {incr i} {
+            set leader_role [CI $leader_idx cluster_raft_role]
+            if {[string equal $leader_role "follower"]} {
+                set stepped_down 1
+                break
+            }
+            after 50
+        }
+        if {!$stepped_down} {
             foreach idx $paused {
                 resume_process [srv [expr {-$idx}] pid]
             }
-            fail "Leader did not step down after losing quorum freshness: role=[CI $leader_idx cluster_raft_role] leader=[CI $leader_idx cluster_raft_leader]"
+            fail "Leader did not step down after losing quorum freshness: role=$leader_role leader=[CI $leader_idx cluster_raft_leader]"
         }
 
         foreach idx $paused {

--- a/tests/unit/cluster/cluster-raft.tcl
+++ b/tests/unit/cluster/cluster-raft.tcl
@@ -16,14 +16,8 @@ test "Raft: leader steps down after losing quorum freshness" {
             fail "Cluster did not form: sizes=[CI 0 cluster_size],[CI 1 cluster_size],[CI 2 cluster_size]"
         }
 
-        set leader_idx -999
-        foreach idx {0 1 2} {
-            if {[CI $idx cluster_raft_role] eq "leader"} {
-                set leader_idx $idx
-                break
-            }
-        }
-        assert {$leader_idx != -999}
+        assert_equal [CI 0 cluster_raft_role] "leader"
+        set leader_idx 0
 
         set paused [list]
         foreach idx {0 1 2} {
@@ -32,21 +26,13 @@ test "Raft: leader steps down after losing quorum freshness" {
             lappend paused $idx
         }
 
-        set stepped_down 0
-        set leader_role ""
-        for {set i 0} {$i < 150} {incr i} {
-            set leader_role [CI $leader_idx cluster_raft_role]
-            if {[string equal $leader_role "follower"]} {
-                set stepped_down 1
-                break
-            }
-            after 50
-        }
-        if {!$stepped_down} {
+        wait_for_condition 100 50 {
+            [CI $leader_idx cluster_raft_role] eq "follower"
+        } else {
             foreach idx $paused {
                 resume_process [srv [expr {-$idx}] pid]
             }
-            fail "Leader did not step down after losing quorum freshness: role=$leader_role leader=[CI $leader_idx cluster_raft_leader]"
+            fail "Leader did not step down after losing quorum freshness: role=[CI $leader_idx cluster_raft_role] leader=[CI $leader_idx cluster_raft_leader]"
         }
 
         foreach idx $paused {


### PR DESCRIPTION
Implement stale leader step-down after quorum loss in the Raft cluster protocol.
Leaders now step down to FOLLOWER when quorum freshness is lost for longer than `cluster-node-timeout`. This typically means that the leader is in a minority partition.

In the cron path, the leader checks if a quorum of nodes have acked AppendEntries within the last cluster-node-timeout.

closes: #3861