### PR TITLE
Avoid random() % 0 undefined behaviour when cluster-node-timeout < 30

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -5672,8 +5672,8 @@ void clusterHandleReplicaFailover(void) {
      * elapsed, we can setup a new one. */
     if (auth_age > auth_retry_time) {
         server.cluster->failover_auth_time = now +
-                                             delay +           /* Fixed delay to let FAIL msg propagate. */
-                                             random() % delay; /* Random delay between 0 and the fixed delay. */
+                                             delay +                         /* Fixed delay to let FAIL msg propagate. */
+                                             (delay ? random() % delay : 0); /* Random delay between 0 and the fixed delay. */
         server.cluster->failover_auth_count = 0;
         server.cluster->failover_auth_sent = 0;
         server.cluster->failover_auth_rank = clusterGetReplicaRank();

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -278,9 +278,5 @@ start_cluster 3 1 {tags {external:skip cluster}} {
 } ;# start_cluster
 
 start_cluster 3 1 {tags {external:skip cluster}} {
-    test_small_timeout 15
-} ;# start_cluster
-
-start_cluster 3 1 {tags {external:skip cluster}} {
     test_small_timeout 0
 } ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -257,3 +257,30 @@ start_cluster 5 5 {tags {external:skip cluster}} {
         }
     }
 } ;# start_cluster
+
+proc test_small_timeout {timeout} {
+    test "Failover with cluster-node-time set to $timeout" {
+        R 3 config set cluster-node-timeout $timeout
+
+        pause_process [srv 0 pid]
+        wait_for_condition 1000 50 {
+            [s -3 role] == "master"
+        } else {
+            fail "Failover did not happen"
+        }
+
+        resume_process [srv 0 pid]
+    }
+}
+
+start_cluster 3 1 {tags {external:skip cluster}} {
+    test_small_timeout 30
+} ;# start_cluster
+
+start_cluster 3 1 {tags {external:skip cluster}} {
+    test_small_timeout 20
+} ;# start_cluster
+
+start_cluster 3 1 {tags {external:skip cluster}} {
+    test_small_timeout 0
+} ;# start_cluster

--- a/tests/unit/cluster/failover.tcl
+++ b/tests/unit/cluster/failover.tcl
@@ -278,7 +278,7 @@ start_cluster 3 1 {tags {external:skip cluster}} {
 } ;# start_cluster
 
 start_cluster 3 1 {tags {external:skip cluster}} {
-    test_small_timeout 20
+    test_small_timeout 15
 } ;# start_cluster
 
 start_cluster 3 1 {tags {external:skip cluster}} {


### PR DESCRIPTION
Since #2449 made the failover delay relative to cluster-node-timeout.
Now delay = min(cluster-node-timeout / 30, 500), any cluster-node-timeout
below 30, including the legal minimum 0 will collapses delay to zero,
and `x % 0` is undefined behaviour.