### PR TITLE
Raft Cluster: add CRC64 checksums to nodes.conf

### DIFF
--- a/design-docs/cluster-raft.md
+++ b/design-docs/cluster-raft.md
@@ -633,10 +633,26 @@ The leader will send AE after reconnection, updating `commit_index`.
 Entries between `lastApplied + 1` and the new `commit_index` are then
 applied.
 
-### Crash detection
+### Integrity checks
 
-Not yet implemented. A future improvement will add per-line checksums
-to detect partial writes and corruption (see Future Work).
+Each log line includes a CRC64 checksum as its first field:
+
+    log <crc64hex> <index> <term> <type> <data...>
+
+The CRC covers the payload (everything after the checksum field). On
+load, each line is validated:
+
+- **CRC matches** → accept the entry (regardless of trailing `\n`)
+- **Invalid + no trailing `\n`** → discard (last line, short write from
+  crash during append; safe because AE_ACK is sent only after fsync)
+- **Invalid + trailing `\n`** → fatal (complete line is corrupted)
+- **Index gap between valid entries** → fatal (missing entry)
+
+The snapshot section (node lines + vars) is protected by a separate
+`crc` line written between vars and log lines.
+
+After loading, a full rewrite is always scheduled to produce a clean
+file (removes any incomplete trailing line).
 
 ### File format
 
