### PR TITLE
Deflake cluster-shards "same shard id after restart" test

### DIFF
--- a/tests/unit/cluster/cluster-shards.tcl
+++ b/tests/unit/cluster/cluster-shards.tcl
@@ -84,7 +84,12 @@ proc cluster_ensure_master {id} {
 }
 
 # start_cluster 4 masters + 5 nodes (4 replicas + 1 standalone R8)
-start_cluster 4 5 {tags {external:skip cluster}} {
+# Disable automatic replica migration: this block manually attaches an extra
+# replica (R8) to a primary, which would otherwise let a replica migrate to a
+# transiently-orphaned primary during the cluster restart test and change its
+# shard id. Migration semantics are not under test here (CLUSTER REPLICATE is
+# manual and unaffected).
+start_cluster 4 5 {tags {external:skip cluster} overrides {cluster-allow-replica-migration no}} {
 
 # cluster_master_nodes and cluster_replica_nodes refer to the active cluster members.
 set ::cluster_master_nodes 4


### PR DESCRIPTION
This test runs `start_cluster 4 5` and manually attaches an extra replica with `CLUSTER REPLICATE`, so one primary ends up with two replicas while the others have one. It then pauses and restarts all 8 nodes and asserts that every node's shard id is unchanged.

This is why the test fails:

- A primary is termed "orphaned" when it owns slots and is flagged `MIGRATE_TO`, but currently has zero working replicas.
- When a primary is orphaned, the cluster moves a spare replica to it. A replica is only spare if its current primary would still have more than `cluster-migration-barrier` replicas after it leaves (default barrier is 1).
- A migrating replica adopts the target primary's shard id, so its shard id changes.

During the staggered restart, a primary can be left with no reachable replica for a short window and become orphaned. Once the cluster returns to OK, the primary that has two replicas is the only one eligible to donate, so one of its replicas migrates to the orphaned primary and takes on its shard id. 

The fix is to set `cluster-allow-replica-migration no` on this block so replicas stay with their original primaries across the restart. Replica migration is not what this test is checking.

Stress Test Passing 100 times: https://github.com/sarthakaggarwal97/valkey/actions/runs/27186417222/job/80256227970

Fixes #3914 