### PR TITLE
Increase the cluster-node-timeout to have longer delay between failover of each shard

### DIFF
--- a/tests/unit/cluster/failover2.tcl
+++ b/tests/unit/cluster/failover2.tcl
@@ -64,7 +64,7 @@ start_cluster 3 4 {tags {external:skip cluster} overrides {cluster-ping-interval
     }
 } ;# start_cluster
 
-start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000}} {
+start_cluster 7 3 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 15000}} {
     test "Primaries will not time out then they are elected in the same epoch" {
         # Since we have the delay time, so these node may not initiate the
         # election at the same time (same epoch). But if they do, we make


### PR DESCRIPTION
We previously attempted to set `cluster-node-timeout` to 15000 in #2793
but failed. This was because we did not explicitly specify it and relied
on the default value, but `start_cluster` internally sets it to 3000.

Closes #3932.