### PR TITLE
Fix unbalanced ']' in bitops (BITFIELD_RO) command

### DIFF
--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1164,7 +1164,8 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
     }
 
     /* Surround an optional arg with brackets, unless it's partially matched. */
-    if ((arg->flags & CMD_ARG_OPTIONAL) && !arg->matched) {
+    int optional_unmatched = (arg->flags & CMD_ARG_OPTIONAL) && !arg->matched;
+    if (optional_unmatched) {
         hint = sdscat(hint, "[");
     }
 
@@ -1204,7 +1205,7 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
 
     hint = addHintForRepeatedArgument(hint, arg);
 
-    if ((arg->flags & CMD_ARG_OPTIONAL) && !arg->matched) {
+    if (optional_unmatched) {
         hint = sdscat(hint, "]");
     }
 

--- a/src/valkey-cli.c
+++ b/src/valkey-cli.c
@@ -1164,6 +1164,9 @@ static sds addHintForArgument(sds hint, cliCommandArg *arg) {
     }
 
     /* Surround an optional arg with brackets, unless it's partially matched. */
+    /* We store this in a variable since arg->matched flag would be 
+       reset inside addHintForRepeatedArgument() which is being called in this codepath 
+    */
     int optional_unmatched = (arg->flags & CMD_ARG_OPTIONAL) && !arg->matched;
     if (optional_unmatched) {
         hint = sdscat(hint, "[");

--- a/tests/assets/test_cli_hint_suite.txt
+++ b/tests/assets/test_cli_hint_suite.txt
@@ -25,13 +25,12 @@
 "BITFIELD_RO k " "[GET encoding offset [GET encoding offset ...]]"
 "BITFIELD_RO k GE" "[GET encoding offset [GET encoding offset ...]]"
 "BITFIELD_RO k GET" "[GET encoding offset [GET encoding offset ...]]"
-# TODO: The following hints end with an unbalanced "]" which shouldn't be there.
-"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]]"
-"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]]"
-"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]]"
+"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]"
+"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]"
+"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]"
+"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]"
+"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]"
+"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]"
 
 # Two-word command with multiple non-token block args:  CONFIG SET parameter value [parameter value ...]
 "CONFIG SET param " "value [parameter value ...]"


### PR DESCRIPTION
Fixed the following issue

# Issue
For the below hint extra/unbalanced ']' was being suggested

```c"BITFIELD_RO k GET " "encoding offset [GET encoding offset ...]]"
"BITFIELD_RO k GET xyz " "offset [GET encoding offset ...]]"
"BITFIELD_RO k GET xyz 12 " "[GET encoding offset ...]]"
"BITFIELD_RO k GET xyz 12 GET " "encoding offset [GET encoding offset ...]]"
"BITFIELD_RO k GET enc1 12 GET enc2 " "offset [GET encoding offset ...]]"
"BITFIELD_RO k GET enc1 12 GET enc2 34 " "[GET encoding offset ...]]"
```

# Fix
`arg->matched` flag is being reset inside `addHintForRepeatedArgument()` function (therefore `if` condition to add ']' evaluated to true), so now in the fix we are evaluating once the conditions used to add '[' and reusing it to check while adding ']'



