### PR TITLE
Fix cluster/cli del-node test on 8.0

### DIFF
--- a/tests/unit/cluster/cli.tcl
+++ b/tests/unit/cluster/cli.tcl
@@ -408,18 +408,10 @@ start_server [list overrides [list cluster-enabled yes cluster-node-timeout 1 cl
 } ;# foreach ip_or_localhost
 
 # Test valkey-cli --cluster del-node
-set base_conf [list cluster-enabled yes cluster-node-timeout 1000]
-start_multiple_servers 3 [list overrides $base_conf] {
-
-    # Create cluster with 1 primary and 2 replicas for del-node tests
-    exec $::VALKEY_CLI_BIN --cluster-yes --cluster create \
-                    127.0.0.1:[srv 0 port] \
-                    127.0.0.1:[srv -1 port] \
-                    127.0.0.1:[srv -2 port] \
-                    --cluster-replicas 2
-
-    # Wait for the cluster to be ready
-    wait_for_cluster_state ok
+# Build the 1-primary + 2-replica cluster directly with CLUSTER commands.
+# valkey-cli --cluster create rejects fewer than 3 primaries on this branch,
+# so the cluster is assembled via start_cluster instead.
+start_cluster 1 2 {} {
 
     test "del-node: Cannot delete node with slots" {
         set node1 [srv 0 client]


### PR DESCRIPTION
Similar problem as the 7.2 fix: #3928

The backported `del-node` test creates its cluster with `valkey-cli --cluster create ... --cluster-replicas 2` over 3 nodes, and 8.0's cli hard-errors on fewer than 3 primaries, so the cli test file aborts.

Error stacktrace: https://github.com/valkey-io/valkey/actions/runs/27011178388/job/79714872447?pr=3736#step:4:3848

```
[exception]: Executing test client: *** ERROR: Invalid configuration for cluster creation.
*** Valkey Cluster requires at least 3 primary nodes.
*** This is not possible with 3 nodes and 2 replicas per node.
*** At least 9 nodes are required.
child process exited abnormally.
*** ERROR: Invalid configuration for cluster creation.
*** Valkey Cluster requires at least 3 primary nodes.
*** This is not possible with 3 nodes and 2 replicas per node.
*** At least 9 nodes are required.

```