### PR TITLE
Reject integer overflow of length fields in zipmapValidateIntegrity

### DIFF
--- a/src/zipmap.c
+++ b/src/zipmap.c
@@ -201,6 +201,12 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
             return 0;
 
         p += s; /* skip the encoded field size */
+        /* Bounds-check the field length before advancing 'p'. Advancing the
+         * pointer first can wrap, since 'l' is an attacker-controlled 32-bit
+         * value, so the OUT_OF_RANGE check below could be bypassed. Compare
+         * against the bytes remaining in the zipmap in 64-bit space so the
+         * arithmetic cannot overflow on 32-bit platforms either (CWE-190). */
+        if ((uint64_t)l > (uint64_t)(zm + size - 1 - p)) return 0;
         p += l; /* skip the field */
 
         /* make sure the entry doesn't reach outside the edge of the zipmap */
@@ -216,8 +222,13 @@ int zipmapValidateIntegrity(unsigned char *zm, size_t size, int deep) {
         /* Sanity check: length < 254 must be encoded in 1 byte, not 5 bytes */
         if (l < ZIPMAP_BIGLEN && s != 1)
             return 0;
-        p += s;     /* skip the encoded value size*/
-        e = *p++;   /* skip the encoded free space (always encoded in one byte) */
+        p += s;   /* skip the encoded value size*/
+        e = *p++; /* skip the encoded free space (always encoded in one byte) */
+        /* Bounds-check 'l + e' before advancing 'p'. Both are unsigned int,
+         * so 'l + e' can wrap to a small value (e.g. l=0xFFFFFFFF, e=1) and
+         * slip past the OUT_OF_RANGE check below, defeating validation. Do
+         * the comparison in 64-bit space so it cannot overflow (CWE-190). */
+        if ((uint64_t)l + e > (uint64_t)(zm + size - 1 - p)) return 0;
         p += l + e; /* skip the value and free space */
         count++;
 

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -36,6 +36,22 @@ test {corrupt payload: hash with valid zip list header, invalid entry len} {
     }
 }
 
+test {corrupt payload: zipmap value length integer overflow} {
+    # A zipmap value length of 0xFFFFFFFF with a free byte of 1 makes the
+    # internal 'l + e' sum wrap to 0 in 32-bit arithmetic. Before the fix the
+    # validator advanced its cursor by the wrapped value and wrongly accepted
+    # the payload, which leads to out-of-bounds access on 32-bit builds.
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        r debug set-skip-checksum-validation 1
+        catch {
+            r restore key 0 "\x09\x0c\x01\x03\x66\x6f\x6f\xfe\xff\xff\xff\xff\x01\xff\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        } err
+        assert_match "*Bad data format*" $err
+        verify_log_message 0 "*Zipmap integrity check failed*" 0
+        assert_equal [r ping] "PONG"
+    }
+}
+
 test {corrupt payload: invalid zlbytes header} {
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         catch {


### PR DESCRIPTION
## Problem

A crafted zipmap entry can set the value length to a value near `UINT32_MAX` so that the `l + e` sum (value length + one-byte free space) wraps in `unsigned int` arithmetic. The wrapped sum advances the validation cursor by a tiny amount, leaving `p` inside the buffer, so the `OUT_OF_RANGE` check passes and `zipmapValidateIntegrity` wrongly returns success. The field-length path has the same shape — advancing `p` by a ~4GB length wraps the pointer on 32-bit builds.

`zipmapValidateIntegrity` is always called with `deep=1` from `rdb.c` when loading `RDB_TYPE_HASH_ZIPMAP`, **including via `RESTORE`**, so any client with `RESTORE` access can submit a payload that passes validation. On 32-bit platforms this leads to out-of-bounds access during the subsequent zipmap→listpack conversion. On 64-bit the downstream `lpSafeToAdd` cap happens to reject it (the raw ~4GB length exceeds `LISTPACK_MAX_SAFETY_SIZE`), but the validator should not accept a malformed payload in the first place — this is the function whose sole job is to reject it.

## Fix

Bounds-check the attacker-controlled length against the bytes remaining in the zipmap, in 64-bit space, **before** any pointer arithmetic, for both the field-length and value-length paths.

## Testing

- `tests/integration/corrupt-dump.tcl`: a `RESTORE`-path test exercising the full attack surface; asserts rejection and that the server stays up.
- Verified the test **fails on the pre-fix code** (validator accepts the value-length payload) and **passes after the fix**, confirmed by stashing the fix during the integration run.
- Full `integration/corrupt-dump` suite: 76 passed, 0 failed.

> [!NOTE]
> Found via structure-aware fuzzing of the RESTORE path. This issue was generated by AI but verified, with love, by a human.