### PR TITLE
Guard sentinel/cluster err.txt valgrind scan with $::valgrind

### DIFF
--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -223,12 +223,15 @@ proc log_crashes {} {
         close $fd
     }
 
-    set logs [glob */err.txt]
-    foreach log $logs {
-        set res [find_valgrind_errors $log true]
-        if {$res != ""} {
-            puts $res
-            incr ::failed
+    # Only scan for valgrind errors when actually running under valgrind.
+    if {$::valgrind} {
+        set logs [glob */err.txt]
+        foreach log $logs {
+            set res [find_valgrind_errors $log true]
+            if {$res != ""} {
+                puts $res
+                incr ::failed
+            }
         }
     }
 


### PR DESCRIPTION
## Issue Description

`log_crashes` in `tests/instances.tcl` — the multi-instance harness used by both `make test-sentinel` and `make test-cluster` — scans every instance's `err.txt` with `find_valgrind_errors` **unconditionally**:

```tcl
set logs [glob */err.txt]
foreach log $logs {
    set res [find_valgrind_errors $log true]
    if {$res != ""} {
        puts $res
        incr ::failed
    }
}
```

The main test framework runs the identical scan only behind a valgrind guard — in `tests/support/server.tcl`, `check_valgrind_errors` is called from `kill_server` inside `if {$::valgrind}`.

`find_valgrind_errors`' fallback (in `tests/support/util.tcl`) treats any stderr that lacks a valgrind leak-free summary as an error:

```tcl
# Look for the absence of a leak free summary
# (happens when the server isn't terminated properly).
if {(![regexp -- {definitely lost: 0 bytes} $buf] &&
     ![regexp -- {no leaks are possible} $buf])} {
    return $buf
}
```

When the suite is **not** running under valgrind, that summary is never present, so **any non-empty `err.txt` is flagged as a failure**.

## Concrete trigger

On hosts whose CPU does not expose the `constant_tsc` flag (common inside VMs / LXD), every `valkey-server` and `valkey-sentinel` prints to stderr at startup (`src/monotonic.c`):

```
monotonic: x86 linux, 'constant_tsc' flag not present
```

The sentinel suite then reports exactly **10 failures** (5 sentinel + 5 valkey instances) on every run — even though every individual test passes and no assertion fails. The cluster suite shares this harness and is affected identically. On hosts that expose `constant_tsc` the message is never printed, so the bug is invisible — which is why it only surfaces in certain CI/VM environments.

## Fix

Wrap the valgrind `err.txt` scan in `if {$::valgrind}`, mirroring `server.tcl`. The sanitizer scan immediately below is left unguarded, matching `check_sanitizer_errors`, which always runs. No test coverage is lost.

```tcl
if {$::valgrind} {
    set logs [glob */err.txt]
    foreach log $logs {
        set res [find_valgrind_errors $log true]
        if {$res != ""} {
            puts $res
            incr ::failed
        }
    }
}
```
