### PR TITLE
Stabilize CLUSTERSCAN unassigned-slot test by retrying DELSLOTS

### DIFF
--- a/tests/unit/cluster/clusterscan.tcl
+++ b/tests/unit/cluster/clusterscan.tcl
@@ -621,10 +621,20 @@ start_cluster 3 0 {tags {external:skip cluster}} {
         # With full-coverage=yes the cluster enters FAIL state.
         # Cursors for slot 0 should get "Hash slot not served".
         # Cursors for assigned but remote slots should get "cluster is down".
-        R 0 CLUSTER DELSLOTS 0
-        catch {R 1 CLUSTER DELSLOTS 0}
-        catch {R 2 CLUSTER DELSLOTS 0}
-        wait_for_cluster_state fail
+        #
+        # Retry DELSLOTS in a loop: R0's old stale packet can rebind slot 0
+        # to R0 on R1/R2 and undoing the DELSLOTS. Loop until all nodes converge
+        # to FAIL with slot 0 unassigned.
+        wait_for_condition 1000 50 {
+            [catch {R 0 CLUSTER DELSLOTS 0}] >= 0 &&
+            [catch {R 1 CLUSTER DELSLOTS 0}] >= 0 &&
+            [catch {R 2 CLUSTER DELSLOTS 0}] >= 0 &&
+            [CI 0 cluster_state] eq "fail" &&
+            [CI 1 cluster_state] eq "fail" &&
+            [CI 2 cluster_state] eq "fail"
+        } else {
+            fail "Cluster did not converge to FAIL after DELSLOTS"
+        }
 
         # Unassigned slot -> specific error.
         assert_error {CLUSTERDOWN Hash slot not served} {R 0 clusterscan "0-{06S}-0"}


### PR DESCRIPTION
The Case 3 portion of the test was flaky: after a single round of
`CLUSTER DELSLOTS 0` on R0/R1/R2, the cluster could stay in OK state
and `wait_for_cluster_state fail` would time out with
`Cluster node 1 cluster_state:ok`.

The race is between R0's local DELSLOTS and the gossip already in
flight from R0. After R1 locally clears slot 0, a stale pre-DELSLOTS
packet from R0 (whose myslots still claims slot 0) hits the
isSlotUnclaimed fast path in clusterUpdateSlotsConfigWith and rebinds
slot 0 back to R0 on R1. See:
```
    if (isSlotUnclaimed(j) ||
        server.cluster->slots[j]->configEpoch < senderConfigEpoch ||
        clusterSlotFailoverGranted(j)) {
        ...
        clusterDelSlot(j);
        clusterAddSlot(sender, j);
        ...
    }
```

R0's subsequent "no longer claiming" PINGs cannot undo this, because
that path only sets owner_not_claiming_slot and never clears slots[j]:
```
    if (server.cluster->slots[j] == sender) {
        /* The slot is currently bound to the sender but the sender is no longer
         * claiming it. We don't want to unbind the slot yet as it can cause the cluster
         * to move to FAIL state and also throw client error. Keeping the slot bound to
         * the previous owner will cause a few client side redirects, but won't throw
         * any errors. We will keep track of the uncertainty in ownership to avoid
         * propagating misinformation about this slot's ownership using UPDATE
         * messages. */
        bitmapSetBit(server.cluster->owner_not_claiming_slot, j);
    }
```

Combined with clusterUpdateState's full-coverage check looking only
at slots[j] == NULL, R1 stays at cluster OK forever.
```
    if (server.cluster->slots[j] == NULL || ...) {
        new_state = CLUSTER_FAIL;
        ...
    }
```

Rather than fighting the protocol's intentional asymmetry around
"soft delete" via gossip, just retry the DELSLOTS pass until all
three nodes converge to FAIL. This keeps the test focused on the
CLUSTERSCAN error semantics it actually wants to verify.

This closes #3891. The test was added in #3674.