### PR TITLE
Raft Cluster: Implement Pre-Vote protocol to prevent term inflation

### DIFF
--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -117,10 +117,11 @@ cluster with only one member. Singleton means that it's alone.
   after 4× cluster-node-timeout if no AE arrives.
 - **Follower**: Participates in elections and counts for quorum.
   Promoted from joiner when the node's NODE_JOIN entry is applied.
-- **Candidate**: Requesting votes after election timeout.
 - **Pre-candidate**: Runs a pre-vote round without incrementing term.
   Reverts to follower if no quorum is reached within one election timeout
   (see [Election timeout](#election-timeout)).
+- **Candidate**: Runs a formal election by sending VOTE_REQ after
+  winning a pre-vote round.
 - **Leader**: Accepts proposals, replicates log, sends heartbeats.
 
 The Raft leader is independent of the data primary/replica role. Any
@@ -496,76 +497,45 @@ timeout. The same log-up-to-date check applies to both message types.
 #### Timeout state machine
 
 ```
-         +----------+
-         | FOLLOWER |
-         +----------+
-              |
-              | election timeout
-              v
-     +---------------+
-     | PRE_CANDIDATE |<----------------------+
-     +---------------+                       |
-          |     |                            |
-          |     | pre-vote timeout           |
-          |     | (no quorum, no term change)|
-          |     v                            |
-          | +----------+                     |
-          | | FOLLOWER |                     |
-          | +----------+                     |
-          |                                  |
-          | quorum PRE_VOTE                  | election timeout
-          v                                  |
-     +-----------+                           |
-     | CANDIDATE |--------------------------+
-     +-----------+
-          |
-          | quorum VOTE
-          v
-       LEADER
+                +----------+
+                | FOLLOWER |
+                +----------+
+                   |    ^
+  election timeout |    | pre-vote timeout
+                   v    |
+              +---------------+
+              | PRE_CANDIDATE |
+              +---------------+
+                   |    ^
+   quorum PRE_VOTE |    | election timeout
+                   v    |
+               +-----------+
+               | CANDIDATE |
+               +-----------+
+                   |
+       quorum VOTE |
+                   v
+               +--------+
+               | LEADER |
+               +--------+
 ```
 
-`clusterRaftCron()` drives three transitions (see `src/cluster_raft.c`):
+The non-obvious transition is `CANDIDATE -> PRE_CANDIDATE`. After a
+split vote, the node has already bumped `currentTerm`; immediately
+starting another election would bump it again even if the node cannot
+reach a majority. Re-entering pre-vote first confirms that a quorum is
+reachable before committing to another term increment.
 
-1. **Follower or candidate → pre-candidate.** When
-   `now - last_heartbeat > election_timeout`, the node calls
-   `clusterRaftStartPreVote()`. This applies to both followers (no
-   leader heartbeats) and candidates (split vote or lost election).
-   Entering pre-candidate randomizes a new timeout and records
-   `pre_vote_started`; `currentTerm` is unchanged.
+Pre-vote is an in-memory probe. It uses the speculative term
+`currentTerm + 1`, but it does not update or persist `currentTerm` or
+`votedFor`. Only `StartElection()` persists a new term and self-vote,
+and only after a majority has granted pre-vote.
 
-2. **Pre-candidate → candidate.** On a majority of `PRE_VOTE` grants
-   for term `currentTerm + 1`, `clusterRaftStartElection()` bumps
-   `currentTerm`, sets `votedFor` to self, persists, and sends
-   `VOTE_REQ`.
-
-3. **Pre-candidate → follower (rollback).** If no quorum arrives within
-   one election timeout (`now - pre_vote_started > election_timeout`),
-   the node drops back to follower **without** incrementing
-   `currentTerm`. It randomizes the election timeout and sets
-   `last_heartbeat = now`, so the next probe waits another full
-   `[T, 2T)` window. This rollback is the piece most absent from the
-   paper: it is what keeps an isolated node from either inflating its
-   term or hammering the network with doomed election attempts.
-
-**Why candidates re-enter pre-vote.** After a formal election the term
-has already been bumped. On split vote the node stays candidate until
-the election timer fires again; at that point it does not immediately
-start another `StartElection()` (which would bump the term again).
-Instead it runs another pre-vote round at the *next* speculative term
-(`currentTerm + 1`) to confirm a majority is reachable before
-committing to another term increment.
-
-**What pre-vote does not undo.** Pre-vote prevents *future* term
-inflation while partitioned. It does not roll back a term that was
-already committed by a prior `StartElection()`. A node that became
-candidate, failed to win, and then regains quorum will proceed from its
-current term (or higher, if it learned a newer term from a denied
-`PRE_VOTE` / `VOTE` response).
-
-**Persistence.** Pre-vote and the pre-candidate rollback touch only
-in-memory role and timers. `currentTerm` and `votedFor` are written to
-`nodes.conf` only when `StartElection()` runs (or when stepping down
-to a higher term learned from a peer).
+The leader lease check is shared by pre-vote and real vote requests:
+nodes that have heard from the leader within one election timeout deny
+both. This keeps a reachable leader stable while still allowing a node
+whose pre-vote timed out to fall back to follower and retry later
+without inflating its term.
 
 ### Backdating on leader election
 

--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -62,6 +62,14 @@ VOTE <term> <granted>
     Response to VOTE_REQ. Indicates whether the vote was granted.
     Always sent, even on deny, so the candidate can learn higher terms.
 
+PRE_VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term>
+    Request for speculative election. Sent by pre-candidates before
+    incrementing currentTerm. The term is currentTerm+1.
+
+PRE_VOTE <term> <granted>
+    Response to PRE_VOTE_REQ. Indicates whether the node would grant
+    a real vote in that term.
+
 PROPOSE <entry>
     Forwards a proposal from a follower to the leader. The entry
     uses the same format as log entries (type followed by data).
@@ -110,6 +118,7 @@ cluster with only one member. Singleton means that it's alone.
 - **Follower**: Participates in elections and counts for quorum.
   Promoted from joiner when the node's NODE_JOIN entry is applied.
 - **Candidate**: Requesting votes after election timeout.
+- **Pre-candidate**: Runs a pre-vote round without incrementing term.
 - **Leader**: Accepts proposals, replicates log, sends heartbeats.
 
 The Raft leader is independent of the data primary/replica role. Any
@@ -459,6 +468,11 @@ The election timeout is based on `cluster-node-timeout`:
 `[T, 2T)` where T = max(cluster-node-timeout, 1000ms). The heartbeat
 interval is `election_timeout / 10`, minimum 100ms.
 
+On timeout, a follower starts a pre-vote round first. It only starts a
+real election (increments `currentTerm` and sends VOTE_REQ) after
+receiving PRE_VOTE grants from a majority. Nodes deny PRE_VOTE and
+VOTE_REQ if they received leader heartbeats within one election timeout.
+
 ### Backdating on leader election
 
 When a node wins an election, it backdates the old leader's
@@ -684,7 +698,8 @@ Entries that don't need a shard-epoch:
 On graceful shutdown, the leader sends a `TIMEOUT_NOW` message to the
 follower with the highest `match_index`. The message is flushed
 synchronously to the socket before shutdown proceeds. The target
-immediately starts an election without waiting for the election timeout.
+immediately starts a real election (skipping pre-vote) without waiting
+for the election timeout.
 (See Ongaro dissertation §3.10.)
 
 Nodes in handshake or with the MEET flag are excluded as transfer
@@ -692,7 +707,6 @@ targets.
 
 ## Future Work
 
-- Pre-vote protocol to avoid term inflation from partitioned nodes.
 - Minority partition detection and leader step-down (prevents append
   entries, especially don't trigger primary/replica failovers in a
   minority partition).

--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -119,6 +119,8 @@ cluster with only one member. Singleton means that it's alone.
   Promoted from joiner when the node's NODE_JOIN entry is applied.
 - **Candidate**: Requesting votes after election timeout.
 - **Pre-candidate**: Runs a pre-vote round without incrementing term.
+  Reverts to follower if no quorum is reached within one election timeout
+  (see [Election timeout](#election-timeout)).
 - **Leader**: Accepts proposals, replicates log, sends heartbeats.
 
 The Raft leader is independent of the data primary/replica role. Any
@@ -468,10 +470,102 @@ The election timeout is based on `cluster-node-timeout`:
 `[T, 2T)` where T = max(cluster-node-timeout, 1000ms). The heartbeat
 interval is `election_timeout / 10`, minimum 100ms.
 
-On timeout, a follower starts a pre-vote round first. It only starts a
-real election (increments `currentTerm` and sends VOTE_REQ) after
-receiving PRE_VOTE grants from a majority. Nodes deny PRE_VOTE and
-VOTE_REQ if they received leader heartbeats within one election timeout.
+#### Pre-vote and term inflation
+
+Ongaro's dissertation (§9.6) introduces pre-vote to reduce disruption
+when a partitioned node rejoins, but it does not spell out the full
+election-timeout state machine that production implementations need.
+In classic Raft, every election timeout on a follower increments
+`currentTerm` and sends RequestVote. A node isolated from the quorum
+will therefore bump its term on every timeout even though it can never
+win — when it rejoins, its higher term forces the real leader to step
+down.
+
+Pre-vote breaks this cycle by separating *connectivity probing* from
+*term commitment*. A pre-vote round sends `PRE_VOTE_REQ` with a
+*speculative* term of `currentTerm + 1` but does **not** change local
+`currentTerm`, `votedFor`, or the on-disk vars line. Only after a
+majority grants `PRE_VOTE` does the node call `StartElection()`, which
+increments `currentTerm`, votes for itself, and persists the new term
+before broadcasting `VOTE_REQ`.
+
+Nodes deny `PRE_VOTE` and `VOTE_REQ` when they still consider the
+current leader alive: `last_heartbeat` is younger than one election
+timeout. The same log-up-to-date check applies to both message types.
+
+#### Timeout state machine
+
+```
+         +----------+
+         | FOLLOWER |
+         +----------+
+              |
+              | election timeout
+              v
+     +---------------+
+     | PRE_CANDIDATE |<----------------------+
+     +---------------+                       |
+          |     |                            |
+          |     | pre-vote timeout           |
+          |     | (no quorum, no term change)|
+          |     v                            |
+          | +----------+                     |
+          | | FOLLOWER |                     |
+          | +----------+                     |
+          |                                  |
+          | quorum PRE_VOTE                  | election timeout
+          v                                  |
+     +-----------+                           |
+     | CANDIDATE |--------------------------+
+     +-----------+
+          |
+          | quorum VOTE
+          v
+       LEADER
+```
+
+`clusterRaftCron()` drives three transitions (see `src/cluster_raft.c`):
+
+1. **Follower or candidate → pre-candidate.** When
+   `now - last_heartbeat > election_timeout`, the node calls
+   `clusterRaftStartPreVote()`. This applies to both followers (no
+   leader heartbeats) and candidates (split vote or lost election).
+   Entering pre-candidate randomizes a new timeout and records
+   `pre_vote_started`; `currentTerm` is unchanged.
+
+2. **Pre-candidate → candidate.** On a majority of `PRE_VOTE` grants
+   for term `currentTerm + 1`, `clusterRaftStartElection()` bumps
+   `currentTerm`, sets `votedFor` to self, persists, and sends
+   `VOTE_REQ`.
+
+3. **Pre-candidate → follower (rollback).** If no quorum arrives within
+   one election timeout (`now - pre_vote_started > election_timeout`),
+   the node drops back to follower **without** incrementing
+   `currentTerm`. It randomizes the election timeout and sets
+   `last_heartbeat = now`, so the next probe waits another full
+   `[T, 2T)` window. This rollback is the piece most absent from the
+   paper: it is what keeps an isolated node from either inflating its
+   term or hammering the network with doomed election attempts.
+
+**Why candidates re-enter pre-vote.** After a formal election the term
+has already been bumped. On split vote the node stays candidate until
+the election timer fires again; at that point it does not immediately
+start another `StartElection()` (which would bump the term again).
+Instead it runs another pre-vote round at the *next* speculative term
+(`currentTerm + 1`) to confirm a majority is reachable before
+committing to another term increment.
+
+**What pre-vote does not undo.** Pre-vote prevents *future* term
+inflation while partitioned. It does not roll back a term that was
+already committed by a prior `StartElection()`. A node that became
+candidate, failed to win, and then regains quorum will proceed from its
+current term (or higher, if it learned a newer term from a denied
+`PRE_VOTE` / `VOTE` response).
+
+**Persistence.** Pre-vote and the pre-candidate rollback touch only
+in-memory role and timers. `currentTerm` and `votedFor` are written to
+`nodes.conf` only when `StartElection()` runs (or when stepping down
+to a higher term learned from a peer).
 
 ### Backdating on leader election
 

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -21,7 +21,7 @@
  *   nodes (including myself) at creation, cleared on NODE_JOIN apply.
  *
  * Constraints:
- * - AE and VOTE_REQ are never sent to nodes with CLUSTER_NODE_MEET.
+ * - AE, PRE_VOTE_REQ, and VOTE_REQ are never sent to nodes with CLUSTER_NODE_MEET.
  *   This prevents AE from arriving before MEET on the same link.
  * - Configuration (quorum) takes effect on apply, not on append.
  *   This allows multiple NODE_JOINs in flight simultaneously.
@@ -75,6 +75,7 @@ enum raftRole {
     RAFT_ROLE_FOLLOWER = 1,
     RAFT_ROLE_CANDIDATE = 2,
     RAFT_ROLE_LEADER = 3,
+    RAFT_ROLE_PRE_CANDIDATE = 4,
 };
 
 /* --------------------------------------------------------------------------
@@ -147,8 +148,10 @@ typedef struct {
 
     /* Election */
     int votes_received;
+    int pre_votes_received;
     mstime_t election_timeout;            /* Randomized timeout */
     mstime_t last_heartbeat;              /* Last time we heard from leader */
+    mstime_t pre_vote_started;            /* Last time we started a pre-vote round */
     mstime_t last_repl_offsets_broadcast; /* Last REPL_OFFSETS broadcast */
     mstime_t joiner_since;                /* When we became a joiner (for timeout) */
 
@@ -310,6 +313,7 @@ static sds clusterRaftBuildMyNodeInfo(void);
 static void clusterRaftCheckSlotCoverage(void);
 static void clusterRaftBroadcastAppendEntries(void);
 static void clusterRaftSendAppendEntries(clusterLink *link, clusterNode *node);
+static void clusterRaftSendPreVote(clusterLink *link, uint64_t term);
 static void clusterRaftUnblockMeet(clusterNode *node);
 static void clusterRaftApplySlotChange(sds data);
 static void clusterRaftApplySetReplica(sds data);
@@ -322,6 +326,8 @@ static uint64_t raftLogLastIndex(void);
 static uint64_t raftLogTermAt(uint64_t index);
 static void raftLogTruncateFrom(uint64_t index);
 static void clusterRaftPersistNewLogEntries(uint64_t from);
+static uint64_t raftLogLastTerm(void);
+static int clusterRaftCanGrantVote(clusterRaftState *rs, uint64_t candidate_last_index, uint64_t candidate_last_term);
 
 static void clusterRaftRandomizeElectionTimeout(void) {
     mstime_t base = server.cluster_node_timeout;
@@ -845,6 +851,11 @@ static int clusterRaftProcessPropose(clusterLink *link, int argc, sds *argv) {
 /* --------------------------------------------------------------------------
  * Raft election and heartbeat
  * -------------------------------------------------------------------------- */
+
+/* Forward declarations for pre-vote handlers. */
+static int clusterRaftProcessPreVote(clusterLink *link, int argc, sds *argv);
+static int clusterRaftProcessPreVoteResponse(clusterLink *link, int argc, sds *argv);
+static void clusterRaftStartPreVote(void);
 
 /* Defer pending proposals for retry after a leader change. The proposals
  * are idempotent, so retrying is safe. They will be resent to the new
@@ -1430,6 +1441,17 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
 }
 
 /* VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
+static void clusterRaftSendPreVote(clusterLink *link, uint64_t term) {
+    sds msg = wireNewMsg("PRE_VOTE_REQ");
+    msg = sdscatlen(msg, " ", 1);
+    msg = sdscatlen(msg, myself->name, CLUSTER_NAMELEN);
+    msg = sdscatfmt(msg, " %U %U %U", (unsigned long long)term,
+                    (unsigned long long)raftLogLastIndex(),
+                    (unsigned long long)raftLogLastTerm());
+    msg = wireFinishMsg(msg);
+    clusterRaftSendMsg(link, msg);
+}
+
 static void clusterRaftSendRequestVote(clusterLink *link) {
     sds msg = wireNewMsg("VOTE_REQ");
     msg = sdscatlen(msg, " ", 1);
@@ -1449,6 +1471,82 @@ static void clusterRaftSendVoteResponse(clusterLink *link, uint64_t term, int gr
     clusterRaftSendMsg(link, msg);
 }
 
+static void clusterRaftSendPreVoteResponse(clusterLink *link, uint64_t term, int granted) {
+    sds msg = wireNewMsg("PRE_VOTE");
+    msg = sdscatfmt(msg, " %U %i", (unsigned long long)term, granted);
+    msg = wireFinishMsg(msg);
+    clusterRaftSendMsg(link, msg);
+}
+
+static int clusterRaftCanGrantVote(clusterRaftState *rs, uint64_t candidate_last_index, uint64_t candidate_last_term) {
+    if (rs->role == RAFT_ROLE_JOINER) return 0;
+
+    /* Don't vote while we still consider a leader alive in this term. */
+    mstime_t now = monotonicMs();
+    if (rs->leader[0] != '\0' &&
+        now - rs->last_heartbeat < rs->election_timeout) {
+        return 0;
+    }
+
+    /* Candidate log must be at least as up-to-date as ours. */
+    uint64_t my_last_term = raftLogLastTerm();
+    if (candidate_last_term != my_last_term) {
+        return candidate_last_term > my_last_term;
+    }
+    return candidate_last_index >= raftLogLastIndex();
+}
+
+static int clusterRaftProcessPreVote(clusterLink *link, int argc, sds *argv) {
+    /* argv: PRE_VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
+    if (argc < 5) return 1;
+    if (sdslen(argv[1]) != CLUSTER_NAMELEN) return 1;
+
+    clusterRaftState *rs = RAFT_STATE();
+    uint64_t msg_term = strtoull(argv[2], NULL, 10);
+    uint64_t candidate_last_index = strtoull(argv[3], NULL, 10);
+    uint64_t candidate_last_term = strtoull(argv[4], NULL, 10);
+    int granted = 0;
+
+    if (msg_term > rs->current_term &&
+        clusterRaftCanGrantVote(rs, candidate_last_index, candidate_last_term)) {
+        granted = 1;
+    }
+
+    clusterRaftSendPreVoteResponse(link, granted ? msg_term : rs->current_term, granted);
+    return 1;
+}
+
+static void clusterRaftStartElection(void);
+
+static int clusterRaftProcessPreVoteResponse(clusterLink *link, int argc, sds *argv) {
+    UNUSED(link);
+    /* argv: PRE_VOTE <term> <granted> */
+    if (argc < 3) return 1;
+
+    clusterRaftState *rs = RAFT_STATE();
+    uint64_t msg_term = strtoull(argv[1], NULL, 10);
+    int granted = atoi(argv[2]);
+
+    /* PRE_VOTE uses a future term (current_term+1). A granted PRE_VOTE must
+     * not cause local term changes; only denied responses may carry a real
+     * higher term worth stepping down for. */
+    if (!granted && msg_term > rs->current_term) {
+        clusterRaftMaybeStepDown(rs, msg_term);
+    }
+
+    if (rs->role != RAFT_ROLE_PRE_CANDIDATE) return 1;
+    if (msg_term != rs->current_term + 1) return 1;
+
+    if (granted) {
+        rs->pre_votes_received++;
+        int quorum = server.cluster->size / 2 + 1;
+        if (rs->pre_votes_received >= quorum) {
+            clusterRaftStartElection();
+        }
+    }
+    return 1;
+}
+
 static int clusterRaftProcessRequestVote(clusterLink *link, int argc, sds *argv) {
     /* argv: VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
     if (argc < 5) return 1;
@@ -1456,27 +1554,21 @@ static int clusterRaftProcessRequestVote(clusterLink *link, int argc, sds *argv)
 
     clusterRaftState *rs = RAFT_STATE();
     uint64_t msg_term = strtoull(argv[2], NULL, 10);
+    uint64_t candidate_last_index = strtoull(argv[3], NULL, 10);
+    uint64_t candidate_last_term = strtoull(argv[4], NULL, 10);
     int granted = 0;
 
     clusterRaftMaybeStepDown(msg_term);
 
     if (msg_term < rs->current_term) {
         /* Stale term. */
-    } else if (clusterRaftIsVotedForNone() || memcmp(rs->voted_for, argv[1], CLUSTER_NAMELEN) == 0) {
-        /* Log completeness check: only grant vote if candidate's log is
-         * at least as up-to-date as ours (Raft §5.4.1). */
-        uint64_t candidate_last_index = strtoull(argv[3], NULL, 10);
-        uint64_t candidate_last_term = strtoull(argv[4], NULL, 10);
-        uint64_t my_last_term = raftLogLastTerm();
-        uint64_t my_last_index = raftLogLastIndex();
-        if (candidate_last_term > my_last_term ||
-            (candidate_last_term == my_last_term && candidate_last_index >= my_last_index)) {
-            granted = 1;
-            memcpy(rs->voted_for, argv[1], CLUSTER_NAMELEN);
-            rs->last_heartbeat = monotonicMs(); /* Reset election timer */
-            rs->todo_save_config = 1;
-            serverLog(LL_NOTICE, "Voted for %.40s in term %llu.", argv[1], (unsigned long long)msg_term);
-        }
+    } else if ((clusterRaftIsVotedForNone() || memcmp(rs->voted_for, argv[1], CLUSTER_NAMELEN) == 0) &&
+               clusterRaftCanGrantVote(rs, candidate_last_index, candidate_last_term)) {
+        granted = 1;
+        memcpy(rs->voted_for, argv[1], CLUSTER_NAMELEN);
+        rs->last_heartbeat = monotonicMs(); /* Reset election timer */
+        rs->todo_save_config = 1;
+        serverLog(LL_NOTICE, "Voted for %.40s in term %llu.", argv[1], (unsigned long long)msg_term);
     }
 
     if (granted) {
@@ -1538,6 +1630,32 @@ static int clusterRaftProcessRequestVoteResponse(clusterLink *link, int argc, sd
         }
     }
     return 1;
+}
+
+static void clusterRaftStartPreVote(void) {
+    clusterRaftState *rs = RAFT_STATE();
+    rs->role = RAFT_ROLE_PRE_CANDIDATE;
+    rs->pre_votes_received = 1; /* Self pre-vote */
+    rs->pre_vote_started = monotonicMs();
+    clusterRaftRandomizeElectionTimeout();
+
+    uint64_t candidate_term = rs->current_term + 1;
+    serverLog(LL_NOTICE, "Starting Raft pre-vote (candidate term %llu).", (unsigned long long)candidate_term);
+
+    dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
+    dictEntry *de;
+    while ((de = dictNext(di)) != NULL) {
+        clusterNode *node = dictGetVal(de);
+        if (node == myself || !node->link) continue;
+        if (node->flags & CLUSTER_NODE_MEET) continue;
+        clusterRaftSendPreVote(node->link, candidate_term);
+    }
+    dictReleaseIterator(di);
+
+    int quorum = server.cluster->size / 2 + 1;
+    if (rs->pre_votes_received >= quorum) {
+        clusterRaftStartElection();
+    }
 }
 
 static void clusterRaftStartElection(void) {
@@ -1745,7 +1863,14 @@ static void clusterRaftCron(void) {
         /* Follower/candidate: check election timeout. */
         if ((rs->role == RAFT_ROLE_FOLLOWER || rs->role == RAFT_ROLE_CANDIDATE) &&
             now - rs->last_heartbeat > rs->election_timeout) {
-            clusterRaftStartElection();
+            clusterRaftStartPreVote();
+        }
+
+        if (rs->role == RAFT_ROLE_PRE_CANDIDATE &&
+            now - rs->pre_vote_started > rs->election_timeout) {
+            rs->role = RAFT_ROLE_FOLLOWER;
+            clusterRaftRandomizeElectionTimeout();
+            rs->last_heartbeat = now;
         }
 
         if (rs->role == RAFT_ROLE_LEADER &&
@@ -2138,6 +2263,10 @@ static int clusterRaftProcessMessage(struct clusterLink *link) {
         ret = clusterRaftProcessAppendEntries(link, argc, argv, lines + 1, line_count - 1);
     } else if (!strcasecmp(argv[0], "AE_ACK")) {
         ret = clusterRaftProcessAppendEntriesResponse(link, argc, argv);
+    } else if (!strcasecmp(argv[0], "PRE_VOTE_REQ")) {
+        ret = clusterRaftProcessPreVote(link, argc, argv);
+    } else if (!strcasecmp(argv[0], "PRE_VOTE")) {
+        ret = clusterRaftProcessPreVoteResponse(link, argc, argv);
     } else if (!strcasecmp(argv[0], "VOTE_REQ")) {
         ret = clusterRaftProcessRequestVote(link, argc, argv);
     } else if (!strcasecmp(argv[0], "VOTE")) {
@@ -2528,10 +2657,11 @@ static sds clusterRaftAppendInfoFields(sds info) {
                      server.cluster->size);
 
     /* Raft-specific fields. */
-    const char *role_str = rs->role == RAFT_ROLE_LEADER      ? "leader"
-                           : rs->role == RAFT_ROLE_CANDIDATE ? "candidate"
-                           : rs->role == RAFT_ROLE_JOINER    ? "joiner"
-                                                             : "follower";
+    const char *role_str = rs->role == RAFT_ROLE_LEADER          ? "leader"
+                           : rs->role == RAFT_ROLE_CANDIDATE     ? "candidate"
+                           : rs->role == RAFT_ROLE_PRE_CANDIDATE ? "precandidate"
+                           : rs->role == RAFT_ROLE_JOINER        ? "joiner"
+                                                                 : "follower";
     info = sdscatprintf(info,
                         "cluster_raft_role:%s\r\n"
                         "cluster_raft_current_term:%llu\r\n"

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1530,7 +1530,7 @@ static int clusterRaftProcessPreVoteResponse(clusterLink *link, int argc, sds *a
      * not cause local term changes; only denied responses may carry a real
      * higher term worth stepping down for. */
     if (!granted && msg_term > rs->current_term) {
-        clusterRaftMaybeStepDown(rs, msg_term);
+        clusterRaftMaybeStepDown(msg_term);
     }
 
     if (rs->role != RAFT_ROLE_PRE_CANDIDATE) return 1;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -1845,7 +1845,7 @@ static void clusterRaftCron(void) {
     clusterRaftState *rs = RAFT_STATE();
     mstime_t now = monotonicMs();
 
-    clusterConnectNodes();
+    if (!server.debug_cluster_disable_reconnection) clusterConnectNodes();
 
     /* Joiner timeout: if we stepped down to join a cluster but never
      * received AE, revert to singleton leader so the admin can retry. */

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -73,9 +73,9 @@ typedef struct {
 enum raftRole {
     RAFT_ROLE_JOINER = 0, /* Stepped down singleton waiting to be added to a cluster */
     RAFT_ROLE_FOLLOWER = 1,
-    RAFT_ROLE_CANDIDATE = 2,
-    RAFT_ROLE_LEADER = 3,
-    RAFT_ROLE_PRE_CANDIDATE = 4,
+    RAFT_ROLE_PRE_CANDIDATE = 2,
+    RAFT_ROLE_CANDIDATE = 3,
+    RAFT_ROLE_LEADER = 4,
 };
 
 /* --------------------------------------------------------------------------
@@ -313,7 +313,7 @@ static sds clusterRaftBuildMyNodeInfo(void);
 static void clusterRaftCheckSlotCoverage(void);
 static void clusterRaftBroadcastAppendEntries(void);
 static void clusterRaftSendAppendEntries(clusterLink *link, clusterNode *node);
-static void clusterRaftSendPreVote(clusterLink *link, uint64_t term);
+static void clusterRaftSendPreVoteRequest(clusterLink *link, uint64_t term);
 static void clusterRaftUnblockMeet(clusterNode *node);
 static void clusterRaftApplySlotChange(sds data);
 static void clusterRaftApplySetReplica(sds data);
@@ -328,6 +328,7 @@ static void raftLogTruncateFrom(uint64_t index);
 static void clusterRaftPersistNewLogEntries(uint64_t from);
 static uint64_t raftLogLastTerm(void);
 static int clusterRaftCanGrantVote(clusterRaftState *rs, uint64_t candidate_last_index, uint64_t candidate_last_term);
+static void clusterRaftStartElection(void);
 
 static void clusterRaftRandomizeElectionTimeout(void) {
     mstime_t base = server.cluster_node_timeout;
@@ -853,7 +854,7 @@ static int clusterRaftProcessPropose(clusterLink *link, int argc, sds *argv) {
  * -------------------------------------------------------------------------- */
 
 /* Forward declarations for pre-vote handlers. */
-static int clusterRaftProcessPreVote(clusterLink *link, int argc, sds *argv);
+static int clusterRaftProcessPreVoteRequest(clusterLink *link, int argc, sds *argv);
 static int clusterRaftProcessPreVoteResponse(clusterLink *link, int argc, sds *argv);
 static void clusterRaftStartPreVote(void);
 
@@ -1440,8 +1441,8 @@ static int clusterRaftProcessAppendEntriesResponse(clusterLink *link, int argc, 
     return 1;
 }
 
-/* VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
-static void clusterRaftSendPreVote(clusterLink *link, uint64_t term) {
+/* PRE_VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
+static void clusterRaftSendPreVoteRequest(clusterLink *link, uint64_t term) {
     sds msg = wireNewMsg("PRE_VOTE_REQ");
     msg = sdscatlen(msg, " ", 1);
     msg = sdscatlen(msg, myself->name, CLUSTER_NAMELEN);
@@ -1496,7 +1497,7 @@ static int clusterRaftCanGrantVote(clusterRaftState *rs, uint64_t candidate_last
     return candidate_last_index >= raftLogLastIndex();
 }
 
-static int clusterRaftProcessPreVote(clusterLink *link, int argc, sds *argv) {
+static int clusterRaftProcessPreVoteRequest(clusterLink *link, int argc, sds *argv) {
     /* argv: PRE_VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term> */
     if (argc < 5) return 1;
     if (sdslen(argv[1]) != CLUSTER_NAMELEN) return 1;
@@ -1515,8 +1516,6 @@ static int clusterRaftProcessPreVote(clusterLink *link, int argc, sds *argv) {
     clusterRaftSendPreVoteResponse(link, granted ? msg_term : rs->current_term, granted);
     return 1;
 }
-
-static void clusterRaftStartElection(void);
 
 static int clusterRaftProcessPreVoteResponse(clusterLink *link, int argc, sds *argv) {
     UNUSED(link);
@@ -1648,7 +1647,7 @@ static void clusterRaftStartPreVote(void) {
         clusterNode *node = dictGetVal(de);
         if (node == myself || !node->link) continue;
         if (node->flags & CLUSTER_NODE_MEET) continue;
-        clusterRaftSendPreVote(node->link, candidate_term);
+        clusterRaftSendPreVoteRequest(node->link, candidate_term);
     }
     dictReleaseIterator(di);
 
@@ -2264,7 +2263,7 @@ static int clusterRaftProcessMessage(struct clusterLink *link) {
     } else if (!strcasecmp(argv[0], "AE_ACK")) {
         ret = clusterRaftProcessAppendEntriesResponse(link, argc, argv);
     } else if (!strcasecmp(argv[0], "PRE_VOTE_REQ")) {
-        ret = clusterRaftProcessPreVote(link, argc, argv);
+        ret = clusterRaftProcessPreVoteRequest(link, argc, argv);
     } else if (!strcasecmp(argv[0], "PRE_VOTE")) {
         ret = clusterRaftProcessPreVoteResponse(link, argc, argv);
     } else if (!strcasecmp(argv[0], "VOTE_REQ")) {
@@ -2659,7 +2658,7 @@ static sds clusterRaftAppendInfoFields(sds info) {
     /* Raft-specific fields. */
     const char *role_str = rs->role == RAFT_ROLE_LEADER          ? "leader"
                            : rs->role == RAFT_ROLE_CANDIDATE     ? "candidate"
-                           : rs->role == RAFT_ROLE_PRE_CANDIDATE ? "precandidate"
+                           : rs->role == RAFT_ROLE_PRE_CANDIDATE ? "pre-candidate"
                            : rs->role == RAFT_ROLE_JOINER        ? "joiner"
                                                                  : "follower";
     info = sdscatprintf(info,

--- a/tests/unit/cluster/cluster-raft-prevote.tcl
+++ b/tests/unit/cluster/cluster-raft-prevote.tcl
@@ -1,0 +1,129 @@
+# Test pre-vote behavior in raft cluster bus.
+
+proc get_cluster_info_field {client field} {
+    set info [$client CLUSTER INFO]
+    foreach line [split $info "\n"] {
+        set line [string trim $line "\r"]
+        if {[string match "${field}:*" $line]} {
+            return [lindex [split $line ":"] 1]
+        }
+    }
+    return ""
+}
+
+proc raft_find_role_idx {role} {
+    foreach idx {0 1 2} {
+        if {[CI $idx cluster_raft_role] eq $role} {
+            return $idx
+        }
+    }
+    return -1
+}
+
+proc raft_form_3node_cluster {} {
+    R 0 CLUSTER MEET [srv -2 host] [srv -2 port]
+    R 0 CLUSTER MEET [srv -1 host] [srv -1 port]
+
+    wait_for_condition 100 100 {
+        [CI 0 cluster_size] == 3 &&
+        [CI 1 cluster_size] == 3 &&
+        [CI 2 cluster_size] == 3
+    } else {
+        fail "cluster did not form"
+    }
+
+    wait_for_condition 100 100 {
+        [raft_find_role_idx leader] >= 0
+    } else {
+        fail "no raft leader after cluster formed"
+    }
+}
+
+proc raft_isolate_node {idx} {
+    set isolated [Rn $idx]
+    $isolated DEBUG DISABLE-CLUSTER-RECONNECTION 1
+    foreach other {0 1 2} {
+        if {$other == $idx} continue
+        set other_c [Rn $other]
+        $isolated DEBUG CLUSTERLINK KILL all [$other_c CLUSTER MYID]
+        $other_c DEBUG CLUSTERLINK KILL all [$isolated CLUSTER MYID]
+    }
+}
+
+proc raft_heal_isolation {idx} {
+    [Rn $idx] DEBUG DISABLE-CLUSTER-RECONNECTION 0
+}
+
+tags {external:skip cluster singledb} {
+
+start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 500}} {
+    test "Raft pre-vote: isolated follower does not inflate term" {
+        raft_form_3node_cluster
+
+        set leader_idx [raft_find_role_idx leader]
+        set leader_term [CI $leader_idx cluster_raft_current_term]
+        set leader_id [CI $leader_idx cluster_raft_leader]
+
+        set follower_idx [raft_find_role_idx follower]
+        assert {$follower_idx >= 0}
+
+        raft_isolate_node $follower_idx
+
+        # Wait long enough to trigger several election timeouts on the isolated node.
+        after 3500
+
+        # Isolated follower should not have inflated term while partitioned.
+        assert_equal $leader_term [CI $follower_idx cluster_raft_current_term]
+
+        # Heal partition and ensure leader remains stable on the majority side.
+        raft_heal_isolation $follower_idx
+        wait_for_condition 100 100 {
+            [CI 0 cluster_raft_leader] eq $leader_id &&
+            [CI 1 cluster_raft_leader] eq $leader_id &&
+            [CI 2 cluster_raft_leader] eq $leader_id
+        } else {
+            fail "leader changed unexpectedly after isolated follower rejoined"
+        }
+    }
+}
+
+start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 500}} {
+    test "Raft pre-vote: leader failure still allows election" {
+        raft_form_3node_cluster
+
+        set leader_idx [raft_find_role_idx leader]
+        set old_term [CI $leader_idx cluster_raft_current_term]
+        set old_leader_id [CI $leader_idx cluster_raft_leader]
+
+        set survivors [list]
+        foreach idx {0 1 2} {
+            if {$idx != $leader_idx} {
+                lappend survivors $idx
+            }
+        }
+
+        catch {R $leader_idx shutdown nosave}
+
+        set s0 [lindex $survivors 0]
+        set s1 [lindex $survivors 1]
+        wait_for_condition 200 100 {
+            [CI $s0 cluster_raft_current_term] > $old_term &&
+            [CI $s1 cluster_raft_current_term] > $old_term &&
+            ([CI $s0 cluster_raft_role] eq "leader" ||
+             [CI $s1 cluster_raft_role] eq "leader")
+        } else {
+            fail "no new leader elected after leader shutdown (term0=[CI $s0 cluster_raft_current_term] term1=[CI $s1 cluster_raft_current_term] role0=[CI $s0 cluster_raft_role] role1=[CI $s1 cluster_raft_role])"
+        }
+
+        if {[CI $s0 cluster_raft_role] eq "leader"} {
+            set new_leader_idx $s0
+        } else {
+            set new_leader_idx $s1
+        }
+        set new_leader_id [CI $new_leader_idx cluster_raft_leader]
+        assert {$new_leader_id ne $old_leader_id}
+        assert {[CI $new_leader_idx cluster_raft_current_term] > $old_term}
+    }
+}
+
+} ;# tags

--- a/tests/unit/cluster/cluster-raft-prevote.tcl
+++ b/tests/unit/cluster/cluster-raft-prevote.tcl
@@ -1,124 +1,48 @@
-# Test pre-vote behavior in raft cluster bus.
+# Test pre-vote behavior in real raft clusters.
 
-proc get_cluster_info_field {client field} {
-    set info [$client CLUSTER INFO]
-    foreach line [split $info "\n"] {
-        set line [string trim $line "\r"]
-        if {[string match "${field}:*" $line]} {
-            return [lindex [split $line ":"] 1]
+proc raft_wait_for_any_prevote_log {srv_a from_a srv_b from_b maxtries delay} {
+    for {set i 0} {$i < $maxtries} {incr i} {
+        set logs_a [exec tail -n +[expr {$from_a + 1}] < [srv $srv_a stdout]]
+        set logs_b [exec tail -n +[expr {$from_b + 1}] < [srv $srv_b stdout]]
+        if {[string match "*Starting Raft pre-vote*" $logs_a]} {
+            return
         }
-    }
-    return ""
-}
-
-proc raft_find_role_idx {role} {
-    foreach idx {0 1 2} {
-        if {[CI $idx cluster_raft_role] eq $role} {
-            return $idx
+        if {[string match "*Starting Raft pre-vote*" $logs_b]} {
+            return
         }
+        after $delay
     }
-    return -1
-}
-
-proc raft_form_3node_cluster {} {
-    R 0 CLUSTER MEET [srv -2 host] [srv -2 port]
-    R 0 CLUSTER MEET [srv -1 host] [srv -1 port]
-
-    wait_for_condition 100 100 {
-        [CI 0 cluster_size] == 3 &&
-        [CI 1 cluster_size] == 3 &&
-        [CI 2 cluster_size] == 3
-    } else {
-        fail "cluster did not form"
-    }
-
-    wait_for_condition 100 100 {
-        [raft_find_role_idx leader] >= 0
-    } else {
-        fail "no raft leader after cluster formed"
-    }
-}
-
-proc raft_isolate_node {idx} {
-    set isolated [Rn $idx]
-    $isolated DEBUG DISABLE-CLUSTER-RECONNECTION 1
-    foreach other {0 1 2} {
-        if {$other == $idx} continue
-        set other_c [Rn $other]
-        $isolated DEBUG CLUSTERLINK KILL all [$other_c CLUSTER MYID]
-        $other_c DEBUG CLUSTERLINK KILL all [$isolated CLUSTER MYID]
-    }
-}
-
-proc raft_heal_isolation {idx} {
-    [Rn $idx] DEBUG DISABLE-CLUSTER-RECONNECTION 0
+    fail "no survivor started Raft pre-vote"
 }
 
 tags {external:skip cluster singledb} {
 
-start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 500}} {
-    test "Raft pre-vote: isolated follower does not inflate term" {
-        raft_form_3node_cluster
+start_cluster 3 0 {overrides {cluster-protocol raft cluster-node-timeout 500}} {
+    test "Raft Cluster: leader failure, successful pre-vote and election" {
+        assert_equal "leader" [CI 0 cluster_raft_role]
 
-        set leader_idx [raft_find_role_idx leader]
-        set leader_term [CI $leader_idx cluster_raft_current_term]
-        set leader_id [CI $leader_idx cluster_raft_leader]
+        set old_term [CI 0 cluster_raft_current_term]
+        set old_leader_id [CI 0 cluster_raft_leader]
+        set loglines1 [count_log_lines -1]
+        set loglines2 [count_log_lines -2]
 
-        set follower_idx [raft_find_role_idx follower]
-        assert {$follower_idx >= 0}
+        pause_process [srv 0 pid]
 
-        raft_isolate_node $follower_idx
+        raft_wait_for_any_prevote_log -1 $loglines1 -2 $loglines2 200 100
 
-        # Wait long enough to trigger several election timeouts on the isolated node.
-        after 3500
-
-        # Isolated follower should not have inflated term while partitioned.
-        assert_equal $leader_term [CI $follower_idx cluster_raft_current_term]
-
-        # Heal partition and ensure leader remains stable on the majority side.
-        raft_heal_isolation $follower_idx
-        wait_for_condition 100 100 {
-            [CI 0 cluster_raft_leader] eq $leader_id &&
-            [CI 1 cluster_raft_leader] eq $leader_id &&
-            [CI 2 cluster_raft_leader] eq $leader_id
-        } else {
-            fail "leader changed unexpectedly after isolated follower rejoined"
-        }
-    }
-}
-
-start_multiple_servers 3 {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 500}} {
-    test "Raft pre-vote: leader failure still allows election" {
-        raft_form_3node_cluster
-
-        set leader_idx [raft_find_role_idx leader]
-        set old_term [CI $leader_idx cluster_raft_current_term]
-        set old_leader_id [CI $leader_idx cluster_raft_leader]
-
-        set survivors [list]
-        foreach idx {0 1 2} {
-            if {$idx != $leader_idx} {
-                lappend survivors $idx
-            }
-        }
-
-        catch {R $leader_idx shutdown nosave}
-
-        set s0 [lindex $survivors 0]
-        set s1 [lindex $survivors 1]
         wait_for_condition 200 100 {
-            [CI $s0 cluster_raft_current_term] > $old_term &&
-            [CI $s1 cluster_raft_current_term] > $old_term &&
-            ([CI $s0 cluster_raft_role] eq "leader" ||
-             [CI $s1 cluster_raft_role] eq "leader")
+            [CI 1 cluster_raft_current_term] > $old_term &&
+            [CI 2 cluster_raft_current_term] > $old_term &&
+            ([CI 1 cluster_raft_role] eq "leader" ||
+             [CI 2 cluster_raft_role] eq "leader")
         } else {
-            fail "no new leader elected after leader shutdown (term0=[CI $s0 cluster_raft_current_term] term1=[CI $s1 cluster_raft_current_term] role0=[CI $s0 cluster_raft_role] role1=[CI $s1 cluster_raft_role])"
+            fail "no new leader elected after leader shutdown (term1=[CI 1 cluster_raft_current_term] term2=[CI 2 cluster_raft_current_term] role1=[CI 1 cluster_raft_role] role2=[CI 2 cluster_raft_role])"
         }
 
-        if {[CI $s0 cluster_raft_role] eq "leader"} {
-            set new_leader_idx $s0
+        if {[CI 1 cluster_raft_role] eq "leader"} {
+            set new_leader_idx 1
         } else {
-            set new_leader_idx $s1
+            set new_leader_idx 2
         }
         set new_leader_id [CI $new_leader_idx cluster_raft_leader]
         assert {$new_leader_id ne $old_leader_id}

--- a/tests/unit/cluster/cluster-raft-prevote.tcl
+++ b/tests/unit/cluster/cluster-raft-prevote.tcl
@@ -1,20 +1,5 @@
 # Test pre-vote behavior in real raft clusters.
 
-proc raft_wait_for_any_prevote_log {srv_a from_a srv_b from_b maxtries delay} {
-    for {set i 0} {$i < $maxtries} {incr i} {
-        set logs_a [exec tail -n +[expr {$from_a + 1}] < [srv $srv_a stdout]]
-        set logs_b [exec tail -n +[expr {$from_b + 1}] < [srv $srv_b stdout]]
-        if {[string match "*Starting Raft pre-vote*" $logs_a]} {
-            return
-        }
-        if {[string match "*Starting Raft pre-vote*" $logs_b]} {
-            return
-        }
-        after $delay
-    }
-    fail "no survivor started Raft pre-vote"
-}
-
 tags {external:skip cluster singledb} {
 
 start_cluster 3 0 {overrides {cluster-protocol raft cluster-node-timeout 500}} {
@@ -23,12 +8,8 @@ start_cluster 3 0 {overrides {cluster-protocol raft cluster-node-timeout 500}} {
 
         set old_term [CI 0 cluster_raft_current_term]
         set old_leader_id [CI 0 cluster_raft_leader]
-        set loglines1 [count_log_lines -1]
-        set loglines2 [count_log_lines -2]
 
         pause_process [srv 0 pid]
-
-        raft_wait_for_any_prevote_log -1 $loglines1 -2 $loglines2 200 100
 
         wait_for_condition 200 100 {
             [CI 1 cluster_raft_current_term] > $old_term &&
@@ -41,12 +22,15 @@ start_cluster 3 0 {overrides {cluster-protocol raft cluster-node-timeout 500}} {
 
         if {[CI 1 cluster_raft_role] eq "leader"} {
             set new_leader_idx 1
+            set new_leader_log_idx -1
         } else {
             set new_leader_idx 2
+            set new_leader_log_idx -2
         }
         set new_leader_id [CI $new_leader_idx cluster_raft_leader]
         assert {$new_leader_id ne $old_leader_id}
         assert {[CI $new_leader_idx cluster_raft_current_term] > $old_term}
+        assert {[count_log_message $new_leader_log_idx "Starting Raft pre-vote"] > 0}
     }
 }
 

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -259,6 +259,124 @@ test "Raft proto: REPL_OFFSETS updates node replication offset" {
     }
 }
 
+test "Raft proto: PRE_VOTE denied while leader lease is active" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set cport [expr {[srv 0 port] + 10000}]
+        set fake_id [string repeat "d" 40]
+        set fake_addr "127.0.0.1:9995@19995,,tls-port=0,shard-id=[string repeat e 40]"
+
+        set fd [raft_connect 127.0.0.1 $cport]
+        raft_send $fd "HELLO $fake_id $fake_addr"
+        set reply [raft_recv $fd]
+        assert_match "HI *" $reply
+
+        set term [CI 0 cluster_raft_current_term]
+        set next_term [expr {$term + 1}]
+        raft_send $fd "PRE_VOTE_REQ $fake_id $next_term 0 0"
+        set reply [raft_recv $fd]
+        assert_match "PRE_VOTE $term 0" $reply
+        assert_equal $term [CI 0 cluster_raft_current_term]
+
+        close $fd
+    }
+}
+
+test "Raft proto: PRE_VOTE granted when no leader lease is active" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set cport [expr {[srv 0 port] + 10000}]
+        set candidate1 [string repeat "g" 40]
+        set addr1 "127.0.0.1:9994@19994,,tls-port=0,shard-id=[string repeat h 40]"
+        set candidate2 [string repeat "i" 40]
+        set addr2 "127.0.0.1:9993@19993,,tls-port=0,shard-id=[string repeat j 40]"
+
+        # Link 1: move node from singleton leader -> follower by higher-term VOTE_REQ.
+        set fd1 [raft_connect 127.0.0.1 $cport]
+        raft_send $fd1 "HELLO $candidate1 $addr1"
+        set reply [raft_recv $fd1]
+        assert_match "HI *" $reply
+
+        set term [CI 0 cluster_raft_current_term]
+        set vote_term [expr {$term + 1}]
+        raft_send $fd1 "VOTE_REQ $candidate1 $vote_term 0 0"
+        set reply [raft_recv $fd1]
+        assert_match "VOTE $vote_term 1" $reply
+        assert_equal "follower" [CI 0 cluster_raft_role]
+        assert_equal "" [CI 0 cluster_raft_leader]
+
+        # Link 2: with leader unknown, PRE_VOTE should be grantable.
+        set fd2 [raft_connect 127.0.0.1 $cport]
+        raft_send $fd2 "HELLO $candidate2 $addr2"
+        set reply [raft_recv $fd2]
+        assert_match "HI *" $reply
+
+        set prevote_term [expr {$vote_term + 1}]
+        raft_send $fd2 "PRE_VOTE_REQ $candidate2 $prevote_term 0 0"
+        set reply [raft_recv $fd2]
+        assert_match "PRE_VOTE $prevote_term 1" $reply
+        assert_equal $vote_term [CI 0 cluster_raft_current_term]
+
+        close $fd1
+        close $fd2
+    }
+}
+
+test "Raft proto: PRE_VOTE denied when candidate log is stale" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set cport [expr {[srv 0 port] + 10000}]
+
+        # 1) Seed one committed log entry so receiver's last_log is not empty.
+        set seed_id [string repeat "k" 40]
+        set seed_addr "127.0.0.1:9992@19992,,tls-port=0,shard-id=[string repeat l 40]"
+        set joined_id [string repeat "m" 40]
+        set joined_addr "127.0.0.1:9991@19991,,tls-port=0,shard-id=[string repeat l 40]"
+        set fd_seed [raft_connect 127.0.0.1 $cport]
+        raft_send $fd_seed "HELLO $seed_id $seed_addr"
+        set reply [raft_recv $fd_seed]
+        assert_match "HI *" $reply
+
+        set ae "AE $seed_id 1 0 0 1 1\n"
+        append ae "1 NODE_JOIN $joined_id $joined_addr"
+        raft_send $fd_seed $ae
+        set reply [raft_recv $fd_seed]
+        assert_match "AE_ACK 1 1 1 *" $reply
+        assert {[CI 0 cluster_raft_log_entries] >= 1}
+
+        # 2) Step down with higher-term VOTE_REQ to clear known leader lease gate.
+        set voter_id [string repeat "n" 40]
+        set voter_addr "127.0.0.1:9990@19990,,tls-port=0,shard-id=[string repeat o 40]"
+        set fd_vote [raft_connect 127.0.0.1 $cport]
+        raft_send $fd_vote "HELLO $voter_id $voter_addr"
+        set reply [raft_recv $fd_vote]
+        assert_match "HI *" $reply
+
+        set current_term [CI 0 cluster_raft_current_term]
+        set vote_term [expr {$current_term + 1}]
+        raft_send $fd_vote "VOTE_REQ $voter_id $vote_term 1 1"
+        set reply [raft_recv $fd_vote]
+        assert_match "VOTE $vote_term 1" $reply
+        assert_equal "follower" [CI 0 cluster_raft_role]
+        assert_equal "" [CI 0 cluster_raft_leader]
+
+        # 3) Candidate with stale log (0/0) must be denied.
+        set stale_id [string repeat "p" 40]
+        set stale_addr "127.0.0.1:9989@19989,,tls-port=0,shard-id=[string repeat q 40]"
+        set fd_prevote [raft_connect 127.0.0.1 $cport]
+        raft_send $fd_prevote "HELLO $stale_id $stale_addr"
+        set reply [raft_recv $fd_prevote]
+        assert_match "HI *" $reply
+
+        set prevote_term [expr {$vote_term + 1}]
+        raft_send $fd_prevote "PRE_VOTE_REQ $stale_id $prevote_term 0 0"
+        set reply [raft_recv $fd_prevote]
+        assert_match "PRE_VOTE $vote_term 0" $reply
+        assert_equal $vote_term [CI 0 cluster_raft_current_term]
+
+        close $fd_seed
+        close $fd_vote
+        close $fd_prevote
+    }
+}
+
 test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
         set port [srv 0 port]

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -70,8 +70,9 @@ proc raft_listen_and_accept {port_var {timeout 5000}} {
     }
     set listen_fd [socket -server _raft_on_accept -myaddr 127.0.0.1 0]
     set listen_port [lindex [fconfigure $listen_fd -sockname] 2]
-    after $timeout {set ::_raft_accepted timeout}
+    set accept_after [after $timeout {set ::_raft_accepted timeout}]
     vwait ::_raft_accepted
+    after cancel $accept_after
     close $listen_fd
     if {$::_raft_accepted eq "timeout"} {
         error "timeout waiting for connection"
@@ -412,8 +413,9 @@ test "Raft proto: pre-vote timeout does not inflate term without quorum" {
         assert_equal 2 [CI 0 cluster_raft_current_term]
         assert_equal 2 [CI 0 cluster_size]
 
-        after 5000 {set ::_raft_accepted timeout}
+        set accept_after [after 5000 {set ::_raft_accepted timeout}]
         vwait ::_raft_accepted
+        after cancel $accept_after
         close $listen_fd
         assert {$::_raft_accepted ne "timeout"}
         set fd $::_raft_accepted
@@ -480,8 +482,9 @@ test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
         $meet_client CLUSTER MEET 127.0.0.1 $fake_port
 
         # Wait for the leader to connect.
-        after 5000 {set ::_raft_accepted timeout}
+        set accept_after [after 5000 {set ::_raft_accepted timeout}]
         vwait ::_raft_accepted
+        after cancel $accept_after
         close $listen_fd
         assert {$::_raft_accepted ne "timeout"}
         set fd $::_raft_accepted

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -377,6 +377,83 @@ test "Raft proto: PRE_VOTE denied when candidate log is stale" {
     }
 }
 
+test "Raft proto: pre-vote timeout does not inflate term without quorum" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 500}} {
+        set cport [expr {[srv 0 port] + 10000}]
+        set node_id [R 0 CLUSTER MYID]
+        set fake_id [string repeat "r" 40]
+
+        # Listen for the server's outbound link to the fake peer. Pre-vote and
+        # RequestVote broadcasts use node->link, not the inbound leader link.
+        set ::_raft_accepted ""
+        proc _raft_on_accept_prevote {fd addr port} {
+            fconfigure $fd -translation binary -buffering full
+            set ::_raft_accepted $fd
+        }
+        set listen_fd [socket -server _raft_on_accept_prevote -myaddr 127.0.0.1 0]
+        set fake_cport [lindex [fconfigure $listen_fd -sockname] 2]
+        set fake_port [expr {$fake_cport - 10000}]
+        set fake_addr "127.0.0.1:${fake_port}@${fake_cport},,tls-port=0,shard-id=[string repeat s 40]"
+
+        set leader_fd [raft_connect 127.0.0.1 $cport]
+        raft_send $leader_fd "HELLO $fake_id $fake_addr"
+        set reply [raft_recv $leader_fd]
+        assert_match "HI *" $reply
+
+        # Commit both nodes into the fake leader's log. The real node must see
+        # the fake peer as joined, otherwise pre-vote requests are skipped.
+        set ae "AE $fake_id 2 0 0 2 2\n"
+        append ae "2 NODE_JOIN $node_id 127.0.0.1:[srv 0 port]@[expr {[srv 0 port] + 10000}],,tls-port=0,shard-id=[string repeat t 40]\n"
+        append ae "2 NODE_JOIN $fake_id $fake_addr"
+        raft_send $leader_fd $ae
+        set reply [raft_recv $leader_fd]
+        assert_match "AE_ACK 2 1 2 *" $reply
+        assert_equal "follower" [CI 0 cluster_raft_role]
+        assert_equal 2 [CI 0 cluster_raft_current_term]
+        assert_equal 2 [CI 0 cluster_size]
+
+        after 5000 {set ::_raft_accepted timeout}
+        vwait ::_raft_accepted
+        close $listen_fd
+        assert {$::_raft_accepted ne "timeout"}
+        set fd $::_raft_accepted
+
+        set reply [raft_recv $fd]
+        assert_match "HELLO *" $reply
+        raft_send $fd "HI $fake_id $fake_addr"
+
+        # Stop heartbeats. The follower should pre-vote in term+1, but without
+        # a grant it must not increment its persisted current term.
+        set reply [raft_recv $fd 5000]
+        assert_match "PRE_VOTE_REQ $node_id 3 2 2" $reply
+        assert_equal 2 [CI 0 cluster_raft_current_term]
+
+        # Do not respond to the first pre-vote. A later timeout starts a new
+        # pre-vote without changing the persisted term.
+        assert_equal 2 [CI 0 cluster_raft_current_term]
+
+        # Granting the second pre-vote should move the
+        # node into a real election and broadcast VOTE_REQ with the bumped term.
+        set reply [raft_recv $fd 5000]
+        assert_match "PRE_VOTE_REQ $node_id 3 2 2" $reply
+        raft_send $fd "PRE_VOTE 3 1"
+
+        set found_vote_req 0
+        for {set i 0} {$i < 20} {incr i} {
+            set reply [raft_recv $fd 5000]
+            if {[string match "VOTE_REQ $node_id 3 2 2" $reply]} {
+                set found_vote_req 1
+                break
+            }
+        }
+        assert_equal 1 $found_vote_req "pre-vote grant should start a real election"
+        assert_equal 3 [CI 0 cluster_raft_current_term]
+
+        close $fd
+        close $leader_fd
+    }
+}
+
 test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
         set port [srv 0 port]

--- a/tests/unit/cluster/cluster-raft-proto.tcl
+++ b/tests/unit/cluster/cluster-raft-proto.tcl
@@ -59,9 +59,10 @@ proc raft_recv {fd {timeout 5000}} {
 
 tags {tls:skip external:skip cluster singledb} {
 
-# Listen on a random port, accept one connection, close the listener.
-# Returns the accepted client fd. Sets the listen port in the upvar port_var.
-proc raft_listen_and_accept {port_var {timeout 5000}} {
+# Listen on a random port, run optional setup code, accept one connection, close
+# the listener. Returns the accepted client fd. Sets the listen port in the
+# upvar port_var before running the setup code.
+proc raft_listen_and_accept {port_var {timeout 5000} {before_accept {}}} {
     upvar $port_var listen_port
     set ::_raft_accepted ""
     proc _raft_on_accept {fd addr port} {
@@ -70,6 +71,9 @@ proc raft_listen_and_accept {port_var {timeout 5000}} {
     }
     set listen_fd [socket -server _raft_on_accept -myaddr 127.0.0.1 0]
     set listen_port [lindex [fconfigure $listen_fd -sockname] 2]
+    if {$before_accept ne {}} {
+        uplevel 1 $before_accept
+    }
     set accept_after [after $timeout {set ::_raft_accepted timeout}]
     vwait ::_raft_accepted
     after cancel $accept_after
@@ -196,70 +200,6 @@ test "Raft proto: joiner reverts to leader after timeout" {
 }
 
 
-test "Raft proto: REPL_OFFSETS updates node replication offset" {
-    start_server {overrides {cluster-enabled yes cluster-protocol raft}} {
-        set port [srv 0 port]
-        set cport [expr {$port + 10000}]
-        set node_id [R 0 CLUSTER MYID]
-
-        # Fake node IDs: one for us (the "leader") and one for a "replica".
-        set leader_id [string repeat "a" 40]
-        set replica_id [string repeat "c" 40]
-        set leader_shard [string repeat "b" 40]
-        set leader_addr "127.0.0.1:9999@19999,,tls-port=0,shard-id=$leader_shard"
-        set replica_addr "127.0.0.1:9998@19998,,tls-port=0,shard-id=$leader_shard"
-
-        # Connect and do HELLO/HI handshake.
-        set fd [raft_connect 127.0.0.1 $cport]
-        raft_send $fd "HELLO $leader_id $leader_addr 1 3 2"
-        set reply [raft_recv $fd]
-        assert_match "HI *" $reply
-
-        # Send AE to establish ourselves as leader and add the replica
-        # via NODE_JOIN in the log.
-        # AE <leader-id> <term> <prev-log-idx> <prev-log-term> <commit> <count>
-        # Entry: <term> <type> <data>
-        set ae "AE $leader_id 1 0 0 2 2\n"
-        append ae "1 NODE_JOIN $replica_id $replica_addr\n"
-        append ae "1 SET_REPLICA_OF $replica_id $leader_id $leader_shard"
-        raft_send $fd $ae
-
-        # Read AE_ACK.
-        set reply [raft_recv $fd]
-        assert_match "AE_ACK *" $reply
-
-        # Verify the replica exists in CLUSTER SHARDS.
-        set shards [R 0 CLUSTER SHARDS]
-        set found 0
-        foreach shard $shards {
-            foreach node [dict get $shard nodes] {
-                if {[dict get $node id] eq $replica_id} {
-                    set found 1
-                }
-            }
-        }
-        assert_equal 1 $found "replica should appear in CLUSTER SHARDS"
-
-        # Send REPL_OFFSETS to update the replica's offset.
-        raft_send $fd "REPL_OFFSETS $replica_id 42000"
-
-        # Give it a moment to process.
-        after 100
-
-        # Verify the offset was updated.
-        set shards [R 0 CLUSTER SHARDS]
-        foreach shard $shards {
-            foreach node [dict get $shard nodes] {
-                if {[dict get $node id] eq $replica_id} {
-                    assert_equal 42000 [dict get $node replication-offset]
-                }
-            }
-        }
-
-        close $fd
-    }
-}
-
 test "Raft proto: PRE_VOTE denied while leader lease is active" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
         set cport [expr {[srv 0 port] + 10000}]
@@ -384,41 +324,30 @@ test "Raft proto: pre-vote timeout does not inflate term without quorum" {
         set node_id [R 0 CLUSTER MYID]
         set fake_id [string repeat "r" 40]
 
-        # Listen for the server's outbound link to the fake peer. Pre-vote and
-        # RequestVote broadcasts use node->link, not the inbound leader link.
-        set ::_raft_accepted ""
-        proc _raft_on_accept_prevote {fd addr port} {
-            fconfigure $fd -translation binary -buffering full
-            set ::_raft_accepted $fd
-        }
-        set listen_fd [socket -server _raft_on_accept_prevote -myaddr 127.0.0.1 0]
-        set fake_cport [lindex [fconfigure $listen_fd -sockname] 2]
-        set fake_port [expr {$fake_cport - 10000}]
-        set fake_addr "127.0.0.1:${fake_port}@${fake_cport},,tls-port=0,shard-id=[string repeat s 40]"
+        # Pre-vote and RequestVote broadcasts use node->link, not the inbound
+        # leader link, so listen for the server's outbound link to the fake peer.
+        set fake_cport 0
+        set fd [raft_listen_and_accept fake_cport 5000 {
+            set fake_port [expr {$fake_cport - 10000}]
+            set fake_addr "127.0.0.1:${fake_port}@${fake_cport},,tls-port=0,shard-id=[string repeat s 40]"
 
-        set leader_fd [raft_connect 127.0.0.1 $cport]
-        raft_send $leader_fd "HELLO $fake_id $fake_addr"
-        set reply [raft_recv $leader_fd]
-        assert_match "HI *" $reply
+            set leader_fd [raft_connect 127.0.0.1 $cport]
+            raft_send $leader_fd "HELLO $fake_id $fake_addr"
+            set reply [raft_recv $leader_fd]
+            assert_match "HI *" $reply
 
-        # Commit both nodes into the fake leader's log. The real node must see
-        # the fake peer as joined, otherwise pre-vote requests are skipped.
-        set ae "AE $fake_id 2 0 0 2 2\n"
-        append ae "2 NODE_JOIN $node_id 127.0.0.1:[srv 0 port]@[expr {[srv 0 port] + 10000}],,tls-port=0,shard-id=[string repeat t 40]\n"
-        append ae "2 NODE_JOIN $fake_id $fake_addr"
-        raft_send $leader_fd $ae
-        set reply [raft_recv $leader_fd]
-        assert_match "AE_ACK 2 1 2 *" $reply
-        assert_equal "follower" [CI 0 cluster_raft_role]
-        assert_equal 2 [CI 0 cluster_raft_current_term]
-        assert_equal 2 [CI 0 cluster_size]
-
-        set accept_after [after 5000 {set ::_raft_accepted timeout}]
-        vwait ::_raft_accepted
-        after cancel $accept_after
-        close $listen_fd
-        assert {$::_raft_accepted ne "timeout"}
-        set fd $::_raft_accepted
+            # Commit both nodes into the fake leader's log. The real node must
+            # see the fake peer as joined, otherwise pre-vote requests are skipped.
+            set ae "AE $fake_id 2 0 0 2 2\n"
+            append ae "2 NODE_JOIN $node_id 127.0.0.1:[srv 0 port]@[expr {[srv 0 port] + 10000}],,tls-port=0,shard-id=[string repeat t 40]\n"
+            append ae "2 NODE_JOIN $fake_id $fake_addr"
+            raft_send $leader_fd $ae
+            set reply [raft_recv $leader_fd]
+            assert_match "AE_ACK 2 1 2 *" $reply
+            assert_equal "follower" [CI 0 cluster_raft_role]
+            assert_equal 2 [CI 0 cluster_raft_current_term]
+            assert_equal 2 [CI 0 cluster_size]
+        }]
 
         set reply [raft_recv $fd]
         assert_match "HELLO *" $reply
@@ -456,6 +385,70 @@ test "Raft proto: pre-vote timeout does not inflate term without quorum" {
     }
 }
 
+test "Raft proto: REPL_OFFSETS updates node replication offset" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft}} {
+        set port [srv 0 port]
+        set cport [expr {$port + 10000}]
+        set node_id [R 0 CLUSTER MYID]
+
+        # Fake node IDs: one for us (the "leader") and one for a "replica".
+        set leader_id [string repeat "a" 40]
+        set replica_id [string repeat "c" 40]
+        set leader_shard [string repeat "b" 40]
+        set leader_addr "127.0.0.1:9999@19999,,tls-port=0,shard-id=$leader_shard"
+        set replica_addr "127.0.0.1:9998@19998,,tls-port=0,shard-id=$leader_shard"
+
+        # Connect and do HELLO/HI handshake.
+        set fd [raft_connect 127.0.0.1 $cport]
+        raft_send $fd "HELLO $leader_id $leader_addr 1 3 2"
+        set reply [raft_recv $fd]
+        assert_match "HI *" $reply
+
+        # Send AE to establish ourselves as leader and add the replica
+        # via NODE_JOIN in the log.
+        # AE <leader-id> <term> <prev-log-idx> <prev-log-term> <commit> <count>
+        # Entry: <term> <type> <data>
+        set ae "AE $leader_id 1 0 0 2 2\n"
+        append ae "1 NODE_JOIN $replica_id $replica_addr\n"
+        append ae "1 SET_REPLICA_OF $replica_id $leader_id $leader_shard"
+        raft_send $fd $ae
+
+        # Read AE_ACK.
+        set reply [raft_recv $fd]
+        assert_match "AE_ACK *" $reply
+
+        # Verify the replica exists in CLUSTER SHARDS.
+        set shards [R 0 CLUSTER SHARDS]
+        set found 0
+        foreach shard $shards {
+            foreach node [dict get $shard nodes] {
+                if {[dict get $node id] eq $replica_id} {
+                    set found 1
+                }
+            }
+        }
+        assert_equal 1 $found "replica should appear in CLUSTER SHARDS"
+
+        # Send REPL_OFFSETS to update the replica's offset.
+        raft_send $fd "REPL_OFFSETS $replica_id 42000"
+
+        # Give it a moment to process.
+        after 100
+
+        # Verify the offset was updated.
+        set shards [R 0 CLUSTER SHARDS]
+        foreach shard $shards {
+            foreach node [dict get $shard nodes] {
+                if {[dict get $node id] eq $replica_id} {
+                    assert_equal 42000 [dict get $node replication-offset]
+                }
+            }
+        }
+
+        close $fd
+    }
+}
+
 test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
         set port [srv 0 port]
@@ -466,28 +459,15 @@ test "Raft proto: leader sends REPL_OFFSETS after follower offset changes" {
 
         # Start listening before MEET so the leader can connect.
         set cport 0
-        set ::_raft_accepted ""
-        proc _raft_on_accept {fd addr port} {
-            fconfigure $fd -translation binary -buffering full
-            set ::_raft_accepted $fd
-        }
-        set listen_fd [socket -server _raft_on_accept -myaddr 127.0.0.1 0]
-        set cport [lindex [fconfigure $listen_fd -sockname] 2]
-        set fake_port [expr {$cport - 10000}]
-        set fake_addr "127.0.0.1:${fake_port}@${cport},,tls-port=0,shard-id=$fake_shard"
+        set fd [raft_listen_and_accept cport 5000 {
+            set fake_port [expr {$cport - 10000}]
+            set fake_addr "127.0.0.1:${fake_port}@${cport},,tls-port=0,shard-id=$fake_shard"
 
-        # Send CLUSTER MEET without waiting for reply (it blocks until
-        # NODE_JOIN commits, which needs our AE_ACK).
-        set meet_client [valkey_deferring_client]
-        $meet_client CLUSTER MEET 127.0.0.1 $fake_port
-
-        # Wait for the leader to connect.
-        set accept_after [after 5000 {set ::_raft_accepted timeout}]
-        vwait ::_raft_accepted
-        after cancel $accept_after
-        close $listen_fd
-        assert {$::_raft_accepted ne "timeout"}
-        set fd $::_raft_accepted
+            # Send CLUSTER MEET without waiting for reply (it blocks until
+            # NODE_JOIN commits, which needs our AE_ACK).
+            set meet_client [valkey_deferring_client]
+            $meet_client CLUSTER MEET 127.0.0.1 $fake_port
+        }]
 
         # Leader sends HELLO + MEET(singleton).
         set reply [raft_recv $fd 5000]


### PR DESCRIPTION
Closes #3860 
## Summary
This PR adds the Pre-Vote extension to Valkey’s Raft-based cluster bus (cluster-protocol raft). Election timeouts now trigger a speculative `PRE_VOTE_REQ` round before current_term is incremented. A node only starts a real election (`VOTE_REQ`) after receiving pre-vote grants from a majority.

This directly addresses the disruption problem described in Diego Ongaro’s dissertation §9.6 (Preventing disruptions when a server rejoins the cluster): a partitioned server should not inflate its term and force an unnecessary leader step-down when it rejoins a healthy majority that is still receiving heartbeats from a valid leader.

## Motivation (Raft §9.6)
Without Pre-Vote, a partitioned follower:
- Stops receiving heartbeats
- Times out and increments current_term to start an election (but cannot win)
- Rejoins the cluster with a higher term
- Propagates that term via VOTE_REQ or AppendEntries responses
- Forces the current leader to step down → **unnecessary election**

With Pre-Vote, a partitioned server:
- Times out but only enters pre-candidate state
- Sends PRE_VOTE_REQ with future term (current_term + 1) without incrementing local term
- Cannot collect a majority of speculative grants while partitioned
- On rejoin, the majority still has an active leader lease (recent heartbeats) → pre-vote is denied
- Once the node receives a real heartbeat, it returns to stable follower state in the same term

It works like this:
```mermaid
flowchart TB
    subgraph Without["Without Pre-Vote (partitioned node)"]
        A1[No heartbeats] --> A2[Timeout]
        A2 --> A3["current_term++"]
        A3 --> A4[Rejoin with higher term]
        A4 --> A5[Force leader step-down]
    end

    subgraph With["With Pre-Vote (partitioned node)"]
        B1[No heartbeats] --> B2[Timeout]
        B2 --> B3[PRE_CANDIDATE<br/>term unchanged]
        B3 --> B4[PRE_VOTE_REQ<br/>term = current+1]
        B4 --> B5{Majority grants?}
        B5 -->|No| B6[Stay at same term]
        B6 --> B7[Rejoin + receive heartbeat]
        B7 --> B8[Stable follower]
        B5 -->|Yes| B9[Real election]
    end
```

## Implementation Overview
### New role and state
Addition | Purpose
-- | --
RAFT_ROLE_PRE_CANDIDATE | Transient state during speculative voting
pre_votes_received | Quorum counter for pre-vote grants
pre_vote_started | Timestamp for pre-vote round timeout

Exposed via CLUSTER INFO as cluster_raft_role:precandidate.

### New wire messages
```text
PRE_VOTE_REQ <candidate-id> <term> <last-log-index> <last-log-term>
PRE_VOTE       <term> <granted>
```
PRE_VOTE_REQ uses future term = receiver’s current_term + 1 (candidate does not bump term yet).
PRE_VOTE responses always sent (like VOTE), so candidates can learn higher terms from denials.
Documented in `design-docs/cluster-raft.md`.

### Election flow change
After this, the election flow should be like this:
```mermaid
stateDiagram-v2
    [*] --> Follower
    Follower --> PreCandidate: election timeout
    PreCandidate --> Candidate: majority PRE_VOTE grants
    PreCandidate --> Follower: pre-vote timeout (no quorum)
    Candidate --> Leader: majority VOTE grants
    Candidate --> Follower: election lost / higher term seen
    Leader --> Follower: step down (higher term)
    Follower --> Candidate: TIMEOUT_NOW (leader transfer)
    note right of PreCandidate
        term NOT incremented
    end note
    note right of Candidate
        term incremented
    end note
```
Cron behavior (clusterRaftCron):

FOLLOWER / CANDIDATE timeout → clusterRaftStartPreVote() (was: direct clusterRaftStartElection())
PRE_CANDIDATE timeout without quorum → revert to FOLLOWER, no term change
TIMEOUT_NOW (graceful leader transfer) → still skips pre-vote, calls clusterRaftStartElection() directly (per dissertation §3.10 / design doc)

### Shared vote eligibility: `clusterRaftCanGrantVote()`
Both PRE_VOTE_REQ and VOTE_REQ use the same helper:

- Reject joiners (`RAFT_ROLE_JOINER`)
- Leader lease gate: deny if leader is known and `now - last_heartbeat < election_timeout`
- Log up-to-date check: standard Raft comparison on (`last_log_term`, `last_log_index`)
Formal VOTE_REQ handling was also hardened to use this helper (replacing a prior TODO).

### Pre-vote handler details (reviewer-critical)
`clusterRaftProcessPreVote()`
```C
if (msg_term > rs->current_term &&
    clusterRaftCanGrantVote(rs, candidate_last_index, candidate_last_term))
    granted = 1;
```

`clusterRaftProcessPreVoteResponse()`
- A granted `PRE_VOTE` carries future term (`current_term + 1`) → must NOT call `clusterRaftMaybeStepDown()` (would incorrectly bump local term).
- Only denied responses with `msg_term > current_term` may trigger step-down.
- On quorum pre-votes → `clusterRaftStartElection()` (which increments term and sends VOTE_REQ).

`clusterRaftStartPreVote()`
- Sets role to `PRE_CANDIDATE`, counts self pre-vote (`pre_votes_received = 1`)
- Sends `PRE_VOTE_REQ` to peers with active links
- Skips nodes with `CLUSTER_NODE_MEET` (joiners not yet in the log — same constraint as `AE` / `VOTE_REQ`)

## Test Plan
```bash
# Build
make -C src valkey-server -j$(nproc)

# Pre-vote integration tests
./runtest --single tests/unit/cluster/cluster-raft-prevote.tcl --baseport 21200

# Protocol-level PRE_VOTE matrix (+ existing raft proto tests)
./runtest --single tests/unit/cluster/cluster-raft-proto.tcl --baseport 21300
```
Expected: 2/2 prevote tests pass; 9/9 proto tests pass (including 3 new PRE_VOTE cases).

## References
- Diego Ongaro, Consensus: Bridging Theory and Practice, §9.6 — Pre-Vote extension for rejoining servers
- Diego Ongaro, §3.10 — `TIMEOUT_NOW` / leadership transfer (pre-vote bypass)