### PR TITLE
Fix crash when active field-expiry leaves a single-entry HT vset buck…

### DIFF
--- a/src/unit/test_vset.cpp
+++ b/src/unit/test_vset.cpp
@@ -410,6 +410,67 @@ TEST_F(VsetTest, TestVsetRemoveExpireShrink) {
     vsetRelease(&set);
 }
 
+/* Regression test for the HT-bucket-size-1 invariant violation.
+ *
+ * vsetBucketRemoveExpired_HASHTABLE() drains an HT-encoded time-bucket up to
+ * a caller-supplied quota but only collapses the bucket when it becomes
+ * fully empty -- it never downgrades HT -> SINGLE when a single entry
+ * survives. This mirrors the production active-expire path
+ * (dbReclaimExpiredFields -> hashTypeDeleteExpiredFields -> vsetRemoveExpired),
+ * whose per-key quota can stop one entry short of draining the bucket.
+ *
+ * Once an HT bucket is left holding exactly one entry, removing that entry
+ * through the *normal* removal path (vsetRemoveEntry -> removeFromBucket_HASHTABLE,
+ * the same path HDEL and a cross-bucket HSETEX update take) deletes the sole
+ * entry and trips:
+ *
+ *     assert(hashtableSize(ht) > 0);   // vset.c, removeFromBucket_HASHTABLE
+ *
+ * because the size goes 1 -> 0. The production crash hit this via
+ * hsetexCommand -> hashTypeSet -> hashTypeTrackUpdateEntry -> vsetUpdateEntry
+ * -> vsetBucketUpdateEntry_RAX -> removeEntryFromRaxBucket -> removeFromBucket_HASHTABLE.
+ *
+ * This test reproduces the precondition deterministically (no timing race):
+ * fill one time-bucket past the VECTOR->HT threshold, expire all but one
+ * entry, then remove the survivor via vsetRemoveEntry. */
+TEST_F(VsetTest, TestVsetRemoveExpiredLeavesHtBucketSizeOne) {
+    vset set;
+    vsetInit(&set);
+
+    /* 200 > VOLATILESET_VECTOR_BUCKET_MAX_SIZE (127): same expiry forces a
+     * single time-bucket that converts to HT encoding. */
+    const long long expiry_time = 1000LL;
+    const size_t total_entries = 200;
+
+    for (size_t i = 0; i < total_entries; i++) {
+        insert_mock_entry_with_expiry(&set, expiry_time);
+    }
+    ASSERT_FALSE(vsetIsEmpty(&set));
+
+    /* Active-expire style drain that stops one entry short of empty,
+     * exactly as the per-key quota does in dbReclaimExpiredFields. This
+     * leaves the HT bucket holding a single entry. */
+    mstime_t now = expiry_time + 10000;
+    size_t count = vsetRemoveExpired(&set, mockGetExpiry, mock_entry_expire, now, mock_entry_count - 1, &now);
+    ASSERT_EQ(count, total_entries - 1);
+    ASSERT_FALSE(vsetIsEmpty(&set));
+    ASSERT_EQ((size_t)mock_entry_count, 1u);
+
+    /* Remove the lone survivor through the normal removal path. With the
+     * bug present this hits removeFromBucket_HASHTABLE on a size-1 HT
+     * bucket and aborts on assert(hashtableSize(ht) > 0). With the fix
+     * (downgrade HT -> SINGLE when one entry remains during expiry) this
+     * succeeds and empties the set. */
+    mock_entry *survivor = mock_entries[0];
+    ASSERT_TRUE(vsetRemoveEntry(&set, mockGetExpiry, survivor));
+    mockFreeEntry(survivor);
+    mock_entries[0] = mock_entries[--mock_entry_count];
+
+    ASSERT_TRUE(vsetIsEmpty(&set));
+
+    vsetRelease(&set);
+}
+
 TEST_F(VsetTest, TestVsetDefrag) {
     srand(time(nullptr));
 

--- a/src/vset.c
+++ b/src/vset.c
@@ -1505,11 +1505,31 @@ static inline size_t vsetBucketRemoveExpired_HASHTABLE(vsetBucket **bucket, vset
     }
     hashtableCleanupIterator(&it);
 
-    /* in case we completed scanning the hashtable which is now empty */
+    /* Collapse or downgrade the bucket based on how many entries remain.
+     *
+     * The active-expire path is bounded by max_count (the per-key expire
+     * quota in dbReclaimExpiredFields), so it can stop *before* the bucket
+     * is fully drained. We must preserve the same bucket-type invariant the
+     * normal removal path relies on:
+     *   - size 0 : free the hashtable, bucket becomes NONE.
+     *   - size 1 : downgrade to SINGLE. An HT bucket must never persist with
+     *              a single entry -- removeFromBucket_HASHTABLE() asserts
+     *              hashtableSize(ht) > 0 after a delete and downgrades to
+     *              SINGLE at size 1. If we leave a size-1 HT bucket here, a
+     *              later normal removal of that entry (HDEL, or a cross-bucket
+     *              HSETEX update via removeEntryFromRaxBucket) deletes the sole
+     *              entry, drops the size 1->0, and trips that assertion. */
     size_t ht_size = hashtableSize(ht);
     if (ht_size == 0) {
         hashtableRelease(ht);
         *bucket = vsetBucketFromNone();
+    } else if (ht_size == 1) {
+        hashtableIterator hi;
+        hashtableInitIterator(&hi, ht, 0);
+        void *ptr;
+        hashtableNext(&hi, &ptr);
+        hashtableRelease(ht);
+        *bucket = vsetBucketFromSingle(ptr);
     }
     return count;
 }


### PR DESCRIPTION
backport of (https://github.com/valkey-io/valkey/pull/3950)

When a hash has many fields whose expirations fall in the same volatile-set time-bucket (>127 entries), that bucket is encoded as a hashtable (HT). The active field-expiry path drains expired entries via vsetBucketRemoveExpired_HASHTABLE(), but it is bounded by the per-key expire quota (max_count, from dbReclaimExpiredFields). When the quota stops the drain one entry short, the function only collapsed the bucket to NONE at size 0 and left it as an HT bucket holding a single entry.

That violates the invariant enforced by removeFromBucket_HASHTABLE(), which asserts hashtableSize(ht) > 0 after a delete and downgrades an HT bucket to SINGLE at size 1. A later normal removal of that lone field -- HDEL, or a cross-bucket HSETEX update routed through removeEntryFromRaxBucket() -- deletes the sole entry, drops the size 1 -> 0, and trips the assertion.

Fix: Apply the same downgrade in the expiry path: when draining leaves exactly one entry, downgrade the HT bucket to SINGLE so the invariant holds. Behavior is unchanged when the bucket drains fully (-> NONE) or retains two or more entries (-> HT, as the normal removal path already tolerates).

Add a regression test that fills one time-bucket past the HT threshold, expires all but one entry, then removes the survivor through the normal path; it crashed before this fix and passes after.