### PR TITLE
Fix typo option name in repl-ping-replica-period comment in valkey.conf

### DIFF
--- a/valkey.conf
+++ b/valkey.conf
@@ -846,7 +846,7 @@ repl-diskless-load disabled
 dual-channel-replication-enabled no
 
 # Master send PINGs to its replicas in a predefined interval. It's possible to
-# change this interval with the repl_ping_replica_period option. The default
+# change this interval with the repl-ping-replica-period option. The default
 # value is 10 seconds.
 #
 # repl-ping-replica-period 10


### PR DESCRIPTION
Minor cleanup, now it is the real option name.