### PR TITLE
Fix cluster/cli del-node test on 7.2

### DIFF
--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -412,18 +412,10 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 }
 
 # Test valkey-cli --cluster del-node
-set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
-start_multiple_servers 3 [list overrides $base_conf] {
-
-    # Create cluster with 1 primary and 2 replicas for del-node tests
-    exec src/valkey-cli --cluster-yes --cluster create \
-                    127.0.0.1:[srv 0 port] \
-                    127.0.0.1:[srv -1 port] \
-                    127.0.0.1:[srv -2 port] \
-                    --cluster-replicas 2
-
-    # Wait for the cluster to be ready
-    wait_for_cluster_state ok
+# Build the 1-primary + 2-replica cluster directly with CLUSTER commands.
+# valkey-cli --cluster create rejects fewer than 3 primaries on this branch,
+# so the cluster is assembled via start_cluster instead.
+start_cluster 1 2 {} {
 
     test "del-node: Cannot delete node with slots" {
         set node1 [srv 0 client]
@@ -480,7 +472,7 @@ start_multiple_servers 3 [list overrides $base_conf] {
 
         # Delete the unreachable empty replica
         set result [catch {
-            exec src/valkey-cli -t 1 --cluster-yes --cluster del-node \
+            exec src/valkey-cli --cluster-timeout 1 --cluster-yes --cluster del-node \
                          127.0.0.1:[srv 0 port] \
                          $node3_id
         } output]


### PR DESCRIPTION
The backported del-node test fails on 7.2 because it sets up its cluster with `valkey-cli --cluster create ... --cluster-replicas 2` over 3 nodes. On 7.2 the cli still hard-errors when fewer than 3 primaries would result (1 primary here), so the whole cli test file aborts before any del-node assertion runs.

Error stacktrace: https://github.com/valkey-io/valkey/actions/runs/27010905476/job/79713973086?pr=3738#step:4:4153

```
[exception]: Executing test client: *** ERROR: Invalid configuration for cluster creation.
*** Valkey Cluster requires at least 3 master nodes.
*** This is not possible with 3 nodes and 2 replicas per node.
*** At least 9 nodes are required.
child process exited abnormally.
*** ERROR: Invalid configuration for cluster creation.
*** Valkey Cluster requires at least 3 master nodes.
*** This is not possible with 3 nodes and 2 replicas per node.
*** At least 9 nodes are required.

```