### PR TITLE
Make CLUSTER FAILOVER no-op when election is already in progress

### DIFF
--- a/src/cluster_legacy.c
+++ b/src/cluster_legacy.c
@@ -8201,6 +8201,18 @@ int clusterCommandSpecial(client *c) {
             addReplyError(c, "Master is down or failed, please use CLUSTER FAILOVER FORCE");
             return 1;
         }
+        /* If a failover is already in progress and the election is authorized,
+         * a failover should be a no-op. This avoids resetting an in-progress
+         * election which would waste the votes already cast and delay the
+         * failover. */
+        if (!takeover && server.cluster->mf_end != 0 && server.cluster->mf_can_start) {
+            sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);
+            serverLog(LL_NOTICE, "Failover already in progress, ignoring duplicate request (from '%s').", client);
+            sdsfree(client);
+            addReply(c, shared.ok);
+            return 1;
+        }
+
         resetManualFailover();
         server.cluster->mf_end = mstime() + server.cluster_mf_timeout;
         sds client = catClientInfoShortString(sdsempty(), c, server.hide_user_data_from_log);

--- a/tests/unit/cluster/manual-failover.tcl
+++ b/tests/unit/cluster/manual-failover.tcl
@@ -584,6 +584,43 @@ start_cluster 3 2 {tags {external:skip cluster}} {
     }
 }
 
+start_cluster 3 1 {tags {external:skip cluster} overrides {cluster-ping-interval 1000 cluster-node-timeout 5000}} {
+    # This test verifies - When a failover is already in progress,
+    # a second failover is a no-op — it does not reset the in-progress election.
+    test "Duplicate CLUSTER FAILOVER is idempotent and does not reset election" {
+        # Make the primary unreachable.
+        R 0 deferred 1
+        R 0 DEBUG SLEEP 5
+
+        set loglines_replica [count_log_lines -3]
+
+        # Send the first CLUSTER FAILOVER FORCE to the replica.
+        R 3 cluster failover force
+
+        # Wait until the replica has actually started the election.
+        wait_for_log_messages -3 {"*Starting a failover election for epoch*"} $loglines_replica 1000 10
+        set loglines_after_first_election [count_log_lines -3]
+
+        # Send a second CLUSTER FAILOVER FORCE to the same replica,
+        # simulating the race where an operator and the dying primary
+        # both trigger failover on the same replica.
+        R 3 cluster failover force
+
+        # Verify the duplicate was ignored (no election reset).
+        verify_log_message -3 "*Failover already in progress, ignoring duplicate request*" $loglines_after_first_election
+
+        # The election should NOT be reset — no new election started.
+        verify_no_log_message -3 "*Resetting the election*" $loglines_after_first_election
+
+        # The failover should complete quickly without any unnecessary delay.
+        wait_for_condition 1000 50 {
+            [s -3 role] == "master"
+        } else {
+            fail "Failover did not complete after duplicate FORCE commands"
+        }
+    }
+} ;# start_cluster
+
 # Disable this test case due to #2441.
 if {false} {
 start_cluster 3 2 {tags {external:skip cluster}} {


### PR DESCRIPTION
Closes #3996

Previously, duplicate FAILOVER commands (e.g., one from the dying primary's
auto-failover-on-shutdown and another from an external operator arriving
within milliseconds) would reset the in-progress election, bump the epoch,
and force a new vote. Since other primaries had already voted for the
original epoch, the new election could fail to reach quorum, delaying the
failover by auth_retry_time (node_timeout * 4). 

The fix adds a guard that returns OK and logs an informational message when
a non-takeover failover command arrives while an election is already
authorized. After the manual failover times out (mf_end is cleared),
retries proceed as before.