### PR TITLE
Deflake clusterscan "cluster down and unassigned slots" test

### DIFF
--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -582,7 +582,7 @@ start_cluster 2 0 {tags {external:skip cluster}} {
     }
 }
 
-start_cluster 3 0 {tags {external:skip cluster}} {
+start_cluster 3 0 {tags {external:skip cluster} overrides {cluster-node-timeout 1000}} {
     test "CLUSTERSCAN returns correct errors on cluster down and unassigned slots" {
         # Hashtag reference: {06S} -> slot 0 -> R0, {6ZJ} -> slot 16383 -> R2.
 


### PR DESCRIPTION
This changes lowers the `cluster-node-timeout` to `1000` for this test's cluster, so failure is detected well within the wait window even on slow runners. Since the node is marked as failed after the timeout has elapsed, on slow runners, it might take 2-3 times more than the configured timeout, and preemptively return cluster state `ok`. 

The same `cluster-node-timeout 1000` override is already used for the same reason in some other [tests](https://github.com/valkey-io/valkey/blob/unstable/tests/unit/cluster/info.tcl), as well.

Stress run: https://github.com/sarthakaggarwal97/valkey/actions/runs/27186417222/job/80256227973

Fixes #3891