### PR TITLE
Exit with error when getRDB ftruncate fails

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -8939,8 +8939,10 @@ static void getRDB(clusterManagerNode *node) {
     }
     if (usemark) {
         payload = ULLONG_MAX - payload - RDB_EOF_MARK_SIZE;
-        if (!write_to_stdout && ftruncate(fd, payload) == -1)
+        if (!write_to_stdout && ftruncate(fd, payload) == -1) {
             fprintf(stderr, "ftruncate failed: %s.\n", strerror(errno));
+            exit(1);
+        }
         fprintf(stderr, "Transfer finished with success after %llu bytes\n", payload);
     } else {
         fprintf(stderr, "Transfer finished with success.\n");


### PR DESCRIPTION
When `valkey-cli --rdb` trims the EOF marker, a failed `ftruncate` only printed a warning but still reported success and exited 0, leaving a corrupt RDB file. This makes it exit non-zero on that failure, matching how the `write()` failure is already handled in the same function.

(Thank you, Madelyn, for tag teaming this with me.)