### PR TITLE
Fix reserved identifier violations in include guards (#3850)

### DIFF
--- a/deps/libvalkey/src/dict.h
+++ b/deps/libvalkey/src/dict.h
@@ -33,8 +33,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __DICT_H
-#define __DICT_H
+#ifndef VALKEY_DICT_H
+#define VALKEY_DICT_H
 
 #include <stdint.h>
 

--- a/deps/libvalkey/src/sds.h
+++ b/deps/libvalkey/src/sds.h
@@ -30,8 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SDS_H
-#define __SDS_H
+#ifndef VALKEY_SDS_H
+#define VALKEY_SDS_H
 
 #define SDS_MAX_PREALLOC (1024 * 1024)
 #ifdef _MSC_VER

--- a/deps/linenoise/linenoise.h
+++ b/deps/linenoise/linenoise.h
@@ -36,8 +36,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LINENOISE_H
-#define __LINENOISE_H
+#ifndef VALKEY_LINENOISE_H
+#define VALKEY_LINENOISE_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/adlist.h
+++ b/src/adlist.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __ADLIST_H__
-#define __ADLIST_H__
+#ifndef VALKEY_ADLIST_H
+#define VALKEY_ADLIST_H
 
 /* Node, List, and Iterator are the only data structures used currently. */
 

--- a/src/ae.h
+++ b/src/ae.h
@@ -30,8 +30,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __AE_H__
-#define __AE_H__
+#ifndef VALKEY_AE_H
+#define VALKEY_AE_H
 
 #include "monotonic.h"
 #include <pthread.h>

--- a/src/allocator_defrag.h
+++ b/src/allocator_defrag.h
@@ -1,5 +1,5 @@
-#ifndef __ALLOCATOR_DEFRAG_H
-#define __ALLOCATOR_DEFRAG_H
+#ifndef VALKEY_ALLOCATOR_DEFRAG_H
+#define VALKEY_ALLOCATOR_DEFRAG_H
 
 #if defined(USE_JEMALLOC)
 #include <jemalloc/jemalloc.h>

--- a/src/bio.h
+++ b/src/bio.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __BIO_H
-#define __BIO_H
+#ifndef VALKEY_BIO_H
+#define VALKEY_BIO_H
 
 typedef void lazy_free_fn(void *args[]);
 

--- a/src/cli_common.h
+++ b/src/cli_common.h
@@ -1,5 +1,5 @@
-#ifndef __CLICOMMON_H
-#define __CLICOMMON_H
+#ifndef VALKEY_CLICOMMON_H
+#define VALKEY_CLICOMMON_H
 
 #include <valkey/valkey.h>
 #include "sds.h"

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -1,5 +1,5 @@
-#ifndef __CLUSTER_H
-#define __CLUSTER_H
+#ifndef VALKEY_CLUSTER_H
+#define VALKEY_CLUSTER_H
 
 #include <stdbool.h>
 /*-----------------------------------------------------------------------------

--- a/src/cluster_migrateslots.h
+++ b/src/cluster_migrateslots.h
@@ -1,5 +1,5 @@
-#ifndef __CLUSTER_MIGRATESLOTS_H
-#define __CLUSTER_MIGRATESLOTS_H
+#ifndef VALKEY_CLUSTER_MIGRATESLOTS_H
+#define VALKEY_CLUSTER_MIGRATESLOTS_H
 
 #include "server.h"
 #include "cluster.h"

--- a/src/commandlog.h
+++ b/src/commandlog.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __COMMANDLOG_H__
-#define __COMMANDLOG_H__
+#ifndef VALKEY_COMMANDLOG_H
+#define VALKEY_COMMANDLOG_H
 
 #include "server.h"
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -31,8 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __DICT_H
-#define __DICT_H
+#ifndef VALKEY_DICT_H
+#define VALKEY_DICT_H
 
 #include "hashtable.h"
 #include "zmalloc.h"

--- a/src/endianconv.h
+++ b/src/endianconv.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD 3-Clause
  */
 
-#ifndef __ENDIANCONV_H
-#define __ENDIANCONV_H
+#ifndef VALKEY_ENDIANCONV_H
+#define VALKEY_ENDIANCONV_H
 
 #include "config.h"
 #include <stdint.h>

--- a/src/fifo.h
+++ b/src/fifo.h
@@ -22,8 +22,8 @@
  * The implementation makes no assumptions about the stored values and keeps them intact.
  */
 
-#ifndef __FIFO_H_
-#define __FIFO_H_
+#ifndef VALKEY_FIFO_H
+#define VALKEY_FIFO_H
 
 #include <stdbool.h>
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __FUNCTIONS_H_
-#define __FUNCTIONS_H_
+#ifndef VALKEY_FUNCTIONS_H
+#define VALKEY_FUNCTIONS_H
 
 /*
  * functions.c unit provides the Functions API:

--- a/src/geo.h
+++ b/src/geo.h
@@ -1,5 +1,5 @@
-#ifndef __GEO_H__
-#define __GEO_H__
+#ifndef VALKEY_GEO_H
+#define VALKEY_GEO_H
 
 #include "server.h"
 

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -1,5 +1,5 @@
-#ifndef __INTRINSICS_H
-#define __INTRINSICS_H
+#ifndef VALKEY_INTRINSICS_H
+#define VALKEY_INTRINSICS_H
 
 #include <stdint.h>
 

--- a/src/intset.h
+++ b/src/intset.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __INTSET_H
-#define __INTSET_H
+#ifndef VALKEY_INTSET_H
+#define VALKEY_INTSET_H
 #include <stdint.h>
 
 typedef struct intset {

--- a/src/latency.h
+++ b/src/latency.h
@@ -31,8 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LATENCY_H
-#define __LATENCY_H
+#ifndef VALKEY_LATENCY_H
+#define VALKEY_LATENCY_H
 
 #include "trace/trace.h"
 

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -32,8 +32,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LISTPACK_H
-#define __LISTPACK_H
+#ifndef VALKEY_LISTPACK_H
+#define VALKEY_LISTPACK_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/lolwut.h
+++ b/src/lolwut.h
@@ -35,8 +35,8 @@
  * It's up to each LOLWUT versions to translate what they draw to the
  * screen, depending on the result to accomplish. */
 
-#ifndef __LOLWUT_H
-#define __LOLWUT_H
+#ifndef VALKEY_LOLWUT_H
+#define VALKEY_LOLWUT_H
 
 typedef struct lwCanvas {
     int width;

--- a/src/lrulfu.h
+++ b/src/lrulfu.h
@@ -1,5 +1,5 @@
-#ifndef __LRULFU_H__
-#define __LRULFU_H__
+#ifndef VALKEY_LRULFU_H
+#define VALKEY_LRULFU_H
 
 /*
  * Important: include fmacros.h before any system header

--- a/src/modules/lua/script_lua.h
+++ b/src/modules/lua/script_lua.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SCRIPT_LUA_H_
-#define __SCRIPT_LUA_H_
+#ifndef VALKEY_SCRIPT_LUA_H
+#define VALKEY_SCRIPT_LUA_H
 
 #include "engine_structs.h"
 

--- a/src/monotonic.h
+++ b/src/monotonic.h
@@ -1,5 +1,5 @@
-#ifndef __MONOTONIC_H
-#define __MONOTONIC_H
+#ifndef VALKEY_MONOTONIC_H
+#define VALKEY_MONOTONIC_H
 /* The monotonic clock is an always increasing clock source.  It is unrelated to
  * the actual time of day and should only be used for relative timings.  The
  * monotonic clock is also not guaranteed to be chronologically precise; there

--- a/src/mt19937-64.h
+++ b/src/mt19937-64.h
@@ -53,8 +53,8 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove spaces)
 */
 
-#ifndef __MT19937_64_H
-#define __MT19937_64_H
+#ifndef VALKEY_MT19937_64_H
+#define VALKEY_MT19937_64_H
 
 /* initializes mt[NN] with a seed */
 void init_genrand64(unsigned long long seed);

--- a/src/mutexqueue.h
+++ b/src/mutexqueue.h
@@ -30,8 +30,8 @@
  * The caller is responsible for memory management for items in the mutexQueue.
  */
 
-#ifndef __MUTEXQUEUE_H
-#define __MUTEXQUEUE_H
+#ifndef VALKEY_MUTEXQUEUE_H
+#define VALKEY_MUTEXQUEUE_H
 
 #include <stdbool.h>
 #include "fifo.h"

--- a/src/pqsort.h
+++ b/src/pqsort.h
@@ -30,8 +30,8 @@
  *
  * See the pqsort.c file for the original copyright notice. */
 
-#ifndef __PQSORT_H
-#define __PQSORT_H
+#ifndef VALKEY_PQSORT_H
+#define VALKEY_PQSORT_H
 
 void
 pqsort(void *a, size_t n, size_t es,

--- a/src/queues.h
+++ b/src/queues.h
@@ -20,8 +20,8 @@
  *    - Allows producer to batch jobs
  */
 
-#ifndef __QUEUES_H__
-#define __QUEUES_H__
+#ifndef VALKEY_QUEUES_H
+#define VALKEY_QUEUES_H
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/quicklist.h
+++ b/src/quicklist.h
@@ -30,8 +30,8 @@
 
 #include <stdint.h> // for UINTPTR_MAX
 
-#ifndef __QUICKLIST_H__
-#define __QUICKLIST_H__
+#ifndef VALKEY_QUICKLIST_H
+#define VALKEY_QUICKLIST_H
 
 /* Node, quicklist, and Iterator are the only data structures used currently. */
 

--- a/src/rdb.h
+++ b/src/rdb.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __RDB_H
-#define __RDB_H
+#ifndef VALKEY_RDB_H
+#define VALKEY_RDB_H
 
 #include <stdio.h>
 #include "rio.h"

--- a/src/script.h
+++ b/src/script.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SCRIPT_H_
-#define __SCRIPT_H_
+#ifndef VALKEY_SCRIPT_H
+#define VALKEY_SCRIPT_H
 
 #include "valkeymodule.h"
 

--- a/src/sds.h
+++ b/src/sds.h
@@ -29,8 +29,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SDS_H
-#define __SDS_H
+#ifndef VALKEY_SDS_H
+#define VALKEY_SDS_H
 
 #define SDS_MAX_PREALLOC (1024 * 1024)
 extern const char *SDS_NOINIT;

--- a/src/sdsalloc.h
+++ b/src/sdsalloc.h
@@ -35,8 +35,8 @@
  * the include of your alternate allocator if needed (not needed in order
  * to use the default libc allocator). */
 
-#ifndef __SDS_ALLOC_H__
-#define __SDS_ALLOC_H__
+#ifndef VALKEY_SDS_ALLOC_H
+#define VALKEY_SDS_ALLOC_H
 
 #include "zmalloc.h"
 #define s_malloc zmalloc

--- a/src/sparkline.h
+++ b/src/sparkline.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SPARKLINE_H
-#define __SPARKLINE_H
+#ifndef VALKEY_SPARKLINE_H
+#define VALKEY_SPARKLINE_H
 
 /* A sequence is represented of many "samples" */
 struct sample {

--- a/src/syscheck.h
+++ b/src/syscheck.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __SYSCHECK_H
-#define __SYSCHECK_H
+#ifndef VALKEY_SYSCHECK_H
+#define VALKEY_SYSCHECK_H
 
 #include "sds.h"
 #include "config.h"

--- a/src/testhelp.h
+++ b/src/testhelp.h
@@ -36,8 +36,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __TESTHELP_H
-#define __TESTHELP_H
+#ifndef VALKEY_TESTHELP_H
+#define VALKEY_TESTHELP_H
 
 #define TEST_ACCURATE (1 << 0)
 #define TEST_LARGE_MEMORY (1 << 1)

--- a/src/tls.h
+++ b/src/tls.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __VALKEY_TLS_H
-#define __VALKEY_TLS_H
+#ifndef VALKEY_TLS_H
+#define VALKEY_TLS_H
 
 /* TLS reload functions - only available when TLS is built-in, not as a module */
 #if defined(USE_OPENSSL) && USE_OPENSSL == 1 /* BUILD_YES */

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -14,8 +14,8 @@
  * ==========================================================================
  */
 
-#if !defined(__VALKEY_TRACE_H__)
-#define __VALKEY_TRACE_H__
+#if !defined(VALKEY_TRACE_H)
+#define VALKEY_TRACE_H
 
 #include "trace_aof.h"
 #include "trace_cluster.h"
@@ -40,4 +40,4 @@ pid_t do_fork(void);
     } while (0)
 #endif
 
-#endif /* __VALKEY_TRACE_H__ */
+#endif /* VALKEY_TRACE_H */

--- a/src/trace/trace_aof.h
+++ b/src/trace/trace_aof.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_aof.h"
 
 #if !defined(__VALKEY_TRACE_AOF_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_AOF_H__
+#define VALKEY_TRACE_AOF_H
 
 #include <lttng/tracepoint.h>
 
@@ -143,8 +143,8 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_AOF_H__
-#define __VALKEY_TRACE_AOF_H__
+#ifndef VALKEY_TRACE_AOF_H
+#define VALKEY_TRACE_AOF_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_aof_trace(void) {

--- a/src/trace/trace_cluster.h
+++ b/src/trace/trace_cluster.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_cluster.h"
 
 #if !defined(__VALKEY_TRACE_CLUSTER_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_CLUSTER_H__
+#define VALKEY_TRACE_CLUSTER_H
 
 #include <lttng/tracepoint.h>
 
@@ -133,8 +133,8 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_CLUSTER_H__
-#define __VALKEY_TRACE_CLUSTER_H__
+#ifndef VALKEY_TRACE_CLUSTER_H
+#define VALKEY_TRACE_CLUSTER_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_cluster_trace(void) {

--- a/src/trace/trace_commands.h
+++ b/src/trace/trace_commands.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_commands.h"
 
 #if !defined(__VALKEY_TRACE_COMMANDS_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_COMMANDS_H__
+#define VALKEY_TRACE_COMMANDS_H
 
 #include <lttng/tracepoint.h>
 
@@ -77,8 +77,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_COMMANDS_H__
-#define __VALKEY_TRACE_COMMANDS_H__
+#ifndef VALKEY_TRACE_COMMANDS_H
+#define VALKEY_TRACE_COMMANDS_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_commands_trace(void) {

--- a/src/trace/trace_db.h
+++ b/src/trace/trace_db.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_db.h"
 
 #if !defined(__VALKEY_TRACE_DB_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_DB_H__
+#define VALKEY_TRACE_DB_H
 
 #include <lttng/tracepoint.h>
 
@@ -133,8 +133,8 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_DB_H__
-#define __VALKEY_TRACE_DB_H__
+#ifndef VALKEY_TRACE_DB_H
+#define VALKEY_TRACE_DB_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_db_trace(void) {

--- a/src/trace/trace_rdb.h
+++ b/src/trace/trace_rdb.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_rdb.h"
 
 #if !defined(__VALKEY_TRACE_SYS_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_SYS_H__
+#define VALKEY_TRACE_SYS_H
 
 #include <lttng/tracepoint.h>
 
@@ -73,8 +73,8 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_SYS_H__
-#define __VALKEY_TRACE_SYS_H__
+#ifndef VALKEY_TRACE_SYS_H
+#define VALKEY_TRACE_SYS_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_rdb_trace(void) {

--- a/src/trace/trace_server.h
+++ b/src/trace/trace_server.h
@@ -23,7 +23,7 @@
 #define LTTNG_UST_TRACEPOINT_INCLUDE "./trace_server.h"
 
 #if !defined(__VALKEY_TRACE_SERVER_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define __VALKEY_TRACE_SERVER_H__
+#define VALKEY_TRACE_SERVER_H
 
 #include <lttng/tracepoint.h>
 
@@ -123,8 +123,8 @@ LTTNG_UST_TRACEPOINT_EVENT_INSTANCE(
 
 #else /* USE_LTTNG */
 
-#ifndef __VALKEY_TRACE_SERVER_H__
-#define __VALKEY_TRACE_SERVER_H__
+#ifndef VALKEY_TRACE_SERVER_H
+#define VALKEY_TRACE_SERVER_H
 
 /* avoid compiler warning on empty source file */
 static inline void __valkey_server_trace(void) {

--- a/src/unit/wrappers.h
+++ b/src/unit/wrappers.h
@@ -31,8 +31,8 @@
 extern "C" {
 #endif
 
-#ifndef __WRAPPERS_H
-#define __WRAPPERS_H
+#ifndef VALKEY_WRAPPERS_H
+#define VALKEY_WRAPPERS_H
 // C/C++ cross-compatibility definitions:
 // Some C keywords or built-in types (e.g., _Atomic, _Bool) are not
 // recognized or have different meanings in C++. To allow C headers

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,5 +1,5 @@
-#ifndef __VECTOR_H_
-#define __VECTOR_H_
+#ifndef VALKEY_VECTOR_H
+#define VALKEY_VECTOR_H
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -28,8 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __ZMALLOC_H
-#define __ZMALLOC_H
+#ifndef VALKEY_ZMALLOC_H
+#define VALKEY_ZMALLOC_H
 
 #include <stddef.h>
 


### PR DESCRIPTION
Rename include guard macros starting with `__` (reserved for the implementation per C/C++ standard) to use `VALKEY_` prefix instead.

Affects 47 header files across `src/`, `src/trace/`, `src/unit/`, `src/modules/lua/`, `deps/linenoise/`, and `deps/libvalkey/src/`.

Fixes #3850