### PR TITLE
Align THP advice in createLatencyReport with checkTHPEnabled

### DIFF
--- a/src/latency.c
+++ b/src/latency.c
@@ -484,11 +484,11 @@ sds createLatencyReport(void) {
             report =
                 sdscat(report, "- I detected a non zero amount of anonymous huge pages used by your process. This "
                                "creates very serious latency events in different conditions, especially when "
-                               "Valkey is persisting on disk. To disable THP support use the command 'echo never > "
+                               "Valkey is persisting on disk. To disable THP support use the command 'echo madvise > "
                                "/sys/kernel/mm/transparent_hugepage/enabled', make sure to also add it into "
                                "/etc/rc.local so that the command will be executed again after a reboot. Note "
-                               "that even if you have already disabled THP, you still need to restart the Valkey "
-                               "process to get rid of the huge pages already created.\n");
+                               "that even if you have already disabled THP (set to 'madvise' or 'never'), you still "
+                               "need to restart the Valkey process to get rid of the huge pages already created.\n");
         }
     }
 


### PR DESCRIPTION
The latency report told users to run 'echo never > .../enabled' to
disable THP, but checkTHPEnabled recommends 'echo madvise' and notes
that 'madvise' or 'never' are both valid. Make createLatencyReport
consistent: suggest 'madvise' in the command and mention both values
in the accompanying note.

This advice was originally added in 1461f02deb65585bb47c4d50d68ef733edfba6f9.