@@ -706,5 +722,3 @@ targets.
   atomically or not.
 - `valkey-cli --cluster` tooling compatibility (uses MULTI internally in
   some cases, which doesn't work with blocking admin commands).
-- Checksums for appended log lines to detect partial writes and
-  bit-rot, instead of relying solely on trailing newline detection.

--- a/src/cluster_bus.h
+++ b/src/cluster_bus.h
@@ -85,7 +85,7 @@ typedef struct clusterBusType {
 
     /* Parse a "log" line from nodes.conf. argv/argc are the split line
      * (argv[0] is "log"). */
-    void (*parseLogLine)(sds *argv, int argc);
+    int (*parseLogLine)(sds *argv, int argc);
 
     /* Append "log" lines during a full config rewrite. */
     sds (*appendLogLines)(sds config);

--- a/src/cluster_bus.h
+++ b/src/cluster_bus.h
@@ -84,7 +84,7 @@ typedef struct clusterBusType {
     int (*parseVarsLine)(const char *name, const char *value);
 
     /* Parse a "log" line from nodes.conf. argv/argc are the split line
-     * (argv[0] is "log"). */
+     * (argv[0] is "log"). Returns C_OK, or C_ERR if the line is corrupt. */
     int (*parseLogLine)(sds *argv, int argc);
 
     /* Append "log" lines during a full config rewrite. */

--- a/src/cluster_nodes.c
+++ b/src/cluster_nodes.c
@@ -687,8 +687,11 @@ int clusterLoadConfig(char *filename) {
 
         /* Handle "log" lines (protocol-specific WAL entries). */
         if (strcasecmp(argv[0], "log") == 0) {
-            if (clusterCurrentBus->parseLogLine)
-                clusterCurrentBus->parseLogLine(argv, argc);
+            if (clusterCurrentBus->parseLogLine &&
+                clusterCurrentBus->parseLogLine(argv, argc) == C_ERR) {
+                sdsfreesplitres(argv, argc);
+                goto fmterr;
+            }
             sdsfreesplitres(argv, argc);
             continue;
         }

--- a/src/cluster_nodes.c
+++ b/src/cluster_nodes.c
@@ -655,6 +655,7 @@ int clusterLoadConfig(char *filename) {
     maxline = 1024 + CLUSTER_SLOTS * 128;
     line = zmalloc(maxline);
     tmp_cluster_nodes = dictCreate(&clusterNodesDictType);
+    uint64_t running_crc = 0;
     while (fgets(line, maxline, fp) != NULL) {
         int argc;
         sds *argv;
@@ -665,6 +666,23 @@ int clusterLoadConfig(char *filename) {
          * editing nodes.conf or by the config writing process if stopped
          * before the truncate() call. */
         if (line[0] == '\n' || line[0] == '\0') continue;
+
+        /* Handle "crc" line: verify integrity of all preceding lines
+         * (including any prior "crc" lines).
+         * Invariant: CRC is computed identically on write and read —
+         * blank lines are excluded, lines include trailing \n. */
+        if (strncasecmp(line, "crc ", 4) == 0) {
+            uint64_t expected = strtoull(line + 4, NULL, 16);
+            if (expected != running_crc) {
+                serverLog(LL_WARNING, "Corrupt cluster config: snapshot CRC mismatch.");
+                goto fmterr;
+            }
+            running_crc = crc64(running_crc, (unsigned char *)line, strlen(line));
+            continue;
+        }
+
+        /* Accumulate running CRC. */
+        running_crc = crc64(running_crc, (unsigned char *)line, strlen(line));
 
         /* Split the line into arguments for processing. */
         argv = sdssplitargs(line, &argc);
@@ -920,6 +938,11 @@ int clusterSaveConfig(int do_fsync) {
     ci = clusterGenNodesDescription(NULL, CLUSTER_NODE_HANDSHAKE, 0);
     if (clusterCurrentBus->appendVarsLine)
         ci = clusterCurrentBus->appendVarsLine(ci);
+    /* CRC over snapshot (node lines + vars), before log lines. */
+    if (clusterCurrentBus->appendLogLines) {
+        uint64_t crc = crc64(0, (unsigned char *)ci, sdslen(ci));
+        ci = sdscatprintf(ci, "crc %016llx\n", (unsigned long long)crc);
+    }
     if (clusterCurrentBus->appendLogLines)
         ci = clusterCurrentBus->appendLogLines(ci);
     content_size = sdslen(ci);

--- a/src/cluster_nodes.c
+++ b/src/cluster_nodes.c
@@ -667,13 +667,25 @@ int clusterLoadConfig(char *filename) {
          * before the truncate() call. */
         if (line[0] == '\n' || line[0] == '\0') continue;
 
+        /* Detect short write: last line without trailing \n that is a
+         * truncated prefix of "log ". Safe to discard since AE_ACK is
+         * only sent after fsync completes. */
+        {
+            size_t linelen = strlen(line);
+            if (linelen > 0 && line[linelen - 1] != '\n' &&
+                linelen <= 4 && strncasecmp(line, "log ", linelen) == 0) {
+                serverLog(LL_WARNING, "Discarding incomplete last log line (short write).");
+                break;
+            }
+        }
+
         /* Handle "crc" line: verify integrity of all preceding lines
          * (including any prior "crc" lines).
          * Invariant: CRC is computed identically on write and read —
          * blank lines are excluded, lines include trailing \n. */
         if (strncasecmp(line, "crc ", 4) == 0) {
             uint64_t expected = strtoull(line + 4, NULL, 16);
-            if (expected != running_crc) {
+            if (expected != 0 && expected != running_crc) {
                 serverLog(LL_WARNING, "Corrupt cluster config: snapshot CRC mismatch.");
                 goto fmterr;
             }
@@ -707,7 +719,7 @@ int clusterLoadConfig(char *filename) {
         if (strcasecmp(argv[0], "log") == 0) {
             if (clusterCurrentBus->parseLogLine) {
                 size_t linelen = strlen(line);
-                int complete = (linelen > 0 && line[linelen - 1] == '\n');
+                int complete = (line[linelen - 1] == '\n');
                 int ret = clusterCurrentBus->parseLogLine(argv, argc);
                 if (ret == C_ERR && !complete) {
                     /* Last line without trailing \n: short write from a

--- a/src/cluster_nodes.c
+++ b/src/cluster_nodes.c
@@ -705,10 +705,22 @@ int clusterLoadConfig(char *filename) {
 
         /* Handle "log" lines (protocol-specific WAL entries). */
         if (strcasecmp(argv[0], "log") == 0) {
-            if (clusterCurrentBus->parseLogLine &&
-                clusterCurrentBus->parseLogLine(argv, argc) == C_ERR) {
-                sdsfreesplitres(argv, argc);
-                goto fmterr;
+            if (clusterCurrentBus->parseLogLine) {
+                size_t linelen = strlen(line);
+                int complete = (linelen > 0 && line[linelen - 1] == '\n');
+                int ret = clusterCurrentBus->parseLogLine(argv, argc);
+                if (ret == C_ERR && !complete) {
+                    /* Last line without trailing \n: short write from a
+                     * crash. Safe to discard since AE_ACK is only sent
+                     * after fsync completes successfully. */
+                    serverLog(LL_WARNING, "Discarding incomplete last log line (short write).");
+                    sdsfreesplitres(argv, argc);
+                    break;
+                } else if (ret == C_ERR) {
+                    /* Complete line that failed validation: corruption. */
+                    sdsfreesplitres(argv, argc);
+                    goto fmterr;
+                }
             }
             sdsfreesplitres(argv, argc);
             continue;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2408,7 +2408,7 @@ static int clusterRaftParseLogLine(sds *argv, int argc) {
     sds payload = sdsjoinsds(argv + 2, argc - 2, " ", 1);
     uint64_t actual_crc = crc64(0, (unsigned char *)payload, sdslen(payload));
     sdsfree(payload);
-    if (expected_crc != actual_crc) {
+    if (expected_crc != 0 && expected_crc != actual_crc) {
         serverLog(LL_WARNING, "Corrupt raft log line: CRC mismatch.");
         return C_ERR;
     }

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -2340,11 +2340,14 @@ static int clusterRaftParseVarsLine(const char *name, const char *value) {
 
 /* Format a single log line with CRC64 checksum. */
 static sds raftLogFormatLine(sds buf, raftLogEntry *e) {
-    sds payload = sdscatprintf(sdsempty(), "%llu %llu %s %s",
+    sds payload = sdscatprintf(sdsempty(), "%llu %llu %s",
                                (unsigned long long)e->index,
                                (unsigned long long)e->term,
-                               raftEntryTypeName(e->type),
-                               e->data);
+                               raftEntryTypeName(e->type));
+    if (sdslen(e->data) > 0) {
+        payload = sdscatlen(payload, " ", 1);
+        payload = sdscatsds(payload, e->data);
+    }
     uint64_t crc = crc64(0, (unsigned char *)payload, sdslen(payload));
     buf = sdscatprintf(buf, "log %016llx %s\n",
                        (unsigned long long)crc, payload);
@@ -2445,8 +2448,9 @@ static void clusterRaftPostLoad(void) {
      * the leader will update it via AE. For now, ensure it's consistent. */
     if (rs->commit_index < rs->last_applied)
         rs->commit_index = rs->last_applied;
-    /* Log entries loaded from disk are already persisted; don't re-write. */
-    rs->todo_persist_log = 0;
+    /* Schedule a full rewrite to produce a clean file (removes any
+     * incomplete trailing line from a short write). */
+    rs->todo_save_config = 1;
     /* Restore cluster size from loaded nodes (NODE_JOIN already applied). */
     dictIterator *di = dictGetSafeIterator(server.cluster->nodes);
     dictEntry *de;

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -138,7 +138,6 @@ typedef struct {
     unsigned int todo_send_ae_ack : 1;
     unsigned int todo_send_vote_response : 1;
     unsigned int todo_broadcast_vote_request : 1;
-    unsigned int log_corrupt : 1;  /* Corrupt log line detected during load */
     uint64_t persist_log_from;     /* First index to persist in next batch */
     uint64_t last_rewrite_applied; /* last_applied at last full rewrite */
 
@@ -2380,14 +2379,11 @@ static void clusterRaftPersistNewLogEntries(uint64_t from) {
 }
 
 
-static void clusterRaftParseLogLine(sds *argv, int argc) {
+static int clusterRaftParseLogLine(sds *argv, int argc) {
     /* Format: log <crc64hex> <index> <term> <type> <data...> */
-    if (RAFT_STATE()->log_corrupt) return;
     if (argc < 6) {
-        serverLog(LL_WARNING, "Corrupt log line in nodes.conf (too few fields), "
-                  "discarding this and all subsequent log lines.");
-        RAFT_STATE()->log_corrupt = 1;
-        return;
+        serverLog(LL_WARNING, "Corrupt raft log line: too few fields (%d).", argc);
+        return C_ERR;
     }
 
     /* Verify CRC over everything after the checksum field. */
@@ -2396,17 +2392,26 @@ static void clusterRaftParseLogLine(sds *argv, int argc) {
     uint64_t actual_crc = crc64(0, (unsigned char *)payload, sdslen(payload));
     sdsfree(payload);
     if (expected_crc != actual_crc) {
-        serverLog(LL_WARNING, "Corrupt log line in nodes.conf (CRC mismatch), "
-                  "discarding this and all subsequent log lines.");
-        /* Signal to stop loading further log lines. */
-        RAFT_STATE()->log_corrupt = 1;
-        return;
+        serverLog(LL_WARNING, "Corrupt raft log line: CRC mismatch.");
+        return C_ERR;
     }
 
     uint64_t index = strtoull(argv[2], NULL, 10);
+    /* Verify indices are consecutive (catches missing log lines). */
+    clusterRaftState *rs = RAFT_STATE();
+    uint64_t expected_index = raftLogLastIndex() > 0 ? raftLogLastIndex() + 1 : rs->last_applied + 1;
+    if (index != expected_index) {
+        serverLog(LL_WARNING, "Corrupt raft log: index gap (expected %llu, got %llu).",
+                  (unsigned long long)expected_index, (unsigned long long)index);
+        return C_ERR;
+    }
     uint64_t term = strtoull(argv[3], NULL, 10);
     int type = raftEntryTypeByName(argv[4]);
-    if (type < 0) return;
+    if (type < 0) {
+        serverLog(LL_WARNING, "Corrupt raft log line at index %llu: unknown type '%s'.",
+                  (unsigned long long)index, argv[4]);
+        return C_ERR;
+    }
 
     /* Reconstruct data from remaining args (space-separated). */
     sds data = sdsdup(argv[5]);
@@ -2417,6 +2422,7 @@ static void clusterRaftParseLogLine(sds *argv, int argc) {
 
     raftLogEntry *e = raftLogCreate(term, index, type, data);
     raftLogAppend(e);
+    return C_OK;
 }
 
 static void clusterRaftPostLoad(void) {

--- a/src/cluster_raft.c
+++ b/src/cluster_raft.c
@@ -138,6 +138,7 @@ typedef struct {
     unsigned int todo_send_ae_ack : 1;
     unsigned int todo_send_vote_response : 1;
     unsigned int todo_broadcast_vote_request : 1;
+    unsigned int log_corrupt : 1;  /* Corrupt log line detected during load */
     uint64_t persist_log_from;     /* First index to persist in next batch */
     uint64_t last_rewrite_applied; /* last_applied at last full rewrite */
 
@@ -2324,6 +2325,20 @@ static int clusterRaftParseVarsLine(const char *name, const char *value) {
     return 0;
 }
 
+/* Format a single log line with CRC64 checksum. */
+static sds raftLogFormatLine(sds buf, raftLogEntry *e) {
+    sds payload = sdscatprintf(sdsempty(), "%llu %llu %s %s",
+                               (unsigned long long)e->index,
+                               (unsigned long long)e->term,
+                               raftEntryTypeName(e->type),
+                               e->data);
+    uint64_t crc = crc64(0, (unsigned char *)payload, sdslen(payload));
+    buf = sdscatprintf(buf, "log %016llx %s\n",
+                       (unsigned long long)crc, payload);
+    sdsfree(payload);
+    return buf;
+}
+
 /* Append uncommitted log entries (index > last_applied) as "log" lines
  * at the end of nodes.conf during a full rewrite. */
 static sds clusterRaftAppendLogLines(sds config) {
@@ -2331,11 +2346,7 @@ static sds clusterRaftAppendLogLines(sds config) {
     for (uint64_t i = 0; i < rs->log_count; i++) {
         raftLogEntry *e = rs->log[i];
         if (e->index <= rs->last_applied) continue;
-        config = sdscatprintf(config, "log %llu %llu %s %s\n",
-                              (unsigned long long)e->index,
-                              (unsigned long long)e->term,
-                              raftEntryTypeName(e->type),
-                              e->data);
+        config = raftLogFormatLine(config, e);
     }
     return config;
 }
@@ -2348,11 +2359,7 @@ static void clusterRaftPersistNewLogEntries(uint64_t from) {
     for (uint64_t i = 0; i < rs->log_count; i++) {
         raftLogEntry *e = rs->log[i];
         if (e->index < from) continue;
-        buf = sdscatprintf(buf, "log %llu %llu %s %s\n",
-                           (unsigned long long)e->index,
-                           (unsigned long long)e->term,
-                           raftEntryTypeName(e->type),
-                           e->data);
+        buf = raftLogFormatLine(buf, e);
     }
     if (sdslen(buf) == 0) {
         sdsfree(buf);
@@ -2374,16 +2381,36 @@ static void clusterRaftPersistNewLogEntries(uint64_t from) {
 
 
 static void clusterRaftParseLogLine(sds *argv, int argc) {
-    /* Format: log <index> <term> <type> <data...> */
-    if (argc < 5) return;
-    uint64_t index = strtoull(argv[1], NULL, 10);
-    uint64_t term = strtoull(argv[2], NULL, 10);
-    int type = raftEntryTypeByName(argv[3]);
+    /* Format: log <crc64hex> <index> <term> <type> <data...> */
+    if (RAFT_STATE()->log_corrupt) return;
+    if (argc < 6) {
+        serverLog(LL_WARNING, "Corrupt log line in nodes.conf (too few fields), "
+                  "discarding this and all subsequent log lines.");
+        RAFT_STATE()->log_corrupt = 1;
+        return;
+    }
+
+    /* Verify CRC over everything after the checksum field. */
+    uint64_t expected_crc = strtoull(argv[1], NULL, 16);
+    sds payload = sdsjoinsds(argv + 2, argc - 2, " ", 1);
+    uint64_t actual_crc = crc64(0, (unsigned char *)payload, sdslen(payload));
+    sdsfree(payload);
+    if (expected_crc != actual_crc) {
+        serverLog(LL_WARNING, "Corrupt log line in nodes.conf (CRC mismatch), "
+                  "discarding this and all subsequent log lines.");
+        /* Signal to stop loading further log lines. */
+        RAFT_STATE()->log_corrupt = 1;
+        return;
+    }
+
+    uint64_t index = strtoull(argv[2], NULL, 10);
+    uint64_t term = strtoull(argv[3], NULL, 10);
+    int type = raftEntryTypeByName(argv[4]);
     if (type < 0) return;
 
     /* Reconstruct data from remaining args (space-separated). */
-    sds data = sdsdup(argv[4]);
-    for (int i = 5; i < argc; i++) {
+    sds data = sdsdup(argv[5]);
+    for (int i = 6; i < argc; i++) {
         data = sdscatlen(data, " ", 1);
         data = sdscatsds(data, argv[i]);
     }

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -85,4 +85,30 @@ test "Raft persistence: corrupt snapshot CRC prevents startup" {
         assert_match "*snapshot CRC mismatch*" $output
     }
 }
+
+test "Raft persistence: incomplete last log line (short write) is discarded" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set dir [lindex [R 0 CONFIG GET dir] 1]
+        set nodes_conf "$dir/nodes.conf"
+        set port [srv 0 port]
+
+        # Stop server gracefully.
+        catch {R 0 SHUTDOWN NOSAVE}
+
+        # Append a corrupt log line WITHOUT trailing newline (simulates
+        # a crash during write — the line was never fully written).
+        set fp [open $nodes_conf a]
+        puts -nonewline $fp "log 0000000000000000 99 1 NODE_JOIN [string repeat f 40] 127.0.0.1:9999@19999"
+        close $fp
+
+        # Server should start normally (discard the incomplete line).
+        restart_server 0 true true
+
+        # Only myself should be known (the corrupt entry was discarded).
+        assert_equal 1 [CI 0 cluster_known_nodes]
+
+        # Verify the warning was logged.
+        verify_log_message 0 "*Discarding incomplete last log line*" 0
+    }
+}
 } ;# tags

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -1,0 +1,54 @@
+# Test raft cluster persistence (nodes.conf format, recovery, corruption).
+
+proc is_alive {pid} {
+    if {[catch {exec kill -0 $pid}]} {
+        return 0
+    }
+    return 1
+}
+
+tags {external:skip cluster singledb} {
+
+test "Raft persistence: corrupt log line CRC is discarded on load" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        # Wait for the singleton to be ready.
+        R 0 CLUSTER ADDSLOTSRANGE 0 16383
+        wait_for_condition 50 100 {
+            [CI 0 cluster_state] eq "ok"
+        } else {
+            fail "Cluster never reached ok state"
+        }
+
+        # Get nodes.conf path and server pid.
+        set dir [lindex [R 0 CONFIG GET dir] 1]
+        set nodes_conf "$dir/nodes.conf"
+        set pid [srv 0 pid]
+
+        # Kill with SIGKILL (no shutdown handler, no rewrite).
+        exec kill -9 $pid
+        wait_for_condition 50 100 {
+            ![is_alive $pid]
+        } else {
+            fail "Server didn't die"
+        }
+
+        # Append a corrupt log line (bad CRC) with a fake NODE_JOIN.
+        set fake_id [string repeat f 40]
+        set fake_addr "127.0.0.1:9999@19999,,tls-port=0,shard-id=[string repeat a 40]"
+        set corrupt_line "log 0000000000000000 99 1 NODE_JOIN $fake_id $fake_addr"
+        set fp [open $nodes_conf a]
+        puts $fp $corrupt_line
+        close $fp
+
+        # Restart server in the same directory.
+        restart_server 0 true true
+
+        # The corrupt NODE_JOIN should be discarded — only myself known.
+        assert_equal 1 [CI 0 cluster_known_nodes]
+
+        # Verify the corruption warning was logged.
+        verify_log_message 0 "*Corrupt log line*CRC mismatch*" 0
+    }
+}
+
+} ;# tags

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -16,7 +16,7 @@ test "Raft persistence: corrupt log line CRC prevents startup" {
         # Append a corrupt log line (bad CRC) to the existing nodes.conf.
         set fake_id [string repeat f 40]
         set fake_addr "127.0.0.1:9999@19999,,tls-port=0,shard-id=[string repeat a 40]"
-        set corrupt_line "log 0000000000000000 99 1 NODE_JOIN $fake_id $fake_addr"
+        set corrupt_line "log ffffffffffffffff 99 1 NODE_JOIN $fake_id $fake_addr"
         set fp [open $nodes_conf a]
         puts $fp $corrupt_line
         close $fp
@@ -75,7 +75,7 @@ test "Raft persistence: corrupt snapshot CRC prevents startup" {
         set fp [open $nodes_conf r]
         set content [read $fp]
         close $fp
-        regsub {crc [0-9a-f]+} $content {crc 0000000000000000} content
+        regsub {crc [0-9a-f]+} $content {crc ffffffffffffffff} content
         set fp [open $nodes_conf w]
         puts -nonewline $fp $content
         close $fp
@@ -98,7 +98,7 @@ test "Raft persistence: incomplete last log line (short write) is discarded" {
         # Append a corrupt log line WITHOUT trailing newline (simulates
         # a crash during write — the line was never fully written).
         set fp [open $nodes_conf a]
-        puts -nonewline $fp "log 0000000000000000 99 1 NODE_JOIN [string repeat f 40] 127.0.0.1:9999@19999"
+        puts -nonewline $fp "log ffffffffffffffff 99 1 NODE_JOIN [string repeat f 40] 127.0.0.1:9999@19999"
         close $fp
 
         # Server should start normally (discard the incomplete line).

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -22,7 +22,7 @@ test "Raft persistence: corrupt log line CRC prevents startup" {
         close $fp
 
         # Try to start server — it should panic.
-        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        catch {exec $::VALKEY_SERVER_BIN $config_file --port $port --dir $dir} output
         assert_match "*Corrupt raft log line: CRC mismatch*" $output
 
         # Restart cleanly for framework teardown (remove corrupt line).
@@ -51,7 +51,7 @@ test "Raft persistence: missing log entry (index gap) prevents startup" {
         close $fp
 
         # Try to start server — it should panic.
-        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        catch {exec $::VALKEY_SERVER_BIN $config_file --port $port --dir $dir} output
         assert_match "*Corrupt raft log: index gap*" $output
 
         # Restart cleanly for framework teardown (remove corrupt line).
@@ -81,7 +81,7 @@ test "Raft persistence: corrupt snapshot CRC prevents startup" {
         close $fp
 
         # Try to start server — it should panic due to CRC mismatch.
-        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        catch {exec $::VALKEY_SERVER_BIN $config_file --port $port --dir $dir} output
         assert_match "*snapshot CRC mismatch*" $output
     }
 }

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -60,4 +60,29 @@ test "Raft persistence: missing log entry (index gap) prevents startup" {
         restart_server 0 true true
     }
 }
+
+test "Raft persistence: corrupt snapshot CRC prevents startup" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set dir [lindex [R 0 CONFIG GET dir] 1]
+        set nodes_conf "$dir/nodes.conf"
+        set port [srv 0 port]
+        set config_file [srv 0 config_file]
+
+        # Stop server gracefully.
+        catch {R 0 SHUTDOWN NOSAVE}
+
+        # Replace the crc line with a wrong checksum.
+        set fp [open $nodes_conf r]
+        set content [read $fp]
+        close $fp
+        regsub {crc [0-9a-f]+} $content {crc 0000000000000000} content
+        set fp [open $nodes_conf w]
+        puts -nonewline $fp $content
+        close $fp
+
+        # Try to start server — it should panic due to CRC mismatch.
+        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        assert_match "*snapshot CRC mismatch*" $output
+    }
+}
 } ;# tags

--- a/tests/unit/cluster/cluster-raft-persistence.tcl
+++ b/tests/unit/cluster/cluster-raft-persistence.tcl
@@ -1,38 +1,19 @@
 # Test raft cluster persistence (nodes.conf format, recovery, corruption).
 
-proc is_alive {pid} {
-    if {[catch {exec kill -0 $pid}]} {
-        return 0
-    }
-    return 1
-}
-
 tags {external:skip cluster singledb} {
 
-test "Raft persistence: corrupt log line CRC is discarded on load" {
+test "Raft persistence: corrupt log line CRC prevents startup" {
     start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
-        # Wait for the singleton to be ready.
-        R 0 CLUSTER ADDSLOTSRANGE 0 16383
-        wait_for_condition 50 100 {
-            [CI 0 cluster_state] eq "ok"
-        } else {
-            fail "Cluster never reached ok state"
-        }
-
-        # Get nodes.conf path and server pid.
+        # Get nodes.conf path and config file.
         set dir [lindex [R 0 CONFIG GET dir] 1]
         set nodes_conf "$dir/nodes.conf"
-        set pid [srv 0 pid]
+        set port [srv 0 port]
+        set config_file [srv 0 config_file]
 
-        # Kill with SIGKILL (no shutdown handler, no rewrite).
-        exec kill -9 $pid
-        wait_for_condition 50 100 {
-            ![is_alive $pid]
-        } else {
-            fail "Server didn't die"
-        }
+        # Stop server gracefully.
+        catch {R 0 SHUTDOWN NOSAVE}
 
-        # Append a corrupt log line (bad CRC) with a fake NODE_JOIN.
+        # Append a corrupt log line (bad CRC) to the existing nodes.conf.
         set fake_id [string repeat f 40]
         set fake_addr "127.0.0.1:9999@19999,,tls-port=0,shard-id=[string repeat a 40]"
         set corrupt_line "log 0000000000000000 99 1 NODE_JOIN $fake_id $fake_addr"
@@ -40,15 +21,43 @@ test "Raft persistence: corrupt log line CRC is discarded on load" {
         puts $fp $corrupt_line
         close $fp
 
-        # Restart server in the same directory.
+        # Try to start server — it should panic.
+        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        assert_match "*Corrupt raft log line: CRC mismatch*" $output
+
+        # Restart cleanly for framework teardown (remove corrupt line).
+        set fp [open $nodes_conf w]
+        close $fp
         restart_server 0 true true
-
-        # The corrupt NODE_JOIN should be discarded — only myself known.
-        assert_equal 1 [CI 0 cluster_known_nodes]
-
-        # Verify the corruption warning was logged.
-        verify_log_message 0 "*Corrupt log line*CRC mismatch*" 0
     }
 }
 
+
+test "Raft persistence: missing log entry (index gap) prevents startup" {
+    start_server {overrides {cluster-enabled yes cluster-protocol raft cluster-node-timeout 1000}} {
+        set dir [lindex [R 0 CONFIG GET dir] 1]
+        set nodes_conf "$dir/nodes.conf"
+        set port [srv 0 port]
+        set config_file [srv 0 config_file]
+
+        # Stop server gracefully.
+        catch {R 0 SHUTDOWN NOSAVE}
+
+        # Append a valid log line at index 2 (skipping index 1) to create
+        # a gap. CRC is precomputed for this exact payload.
+        set line "log 33420fe746511517 2 1 NODE_JOIN ffffffffffffffffffffffffffffffffffffffff 127.0.0.1:9999@19999,,tls-port=0,shard-id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        set fp [open $nodes_conf a]
+        puts $fp $line
+        close $fp
+
+        # Try to start server — it should panic.
+        catch {exec src/valkey-server $config_file --port $port --dir $dir} output
+        assert_match "*Corrupt raft log: index gap*" $output
+
+        # Restart cleanly for framework teardown (remove corrupt line).
+        set fp [open $nodes_conf w]
+        close $fp
+        restart_server 0 true true
+    }
+}
 } ;# tags


### PR DESCRIPTION
Add a CRC64 checksum as the first field of each log line:

    log <crc64hex> <index> <term> <type> <data...>

For the node lines and the vars line, a CRC checksum is also added to detect corruption.

    crc <crc64hex>

This line contains the crc64 checksum of all previous lines up to this line.

On load, verify the CRC. If a corrupt line is found, abort the loading and refuse to start the server, with one exception: If the check fails on the very last log line, it indicates a short write, meaning the server crashed before acking the entry. Ignore it and start the server. Without this exception, the server wouldn't be able to recover after a crash during a write/fsync.

Checksums that are all zeroes are ignored. This allows manual editing of the file without computing the real checksums (e.g. for rescuing a cluster that is stuck). This matches the RDB checksum checks where all-zero checksums are ignored.

Extract raftLogFormatLine helper to avoid duplicating the format logic between clusterRaftAppendLogLines and clusterRaftPersistNewLogEntries.

Closes #3960