### PR TITLE
Omit alldbs rule in ACL SAVE/LIST and CONFIG REWRITE for compatibility

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -866,7 +866,7 @@ static sds ACLDescribeSelector(aclSelector *selector) {
 
     /* Database permissions. */
     if (selector->flags & SELECTOR_FLAG_ALLDBS) {
-        res = sdscatlen(res, "alldbs ", 7);
+        /* alldbs is default, avoid emitting it in ACL strings for compatibility. */
     } else if (intsetLen(selector->dbs) == 0) {
         res = sdscatlen(res, "resetdbs ", 9);
     } else {

--- a/tests/unit/acl-v2.tcl
+++ b/tests/unit/acl-v2.tcl
@@ -347,6 +347,24 @@ start_server {tags {"acl external:skip"}} {
         assert_equal "" [dict get $secondary_selector databases]
     }
 
+    test {Test ACL LIST omits implicit alldbs} {
+        set response [lindex [r ACL LIST] [lsearch [r ACL LIST] "user default*"]]
+        assert_no_match "* alldbs *" $response
+
+        r ACL SETUSER user-list-alldbs on nopass -@all +get ~* &* alldbs
+        set response [lindex [r ACL LIST] [lsearch [r ACL LIST] "user user-list-alldbs*"]]
+        assert_no_match "* alldbs *" $response
+
+        r ACL SETUSER user-list-alldbs db=0,1
+        set response [lindex [r ACL LIST] [lsearch [r ACL LIST] "user user-list-alldbs*"]]
+        assert_match "* db=0,1 *" $response
+
+        r ACL SETUSER user-list-alldbs resetdbs
+        set response [lindex [r ACL LIST] [lsearch [r ACL LIST] "user user-list-alldbs*"]]
+        assert_match "* resetdbs *" $response
+
+        r ACL DELUSER user-list-alldbs
+    }
 
     test {Test ACL list idempotency} {
         r ACL SETUSER user-idempotency off -@all +get resetchannels &channel1 %R~foo1 %W~bar1 ~baz1 (-@all +set resetchannels &channel2 %R~foo2 %W~bar2 ~baz2)

--- a/tests/unit/acl.tcl
+++ b/tests/unit/acl.tcl
@@ -179,7 +179,7 @@ start_server {tags {"acl external:skip"}} {
         set curruser "hpuser"
         foreach user [lshuffle $users] {
             if {[string first $curruser $user] != -1} {
-                assert_equal {user hpuser on nopass resetchannels &foo alldbs +@all} $user
+                assert_equal {user hpuser on nopass resetchannels &foo +@all} $user
             }
         }
 
@@ -1145,8 +1145,15 @@ start_server [list overrides [list "dir" $server_path "acl-pubsub-default" "allc
     } {} {needs:debug}
 
     test {ACL load and save} {
-        r ACL setuser eve +get allkeys >eve on
+        r ACL setuser eve +get allkeys >eve on alldbs
         r ACL save
+
+        # ACL SAVE uses the same serialization as ACL LIST,
+        # verify that ACL file omits the implicit alldbs rule.
+        set aclfile [file join \
+            [lindex [r CONFIG GET dir] 1] \
+            [lindex [r CONFIG GET aclfile] 1]]
+        assert_equal 0 [count_message_lines $aclfile alldbs]
 
         r ACL load
 
@@ -1357,6 +1364,12 @@ start_server {overrides {user "default on nopass ~* +@all -flushdb"} tags {acl e
     test {ACL from config file and config rewrite} {
         assert_error {NOPERM *} {r flushdb}
         r config rewrite
+
+        # CONFIG REWRITE persists ACL users through the ACL string
+        # serializer, and should not have the implicit alldbs rule.
+        set config_file [srv 0 config_file]
+        assert_equal 0 [count_message_lines $config_file alldbs]
+
         restart_server 0 true false
         assert_error {NOPERM *} {r flushdb}
     }

--- a/tests/unit/moduleapi/usercall.tcl
+++ b/tests/unit/moduleapi/usercall.tcl
@@ -29,7 +29,7 @@ start_server {tags {"modules usercall network"}} {
             assert_equal [r usercall.reset_user] OK
             assert_equal [r usercall.add_to_acl "~* &* +@all -set"] OK
             # off because module user / default value
-            assert_equal [r usercall.get_acl] "off ~* &* alldbs +@all -set"
+            assert_equal [r usercall.get_acl] "off ~* &* +@all -set"
 
             # doesn't fail for regular commands as just testing acl here
             assert_equal [r usercall.$cmd {} set x 10] OK
@@ -48,7 +48,7 @@ start_server {tags {"modules usercall network"}} {
             assert_equal [r usercall.reset_user] OK
             assert_equal [r usercall.add_to_acl "~* &* +@all -set"] OK
             # off because module user / default value
-            assert_equal [r usercall.get_acl] "off ~* &* alldbs +@all -set"
+            assert_equal [r usercall.get_acl] "off ~* &* +@all -set"
 
             # fails here as testing acl in rm call
             assert_error {*NOPERM User module_user has no permissions*} {r usercall.$cmd C set x 10}
@@ -111,7 +111,7 @@ start_server {tags {"modules usercall network"}} {
             assert_equal [r usercall.reset_user] OK
             assert_equal [r usercall.add_to_acl "~* &* +@all -set"] OK
             # off because module user / default value
-            assert_equal [r usercall.get_acl] "off ~* &* alldbs +@all -set"
+            assert_equal [r usercall.get_acl] "off ~* &* +@all -set"
 
             # passes as not checking ACL
             assert_equal [r usercall.$cmd {} evalsha $sha_set 0] 1


### PR DESCRIPTION
Database-level ACL #2309 introduced `alldbs` rule that was explicit for all users and because of that previous versions no longer had the ability to parse ACL strings produced by later versions. 
Omit `alldbs` in `ACLDescribeSelector()`, that is used in `ACL SAVE/LOAD` and `CONFIG REWRITE` command paths so that downgrades would be possible if new feature was not used (`db=` and `resetdbs` rules).
Keep `ACL GETUSER` command's output as is and return `alldbs` in `databases` field because of command's field-value format.
Add test to check that `ACL LIST` omits implicit `alldbs` and add check to existing `ACL SAVE` and `CONFIG REWRITE` tests.

Fixes #3915