### PR TITLE
Fix server crash on FUNCTION DELETE after case-only function name collision

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -97,10 +97,14 @@ static void dictEntryDestructorSdsKeyEngineFunctionValue(void *entry) {
     zfree(de);
 }
 
+/* Must be case-insensitive to stay consistent with functionDictType (the
+ * global function dict). Otherwise names differing only in case (e.g. "aaa"
+ * and "AAA") are stored as distinct entries here but collapse to one entry in
+ * the global dict, which later trips an assertion in libraryUnlink. */
 dictType libraryFunctionDictType = {
     .entryGetKey = dictEntryGetKey,
-    .hashFunction = dictSdsHash,
-    .keyCompare = dictSdsKeyCompare,
+    .hashFunction = dictCStrCaseHash,
+    .keyCompare = dictSdsKeyCaseCompare,
     .entryDestructor = dictEntryDestructorSdsKeyEngineFunctionValue,
 };
 

--- a/tests/unit/functions.tcl
+++ b/tests/unit/functions.tcl
@@ -63,6 +63,25 @@ start_server {tags {"scripting"}} {
         r fcall TEST 0
     } {hello1}
 
+    test {FUNCTION - registering names differing only in case is rejected} {
+        catch {
+            r function load {#!lua name=casecollision
+                server.register_function('myfunc', function() return 1 end)
+                server.register_function('MYFUNC', function() return 2 end)}
+        } e
+        set _ $e
+    } {*Function already exists in the library*}
+
+    test {FUNCTION - delete after case collision attempt does not crash server} {
+        # Before the fix, the rejected case-collision above could leave the
+        # library and the global function dict inconsistent and crash the
+        # server on the next delete. Confirm the server is still responsive.
+        r function load REPLACE {#!lua name=casecollision
+            server.register_function('safefunc', function() return 1 end)}
+        assert_equal {OK} [r function delete casecollision]
+        r ping
+    } {PONG}
+
     test {FUNCTION - test replace argument with failure keeps old libraries} {
         catch {r function load REPLACE [get_function_code LUA test test {error}]} e
         assert_match {ERR Error compiling function*} $e


### PR DESCRIPTION
## Problem

The per-library function dict (`libraryFunctionDictType`) compares function names **case-sensitively**, while the global function dict (`functionDictType`) compares them **case-insensitively** (`dictCStrCaseHash` + `dictSdsKeyCaseCompare`). This asymmetry lets a single library register two functions whose names differ only in case, leaving the two dicts inconsistent and crashing the server on the next unlink.

### Reproducer (any client with the default `SCRIPTING` ACL category)

```
FUNCTION LOAD "#!lua name=poc
redis.register_function('aaa', function() return 1 end)
redis.register_function('AAA', function() return 2 end)"
FUNCTION DELETE poc
```

The server aborts with:

```
=== ASSERTION FAILED ===
==> functions.c:332 'ret == DICT_OK' is not true
0   valkey-server   ... libraryUnlink + ...
```

### Mechanism

1. `FUNCTION LOAD` — `functionLibCreateFunction` checks for duplicates in the per-library dict case-sensitively, so `aaa` and `AAA` are both stored there. `libraryLink` then inserts both into the global dict, but the second `dictAdd` silently returns `DICT_ERR` (return value ignored) because the global dict is case-insensitive. The load-path global-collision check iterates the per-library functions and looks each up in the global dict, but since `AAA` was never inserted there it finds no conflict and the load succeeds.
2. `FUNCTION DELETE` — `libraryUnlink` iterates the per-library dict (2 entries) and deletes each from the global dict. The first delete (`aaa`) succeeds; the second (`AAA`) resolves to the same case-insensitive slot, already removed, so `dictDelete` returns `DICT_ERR` and `serverAssert(ret == DICT_OK)` at `functions.c:332` aborts the server.

`FUNCTION LOAD REPLACE` of an affected library hits the same path, since it calls `libraryUnlink` on the old library internally.

Requires only the `SCRIPTING` ACL category, granted to users by default. No admin, cluster, or special config needed.

## Fix

Make `libraryFunctionDictType` case-insensitive (`dictCStrCaseHash` + `dictSdsKeyCaseCompare`) to match the global dict. Names differing only in case now collide at registration, and `FUNCTION LOAD` is rejected cleanly with `Function already exists in the library`. This is consistent with the long-standing case-insensitive `FCALL` contract (see the existing `FUNCTION - test function case insensitive` test).

## Testing

- Reproduced the crash on `unstable` before the fix; confirmed the server stays up and `FUNCTION LOAD` is rejected after.
- Added two regression tests in `tests/unit/functions.tcl`. Verified they **fail on pre-fix code** (load wrongly succeeds, delete crashes the server) and **pass after the fix**.
- `unit/functions`: 122 passed, 0 failed. `unit/scripting`: 683 passed, 0 failed.